### PR TITLE
Remove grace config value 120 seconds to fall back to the default 5 seconds.

### DIFF
--- a/confgenerator/testdata/valid/default_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/default_config/golden_fluent_bit_main.conf
@@ -2,8 +2,8 @@
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 120 seconds after receiving a SIGTERM before it shuts down to minimize log loss.
-    Grace      120
+    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
+    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).

--- a/confgenerator/testdata/valid/default_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/default_config/golden_fluent_bit_main.conf
@@ -2,8 +2,6 @@
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
-    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).

--- a/confgenerator/testdata/valid/empty_log_service/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/empty_log_service/golden_fluent_bit_main.conf
@@ -2,8 +2,8 @@
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 120 seconds after receiving a SIGTERM before it shuts down to minimize log loss.
-    Grace      120
+    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
+    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).

--- a/confgenerator/testdata/valid/empty_log_service/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/empty_log_service/golden_fluent_bit_main.conf
@@ -2,8 +2,6 @@
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
-    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).

--- a/confgenerator/testdata/valid/logging-complex_logs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-complex_logs/golden_fluent_bit_main.conf
@@ -2,8 +2,8 @@
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 120 seconds after receiving a SIGTERM before it shuts down to minimize log loss.
-    Grace      120
+    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
+    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).

--- a/confgenerator/testdata/valid/logging-complex_logs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-complex_logs/golden_fluent_bit_main.conf
@@ -2,8 +2,6 @@
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
-    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).

--- a/confgenerator/testdata/valid/logging-complex_logs_with_processors/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-complex_logs_with_processors/golden_fluent_bit_main.conf
@@ -2,8 +2,8 @@
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 120 seconds after receiving a SIGTERM before it shuts down to minimize log loss.
-    Grace      120
+    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
+    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).

--- a/confgenerator/testdata/valid/logging-complex_logs_with_processors/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-complex_logs_with_processors/golden_fluent_bit_main.conf
@@ -2,8 +2,6 @@
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
-    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).

--- a/confgenerator/testdata/valid/logging-multiple_file_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-multiple_file_sources/golden_fluent_bit_main.conf
@@ -2,8 +2,8 @@
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 120 seconds after receiving a SIGTERM before it shuts down to minimize log loss.
-    Grace      120
+    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
+    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).

--- a/confgenerator/testdata/valid/logging-multiple_file_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-multiple_file_sources/golden_fluent_bit_main.conf
@@ -2,8 +2,6 @@
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
-    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).

--- a/confgenerator/testdata/valid/logging-multiple_syslog_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-multiple_syslog_sources/golden_fluent_bit_main.conf
@@ -2,8 +2,8 @@
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 120 seconds after receiving a SIGTERM before it shuts down to minimize log loss.
-    Grace      120
+    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
+    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).

--- a/confgenerator/testdata/valid/logging-multiple_syslog_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-multiple_syslog_sources/golden_fluent_bit_main.conf
@@ -2,8 +2,6 @@
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
-    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).

--- a/confgenerator/testdata/valid/logging-no_conf/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-no_conf/golden_fluent_bit_main.conf
@@ -2,8 +2,8 @@
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 120 seconds after receiving a SIGTERM before it shuts down to minimize log loss.
-    Grace      120
+    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
+    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).

--- a/confgenerator/testdata/valid/logging-no_conf/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-no_conf/golden_fluent_bit_main.conf
@@ -2,8 +2,6 @@
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
-    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).

--- a/confgenerator/testdata/valid/metrics-custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/metrics-custom_collection_interval/golden_fluent_bit_main.conf
@@ -2,8 +2,8 @@
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 120 seconds after receiving a SIGTERM before it shuts down to minimize log loss.
-    Grace      120
+    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
+    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).

--- a/confgenerator/testdata/valid/metrics-custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/metrics-custom_collection_interval/golden_fluent_bit_main.conf
@@ -2,8 +2,6 @@
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
-    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).

--- a/confgenerator/testdata/valid/windows_default_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_default_config/golden_fluent_bit_main.conf
@@ -2,8 +2,8 @@
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 120 seconds after receiving a SIGTERM before it shuts down to minimize log loss.
-    Grace      120
+    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
+    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).

--- a/confgenerator/testdata/valid/windows_default_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_default_config/golden_fluent_bit_main.conf
@@ -2,8 +2,6 @@
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
-    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).

--- a/confgenerator/testdata/valid/windows_logging-multiple_file_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_logging-multiple_file_sources/golden_fluent_bit_main.conf
@@ -2,8 +2,8 @@
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 120 seconds after receiving a SIGTERM before it shuts down to minimize log loss.
-    Grace      120
+    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
+    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).

--- a/confgenerator/testdata/valid/windows_logging-multiple_file_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_logging-multiple_file_sources/golden_fluent_bit_main.conf
@@ -2,8 +2,6 @@
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
-    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).

--- a/confgenerator/testdata/valid/windows_logging-no_conf/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_logging-no_conf/golden_fluent_bit_main.conf
@@ -2,8 +2,8 @@
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 120 seconds after receiving a SIGTERM before it shuts down to minimize log loss.
-    Grace      120
+    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
+    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).

--- a/confgenerator/testdata/valid/windows_logging-no_conf/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_logging-no_conf/golden_fluent_bit_main.conf
@@ -2,8 +2,6 @@
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
-    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).

--- a/fluentbit/conf/conf.go
+++ b/fluentbit/conf/conf.go
@@ -27,8 +27,8 @@ const (
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 120 seconds after receiving a SIGTERM before it shuts down to minimize log loss.
-    Grace      120
+    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
+    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).

--- a/fluentbit/conf/conf.go
+++ b/fluentbit/conf/conf.go
@@ -27,8 +27,6 @@ const (
     # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
     # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
     Flush      1
-    # Waits 30 seconds after receiving a SIGTERM before it shuts down to minimize log loss. Since we use file based buffering, this should be sufficient.
-    Grace      30
     # We use systemd to manage Fluent Bit instead.
     Daemon     off
     # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).


### PR DESCRIPTION
Looking at how Fluentd handles this, it turned out we are not flushing at shutdown at all because we are using file based buffering. We are not setting `flush_at_shutdown` explicitly so it defaults to false: https://docs.fluentd.org/configuration/buffer-section#flushing-parameters. So in theory this setting is not important for Fluent Bit either, because we also use file based buffering there.