### PR TITLE
Support OTEL

### DIFF
--- a/cmd/generate_config/main.go
+++ b/cmd/generate_config/main.go
@@ -75,6 +75,19 @@ func run() error {
 		if err := ioutil.WriteFile(path, []byte(collectdConfig), 0644); err != nil {
 			return fmt.Errorf("can't write %q: %w", path, err)
 		}
+	case "otel":
+		otelConfig, err := confgenerator.GenerateOtelConfig(data, *logsDir)
+		if err != nil {
+			return fmt.Errorf("can't parse configuration: %w", err)
+		}
+		// Make sure the output directory exists before generating configs.
+		if err := os.MkdirAll(*outDir, 0755); err != nil {
+			return fmt.Errorf("can't create output directory %q: %w", *outDir, err)
+		}
+		path := filepath.Join(*outDir, "otel.conf")
+		if err := ioutil.WriteFile(path, []byte(otelConfig), 0644); err != nil {
+			return fmt.Errorf("can't write %q: %w", path, err)
+		}
 	default:
 		return fmt.Errorf("unknown service %q", *service)
 	}

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -434,10 +434,10 @@ func generateOtelReceivers(hostmetricsReceiverFactories map[string]*hostmetricsR
 	for _, pID := range pipelineIDs {
 		p := pipelines[pID]
 		for _, rID := range p.Receivers {
-			if _, ok := hostmetricsReceiverFactories[rID]; ok {
+			if h, ok := hostmetricsReceiverFactories[rID]; ok {
 				hostMetrics := otel.HostMetrics{
 					HostMetricsID:      rID,
-					CollectionInterval: "1",
+					CollectionInterval: h.CollectionInterval,
 				}
 				hostMetricsList = append(hostMetricsList, &hostMetrics)
 				receiveNameMap[rID] = "hostmetrics/" + rID

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -409,19 +409,20 @@ func generateOtelExporters(exporters map[string]*otelExporter, pipelines map[str
 	sort.Strings(pipelineIDs)
 	for _, pID := range pipelineIDs {
 		p := pipelines[pID]
-		for _, rID := range p.Receivers {
+		for _, rID := range p.Exporters {
 			if _, ok := exporters[rID]; ok {
 				stackdriver := otel.Stackdriver{
+					StackdriverID: rID,
 					UserAgent: "$USERAGENT",
 					Prefix: "agent.googleapis.com/",
 				}
 				stackdriverList = append(stackdriverList, &stackdriver)
 				continue
 			}
-			return nil, fmt.Errorf(`receiver %q of pipeline %q is not defined`, rID, pID)
+			return nil, fmt.Errorf(`exporter %q of pipeline %q is not defined`, rID, pID)
 		}
 	}
-	return stackdriverList, nil	
+	return stackdriverList, nil
 }
 
 func generateFluentBitInputs(fileReceiverFactories map[string]*fileReceiverFactory, syslogReceiverFactories map[string]*syslogReceiverFactory, wineventlogReceiverFactories map[string]*wineventlogReceiverFactory, pipelines map[string]*loggingPipeline, stateDir string) ([]*conf.Tail, []*conf.Syslog, []*conf.WindowsEventlog, error) {

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -33,8 +33,8 @@ type unifiedConfig struct {
 }
 
 type unifiedConfigWindows struct {
-	Logging *logging         `yaml:"logging"`
-	Metrics *otelMetrics     `yaml:"metrics"`
+	Logging *logging     `yaml:"logging"`
+	Metrics *otelMetrics `yaml:"metrics"`
 }
 
 type logging struct {
@@ -90,19 +90,19 @@ type loggingPipeline struct {
 }
 
 type otelReceiver struct {
-        Type string `yaml:"type"`
+	Type string `yaml:"type"`
 	// Valid for type "hostmetrics".
-        CollectionInterval string `yaml:"collection_interval"`
+	CollectionInterval string `yaml:"collection_interval"`
 }
 
 type otelExporter struct {
-        Type string `yaml:"type"`
+	Type string `yaml:"type"`
 }
 
 type otelMetrics struct {
-    Receivers map[string]*otelReceiver `yaml:"receivers"`
-    Exporters map[string]*otelExporter `yaml:"exporters"`
-	Service *otelService `yaml:"service"`
+	Receivers map[string]*otelReceiver `yaml:"receivers"`
+	Exporters map[string]*otelExporter `yaml:"exporters"`
+	Service   *otelService             `yaml:"service"`
 }
 
 type otelService struct {
@@ -115,7 +115,7 @@ type otelPipeline struct {
 	Exporters  []string `yaml:"exporters"`
 }
 
-func GenerateOtelConfig(input []byte, logsDir string) (config string, err error){
+func GenerateOtelConfig(input []byte, logsDir string) (config string, err error) {
 	unifiedConfig, err := unifiedConfigWindowsReader(input)
 	if err != nil {
 		return "", err
@@ -171,7 +171,7 @@ func unifiedConfigWindowsReader(input []byte) (unifiedConfigWindows, error) {
 	return config, nil
 }
 
-func generateOtelConfig(metrics *otelMetrics, logsDir string) (string, error){
+func generateOtelConfig(metrics *otelMetrics, logsDir string) (string, error) {
 	hostMetricsList := []*otel.HostMetrics{}
 	stackdriverList := []*otel.Stackdriver{}
 	serviceList := []*otel.Service{}
@@ -217,24 +217,24 @@ func generateOtelServices(receiverNameMap map[string]string, exporterNameMap map
 				isHostMetrics = true
 			}
 		}
-                var pExportIDs []string
-                for _, eID := range p.Exporters {
-                        pExportIDs = append(pExportIDs, exporterNameMap[eID])
-                }
+		var pExportIDs []string
+		for _, eID := range p.Exporters {
+			pExportIDs = append(pExportIDs, exporterNameMap[eID])
+		}
 		service := otel.Service{}
 		if isHostMetrics {
 			defaultProcessors := []string{"agentmetrics/system", "filter/system", "metricstransform/system", "resourcedetection"}
 			service = otel.Service{
-				ID: "system",
-				Receivers: fmt.Sprintf("[%s]", strings.Join(pRecevieIDs, ",")),
+				ID:         "system",
+				Receivers:  fmt.Sprintf("[%s]", strings.Join(pRecevieIDs, ",")),
 				Processors: fmt.Sprintf("[%s]", strings.Join(defaultProcessors, ",")),
-				Exporters: fmt.Sprintf("[%s]", strings.Join(pExportIDs, ",")),
+				Exporters:  fmt.Sprintf("[%s]", strings.Join(pExportIDs, ",")),
 			}
 		} else {
 			service = otel.Service{
-				ID: pID,
-				Receivers: fmt.Sprintf("[%s]", strings.Join(pRecevieIDs, ",")),
-				Exporters: fmt.Sprintf("[%s]", strings.Join(pExportIDs, ",")),
+				ID:         pID,
+				Receivers:  fmt.Sprintf("[%s]", strings.Join(pRecevieIDs, ",")),
+				Exporters:  fmt.Sprintf("[%s]", strings.Join(pExportIDs, ",")),
 				Processors: fmt.Sprintf("[%s]", strings.Join(p.Processors, ",")),
 			}
 		}
@@ -334,11 +334,11 @@ type wineventlogReceiverFactory struct {
 	Channels []string
 }
 
-type hostmetricsReceiverFactory struct{
+type hostmetricsReceiverFactory struct {
 	CollectionInterval string
 }
 
-func extractOtelReceiverFactories(receivers map[string]*otelReceiver) (map[string]*hostmetricsReceiverFactory, error){
+func extractOtelReceiverFactories(receivers map[string]*otelReceiver) (map[string]*hostmetricsReceiverFactory, error) {
 	hostmetricsReceiverFactories := map[string]*hostmetricsReceiverFactory{}
 	for n, r := range receivers {
 		switch r.Type {
@@ -436,11 +436,11 @@ func generateOtelReceivers(hostmetricsReceiverFactories map[string]*hostmetricsR
 		for _, rID := range p.Receivers {
 			if _, ok := hostmetricsReceiverFactories[rID]; ok {
 				hostMetrics := otel.HostMetrics{
-					HostMetricsID: rID,
+					HostMetricsID:      rID,
 					CollectionInterval: "1",
 				}
 				hostMetricsList = append(hostMetricsList, &hostMetrics)
-				receiveNameMap[rID] = "hostmetrics/"+rID
+				receiveNameMap[rID] = "hostmetrics/" + rID
 				continue
 			}
 			return nil, nil, fmt.Errorf(`receiver %q of pipeline %q is not defined`, rID, pID)
@@ -463,8 +463,8 @@ func generateOtelExporters(exporters map[string]*otelExporter, pipelines map[str
 			if _, ok := exporters[eID]; ok {
 				stackdriver := otel.Stackdriver{
 					StackdriverID: eID,
-					UserAgent: "$USERAGENT",
-					Prefix: "agent.googleapis.com/",
+					UserAgent:     "$USERAGENT",
+					Prefix:        "agent.googleapis.com/",
 				}
 				stackdriverList = append(stackdriverList, &stackdriver)
 				exportNameMap[eID] = "stackdriver/" + eID

--- a/confgenerator/windows-default-config.yaml
+++ b/confgenerator/windows-default-config.yaml
@@ -31,7 +31,11 @@ metrics:
     hostmetrics:
       type: hostmetrics
       collection_interval: 60s
+  exporters:
+    google:
+      type: google_cloud_monitoring
   service:
     pipelines:
       default_pipeline:
         receivers: [hostmetrics]
+        exporters: [google]

--- a/confgenerator/windows-default-config.yaml
+++ b/confgenerator/windows-default-config.yaml
@@ -25,3 +25,13 @@ logging:
       default_pipeline:
         receivers: [windows_event_log]
         exporters: [google]
+
+metrics:
+  receivers:
+    hostmetrics:
+      type: hostmetrics
+      collection_interval: 60s
+  service:
+    pipelines:
+      default_pipeline:
+        receivers: [hostmetrics]

--- a/otel/conf.go
+++ b/otel/conf.go
@@ -92,7 +92,7 @@ service:
       exporters: {{.Exporters}}`
 
 	defaultProcessorConf = `resourcedetection:
-    detectors: [gce, ec2]
+    detectors: [gce]
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:

--- a/otel/conf.go
+++ b/otel/conf.go
@@ -40,11 +40,12 @@ extensions:
   {{.}}
   {{end}}
 service:
-  {{range .ServiceConfigSection -}}
-  {{.}}
-  {{end}}`
+  pipelines:
+    {{range .ServiceConfigSection -}}
+    {{.}}
+    {{end}}`
 
-	hostmetricsConf = `hostmetrics/{{.HostMetricsID}}:
+	hostmetricsReceiverConf = `hostmetrics/{{.HostMetricsID}}:
     collection_interval: {{.CollectionInterval}}
     scrapers:
       cpu:
@@ -56,10 +57,421 @@ service:
       swap:
       process:`
 
-	stackdriverConf = `stackdriver/{{.StackdriverID}}:
+	stackdriverExporterConf = `stackdriver/{{.StackdriverID}}:
     user_agent: {{.UserAgent}}
     metric:
       prefix: {{.Prefix}}`
+
+	agentReceiverConf = `prometheus/agent:
+    config:
+      scrape_configs:
+      - job_name: 'otel-collector'
+        scrape_interval: 1m
+        static_configs:
+        - targets: ['0.0.0.0:8888']`
+
+	agentExporterConf = `stackdriver/agent:
+    user_agent: $USERAGENT
+    metric:
+      prefix: agent.googleapis.com/`
+
+	agentServiceConf = `# reports agent self-observability metrics to cloud monitoring
+    metrics/agent:
+      receivers:
+        - prometheus/agent
+      processors:
+        - filter/agent
+        - metricstransform/agent
+        - resourcedetection
+      exporters:
+        - stackdriver/agent`
+
+	systemServiceConf = `metrics/system:
+      receivers:  {{.Receivers}}
+      processors:
+        # leave these custom processors here to support cloud monitoring agent metric format
+        - agentmetrics/system
+        - filter/system
+        - metricstransform/system
+        # add additional custom processors below this line if desired
+        - resourcedetection
+      exporters: {{.Exporters}}`
+
+	serviceConf = `metrics/{{.ID}}:
+      receivers:  {{.Receivers}}
+      processors: {{.Processors}}
+      exporters: {{.Exporters}}`
+
+      defaultProcessorConf = `resourcedetection:
+    detectors: [gce, ec2]
+
+  # perform custom transformations that aren't supported by the metricstransform processor
+  agentmetrics/system:
+    # 1. converts up down sum types to gauges
+    # 2. combines resource process metrics into metrics with processes as labels
+    # 3. splits "disk.io" metrics into read & write metrics
+    # 4. creates utilization metrics from usage metrics
+
+  # filter out metrics not currently supported by cloud monitoring
+  filter/system:
+    metrics:
+      exclude:
+        match_type: strict
+        metric_names:
+          - system.network.dropped_packets
+
+  # convert from opentelemetry metric formats to cloud monitoring formats
+  metricstransform/system:
+    transforms:
+      # system.cpu.time -> cpu/usage_time
+      - metric_name: system.cpu.time
+        action: update
+        new_name: cpu/usage_time
+        operations:
+          # change data type from double -> int64
+          - action: toggle_scalar_data_type
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
+            new_label: cpu_number
+          # change label state -> cpu_state
+          - action: update_label
+            label: state
+            new_label: cpu_state
+          # take mean over cpu_number dimension, retaining only cpu_state
+          - action: aggregate_labels
+            label_set: [ cpu_state ]
+            aggregation_type: mean
+      # system.cpu.utilization -> cpu/utilization
+      - metric_name: system.cpu.utilization
+        action: update
+        new_name: cpu/utilization
+        operations:
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
+            new_label: cpu_number
+          # change label state -> cpu_state
+          - action: update_label
+            label: state
+            new_label: cpu_state
+          # take mean over cpu_number dimension, retaining only cpu_state
+          - action: aggregate_labels
+            label_set: [ cpu_state ]
+            aggregation_type: mean
+      # system.cpu.load_average.1m -> cpu/load_1m
+      - metric_name: system.cpu.load_average.1m
+        action: update
+        new_name: cpu/load_1m
+      # system.cpu.load_average.5m -> cpu/load_5m
+      - metric_name: system.cpu.load_average.5m
+        action: update
+        new_name: cpu/load_5m
+      # system.cpu.load_average.15m -> cpu/load_15m
+      - metric_name: system.cpu.load_average.15m
+        action: update
+        new_name: cpu/load_15m
+      # system.disk.read_io (as named after custom split logic) -> disk/read_bytes_count
+      - metric_name: system.disk.read_io
+        action: update
+        new_name: disk/read_bytes_count
+      # system.disk.write_io (as named after custom split logic) -> processes/write_bytes_count
+      - metric_name: system.disk.write_io
+        action: update
+        new_name: disk/write_bytes_count
+      # system.disk.ops -> disk/operation_count
+      - metric_name: system.disk.ops
+        action: update
+        new_name: disk/operation_count
+      # system.disk.io_time -> disk/io_time
+      - metric_name: system.disk.io_time
+        action: update
+        new_name: disk/io_time
+        operations:
+          # change data type from double -> int64
+          - action: toggle_scalar_data_type
+      # system.disk.operation_time -> disk/operation_time
+      - metric_name: system.disk.operation_time
+        action: update
+        new_name: disk/operation_time
+        operations:
+          # change data type from double -> int64
+          - action: toggle_scalar_data_type
+      # system.disk.pending_operations -> disk/pending_operations
+      - metric_name: system.disk.pending_operations
+        action: update
+        new_name: disk/pending_operations
+        operations:
+          # change data type from int64 -> double
+          - action: toggle_scalar_data_type
+      # system.filesystem.usage -> disk/bytes_used
+      - metric_name: system.filesystem.usage
+        action: update
+        new_name: disk/bytes_used
+        operations:
+          # change data type from int64 -> double
+          - action: toggle_scalar_data_type
+          # take sum over mode, mountpoint & type dimensions, retaining only device & state
+          - action: aggregate_labels
+            label_set: [ device, state ]
+            aggregation_type: sum
+      # system.filesystem.utilization -> disk/percent_used
+      - metric_name: system.filesystem.utilization
+        action: update
+        new_name: disk/percent_used
+        operations:
+          # take sum over mode, mountpoint & type dimensions, retaining only device & state
+          - action: aggregate_labels
+            label_set: [ device, state ]
+            aggregation_type: sum
+      # system.memory.usage -> memory/bytes_used
+      - metric_name: system.memory.usage
+        action: update
+        new_name: memory/bytes_used
+        operations:
+          # change data type from int64 -> double
+          - action: toggle_scalar_data_type
+          # aggregate state label values: slab_reclaimable & slab_unreclaimable -> slab (note this is not currently supported)
+          - action: aggregate_label_values
+            label: state
+            aggregated_values: [slab_reclaimable, slab_unreclaimable]
+            new_value: slab
+            aggregation_type: sum
+      # system.memory.utilization -> memory/percent_used
+      - metric_name: system.memory.utilization
+        action: update
+        new_name: memory/percent_used
+        operations:
+          # sum state label values: slab = slab_reclaimable + slab_unreclaimable
+          - action: aggregate_label_values
+            label: state
+            aggregated_values: [slab_reclaimable, slab_unreclaimable]
+            new_value: slab
+            aggregation_type: sum
+      # system.network.io -> interface/traffic
+      - metric_name: system.network.io
+        action: update
+        new_name: interface/traffic
+        operations:
+          # change label interface -> device
+          - action: update_label
+            label: interface
+            new_label: device
+          # change direction label values receive -> rx
+          - action: update_label
+            label: direction
+            value_actions:
+              # receive -> rx
+              - value: receive
+                new_value: rx
+              # transmit -> tx
+              - value: transmit
+                new_value: tx
+      # system.network.errors -> interface/errors
+      - metric_name: system.network.errors
+        action: update
+        new_name: interface/errors
+        operations:
+          # change label interface -> device
+          - action: update_label
+            label: interface
+            new_label: device
+          # change direction label values receive -> rx
+          - action: update_label
+            label: direction
+            value_actions:
+              # receive -> rx
+              - value: receive
+                new_value: rx
+              # transmit -> tx
+              - value: transmit
+                new_value: tx
+      # system.network.packets -> interface/packets
+      - metric_name: system.network.packets
+        action: update
+        new_name: interface/packets
+        operations:
+          # change label interface -> device
+          - action: update_label
+            label: interface
+            new_label: device
+          # change direction label values receive -> rx
+          - action: update_label
+            label: direction
+            value_actions:
+              # receive -> rx
+              - value: receive
+                new_value: rx
+              # transmit -> tx
+              - value: transmit
+                new_value: tx
+      # system.network.tcp_connections -> network/tcp_connections
+      - metric_name: system.network.tcp_connections
+        action: update
+        new_name: network/tcp_connections
+        operations:
+          # change data type from int64 -> double
+          - action: toggle_scalar_data_type
+          # change label state -> tcp_state
+          - action: update_label
+            label: state
+            new_label: tcp_state
+      # system.swap.usage -> swap/bytes_used
+      - metric_name: system.swap.usage
+        action: update
+        new_name: swap/bytes_used
+        operations:
+          # change data type from int64 -> double
+          - action: toggle_scalar_data_type
+      # system.swap.utilization -> swap/percent_used
+      - metric_name: system.swap.utilization
+        action: update
+        new_name: swap/percent_used
+      # duplicate swap/percent_used -> pagefile/percent_used
+      - metric_name: swap/percent_used
+        action: insert
+        new_name: pagefile/percent_used
+        operations:
+          # take sum over device dimension, retaining only state
+          - action: aggregate_labels
+            label_set: [ state ]
+            aggregation_type: sum
+      # system.swap.paging_ops -> swap/io
+      - metric_name: system.swap.paging_ops
+        action: update
+        new_name: swap/io
+        operations:
+          # delete single-valued type dimension, retaining only direction
+          - action: aggregate_labels
+            label_set: [ direction ]
+            aggregation_type: sum
+      # process.cpu.time -> processes/cpu_time
+      - metric_name: process.cpu.time
+        action: update
+        new_name: processes/cpu_time
+        operations:
+          # change data type from double -> int64
+          - action: toggle_scalar_data_type
+          # change label state -> user_or_syst
+          - action: update_label
+            label: state
+            new_label: user_or_syst
+            # change label value system -> syst
+            value_actions:
+              - value: system
+                new_value: syst
+      # process.disk.read_io (as named after custom split logic) -> processes/disk/read_bytes_count
+      - metric_name: process.disk.read_io
+        action: update
+        new_name: processes/disk/read_bytes_count
+      # process.disk.write_io (as named after custom split logic) -> processes/disk/write_bytes_count
+      - metric_name: process.disk.write_io
+        action: update
+        new_name: processes/disk/write_bytes_count
+      # process.memory.physical_usage -> processes/rss_usage
+      - metric_name: process.memory.physical_usage
+        action: update
+        new_name: processes/rss_usage
+        operations:
+          # change data type from int64 -> double
+          - action: toggle_scalar_data_type
+      # process.memory.virtual_usage -> processes/vm_usage
+      - metric_name: process.memory.virtual_usage
+        action: update
+        new_name: processes/vm_usage
+        operations:
+          # change data type from int64 -> double
+          - action: toggle_scalar_data_type
+
+  # filter to include only agent metrics supported by cloud monitoring
+  filter/agent:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+          - otelcol_process_uptime
+          - otelcol_process_memory_rss
+          - otelcol_grpc_io_client_completed_rpcs
+          - otelcol_googlecloudmonitoring_point_count
+
+  # convert from windows perf counter formats to cloud monitoring formats
+  metricstransform/iis:
+    transforms:
+      - include: \Web Service(_Total)\Current Connections
+        action: update
+        new_name: iis/current_connections
+      - include: ^\\Web Service\(_Total\)\\Total Bytes (?P<direction>.*)$
+        match_type: regexp
+        action: combine
+        new_name: iis/network/transferred_bytes_count
+        submatch_case: lower
+      - include: \Web Service(_Total)\Total Connection Attempts (all instances)
+        action: update
+        new_name: iis/new_connection_count
+      - include: ^\\Web Service\(_Total\)\\Total (?P<http_method>.*) Requests$
+        match_type: regexp
+        action: combine
+        new_name: iis/request_count
+        submatch_case: lower
+
+  # convert from windows perf counter formats to cloud monitoring formats
+  metricstransform/mssql:
+    transforms:
+      - include: \SQLServer:General Statistics(_Total)\User Connections
+        action: update
+        new_name: mssql/connections/user
+      - include: \SQLServer:Databases(_Total)\Transactions/sec
+        action: update
+        new_name: mssql/transaction_rate
+      - include: \SQLServer:Databases(_Total)\Write Transactions/sec
+        action: update
+        new_name: mssql/write_transaction_rate
+
+  # convert from opentelemetry metric formats to cloud monitoring formats
+  metricstransform/agent:
+    transforms:
+      # otelcol_process_uptime -> agent/uptime
+      - metric_name: otelcol_process_uptime
+        action: update
+        new_name: agent/uptime
+        operations:
+          # change data type from double -> int64
+          - action: toggle_scalar_data_type
+          # add version label
+          - action: add_label
+            new_label: version
+            new_value: $USERAGENT
+      # otelcol_process_memory_rss -> agent/memory_usage
+      - metric_name: otelcol_process_memory_rss
+        action: update
+        new_name: agent/memory_usage
+      # otelcol_grpc_io_client_completed_rpcs -> agent/api_request_count
+      - metric_name: otelcol_grpc_io_client_completed_rpcs
+        action: update
+        new_name: agent/api_request_count
+        operations:
+          # change data type from double -> int64
+          - action: toggle_scalar_data_type
+        # TODO: below is proposed new configuration for the metrics transform processor
+          # ignore any non "google.monitoring" RPCs (note there won't be any other RPCs for now)
+        # - action: select_label_values
+        #   label: grpc_client_method
+        #   value_regexp: ^google\.monitoring
+          # change label grpc_client_status -> state
+          - action: update_label
+            label: grpc_client_status
+            new_label: state
+          # delete grpc_client_method dimension, retaining only state
+          - action: aggregate_labels
+            label_set: [ state ]
+            aggregation_type: sum
+      # otelcol_googlecloudmonitoring_point_count -> agent/monitoring/point_count
+      - metric_name: otelcol_googlecloudmonitoring_point_count
+        action: update
+        new_name: agent/monitoring/point_count
+        operations:
+          # change data type from double -> int64
+          - action: toggle_scalar_data_type`
 )
 
 type configSections struct {
@@ -84,7 +496,7 @@ type HostMetrics struct {
 	CollectionInterval string
 }
 
-var hostMetricsTemplate = template.Must(template.New("hostmetrics").Parse(hostmetricsConf))
+var hostMetricsTemplate = template.Must(template.New("hostmetrics").Parse(hostmetricsReceiverConf))
 
 func (h HostMetrics) renderConfig() (string, error) {
 	if h.CollectionInterval == "" {
@@ -101,13 +513,45 @@ func (h HostMetrics) renderConfig() (string, error) {
 	return renderedHostMetricsConfig.String(), nil
 }
 
+type SystemService struct {
+	Receivers []string
+	Exporters []string
+}
+
+var systemserviceTemplate = template.Must(template.New("systemservice").Parse(systemServiceConf))
+
+func (s SystemService) renderConfig() (string, error) {
+	var renderedServiceConfig strings.Builder
+	if err := systemserviceTemplate.Execute(&renderedServiceConfig, s); err != nil {
+		return "", err
+	}
+	return renderedServiceConfig.String(), nil
+}
+
+type Service struct {
+	ID string
+	Processors string
+	Receivers string
+	Exporters string
+}
+
+var serviceTemplate = template.Must(template.New("service").Parse(serviceConf))
+
+func (s Service) renderConfig() (string, error) {
+	var renderedServiceConfig strings.Builder
+	if err := serviceTemplate.Execute(&renderedServiceConfig, s); err != nil {
+		return "", err
+	}
+	return renderedServiceConfig.String(), nil
+}
+
 type Stackdriver struct {
 	StackdriverID string
 	UserAgent string
 	Prefix string
 }
 
-var stackdriverTemplate = template.Must(template.New("stackdriver").Parse(stackdriverConf))
+var stackdriverTemplate = template.Must(template.New("stackdriver").Parse(stackdriverExporterConf))
 
 func (s Stackdriver) renderConfig() (string, error) {
 	var renderedStackdriverConfig strings.Builder
@@ -117,9 +561,14 @@ func (s Stackdriver) renderConfig() (string, error) {
 	return renderedStackdriverConfig.String(), nil
 }
 
-func GenerateOtelConfig(hostMetricsList []*HostMetrics, stackdriverList []*Stackdriver) (string, error) {
+func GenerateOtelConfig(hostMetricsList []*HostMetrics, stackdriverList []*Stackdriver, serviceList []*Service) (string, error) {
 	receiversConfigSection := []string{}
 	exportersConfigSection := []string{}
+	processorsConfigSection := []string{}
+	serviceConfigSection := []string{}
+	receiversConfigSection = append(receiversConfigSection, agentReceiverConf)
+	exportersConfigSection = append(exportersConfigSection, agentExporterConf)
+	serviceConfigSection = append(serviceConfigSection, agentServiceConf)
 	for _, h := range hostMetricsList {
 		configSection, err := h.renderConfig()
 		if err != nil {
@@ -134,11 +583,19 @@ func GenerateOtelConfig(hostMetricsList []*HostMetrics, stackdriverList []*Stack
 		}
 		exportersConfigSection = append(exportersConfigSection, configSection)
 	}
-
+	for _, s := range serviceList {
+		configSection, err := s.renderConfig()
+                 if err != nil {
+                         return "", err
+                 }
+                 serviceConfigSection = append(serviceConfigSection, configSection)
+	}
+	processorsConfigSection =append(processorsConfigSection, defaultProcessorConf)
 	configSections := configSections{
 		ReceiversConfigSection: receiversConfigSection,
+		ProcessorsConfigSection: processorsConfigSection,
 		ExportersConfigSection: exportersConfigSection,
-		//ServiceConfigSection: serviceConfigSection,
+		ServiceConfigSection: serviceConfigSection,
 	}
 	conf, err := template.New("otelConf").Parse(confTemplate)
 	if err != nil {

--- a/otel/conf.go
+++ b/otel/conf.go
@@ -44,7 +44,7 @@ service:
   {{.}}
   {{end}}`
 
-	hostmetricsConf = `  hostmetrics/{{.HostMetricsID}}:
+	hostmetricsConf = `hostmetrics/{{.HostMetricsID}}:
     collection_interval: {{.CollectionInterval}}
     scrapers:
       cpu:
@@ -56,10 +56,10 @@ service:
       swap:
       process:`
 
-	stackdriverConf = `  stackdriver/{{.StackdriverID}}:
-	  user_agent: {{.UserAgent}}
-	  metric:
-        prefix: {{.Prefix}}`
+	stackdriverConf = `stackdriver/{{.StackdriverID}}:
+    user_agent: {{.UserAgent}}
+    metric:
+      prefix: {{.Prefix}}`
 )
 
 type configSections struct {
@@ -102,6 +102,7 @@ func (h HostMetrics) renderConfig() (string, error) {
 }
 
 type Stackdriver struct {
+	StackdriverID string
 	UserAgent string
 	Prefix string
 }
@@ -126,7 +127,6 @@ func GenerateOtelConfig(hostMetricsList []*HostMetrics, stackdriverList []*Stack
 		}
 		receiversConfigSection = append(receiversConfigSection, configSection)
 	}
-
 	for _, s := range stackdriverList {
 		configSection, err := s.renderConfig()
 		if err != nil {

--- a/otel/conf.go
+++ b/otel/conf.go
@@ -1,0 +1,122 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//Package otel provides data structures to represent and generate otel configuration.
+package otel
+
+import (
+	"fmt"
+//	"net"
+	"strings"
+	"text/template"
+)
+
+const (
+	confTemplate = `receivers:
+  {{range .ReceiversConfigSection -}}
+  {{.}}
+  {{end}}
+processors:
+  {{range .ProcessorsConfigSection -}}
+  {{.}}
+  {{end}}
+exporters:
+  {{range .ExportersConfigSection -}}
+  {{.}}
+  {{end}}
+extensions:
+  {{range .ExtensionsConfigSection -}}
+  {{.}}
+  {{end}}
+service:
+  {{range .ServiceConfigSection -}}
+  {{.}}
+  {{end}}`
+
+	hostmetricsConf = `  hostmetrics/{{.HostMetricsID}}:
+    collection_interval: {{.CollectionInterval}}
+    scrapers:
+      cpu:
+      load:
+      memory:
+      disk:
+      filesystem:
+      network:
+      swap:
+      process:`
+)
+
+type configSections struct {
+	ReceiversConfigSection		[]string
+	ProcessorsConfigSection		[]string
+	ExportersConfigSection		[]string
+	ExtensionsConfigSection		[]string
+	ServiceConfigSection		[]string
+}
+
+type emptyFieldErr struct {
+	plugin string
+	field  string
+}
+
+func (e emptyFieldErr) Error() string {
+	return fmt.Sprintf("%q plugin should not have empty field: %q", e.plugin, e.field)
+}
+
+type HostMetrics struct {
+	HostMetricsID string
+	CollectionInterval string
+}
+
+var hostMetricsTemplate = template.Must(template.New("hostmetrics").Parse(hostmetricsConf))
+
+func (h HostMetrics) renderConfig() (string, error) {
+	if h.CollectionInterval == "" {
+		return "", emptyFieldErr{
+			plugin: "hostmetrics",
+			field:  "collection_interval",
+		}
+	}
+
+	var renderedHostMetricsConfig strings.Builder
+	if err := hostMetricsTemplate.Execute(&renderedHostMetricsConfig, h); err != nil {
+		return "", err
+	}
+	return renderedHostMetricsConfig.String(), nil
+}
+
+func GenerateOtelConfig(hostMetricsList []*HostMetrics) (string, error) {
+	receiversConfigSection := []string{}
+	for _, h := range hostMetricsList {
+		configSection, err := h.renderConfig()
+		if err != nil {
+			return "", err
+		}
+		receiversConfigSection = append(receiversConfigSection, configSection)
+	}
+	configSections := configSections{
+		ReceiversConfigSection: receiversConfigSection,
+		ServiceConfigSection: serviceConfigSection,
+	}
+	conf, err := template.New("otelConf").Parse(confTemplate)
+	if err != nil {
+		return "", err
+	}
+
+	var configBuilder strings.Builder
+	if err := conf.Execute(&configBuilder, configSections); err != nil {
+		return "", err
+	}
+	return configBuilder.String(), nil
+}


### PR DESCRIPTION
Adding support for converting upper-level metrics configuration to otel understandable configuration.
It includes:
- A separate folder called as "otel"
- A unit test under folder otel/

Also as i added "otel" in main.go, i've tested generating the otel.conf manually by executing: `go run -mod=mod cmd/generate_config/main.go --service=otel --in=confgenerator/windows-default-config.yaml --out=/tmp/google-cloud-ops-agent`. See b/176757501#comment2 for generated otel conf

It doesn't include:
-  tests under confgenerator/ yet 
This will come up in a separate PR as the test is for both logging and metrics.There are things i need to clean up before writing tests for both. I will need to first submit a PR to get rid of the tail collectd part for Windows. As windows uses OTEl and OTEL metrics agent emits its own log via windows event log so no need for tail any log files for its own log. After that PR, i will write the tests under confgenerator folder)
[](url)