### PR TITLE
[DO NOT MERGE] Register all 3 services with Event Log to suppress spamming messages.

### DIFF
--- a/cmd/ops_agent_windows/install_windows.go
+++ b/cmd/ops_agent_windows/install_windows.go
@@ -57,10 +57,10 @@ func install() error {
 		}
 		defer serviceHandle.Close()
 		handles[i] = serviceHandle
-	}
-	// Registering with the event log is required to suppress the "The description for Event ID 1 from source Google Cloud Ops Agent cannot be found" message in the logs.
-	if err := eventlog.InstallAsEventCreate(serviceName, eventlog.Error|eventlog.Warning|eventlog.Info); err != nil {
-		// Ignore error since it likely means the event log already existss.
+		// Registering with the event log is required to suppress messages like "The description for Event ID 1 from source Google Cloud Ops Agent cannot be found" in the logs.
+		if err := eventlog.InstallAsEventCreate(services[0].name, eventlog.Error|eventlog.Warning|eventlog.Info); err != nil {
+			// Ignore error since it likely means the event log already existss.
+		}
 	}
 	// Automatically start the Ops Agent service
 	return handles[0].Start()


### PR DESCRIPTION
Sample error:

```
The description for Event ID 3 from source Google Cloud Ops Agent - Metrics Agent cannot be found. Either the component that raises this event is not installed on your local computer or the installation is corrupted. You can install or repair the component on the local computer.

If the event originated on another computer, the display information had to be saved with the event.

The following information was included with the event: 

Error scraping metrics

Stack Trace:
go.opentelemetry.io/collector/receiver/receiverhelper.(*scraperController).scrapeMetricsAndReport
	C:/Users/ContainerAdministrator/go/pkg/mod/go.opentelemetry.io/collector@v0.15.0/receiver/receiverhelper/scrapercontroller.go:214
go.opentelemetry.io/collector/receiver/receiverhelper.(*scraperController).startScraping.func1
	C:/Users/ContainerAdministrator/go/pkg/mod/go.opentelemetry.io/collector@v0.15.0/receiver/receiverhelper/scrapercontroller.go:194
```