### PR TITLE
Use updated 'powertools' repo name for CentOS 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,7 +112,7 @@ FROM centos:8 AS centos8
 
 RUN yum -y update && \
     dnf -y install 'dnf-command(config-manager)' && \
-    yum config-manager --set-enabled PowerTools && \
+    yum config-manager --set-enabled powertools && \
     yum -y install golang git systemd \
     autoconf libtool libcurl-devel libtool-ltdl-devel openssl-devel yajl-devel \
     gcc gcc-c++ make cmake bison flex file systemd-devel zlib-devel gtest-devel rpm-build systemd-rpm-macros \


### PR DESCRIPTION
The repo name was [changed from 'PowerTools' to 'powertools'](https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2011#Yum_repo_file_and_repoid_changes) with the latest release (on December 7, 2020). 

<img width="969" alt="Screen Shot 2020-12-16 at 5 25 55 PM" src="https://user-images.githubusercontent.com/35477443/102414071-e5b5c680-3fc3-11eb-9015-9b96e37e2d26.png">

Also see https://bugs.centos.org/view.php?id=17920