### PR TITLE
Fix misplaced deb pkgs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ RUN apt-get update && \
 COPY . /work
 WORKDIR /work
 RUN ./pkg/deb/build.sh
-COPY ./pkg/google-cloud-ops-agent*.deb /
+COPY --from=bionic /pkg/google-cloud-ops-agent*.deb /
 
 FROM ubuntu:xenial AS xenial
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,7 @@ RUN apt-get update && \
 COPY . /work
 WORKDIR /work
 RUN ./pkg/deb/build.sh
+COPY /pkg/google-cloud-ops-agent*.deb /
 
 FROM ubuntu:xenial AS xenial
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,6 @@ RUN apt-get update && \
 COPY . /work
 WORKDIR /work
 RUN ./pkg/deb/build.sh
-COPY --from=bionic /pkg/google-cloud-ops-agent*.deb /
 
 FROM ubuntu:xenial AS xenial
 
@@ -157,19 +156,19 @@ RUN ./pkg/rpm/build.sh
 
 FROM scratch
 COPY --from=buster /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-debian-buster.tgz
-COPY --from=buster /pkg/google-cloud-ops-agent*.deb /
+COPY --from=buster /google-cloud-ops-agent*.deb /
 
 COPY --from=stretch /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-debian-stretch.tgz
-COPY --from=stretch /pkg/google-cloud-ops-agent*.deb /
+COPY --from=stretch /google-cloud-ops-agent*.deb /
 
 COPY --from=focal /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-focal.tgz
-COPY --from=focal /pkg/google-cloud-ops-agent*.deb /
+COPY --from=focal /google-cloud-ops-agent*.deb /
 
 COPY --from=bionic /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-bionic.tgz
-COPY --from=bionic /pkg/google-cloud-ops-agent*.deb /
+COPY --from=bionic /google-cloud-ops-agent*.deb /
 
 COPY --from=xenial /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-xenial.tgz
-COPY --from=xenial /pkg/google-cloud-ops-agent*.deb /
+COPY --from=xenial /google-cloud-ops-agent*.deb /
 
 COPY --from=centos7 /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-centos-7.tgz
 COPY --from=centos7 /google-cloud-ops-agent*.rpm /

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ RUN apt-get update && \
 COPY . /work
 WORKDIR /work
 RUN ./pkg/deb/build.sh
-COPY /pkg/google-cloud-ops-agent*.deb /
+COPY ./pkg/google-cloud-ops-agent*.deb /
 
 FROM ubuntu:xenial AS xenial
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -156,19 +156,19 @@ RUN ./pkg/rpm/build.sh
 
 FROM scratch
 COPY --from=buster /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-debian-buster.tgz
-COPY --from=buster /google-cloud-ops-agent*.deb /
+COPY --from=buster /pkg/google-cloud-ops-agent*.deb /
 
 COPY --from=stretch /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-debian-stretch.tgz
-COPY --from=stretch /google-cloud-ops-agent*.deb /
+COPY --from=stretch /pkg/google-cloud-ops-agent*.deb /
 
 COPY --from=focal /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-focal.tgz
-COPY --from=focal /google-cloud-ops-agent*.deb /
+COPY --from=focal /pkg/google-cloud-ops-agent*.deb /
 
 COPY --from=bionic /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-bionic.tgz
-COPY --from=bionic /google-cloud-ops-agent*.deb /
+COPY --from=bionic /pkg/google-cloud-ops-agent*.deb /
 
 COPY --from=xenial /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-xenial.tgz
-COPY --from=xenial /google-cloud-ops-agent*.deb /
+COPY --from=xenial /pkg/google-cloud-ops-agent*.deb /
 
 COPY --from=centos7 /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-centos-7.tgz
 COPY --from=centos7 /google-cloud-ops-agent*.rpm /

--- a/pkg/deb/build.sh
+++ b/pkg/deb/build.sh
@@ -14,3 +14,4 @@ dch --create -b --package google-cloud-ops-agent -M \
 
 # Build .debs
 debuild -us -uc -sa
+cp pkg/google-cloud-ops-agent*.deb /

--- a/pkg/deb/build.sh
+++ b/pkg/deb/build.sh
@@ -14,5 +14,5 @@ dch --create -b --package google-cloud-ops-agent -M \
 
 # Build .debs
 debuild -us -uc -sa
-cd ..
-cp google-cloud-ops-agent*.deb /
+cd ../..
+cp pkg/google-cloud-ops-agent*.deb /

--- a/pkg/deb/build.sh
+++ b/pkg/deb/build.sh
@@ -14,4 +14,5 @@ dch --create -b --package google-cloud-ops-agent -M \
 
 # Build .debs
 debuild -us -uc -sa
+cd ..
 cp pkg/google-cloud-ops-agent*.deb /

--- a/pkg/deb/build.sh
+++ b/pkg/deb/build.sh
@@ -15,4 +15,4 @@ dch --create -b --package google-cloud-ops-agent -M \
 # Build .debs
 debuild -us -uc -sa
 cd ..
-cp pkg/google-cloud-ops-agent*.deb /
+cp google-cloud-ops-agent*.deb /


### PR DESCRIPTION
After this PR:https://github.com/GoogleCloudPlatform/ops-agent/pull/22#issuecomment-776195974

e.x. debian pkgs has been moved under:

```
	pkg/deb/debian/.debhelper/
	pkg/deb/debian/changelog
	pkg/deb/debian/debhelper-build-stamp
	pkg/deb/debian/files
	pkg/deb/debian/google-cloud-ops-agent.debhelper.log
	pkg/deb/debian/google-cloud-ops-agent.postrm.debhelper
	pkg/deb/debian/google-cloud-ops-agent.substvars
	pkg/deb/debian/google-cloud-ops-agent/
	pkg/google-cloud-ops-agent-dbgsym_1.0.1~ubuntu18.04_amd64.ddeb
	pkg/google-cloud-ops-agent_1.0.1~ubuntu18.04.dsc
	pkg/google-cloud-ops-agent_1.0.1~ubuntu18.04.tar.gz
	pkg/google-cloud-ops-agent_1.0.1~ubuntu18.04_amd64.build
	pkg/google-cloud-ops-agent_1.0.1~ubuntu18.04_amd64.buildinfo
	pkg/google-cloud-ops-agent_1.0.1~ubuntu18.04_amd64.changes
	pkg/google-cloud-ops-agent_1.0.1~ubuntu18.04_amd64.deb
```