### PR TITLE
Unify version assignment

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,10 +22,6 @@ sysconfdir=/etc
 systemdsystemunitdir=$(pkg-config systemd --variable=systemdsystemunitdir)
 systemdsystempresetdir=$(pkg-config systemd --variable=systemdsystempresetdir)
 subagentdir=$prefix/subagents
-# TODO: Get version number from packaging
-if [ -z "$version" ]; then
-  version=1.0.4
-fi
 
 set -x -e
 

--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,7 @@ function build_collectd() {
   cd submodules/collectd
   autoreconf -f -i
   ./configure --prefix=$subagentdir/collectd \
-    --with-useragent="google-cloud-ops-agent-metrics/$version" \
+    --with-useragent="google-cloud-ops-agent-metrics/${PKG_VERSION}" \
     --with-data-max-name-len=256 \
     --disable-all-plugins \
     --disable-static \

--- a/build.sh
+++ b/build.sh
@@ -23,6 +23,8 @@ systemdsystemunitdir=$(pkg-config systemd --variable=systemdsystemunitdir)
 systemdsystempresetdir=$(pkg-config systemd --variable=systemdsystempresetdir)
 subagentdir=$prefix/subagents
 
+. VERSION
+
 set -x -e
 
 if [ -z "$DESTDIR" ]; then


### PR DESCRIPTION
`ops-agent/build.sh` is only called via `pkg/rpm/build.sh` and` pkg/rpm/build.sh`. Since both files use `. VERSION` to obtain the version, however, those two files didn't pass the `$PKG_VERSION` into the `ops-agent\build.sh`. Thus sourcing VERSION file inside `ops-agent\build.sh`