### PR TITLE
Fix config generation test when metrics config is empty.

### DIFF
--- a/collectd/conf.go
+++ b/collectd/conf.go
@@ -178,7 +178,7 @@ func validatedCollectdConfig(metrics *Metrics) (*collectdConf, error) {
 
 	// Skip validation if metrics config is not set.
 	// In other words receivers, exporters and pipelines are all empty.
-	if len(metrics.Receivers) == 0 && len(metrics.Exporters) == 0 && len(metrics.Service.Pipelines) == 0 {
+	if metrics == nil || (len(metrics.Receivers) == 0 && len(metrics.Exporters) == 0 && len(metrics.Service.Pipelines) == 0) {
 		return &collectdConf, nil
 	}
 


### PR DESCRIPTION
Fixes:

```
--- FAIL: TestGenerateConfsWithValidInput (0.01s)
    --- FAIL: TestGenerateConfsWithValidInput/metrics-no_conf (0.00s)
        confgenerator_test.go:124: test "metrics-no_conf": Golden conf not detected at testdata/valid/metrics-no_conf/golden_fluent_bit_main.conf. Using the default at testdata/valid/default_config/golden_fluent_bit_main.conf instead.
        confgenerator_test.go:124: test "metrics-no_conf": Golden conf not detected at testdata/valid/metrics-no_conf/golden_fluent_bit_parser.conf. Using the default at testdata/valid/default_config/golden_fluent_bit_parser.conf instead.
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x575f7f]

goroutine 96 [running]:
testing.tRunner.func1.2(0x616aa0, 0x7aea40)
        /usr/lib/google-golang/src/testing/testing.go:1144 +0x332
testing.tRunner.func1(0xc000430300)
        /usr/lib/google-golang/src/testing/testing.go:1147 +0x4b6
panic(0x616aa0, 0x7aea40)
        /usr/lib/google-golang/src/runtime/panic.go:965 +0x1b9
github.com/GoogleCloudPlatform/ops-agent/collectd.validatedCollectdConfig(0x0, 0xc00040cc40, 0xc000186ea8, 0xc000186ea0)
        /usr/local/google/home/lingshi/repo/ops-agent/collectd/conf.go:181 +0x13f
github.com/GoogleCloudPlatform/ops-agent/collectd.GenerateCollectdConfig(0x0, 0x6586c4, 0x29, 0x26, 0xc000430300, 0xc000450900, 0xc0002e38c0)
        /usr/local/google/home/lingshi/repo/ops-agent/collectd/conf.go:150 +0x49
github.com/GoogleCloudPlatform/ops-agent/confgenerator.(*UnifiedConfig).GenerateCollectdConfig(...)
        /usr/local/google/home/lingshi/repo/ops-agent/confgenerator/confgenerator.go:101
github.com/GoogleCloudPlatform/ops-agent/confgenerator.TestGenerateConfsWithValidInput.func1(0xc000430300)
        /usr/local/google/home/lingshi/repo/ops-agent/confgenerator/confgenerator_test.go:103 +0x73b
testing.tRunner(0xc000430300, 0xc00040c780)
        /usr/lib/google-golang/src/testing/testing.go:1194 +0xef
created by testing.(*T).Run
        /usr/lib/google-golang/src/testing/testing.go:1239 +0x2b3
FAIL    github.com/GoogleCloudPlatform/ops-agent/confgenerator  0.042s
FAIL
```