### PR TITLE
Modify grep systemd version as syntax changed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -94,7 +94,7 @@ function build_systemd() {
   for f in systemd/*.service systemd/*.target; do
     install_unit "$f" "$(basename "$f")"
   done
-  if [ "$(systemctl --version | grep -Po '^systemd \K\d+$')" -lt 240 ]; then
+  if [ "$(systemctl --version | grep -Po '^systemd \K\d+')" -lt 240 ]; then
     for d in systemd/*.service.d; do
       mkdir "$DESTDIR$systemdsystemunitdir/$(basename "$d")"
       for f in "$d"/*.conf; do


### PR DESCRIPTION
Building agent gets error message which will cause the missing service.d folders inside the packaging.
```
++ grep -Po '^systemd \K\d+$'
+ '[' '' -lt 240 ']'
./build.sh: line 97: [: : integer expression expected
```
Good PKG:

```
[sophieyfang@centos8-test ~]$ ls /usr/lib/systemd/system/ | grep ops
google-cloud-ops-agent-collectd.service
google-cloud-ops-agent-collectd.service.d
google-cloud-ops-agent-fluent-bit.service
google-cloud-ops-agent-fluent-bit.service.d
google-cloud-ops-agent.service
google-cloud-ops-agent.target
```

Bad PKG:

```
[sophieyfang@centos8-pre ~]$ ls /usr/lib/systemd/system/ | grep ops
google-cloud-ops-agent-collectd.service
google-cloud-ops-agent-fluent-bit.service
google-cloud-ops-agent.service
google-cloud-ops-agent.target
```

`systemctl --version | grep -Po '^systemd \K\d+'` shall be it

```
[root@a3b2e6d26f37 /]# /usr/lib/systemd/systemd --version
systemd 239 (239-41.el8_3.1)
+PAM +AUDIT +SELINUX +IMA -APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD +IDN2 -IDN +PCRE2 default-hierarchy=legacy
[root@a3b2e6d26f37 /]# systemctl --version | grep -Po '^systemd \K\d+'
239
```

```
[root@bb71ab53d63b /]# /usr/lib/systemd/systemd --version
systemd 219
+PAM +AUDIT +SELINUX +IMA -APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 -SECCOMP +BLKID +ELFUTILS +KMOD +IDN
[root@bb71ab53d63b /]# systemctl --version | grep -Po '^systemd \K\d+$'
219
[root@bb71ab53d63b /]# systemctl --version | grep -Po '^systemd \K\d+'
219
```