### PR TITLE
Support windows event log in fluent-bit

### DIFF
--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -212,7 +212,6 @@ func extractReceiverFactories(receivers map[string]*receiver) (map[string]*fileR
 	fileReceiverFactories := map[string]*fileReceiverFactory{}
 	syslogReceiverFactories := map[string]*syslogReceiverFactory{}
 	winlogReceiverFactories := map[string]*winlogReceiverFactory{}
-	fmt.Print(receivers)
 	for n, r := range receivers {
 		if strings.HasPrefix(n, "lib:") {
 			return nil, nil, nil, fmt.Errorf(`receiver id prefix 'lib:' is reserved for pre-defined receivers. Receiver ID %q is not allowed.`, n)

--- a/confgenerator/windows-default-config.yaml
+++ b/confgenerator/windows-default-config.yaml
@@ -14,14 +14,14 @@
 
 logging:
   receivers:
-    syslog:
+    windows_event_log:
       type: windows_event_log
-      channels: [System,Applications,Security]
+      channels: [System,Application,Security]
   exporters:
     google:
       type: google_cloud_logging
   service:
     pipelines:
       default_pipeline:
-        receivers: [syslog]
+        receivers: [windows_event_log]
         exporters: [google]

--- a/confgenerator/windows-default-config.yaml
+++ b/confgenerator/windows-default-config.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+logging:
+  receivers:
+    syslog:
+      type: windows_event_log
+      channels: [System,Applications,Security]
+  exporters:
+    google:
+      type: google_cloud_logging
+  service:
+    pipelines:
+      default_pipeline:
+        receivers: [syslog]
+        exporters: [google]

--- a/fluentbit/conf/conf.go
+++ b/fluentbit/conf/conf.go
@@ -364,7 +364,6 @@ func GenerateFluentBitMainConfig(tails []*Tail, syslogs []*Syslog, winlogs []*Wi
 		FilterModifyRemoveLogNameConfigSections: filterModifyRemoveLogNameConfigSections,
 		StackdriverConfigSections:               stackdriverConfigSections,
 	}
-	fmt.Print(mainConfTemplate)
 	mt, err := template.New("fluentBitMainConf").Parse(mainConfTemplate)
 	if err != nil {
 		return "", err

--- a/fluentbit/conf/conf.go
+++ b/fluentbit/conf/conf.go
@@ -62,7 +62,7 @@ const (
 {{.}}
 
 {{end}}
-{{- range .WinlogConfigSections -}}
+{{- range .WineventlogConfigSections -}}
 {{.}}
 
 {{end}}
@@ -244,8 +244,9 @@ const (
     # as a hint to set "how much data can be up in memory", once the limit is reached it continues writing to disk.
     Mem_Buf_Limit  10M`
 
-	winlogConf = `[INPUT]
+	wineventlogConf = `[INPUT]
     # https://docs.fluentbit.io/manual/pipeline/inputs/windows-event-log
+    Tag            {{.Tag}}
     Name           winlog
     Channels       {{.Channels}}
     Interval_Sec   1
@@ -271,7 +272,7 @@ const (
 type mainConfigSections struct {
 	TailConfigSections                      []string
 	SyslogConfigSections                    []string
-	WinlogConfigSections                    []string
+	WineventlogConfigSections                    []string
 	FilterParserConfigSections              []string
 	FilterModifyAddLogNameConfigSections    []string
 	FilterRewriteTagSections                []string
@@ -285,14 +286,14 @@ type parserConfigSections struct {
 }
 
 // GenerateFluentBitMainConfig generates a FluentBit main configuration.
-func GenerateFluentBitMainConfig(tails []*Tail, syslogs []*Syslog, winlogs []*WindowsEventlog, filterParsers []*FilterParser,
+func GenerateFluentBitMainConfig(tails []*Tail, syslogs []*Syslog, wineventlogs []*WindowsEventlog, filterParsers []*FilterParser,
 	filterModifyAddLogNames []*FilterModifyAddLogName,
 	filterRewriteTags []*FilterRewriteTag,
 	filterModifyRemoveLogNames []*FilterModifyRemoveLogName,
 	stackdrivers []*Stackdriver) (string, error) {
 	tailConfigSections := []string{}
 	syslogConfigSections := []string{}
-	winlogConfigSections := []string{}
+	wineventlogConfigSections := []string{}
 	filterParserConfigSections := []string{}
 	filterModifyAddLogNameConfigSections := []string{}
 	filterRewriteTagSections := []string{}
@@ -312,12 +313,12 @@ func GenerateFluentBitMainConfig(tails []*Tail, syslogs []*Syslog, winlogs []*Wi
 		}
 		syslogConfigSections = append(syslogConfigSections, configSection)
 	}
-	for _, w := range winlogs {
+	for _, w := range wineventlogs {
 		configSection, err := w.renderConfig()
 		if err != nil {
 			return "", err
 		}
-		winlogConfigSections = append(winlogConfigSections, configSection)
+		wineventlogConfigSections = append(wineventlogConfigSections, configSection)
 	}
 	for _, f := range filterParsers {
 		configSection, err := f.renderConfig()
@@ -357,7 +358,7 @@ func GenerateFluentBitMainConfig(tails []*Tail, syslogs []*Syslog, winlogs []*Wi
 	configSections := mainConfigSections{
 		TailConfigSections:                      tailConfigSections,
 		SyslogConfigSections:                    syslogConfigSections,
-		WinlogConfigSections:                    winlogConfigSections,
+		WineventlogConfigSections:                    wineventlogConfigSections,
 		FilterParserConfigSections:              filterParserConfigSections,
 		FilterModifyAddLogNameConfigSections:    filterModifyAddLogNameConfigSections,
 		FilterRewriteTagSections:                filterRewriteTagSections,
@@ -691,27 +692,35 @@ func (s Syslog) renderConfig() (string, error) {
 
 // A WindowsEventlog represents the configuration data for fluentbit's winlog input plugin
 type WindowsEventlog struct {
-        Channels string
+        Tag string
+	Channels string
         Interval_Sec string
         DB string
 }
 
-var winlogTemplate = template.Must(template.New("winlog").Parse(winlogConf))
+var wineventlogTemplate = template.Must(template.New("wineventlog").Parse(wineventlogConf))
 
-// renderConfig generates a section for configure fluentBit winlog input plugin.
+// renderConfig generates a section for configure fluentBit wineventlog input plugin.
 func (w WindowsEventlog) renderConfig() (string, error) {
 	if w.Channels == "" {
 		return "", emptyFieldErr{
-			plugin: "winlog",
+			plugin: "windows_event_log",
 			field: "Channels",
 		}
 	}
 
-	var renderedWinlogConfig strings.Builder
-	if err := winlogTemplate.Execute(&renderedWinlogConfig, w); err != nil {
+	if w.Tag == "" {
+		return "", emptyFieldErr{
+			plugin: "windows_event_log",
+			field:  "Tag",
+		}
+	}
+
+	var renderedWineventlogConfig strings.Builder
+	if err := wineventlogTemplate.Execute(&renderedWineventlogConfig, w); err != nil {
 		return "", err
 	}
-	return renderedWinlogConfig.String(), nil
+	return renderedWineventlogConfig.String(), nil
 }
 
 // A Stackdriver represents the configurable data for fluentBit's stackdriver output plugin.

--- a/fluentbit/conf/conf.go
+++ b/fluentbit/conf/conf.go
@@ -272,7 +272,7 @@ const (
 type mainConfigSections struct {
 	TailConfigSections                      []string
 	SyslogConfigSections                    []string
-	WineventlogConfigSections                    []string
+	WineventlogConfigSections               []string
 	FilterParserConfigSections              []string
 	FilterModifyAddLogNameConfigSections    []string
 	FilterRewriteTagSections                []string
@@ -358,7 +358,7 @@ func GenerateFluentBitMainConfig(tails []*Tail, syslogs []*Syslog, wineventlogs 
 	configSections := mainConfigSections{
 		TailConfigSections:                      tailConfigSections,
 		SyslogConfigSections:                    syslogConfigSections,
-		WineventlogConfigSections:                    wineventlogConfigSections,
+		WineventlogConfigSections:               wineventlogConfigSections,
 		FilterParserConfigSections:              filterParserConfigSections,
 		FilterModifyAddLogNameConfigSections:    filterModifyAddLogNameConfigSections,
 		FilterRewriteTagSections:                filterRewriteTagSections,
@@ -608,6 +608,7 @@ func (t Tail) renderConfig() (string, error) {
 			field:  "Tag",
 		}
 	}
+	//TODO: Add check that Path is a comma separated list.
 	if t.Path == "" {
 		return "", emptyFieldErr{
 			plugin: "tail",
@@ -692,20 +693,21 @@ func (s Syslog) renderConfig() (string, error) {
 
 // A WindowsEventlog represents the configuration data for fluentbit's winlog input plugin
 type WindowsEventlog struct {
-        Tag string
-	Channels string
-        Interval_Sec string
-        DB string
+	Tag          string
+	Channels     string
+	Interval_Sec string
+	DB           string
 }
 
 var wineventlogTemplate = template.Must(template.New("wineventlog").Parse(wineventlogConf))
 
 // renderConfig generates a section for configure fluentBit wineventlog input plugin.
 func (w WindowsEventlog) renderConfig() (string, error) {
+	//TODO: Add check that Channels is a comma separated list.
 	if w.Channels == "" {
 		return "", emptyFieldErr{
 			plugin: "windows_event_log",
-			field: "Channels",
+			field:  "Channels",
 		}
 	}
 

--- a/fluentbit/conf/conf_test.go
+++ b/fluentbit/conf/conf_test.go
@@ -565,7 +565,7 @@ func TestWinlog(t *testing.T) {
 
 func TestWinlogErrors(t *testing.T) {
 	tests := []struct {
-		name   string
+		name        string
 		wineventlog WindowsEventlog
 	}{
 		{
@@ -870,10 +870,10 @@ func TestGenerateFluentBitMainConfigErrors(t *testing.T) {
 
 func TestGenerateFluentBitMainConfigWindows(t *testing.T) {
 	tests := []struct {
-		name    string
-		tails   []*Tail
+		name         string
+		tails        []*Tail
 		wineventlogs []*WindowsEventlog
-		want    string
+		want         string
 	}{
 		{
 			name: "multiple tail and winlog plugins",


### PR DESCRIPTION
This PR will 

- add a new receiver type as [windows_event_log](https://docs.fluentbit.io/manual/pipeline/inputs/windows-event-log)
- add a default windows configuration file (only logging section, metrics sections will be there when i start on OTEL work)
- add fluent-bit test for this new feature
- NOT add any tests in confgenerator_test.go yet as the structure is for testing both logging and metrics. Though i can supply an empty golden. Also considering now the default metrics is in collectd. I need to think better on how to decouple that and add otel as the replacement. And this work will come around when i start on OTEL work.

Note that i use winlog as the name in many places as that's the name of the fluent-bit windows event log input plugin.

