### PR TITLE
Create stackdriver plugin on request, and use a dedicated output for handling agents' logs

### DIFF
--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -214,7 +214,7 @@ func defaultTails(logsDir string, stateDir string) (tails []*conf.Tail) {
 func defaultStackdriverOutputs() (stackdrivers []*conf.Stackdriver) {
 	return []*conf.Stackdriver{
 		{
-			Match: "ops-agent-fluent-bit, ops-agent-collectd",
+			Match: "ops-agent-fluent-bit,ops-agent-collectd",
 		},
 	}
 }

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -214,7 +214,7 @@ func defaultTails(logsDir string, stateDir string) (tails []*conf.Tail) {
 func defaultStackdriverOutputs() (stackdrivers []*conf.Stackdriver) {
 	return []*conf.Stackdriver{
 		{
-			Match: "^(ops-agent-fluent-bit|ops-agent-collectd)$",
+			Match: "ops-agent-fluent-bit|ops-agent-collectd",
 		},
 	}
 }

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -214,7 +214,7 @@ func defaultTails(logsDir string, stateDir string) (tails []*conf.Tail) {
 func defaultStackdriverOutputs() (stackdrivers []*conf.Stackdriver) {
 	return []*conf.Stackdriver{
 		{
-			Match: "ops-agent-fluent-bit,ops-agent-collectd",
+			Match: "ops-agent-fluent-bit|ops-agent-collectd",
 		},
 	}
 }
@@ -614,7 +614,7 @@ func extractExporterPlugins(exporters map[string]*exporter, pipelines map[string
 	}
 	for _, tags := range stackdriverExporters {
 		fbStackdrivers = append(fbStackdrivers, &conf.Stackdriver{
-			Match: strings.Join(tags, ","),
+			Match: strings.Join(tags, "|"),
 		})
 	}
 	return fbFilterModifyAddLogNames, fbFilterRewriteTags, fbFilterModifyRemoveLogNames, fbStackdrivers, nil

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -214,7 +214,7 @@ func defaultTails(logsDir string, stateDir string) (tails []*conf.Tail) {
 func defaultStackdriverOutputs() (stackdrivers []*conf.Stackdriver) {
 	return []*conf.Stackdriver{
 		{
-			Match: "ops-agent-fluent-bit|ops-agent-collectd",
+			Match: "^(ops-agent-fluent-bit|ops-agent-collectd)$",
 		},
 	}
 }

--- a/confgenerator/testdata/valid/default_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/default_config/golden_fluent_bit_main.conf
@@ -132,23 +132,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    ops-agent-collectd
+    Match    ops-agent-fluent-bit, ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/default_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/default_config/golden_fluent_bit_main.conf
@@ -132,7 +132,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
+    Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/default_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/default_config/golden_fluent_bit_main.conf
@@ -132,7 +132,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit, ops-agent-collectd
+    Match    ops-agent-fluent-bit,ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/default_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/default_config/golden_fluent_bit_main.conf
@@ -132,7 +132,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
+    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -148,7 +148,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    syslog
+    Match_Regex    ^(syslog)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/default_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/default_config/golden_fluent_bit_main.conf
@@ -132,7 +132,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit,ops-agent-collectd
+    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -148,7 +148,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    syslog
+    Match_Regex    syslog
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/default_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/default_config/golden_fluent_bit_main.conf
@@ -130,8 +130,8 @@
 
 [OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
+    Name           stackdriver
+    resource       gce_instance
     Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -146,8 +146,8 @@
 
 [OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
+    Name           stackdriver
+    resource       gce_instance
     Match_Regex    ^(syslog)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/empty_log_service/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/empty_log_service/golden_fluent_bit_main.conf
@@ -85,8 +85,8 @@
 
 [OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
+    Name           stackdriver
+    resource       gce_instance
     Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/empty_log_service/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/empty_log_service/golden_fluent_bit_main.conf
@@ -87,7 +87,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
+    Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/empty_log_service/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/empty_log_service/golden_fluent_bit_main.conf
@@ -87,23 +87,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    ops-agent-collectd
+    Match    ops-agent-fluent-bit, ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/empty_log_service/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/empty_log_service/golden_fluent_bit_main.conf
@@ -87,7 +87,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
+    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/empty_log_service/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/empty_log_service/golden_fluent_bit_main.conf
@@ -87,7 +87,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit,ops-agent-collectd
+    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/empty_log_service/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/empty_log_service/golden_fluent_bit_main.conf
@@ -87,7 +87,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit, ops-agent-collectd
+    Match    ops-agent-fluent-bit,ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-complex_logs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-complex_logs/golden_fluent_bit_main.conf
@@ -267,7 +267,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
+    Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-complex_logs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-complex_logs/golden_fluent_bit_main.conf
@@ -267,7 +267,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit, ops-agent-collectd
+    Match    ops-agent-fluent-bit,ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-complex_logs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-complex_logs/golden_fluent_bit_main.conf
@@ -267,7 +267,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit
+    Match    ops-agent-fluent-bit, ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -283,71 +283,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-collectd
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    log_source_id1
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    log_source_id2
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    test_syslog_source_id_tcp
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    test_syslog_source_id_udp
+    Match    log_source_id1,log_source_id2,test_syslog_source_id_tcp,test_syslog_source_id_udp
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-complex_logs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-complex_logs/golden_fluent_bit_main.conf
@@ -267,7 +267,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
+    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -283,7 +283,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    log_source_id1|log_source_id2|test_syslog_source_id_tcp|test_syslog_source_id_udp
+    Match_Regex    ^(log_source_id1|log_source_id2|test_syslog_source_id_tcp|test_syslog_source_id_udp)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-complex_logs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-complex_logs/golden_fluent_bit_main.conf
@@ -267,7 +267,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit,ops-agent-collectd
+    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -283,7 +283,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    log_source_id1,log_source_id2,test_syslog_source_id_tcp,test_syslog_source_id_udp
+    Match_Regex    log_source_id1|log_source_id2|test_syslog_source_id_tcp|test_syslog_source_id_udp
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-complex_logs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-complex_logs/golden_fluent_bit_main.conf
@@ -265,8 +265,8 @@
 
 [OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
+    Name           stackdriver
+    resource       gce_instance
     Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -281,8 +281,8 @@
 
 [OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
+    Name           stackdriver
+    resource       gce_instance
     Match_Regex    ^(log_source_id1|log_source_id2|test_syslog_source_id_tcp|test_syslog_source_id_udp)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/logging-complex_logs_with_processors/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-complex_logs_with_processors/golden_fluent_bit_main.conf
@@ -279,7 +279,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit
+    Match    ops-agent-fluent-bit, ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -295,71 +295,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-collectd
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    log_source_id1
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    log_source_id2
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    test_syslog_source_id_tcp
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    test_syslog_source_id_udp
+    Match    log_source_id1,log_source_id2,test_syslog_source_id_tcp,test_syslog_source_id_udp
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-complex_logs_with_processors/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-complex_logs_with_processors/golden_fluent_bit_main.conf
@@ -279,7 +279,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit,ops-agent-collectd
+    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -295,7 +295,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    log_source_id1,log_source_id2,test_syslog_source_id_tcp,test_syslog_source_id_udp
+    Match_Regex    log_source_id1|log_source_id2|test_syslog_source_id_tcp|test_syslog_source_id_udp
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-complex_logs_with_processors/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-complex_logs_with_processors/golden_fluent_bit_main.conf
@@ -279,7 +279,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
+    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -295,7 +295,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    log_source_id1|log_source_id2|test_syslog_source_id_tcp|test_syslog_source_id_udp
+    Match_Regex    ^(log_source_id1|log_source_id2|test_syslog_source_id_tcp|test_syslog_source_id_udp)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-complex_logs_with_processors/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-complex_logs_with_processors/golden_fluent_bit_main.conf
@@ -279,7 +279,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit, ops-agent-collectd
+    Match    ops-agent-fluent-bit,ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-complex_logs_with_processors/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-complex_logs_with_processors/golden_fluent_bit_main.conf
@@ -279,7 +279,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
+    Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-complex_logs_with_processors/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-complex_logs_with_processors/golden_fluent_bit_main.conf
@@ -277,8 +277,8 @@
 
 [OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
+    Name           stackdriver
+    resource       gce_instance
     Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -293,8 +293,8 @@
 
 [OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
+    Name           stackdriver
+    resource       gce_instance
     Match_Regex    ^(log_source_id1|log_source_id2|test_syslog_source_id_tcp|test_syslog_source_id_udp)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/logging-multiple_file_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-multiple_file_sources/golden_fluent_bit_main.conf
@@ -322,7 +322,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit,ops-agent-collectd
+    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -338,7 +338,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    log_source_id1,log_source_id2,log_source_id3,log_source_id4,log_source_id5
+    Match_Regex    log_source_id1|log_source_id2|log_source_id3|log_source_id4|log_source_id5
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-multiple_file_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-multiple_file_sources/golden_fluent_bit_main.conf
@@ -322,7 +322,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit, ops-agent-collectd
+    Match    ops-agent-fluent-bit,ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-multiple_file_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-multiple_file_sources/golden_fluent_bit_main.conf
@@ -320,8 +320,8 @@
 
 [OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
+    Name           stackdriver
+    resource       gce_instance
     Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -336,8 +336,8 @@
 
 [OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
+    Name           stackdriver
+    resource       gce_instance
     Match_Regex    ^(log_source_id1|log_source_id2|log_source_id3|log_source_id4|log_source_id5)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/logging-multiple_file_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-multiple_file_sources/golden_fluent_bit_main.conf
@@ -322,7 +322,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit
+    Match    ops-agent-fluent-bit, ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -338,87 +338,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-collectd
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    log_source_id1
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    log_source_id2
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    log_source_id3
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    log_source_id4
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    log_source_id5
+    Match    log_source_id1,log_source_id2,log_source_id3,log_source_id4,log_source_id5
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-multiple_file_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-multiple_file_sources/golden_fluent_bit_main.conf
@@ -322,7 +322,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
+    Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-multiple_file_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-multiple_file_sources/golden_fluent_bit_main.conf
@@ -322,7 +322,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
+    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -338,7 +338,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    log_source_id1|log_source_id2|log_source_id3|log_source_id4|log_source_id5
+    Match_Regex    ^(log_source_id1|log_source_id2|log_source_id3|log_source_id4|log_source_id5)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-multiple_syslog_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-multiple_syslog_sources/golden_fluent_bit_main.conf
@@ -173,7 +173,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
+    Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-multiple_syslog_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-multiple_syslog_sources/golden_fluent_bit_main.conf
@@ -173,7 +173,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit, ops-agent-collectd
+    Match    ops-agent-fluent-bit,ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-multiple_syslog_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-multiple_syslog_sources/golden_fluent_bit_main.conf
@@ -173,7 +173,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit
+    Match    ops-agent-fluent-bit, ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -189,39 +189,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-collectd
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    test_syslog_source_id_tcp
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    test_syslog_source_id_udp
+    Match    test_syslog_source_id_tcp,test_syslog_source_id_udp
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-multiple_syslog_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-multiple_syslog_sources/golden_fluent_bit_main.conf
@@ -173,7 +173,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit,ops-agent-collectd
+    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -189,7 +189,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    test_syslog_source_id_tcp,test_syslog_source_id_udp
+    Match_Regex    test_syslog_source_id_tcp|test_syslog_source_id_udp
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-multiple_syslog_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-multiple_syslog_sources/golden_fluent_bit_main.conf
@@ -173,7 +173,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
+    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -189,7 +189,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    test_syslog_source_id_tcp|test_syslog_source_id_udp
+    Match_Regex    ^(test_syslog_source_id_tcp|test_syslog_source_id_udp)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-multiple_syslog_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-multiple_syslog_sources/golden_fluent_bit_main.conf
@@ -171,8 +171,8 @@
 
 [OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
+    Name           stackdriver
+    resource       gce_instance
     Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -187,8 +187,8 @@
 
 [OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
+    Name           stackdriver
+    resource       gce_instance
     Match_Regex    ^(test_syslog_source_id_tcp|test_syslog_source_id_udp)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/logging-mutiple_google_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-mutiple_google_exporters/golden_fluent_bit_main.conf
@@ -1,0 +1,368 @@
+[SERVICE]
+    # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
+    # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
+    Flush      1
+    # We use systemd to manage Fluent Bit instead.
+    Daemon     off
+    # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).
+    Log_Level  info
+
+    # https://docs.fluentbit.io/manual/administration/monitoring
+    # Enable a built-in HTTP server that can be used to query internal information and monitor metrics of each running plugin.
+    HTTP_Server  On
+    HTTP_Listen  0.0.0.0
+    HTTP_PORT    2020
+
+    # https://docs.fluentbit.io/manual/administration/buffering-and-storage#service-section-configuration
+    # storage.path is set by Fluent Bit systemd unit (e.g. /var/lib/google-cloud-ops-agent/fluent-bit/buffers).
+    storage.sync               normal
+    # Enable the data integrity check when writing and reading data from the filesystem.
+    storage.checksum           on
+    # The maximum amount of data to load into the memory when processing old chunks from the backlog that is from previous Fluent Bit processes (e.g. Fluent Bit may have crashed or restarted).
+    storage.backlog.mem_limit  50M
+    # Enable storage metrics in the built-in HTTP server.
+    storage.metrics            on
+    # This is exclusive to filesystem storage type. It specifies the number of chunks (every chunk is a file) that can be up in memory.
+    # Every chunk is a file, so having it up in memory means having an open file descriptor. In case there are thousands of chunks,
+    # we don't want them to all be loaded into the memory.
+    storage.max_chunks_up      128
+
+[INPUT]
+    # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
+    Name               tail
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-fluent-bit
+    Path               /var/log/google-cloud-ops-agent/subagents/logging-module.log
+    Tag                ops-agent-fluent-bit
+    # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
+    Buffer_Chunk_Size  512k
+    # Set the max size a bit larger to accommodate for long log lines.
+    Buffer_Max_Size    5M
+    # When a message is unstructured (no parser applied), append it under a key named "message".
+    Key                message
+    # Increase this to 30 seconds so log rotations are handled more gracefully.
+    Rotate_Wait        30
+    # Skip long lines instead of skipping the entire file when a long line exceeds buffer size.
+    Skip_Long_Lines    On
+
+    # https://docs.fluentbit.io/manual/administration/buffering-and-storage#input-section-configuration
+    # Buffer in disk to improve reliability.
+    storage.type       filesystem
+
+    # https://docs.fluentbit.io/manual/administration/backpressure#mem_buf_limit
+    # This controls how much data the input plugin can hold in memory once the data is ingested into the core.
+    # This is used to deal with backpressure scenarios (e.g: cannot flush data for some reason).
+    # When the input plugin hits "mem_buf_limit", because we have enabled filesystem storage type, mem_buf_limit acts
+    # as a hint to set "how much data can be up in memory", once the limit is reached it continues writing to disk.
+    Mem_Buf_Limit      10M
+
+[INPUT]
+    # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
+    Name               tail
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-collectd
+    Path               /var/log/google-cloud-ops-agent/subagents/metrics-module.log
+    Tag                ops-agent-collectd
+    # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
+    Buffer_Chunk_Size  512k
+    # Set the max size a bit larger to accommodate for long log lines.
+    Buffer_Max_Size    5M
+    # When a message is unstructured (no parser applied), append it under a key named "message".
+    Key                message
+    # Increase this to 30 seconds so log rotations are handled more gracefully.
+    Rotate_Wait        30
+    # Skip long lines instead of skipping the entire file when a long line exceeds buffer size.
+    Skip_Long_Lines    On
+
+    # https://docs.fluentbit.io/manual/administration/buffering-and-storage#input-section-configuration
+    # Buffer in disk to improve reliability.
+    storage.type       filesystem
+
+    # https://docs.fluentbit.io/manual/administration/backpressure#mem_buf_limit
+    # This controls how much data the input plugin can hold in memory once the data is ingested into the core.
+    # This is used to deal with backpressure scenarios (e.g: cannot flush data for some reason).
+    # When the input plugin hits "mem_buf_limit", because we have enabled filesystem storage type, mem_buf_limit acts
+    # as a hint to set "how much data can be up in memory", once the limit is reached it continues writing to disk.
+    Mem_Buf_Limit      10M
+
+[INPUT]
+    # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
+    Name               tail
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/pipeline1_log_source_id1
+    Path               /path/to/log/1/*
+    Tag                pipeline1.log_source_id1
+    # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
+    Buffer_Chunk_Size  512k
+    # Set the max size a bit larger to accommodate for long log lines.
+    Buffer_Max_Size    5M
+    # When a message is unstructured (no parser applied), append it under a key named "message".
+    Key                message
+    # Increase this to 30 seconds so log rotations are handled more gracefully.
+    Rotate_Wait        30
+    # Skip long lines instead of skipping the entire file when a long line exceeds buffer size.
+    Skip_Long_Lines    On
+
+    # https://docs.fluentbit.io/manual/administration/buffering-and-storage#input-section-configuration
+    # Buffer in disk to improve reliability.
+    storage.type       filesystem
+
+    # https://docs.fluentbit.io/manual/administration/backpressure#mem_buf_limit
+    # This controls how much data the input plugin can hold in memory once the data is ingested into the core.
+    # This is used to deal with backpressure scenarios (e.g: cannot flush data for some reason).
+    # When the input plugin hits "mem_buf_limit", because we have enabled filesystem storage type, mem_buf_limit acts
+    # as a hint to set "how much data can be up in memory", once the limit is reached it continues writing to disk.
+    Mem_Buf_Limit      10M
+
+[INPUT]
+    # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
+    Name               tail
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/pipeline2_log_source_id2
+    Path               /path/to/log/2/a,/path/to/log/2/b
+    Tag                pipeline2.log_source_id2
+    # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
+    Buffer_Chunk_Size  512k
+    # Set the max size a bit larger to accommodate for long log lines.
+    Buffer_Max_Size    5M
+    # When a message is unstructured (no parser applied), append it under a key named "message".
+    Key                message
+    # Increase this to 30 seconds so log rotations are handled more gracefully.
+    Rotate_Wait        30
+    # Skip long lines instead of skipping the entire file when a long line exceeds buffer size.
+    Skip_Long_Lines    On
+
+    # https://docs.fluentbit.io/manual/administration/buffering-and-storage#input-section-configuration
+    # Buffer in disk to improve reliability.
+    storage.type       filesystem
+
+    # https://docs.fluentbit.io/manual/administration/backpressure#mem_buf_limit
+    # This controls how much data the input plugin can hold in memory once the data is ingested into the core.
+    # This is used to deal with backpressure scenarios (e.g: cannot flush data for some reason).
+    # When the input plugin hits "mem_buf_limit", because we have enabled filesystem storage type, mem_buf_limit acts
+    # as a hint to set "how much data can be up in memory", once the limit is reached it continues writing to disk.
+    Mem_Buf_Limit      10M
+
+[INPUT]
+    # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
+    Name               tail
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/pipeline3_log_source_id3
+    Path               /path/to/log/3/*
+    Tag                pipeline3.log_source_id3
+    # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
+    Buffer_Chunk_Size  512k
+    # Set the max size a bit larger to accommodate for long log lines.
+    Buffer_Max_Size    5M
+    # When a message is unstructured (no parser applied), append it under a key named "message".
+    Key                message
+    # Increase this to 30 seconds so log rotations are handled more gracefully.
+    Rotate_Wait        30
+    # Skip long lines instead of skipping the entire file when a long line exceeds buffer size.
+    Skip_Long_Lines    On
+    # Exclude files matching this criteria.
+    Exclude_Path       /path/to/log/3/exclude
+
+    # https://docs.fluentbit.io/manual/administration/buffering-and-storage#input-section-configuration
+    # Buffer in disk to improve reliability.
+    storage.type       filesystem
+
+    # https://docs.fluentbit.io/manual/administration/backpressure#mem_buf_limit
+    # This controls how much data the input plugin can hold in memory once the data is ingested into the core.
+    # This is used to deal with backpressure scenarios (e.g: cannot flush data for some reason).
+    # When the input plugin hits "mem_buf_limit", because we have enabled filesystem storage type, mem_buf_limit acts
+    # as a hint to set "how much data can be up in memory", once the limit is reached it continues writing to disk.
+    Mem_Buf_Limit      10M
+
+[INPUT]
+    # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
+    Name               tail
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/pipeline4_log_source_id4
+    Path               /path/to/log/4/*
+    Tag                pipeline4.log_source_id4
+    # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
+    Buffer_Chunk_Size  512k
+    # Set the max size a bit larger to accommodate for long log lines.
+    Buffer_Max_Size    5M
+    # When a message is unstructured (no parser applied), append it under a key named "message".
+    Key                message
+    # Increase this to 30 seconds so log rotations are handled more gracefully.
+    Rotate_Wait        30
+    # Skip long lines instead of skipping the entire file when a long line exceeds buffer size.
+    Skip_Long_Lines    On
+    # Exclude files matching this criteria.
+    Exclude_Path       /path/to/log/4/exclude_a,/path/to/log/4/exclude_b
+
+    # https://docs.fluentbit.io/manual/administration/buffering-and-storage#input-section-configuration
+    # Buffer in disk to improve reliability.
+    storage.type       filesystem
+
+    # https://docs.fluentbit.io/manual/administration/backpressure#mem_buf_limit
+    # This controls how much data the input plugin can hold in memory once the data is ingested into the core.
+    # This is used to deal with backpressure scenarios (e.g: cannot flush data for some reason).
+    # When the input plugin hits "mem_buf_limit", because we have enabled filesystem storage type, mem_buf_limit acts
+    # as a hint to set "how much data can be up in memory", once the limit is reached it continues writing to disk.
+    Mem_Buf_Limit      10M
+
+[INPUT]
+    # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
+    Name               tail
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/pipeline5_log_source_id5
+    Path               /path/to/log/5/*
+    Tag                pipeline5.log_source_id5
+    # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
+    Buffer_Chunk_Size  512k
+    # Set the max size a bit larger to accommodate for long log lines.
+    Buffer_Max_Size    5M
+    # When a message is unstructured (no parser applied), append it under a key named "message".
+    Key                message
+    # Increase this to 30 seconds so log rotations are handled more gracefully.
+    Rotate_Wait        30
+    # Skip long lines instead of skipping the entire file when a long line exceeds buffer size.
+    Skip_Long_Lines    On
+
+    # https://docs.fluentbit.io/manual/administration/buffering-and-storage#input-section-configuration
+    # Buffer in disk to improve reliability.
+    storage.type       filesystem
+
+    # https://docs.fluentbit.io/manual/administration/backpressure#mem_buf_limit
+    # This controls how much data the input plugin can hold in memory once the data is ingested into the core.
+    # This is used to deal with backpressure scenarios (e.g: cannot flush data for some reason).
+    # When the input plugin hits "mem_buf_limit", because we have enabled filesystem storage type, mem_buf_limit acts
+    # as a hint to set "how much data can be up in memory", once the limit is reached it continues writing to disk.
+    Mem_Buf_Limit      10M
+
+[FILTER]
+    Name     parser
+    Match    pipeline5.*
+    Key_Name key_5
+    Parser   parser_id5
+
+[FILTER]
+    Name  modify
+    Match pipeline1.log_source_id1
+    Add   logName log_source_id1
+
+[FILTER]
+    Name  modify
+    Match pipeline2.log_source_id2
+    Add   logName log_source_id2
+
+[FILTER]
+    Name  modify
+    Match pipeline3.log_source_id3
+    Add   logName log_source_id3
+
+[FILTER]
+    Name  modify
+    Match pipeline4.log_source_id4
+    Add   logName log_source_id4
+
+[FILTER]
+    Name  modify
+    Match pipeline5.log_source_id5
+    Add   logName log_source_id5
+
+[FILTER]
+    Name                  rewrite_tag
+    Match                 pipeline1.log_source_id1
+    Rule                  $logName .* $logName false
+    Emitter_Storage.type  filesystem
+    Emitter_Mem_Buf_Limit 10M
+
+[FILTER]
+    Name                  rewrite_tag
+    Match                 pipeline2.log_source_id2
+    Rule                  $logName .* $logName false
+    Emitter_Storage.type  filesystem
+    Emitter_Mem_Buf_Limit 10M
+
+[FILTER]
+    Name                  rewrite_tag
+    Match                 pipeline3.log_source_id3
+    Rule                  $logName .* $logName false
+    Emitter_Storage.type  filesystem
+    Emitter_Mem_Buf_Limit 10M
+
+[FILTER]
+    Name                  rewrite_tag
+    Match                 pipeline4.log_source_id4
+    Rule                  $logName .* $logName false
+    Emitter_Storage.type  filesystem
+    Emitter_Mem_Buf_Limit 10M
+
+[FILTER]
+    Name                  rewrite_tag
+    Match                 pipeline5.log_source_id5
+    Rule                  $logName .* $logName false
+    Emitter_Storage.type  filesystem
+    Emitter_Mem_Buf_Limit 10M
+
+[FILTER]
+    Name   modify
+    Match  log_source_id1
+    Remove logName
+
+[FILTER]
+    Name   modify
+    Match  log_source_id2
+    Remove logName
+
+[FILTER]
+    Name   modify
+    Match  log_source_id3
+    Remove logName
+
+[FILTER]
+    Name   modify
+    Match  log_source_id4
+    Remove logName
+
+[FILTER]
+    Name   modify
+    Match  log_source_id5
+    Remove logName
+
+[OUTPUT]
+    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
+    Name     stackdriver
+    resource gce_instance
+    Match    ops-agent-fluent-bit,ops-agent-collectd
+
+    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
+    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
+    Retry_Limit  3
+
+    # https://docs.fluentbit.io/manual/administration/security
+    # Enable TLS support.
+    tls         On
+    # Do not force certificate validation.
+    tls.verify  Off
+
+[OUTPUT]
+    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
+    Name     stackdriver
+    resource gce_instance
+    Match    log_source_id1,log_source_id3
+
+    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
+    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
+    Retry_Limit  3
+
+    # https://docs.fluentbit.io/manual/administration/security
+    # Enable TLS support.
+    tls         On
+    # Do not force certificate validation.
+    tls.verify  Off
+
+[OUTPUT]
+    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
+    Name     stackdriver
+    resource gce_instance
+    Match    log_source_id2,log_source_id4,log_source_id5
+
+    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
+    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
+    Retry_Limit  3
+
+    # https://docs.fluentbit.io/manual/administration/security
+    # Enable TLS support.
+    tls         On
+    # Do not force certificate validation.
+    tls.verify  Off
+

--- a/confgenerator/testdata/valid/logging-mutiple_google_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-mutiple_google_exporters/golden_fluent_bit_main.conf
@@ -322,7 +322,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit,ops-agent-collectd
+    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -338,7 +338,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    log_source_id1,log_source_id3
+    Match_Regex    log_source_id1|log_source_id3
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -354,7 +354,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    log_source_id2,log_source_id4,log_source_id5
+    Match_Regex    log_source_id2|log_source_id4|log_source_id5
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-mutiple_google_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-mutiple_google_exporters/golden_fluent_bit_main.conf
@@ -322,7 +322,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
+    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -338,7 +338,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    log_source_id1|log_source_id3
+    Match_Regex    ^(log_source_id1|log_source_id3)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -354,7 +354,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    log_source_id2|log_source_id4|log_source_id5
+    Match_Regex    ^(log_source_id2|log_source_id4|log_source_id5)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-mutiple_google_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-mutiple_google_exporters/golden_fluent_bit_main.conf
@@ -322,7 +322,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
+    Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-mutiple_google_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-mutiple_google_exporters/golden_fluent_bit_main.conf
@@ -320,8 +320,8 @@
 
 [OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
+    Name           stackdriver
+    resource       gce_instance
     Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -336,8 +336,8 @@
 
 [OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
+    Name           stackdriver
+    resource       gce_instance
     Match_Regex    ^(log_source_id1|log_source_id3)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -352,8 +352,8 @@
 
 [OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
+    Name           stackdriver
+    resource       gce_instance
     Match_Regex    ^(log_source_id2|log_source_id4|log_source_id5)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/logging-mutiple_google_exporters/golden_fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/logging-mutiple_google_exporters/golden_fluent_bit_parser.conf
@@ -1,0 +1,59 @@
+[PARSER]
+    Name        lib:default_message_parser
+    Format      regex
+    Regex       ^(?<message>.*)$
+
+[PARSER]
+    Name        lib:apache
+    Format      regex
+    Regex       ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+    Time_Key    time
+    Time_Format %d/%b/%Y:%H:%M:%S %z
+
+[PARSER]
+    Name        lib:apache2
+    Format      regex
+    Regex       ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>.*)")?$
+    Time_Key    time
+    Time_Format %d/%b/%Y:%H:%M:%S %z
+
+[PARSER]
+    Name   lib:apache_error
+    Format regex
+    Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
+
+[PARSER]
+    Name        lib:mongodb
+    Format      regex
+    Regex       ^(?<time>[^ ]*)\s+(?<severity>\w)\s+(?<component>[^ ]+)\s+\[(?<context>[^\]]+)]\s+(?<message>.*?) *(?<ms>(\d+))?(:?ms)?$
+    Time_Key    time
+    Time_Format %Y-%m-%dT%H:%M:%S.%L
+
+[PARSER]
+    Name        lib:nginx
+    Format      regex
+    Regex       ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")
+    Time_Key    time
+    Time_Format %d/%b/%Y:%H:%M:%S %z
+
+[PARSER]
+    Name        lib:syslog-rfc5424
+    Format      regex
+    Regex       ^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*?)\]|-)) (?<message>.+)$
+    Time_Key    time
+    Time_Format %Y-%m-%dT%H:%M:%S.%L%Z
+
+[PARSER]
+    Name        lib:syslog-rfc3164
+    Format      regex
+    Regex       /^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
+    Time_Key    time
+    Time_Format %b %d %H:%M:%S
+
+[PARSER]
+    Name        parser_id5
+    Format      regex
+    Regex       regex_pattern_5
+    Time_Key    time_key_5
+    Time_Format time_format_5
+

--- a/confgenerator/testdata/valid/logging-mutiple_google_exporters/input.yaml
+++ b/confgenerator/testdata/valid/logging-mutiple_google_exporters/input.yaml
@@ -1,0 +1,96 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+logging:
+  receivers:
+    log_source_id1:
+      type: files
+      include_paths:
+      - /path/to/log/1/*
+    log_source_id2:
+      type: files
+      include_paths:
+      - /path/to/log/2/a
+      - /path/to/log/2/b
+    log_source_id3:
+      type: files
+      include_paths:
+      - /path/to/log/3/*
+      exclude_paths:
+      - /path/to/log/3/exclude
+    log_source_id4:
+      type: files
+      include_paths:
+      - /path/to/log/4/*
+      exclude_paths:
+      - /path/to/log/4/exclude_a
+      - /path/to/log/4/exclude_b
+    log_source_id5:
+      type: files
+      include_paths:
+      - /path/to/log/5/*
+  processors:
+    parser_id5:
+      type: parse_regex
+      field: key_5
+      regex: regex_pattern_5
+      time_key: time_key_5
+      time_format: time_format_5
+  exporters:
+    google:
+      type: google_cloud_logging
+    google1:
+      type: google_cloud_logging
+  service:
+    pipelines:
+      pipeline1:
+        receivers:
+        - log_source_id1
+        exporters:
+        - google1
+      pipeline2:
+        receivers:
+        - log_source_id2
+        exporters:
+        - google
+      pipeline3:
+        receivers:
+        - log_source_id3
+        exporters:
+        - google1
+      pipeline4:
+        receivers:
+        - log_source_id4
+        exporters:
+        - google
+      pipeline5:
+        receivers:
+        - log_source_id5
+        processors:
+        - parser_id5
+        exporters:
+        - google
+metrics:
+  receivers:
+    hostmetrics_receiver:
+      type: hostmetrics
+      collection_interval: 60s
+  exporters:
+    google_exporter:
+      type: google_cloud_monitoring
+  service:
+    pipelines:
+      default_pipeline:
+        receivers: [hostmetrics_receiver]
+        exporters: [google_exporter]

--- a/confgenerator/testdata/valid/logging-no_conf/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-no_conf/golden_fluent_bit_main.conf
@@ -85,8 +85,8 @@
 
 [OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
+    Name           stackdriver
+    resource       gce_instance
     Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/logging-no_conf/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-no_conf/golden_fluent_bit_main.conf
@@ -87,7 +87,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
+    Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-no_conf/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-no_conf/golden_fluent_bit_main.conf
@@ -87,23 +87,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    ops-agent-collectd
+    Match    ops-agent-fluent-bit, ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-no_conf/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-no_conf/golden_fluent_bit_main.conf
@@ -87,7 +87,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
+    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-no_conf/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-no_conf/golden_fluent_bit_main.conf
@@ -87,7 +87,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit,ops-agent-collectd
+    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/logging-no_conf/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/logging-no_conf/golden_fluent_bit_main.conf
@@ -87,7 +87,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit, ops-agent-collectd
+    Match    ops-agent-fluent-bit,ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/metrics-custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/metrics-custom_collection_interval/golden_fluent_bit_main.conf
@@ -132,23 +132,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    ops-agent-collectd
+    Match    ops-agent-fluent-bit, ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/metrics-custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/metrics-custom_collection_interval/golden_fluent_bit_main.conf
@@ -132,7 +132,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
+    Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/metrics-custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/metrics-custom_collection_interval/golden_fluent_bit_main.conf
@@ -132,7 +132,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit, ops-agent-collectd
+    Match    ops-agent-fluent-bit,ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/metrics-custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/metrics-custom_collection_interval/golden_fluent_bit_main.conf
@@ -132,7 +132,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
+    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -148,7 +148,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    syslog
+    Match_Regex    ^(syslog)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/metrics-custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/metrics-custom_collection_interval/golden_fluent_bit_main.conf
@@ -132,7 +132,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit,ops-agent-collectd
+    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -148,7 +148,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    syslog
+    Match_Regex    syslog
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/metrics-custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/metrics-custom_collection_interval/golden_fluent_bit_main.conf
@@ -130,8 +130,8 @@
 
 [OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
+    Name           stackdriver
+    resource       gce_instance
     Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -146,8 +146,8 @@
 
 [OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
+    Name           stackdriver
+    resource       gce_instance
     Match_Regex    ^(syslog)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/windows_default_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_default_config/golden_fluent_bit_main.conf
@@ -112,23 +112,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    ops-agent-collectd
+    Match    ops-agent-fluent-bit, ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows_default_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_default_config/golden_fluent_bit_main.conf
@@ -112,7 +112,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit,ops-agent-collectd
+    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -128,7 +128,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    windows_event_log
+    Match_Regex    windows_event_log
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows_default_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_default_config/golden_fluent_bit_main.conf
@@ -112,7 +112,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
+    Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows_default_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_default_config/golden_fluent_bit_main.conf
@@ -110,8 +110,8 @@
 
 [OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
+    Name           stackdriver
+    resource       gce_instance
     Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -126,8 +126,8 @@
 
 [OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
+    Name           stackdriver
+    resource       gce_instance
     Match_Regex    ^(windows_event_log)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/windows_default_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_default_config/golden_fluent_bit_main.conf
@@ -112,7 +112,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
+    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -128,7 +128,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    windows_event_log
+    Match_Regex    ^(windows_event_log)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows_default_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_default_config/golden_fluent_bit_main.conf
@@ -112,7 +112,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit, ops-agent-collectd
+    Match    ops-agent-fluent-bit,ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows_logging-multiple_file_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_logging-multiple_file_sources/golden_fluent_bit_main.conf
@@ -206,8 +206,8 @@
 
 [OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
+    Name           stackdriver
+    resource       gce_instance
     Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -222,8 +222,8 @@
 
 [OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
+    Name           stackdriver
+    resource       gce_instance
     Match_Regex    ^(windows_event_log|log_source_id1|log_source_id2)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/windows_logging-multiple_file_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_logging-multiple_file_sources/golden_fluent_bit_main.conf
@@ -208,7 +208,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit
+    Match    ops-agent-fluent-bit, ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -224,55 +224,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-collectd
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    windows_event_log
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    log_source_id1
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    log_source_id2
+    Match    windows_event_log,log_source_id1,log_source_id2
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows_logging-multiple_file_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_logging-multiple_file_sources/golden_fluent_bit_main.conf
@@ -208,7 +208,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit, ops-agent-collectd
+    Match    ops-agent-fluent-bit,ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows_logging-multiple_file_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_logging-multiple_file_sources/golden_fluent_bit_main.conf
@@ -208,7 +208,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit,ops-agent-collectd
+    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -224,7 +224,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    windows_event_log,log_source_id1,log_source_id2
+    Match_Regex    windows_event_log|log_source_id1|log_source_id2
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows_logging-multiple_file_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_logging-multiple_file_sources/golden_fluent_bit_main.conf
@@ -208,7 +208,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
+    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -224,7 +224,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    windows_event_log|log_source_id1|log_source_id2
+    Match_Regex    ^(windows_event_log|log_source_id1|log_source_id2)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows_logging-multiple_file_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_logging-multiple_file_sources/golden_fluent_bit_main.conf
@@ -208,7 +208,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
+    Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows_logging-no_conf/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_logging-no_conf/golden_fluent_bit_main.conf
@@ -85,8 +85,8 @@
 
 [OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
+    Name           stackdriver
+    resource       gce_instance
     Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/windows_logging-no_conf/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_logging-no_conf/golden_fluent_bit_main.conf
@@ -87,7 +87,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
+    Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows_logging-no_conf/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_logging-no_conf/golden_fluent_bit_main.conf
@@ -87,23 +87,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
-    Match    ops-agent-collectd
+    Match    ops-agent-fluent-bit, ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows_logging-no_conf/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_logging-no_conf/golden_fluent_bit_main.conf
@@ -87,7 +87,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
+    Match_Regex    ^(^(ops-agent-fluent-bit|ops-agent-collectd)$)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows_logging-no_conf/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_logging-no_conf/golden_fluent_bit_main.conf
@@ -87,7 +87,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit,ops-agent-collectd
+    Match_Regex    ops-agent-fluent-bit|ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows_logging-no_conf/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows_logging-no_conf/golden_fluent_bit_main.conf
@@ -87,7 +87,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    ops-agent-fluent-bit, ops-agent-collectd
+    Match    ops-agent-fluent-bit,ops-agent-collectd
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/fluentbit/conf/conf.go
+++ b/fluentbit/conf/conf.go
@@ -254,7 +254,7 @@ const (
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    {{.Match}}
+    Match_Regex    {{.Match}}
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/fluentbit/conf/conf.go
+++ b/fluentbit/conf/conf.go
@@ -252,8 +252,8 @@ const (
 
 	stackdriverConf = `[OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name     stackdriver
-    resource gce_instance
+    Name           stackdriver
+    resource       gce_instance
     Match_Regex    ^({{.Match}})$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/fluentbit/conf/conf.go
+++ b/fluentbit/conf/conf.go
@@ -254,7 +254,7 @@ const (
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match_Regex    {{.Match}}
+    Match_Regex    ^({{.Match}})$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/fluentbit/conf/conf_test.go
+++ b/fluentbit/conf/conf_test.go
@@ -602,7 +602,7 @@ func TestStackdriver(t *testing.T) {
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name     stackdriver
     resource gce_instance
-    Match    test_match
+    Match_Regex    ^(test_match)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.


### PR DESCRIPTION
- Make a dedicated stackdirver output plugin for handling agents' log
- Aggregate logs handling by the exporter's ID mentioned in the pipeline.
   - if there are multiple receivers are going to the same exporter ID. Share the same exporter plugin among those logs stream by doing `Match_Regex ^(input-1|input-2)$`
- Create another testcase folder for having multiple stackdriver exporters 