### PR TITLE
Use systemd_postun_with_restart for RPM so that agent service enters running state post upgrades or re-installations

### DIFF
--- a/pkg/rpm/google-cloud-ops-agent.spec
+++ b/pkg/rpm/google-cloud-ops-agent.spec
@@ -56,6 +56,6 @@ fi
 %systemd_preun google-cloud-ops-agent.target
 
 %postun
-%systemd_postun google-cloud-ops-agent.target
+%systemd_postun_with_restart google-cloud-ops-agent.target
 
 %changelog


### PR DESCRIPTION
We shall use `systemd_postun_with_restart` here: https://github.com/GoogleCloudPlatform/ops-agent/blame/master/pkg/rpm/google-cloud-ops-agent.spec#L59
``` 
%postun
%systemd_postun_with_restart apache-httpd.service
``` 

This is based on readings from: https://screenshot.googleplex.com/AizcYk5n4mW4LPo
