### PR TITLE
Use filepath 

### DIFF
--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -249,13 +249,13 @@ func defaultTails(logsDir string, stateDir string) (tails []*conf.Tail) {
 	return []*conf.Tail{
 		{
 			Tag:  "ops-agent-fluent-bit",
-			DB:   filepath.Join(stateDir, "/buffers/ops-agent-fluent-bit"),
-			Path: filepath.Join(logsDir, "/logging-module.log"),
+			DB:   filepath.Join(stateDir, "buffers", "ops-agent-fluent-bit"),
+			Path: filepath.Join(logsDir, "logging-module.log"),
 		},
 		{
 			Tag:  "ops-agent-collectd",
-			DB:   fmt.Sprintf("%s/buffers/ops-agent-collectd", stateDir),
-			Path: fmt.Sprintf("%s/metrics-module.log", logsDir),
+			DB:   filepath.Join(stateDir, "buffers", "ops-agent-collectd"),
+			Path: filepath.Join(logsDir, "metrics-module.log"),
 		},
 	}
 }

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -17,9 +17,10 @@ package confgenerator
 
 import (
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
-        "path/filepath"
+
 	"github.com/GoogleCloudPlatform/ops-agent/collectd"
 	"github.com/GoogleCloudPlatform/ops-agent/fluentbit/conf"
 	"github.com/GoogleCloudPlatform/ops-agent/otel"

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-
+        "path/filepath"
 	"github.com/GoogleCloudPlatform/ops-agent/collectd"
 	"github.com/GoogleCloudPlatform/ops-agent/fluentbit/conf"
 	"github.com/GoogleCloudPlatform/ops-agent/otel"
@@ -249,8 +249,8 @@ func defaultTails(logsDir string, stateDir string) (tails []*conf.Tail) {
 	return []*conf.Tail{
 		{
 			Tag:  "ops-agent-fluent-bit",
-			DB:   fmt.Sprintf("%s/buffers/ops-agent-fluent-bit", stateDir),
-			Path: fmt.Sprintf("%s/logging-module.log", logsDir),
+			DB:   filepath.Join(stateDir, "/buffers/ops-agent-fluent-bit"),
+			Path: filepath.Join(logsDir, "/logging-module.log"),
 		},
 		{
 			Tag:  "ops-agent-collectd",


### PR DESCRIPTION
remove the hardcode path string and use filepath instead.

`go test -mod=mod ./...`  all pass

but for better referencing, the test_data/valid/windows_default_config needs to update the paths to `C:\ProgramData\Google\Cloud Operations\Ops Agent\run\buffers` and decouple the current configenerator_test.go to use different path prefix for windows. Will do in a followup PR
