### PR TITLE
make confgenerator generated stanzas in alphabetical order

### DIFF
--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -20,10 +20,11 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"github.com/shirou/gopsutil/host"
+
 	"github.com/GoogleCloudPlatform/ops-agent/collectd"
 	"github.com/GoogleCloudPlatform/ops-agent/fluentbit/conf"
 	"github.com/GoogleCloudPlatform/ops-agent/otel"
+	"github.com/shirou/gopsutil/host"
 
 	yaml "gopkg.in/yaml.v2"
 )
@@ -198,18 +199,18 @@ func generateOtelServices(receiverNameMap map[string]string, exporterNameMap map
 func defaultTails(logsDir string, stateDir string) (tails []*conf.Tail) {
 	tails = []*conf.Tail{}
 	tailFluentbit := conf.Tail{
-			Tag:  "ops-agent-fluent-bit",
-			DB:   filepath.Join(stateDir, "buffers", "ops-agent-fluent-bit"),
-			Path: filepath.Join(logsDir, "logging-module.log"),
-		}
+		Tag:  "ops-agent-fluent-bit",
+		DB:   filepath.Join(stateDir, "buffers", "ops-agent-fluent-bit"),
+		Path: filepath.Join(logsDir, "logging-module.log"),
+	}
 	tailCollectd := conf.Tail{
-			Tag:  "ops-agent-collectd",
-			DB:   filepath.Join(stateDir, "buffers", "ops-agent-collectd"),
-			Path: filepath.Join(logsDir, "metrics-module.log"),
-		}
+		Tag:  "ops-agent-collectd",
+		DB:   filepath.Join(stateDir, "buffers", "ops-agent-collectd"),
+		Path: filepath.Join(logsDir, "metrics-module.log"),
+	}
 	tails = append(tails, &tailFluentbit)
 	hostInfo, _ := host.Info()
-        if hostInfo.OS != "windows" {
+	if hostInfo.OS != "windows" {
 		tails = append(tails, &tailCollectd)
 	}
 	return tails

--- a/confgenerator/confgenerator_test.go
+++ b/confgenerator/confgenerator_test.go
@@ -20,8 +20,9 @@ import (
 	"io/ioutil"
 	"strings"
 	"testing"
-	"github.com/shirou/gopsutil/host"
+
 	"github.com/google/go-cmp/cmp"
+	"github.com/shirou/gopsutil/host"
 )
 
 const (
@@ -40,24 +41,24 @@ var (
 	//   ops-agent$ go test -mod=mod github.com/GoogleCloudPlatform/ops-agent/confgenerator -update_golden
 	// Add "-v" to show details for which files are updated with what:
 	//   ops-agent$ go test -mod=mod github.com/GoogleCloudPlatform/ops-agent/confgenerator -update_golden -v
-	updateGolden                     = flag.Bool("update_golden", false, "Whether to update the expected golden confs if they differ from the actual generated confs.")
-	goldenMainPath                   = validTestdataDir + "/%s/%s/golden_fluent_bit_main.conf"
-	goldenParserPath                 = validTestdataDir + "/%s/%s/golden_fluent_bit_parser.conf"
-	goldenCollectdPath               = validTestdataDir + "/%s/%s/golden_collectd.conf"
-	goldenOtelPath                   = validTestdataDir + "/%s/%s/golden_otel.conf"
+	updateGolden       = flag.Bool("update_golden", false, "Whether to update the expected golden confs if they differ from the actual generated confs.")
+	goldenMainPath     = validTestdataDir + "/%s/%s/golden_fluent_bit_main.conf"
+	goldenParserPath   = validTestdataDir + "/%s/%s/golden_fluent_bit_parser.conf"
+	goldenCollectdPath = validTestdataDir + "/%s/%s/golden_collectd.conf"
+	goldenOtelPath     = validTestdataDir + "/%s/%s/golden_otel.conf"
 )
 
 var isWindows bool
 
 func init() {
 	hostInfo, _ := host.Info()
-        if hostInfo.OS ==  "windows"{
+	if hostInfo.OS == "windows" {
 		isWindows = true
 	}
 }
 
 func TestGenerateConfsWithValidInput(t *testing.T) {
-	dirPath := validTestdataDir +  "/linux"
+	dirPath := validTestdataDir + "/linux"
 	logsDir := defaultLogsDir
 	stateDir := defaultStateDir
 	if isWindows {
@@ -73,7 +74,7 @@ func TestGenerateConfsWithValidInput(t *testing.T) {
 	for _, d := range dirs {
 		testName := d.Name()
 		t.Run(testName, func(t *testing.T) {
-			unifiedConfigFilePath := fmt.Sprintf(dirPath + "/%s/input.yaml", testName)
+			unifiedConfigFilePath := fmt.Sprintf(dirPath+"/%s/input.yaml", testName)
 			// Special-case the default config.  It lives directly in the
 			// confgenerator directory.  The golden files are still in the
 			// testdata directory.
@@ -166,7 +167,7 @@ func updateOrCompareGolden(t *testing.T, testName string, expected string, actua
 }
 
 func TestGenerateConfigsWithInvalidInput(t *testing.T) {
-	filePath := invalidTestdataDir +  "/linux"
+	filePath := invalidTestdataDir + "/linux"
 	if isWindows {
 		filePath = invalidTestdataDir + "/windows"
 	}
@@ -177,7 +178,7 @@ func TestGenerateConfigsWithInvalidInput(t *testing.T) {
 	for _, f := range files {
 		testName := f.Name()
 		t.Run(testName, func(t *testing.T) {
-			unifiedConfigFilePath := fmt.Sprintf(filePath + "/%s", testName)
+			unifiedConfigFilePath := fmt.Sprintf(filePath+"/%s", testName)
 			data, err := ioutil.ReadFile(unifiedConfigFilePath)
 			if err != nil {
 				t.Fatalf("ReadFile(%q) got %v", unifiedConfigFilePath, err)

--- a/confgenerator/testdata/valid/linux/default_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/default_config/golden_fluent_bit_main.conf
@@ -30,9 +30,9 @@
 [INPUT]
     # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
     Name               tail
-    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-fluent-bit
-    Path               /var/log/google-cloud-ops-agent/subagents/logging-module.log
-    Tag                ops-agent-fluent-bit
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/default_pipeline_syslog
+    Path               /var/log/messages,/var/log/syslog
+    Tag                default_pipeline.syslog
     # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
     Buffer_Chunk_Size  512k
     # Set the max size a bit larger to accommodate for long log lines.
@@ -86,9 +86,9 @@
 [INPUT]
     # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
     Name               tail
-    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/default_pipeline_syslog
-    Path               /var/log/messages,/var/log/syslog
-    Tag                default_pipeline.syslog
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-fluent-bit
+    Path               /var/log/google-cloud-ops-agent/subagents/logging-module.log
+    Tag                ops-agent-fluent-bit
     # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
     Buffer_Chunk_Size  512k
     # Set the max size a bit larger to accommodate for long log lines.

--- a/confgenerator/testdata/valid/linux/empty_log_service/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/empty_log_service/golden_fluent_bit_main.conf
@@ -30,9 +30,9 @@
 [INPUT]
     # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
     Name               tail
-    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-fluent-bit
-    Path               /var/log/google-cloud-ops-agent/subagents/logging-module.log
-    Tag                ops-agent-fluent-bit
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-collectd
+    Path               /var/log/google-cloud-ops-agent/subagents/metrics-module.log
+    Tag                ops-agent-collectd
     # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
     Buffer_Chunk_Size  512k
     # Set the max size a bit larger to accommodate for long log lines.
@@ -58,9 +58,9 @@
 [INPUT]
     # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
     Name               tail
-    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-collectd
-    Path               /var/log/google-cloud-ops-agent/subagents/metrics-module.log
-    Tag                ops-agent-collectd
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-fluent-bit
+    Path               /var/log/google-cloud-ops-agent/subagents/logging-module.log
+    Tag                ops-agent-fluent-bit
     # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
     Buffer_Chunk_Size  512k
     # Set the max size a bit larger to accommodate for long log lines.

--- a/confgenerator/testdata/valid/linux/logging-complex_logs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs/golden_fluent_bit_main.conf
@@ -30,9 +30,9 @@
 [INPUT]
     # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
     Name               tail
-    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-fluent-bit
-    Path               /var/log/google-cloud-ops-agent/subagents/logging-module.log
-    Tag                ops-agent-fluent-bit
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-collectd
+    Path               /var/log/google-cloud-ops-agent/subagents/metrics-module.log
+    Tag                ops-agent-collectd
     # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
     Buffer_Chunk_Size  512k
     # Set the max size a bit larger to accommodate for long log lines.
@@ -58,9 +58,9 @@
 [INPUT]
     # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
     Name               tail
-    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-collectd
-    Path               /var/log/google-cloud-ops-agent/subagents/metrics-module.log
-    Tag                ops-agent-collectd
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-fluent-bit
+    Path               /var/log/google-cloud-ops-agent/subagents/logging-module.log
+    Tag                ops-agent-fluent-bit
     # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
     Buffer_Chunk_Size  512k
     # Set the max size a bit larger to accommodate for long log lines.
@@ -267,7 +267,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name           stackdriver
     resource       gce_instance
-    Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
+    Match_Regex    ^(log_source_id1|log_source_id2|test_syslog_source_id_tcp|test_syslog_source_id_udp)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -283,7 +283,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name           stackdriver
     resource       gce_instance
-    Match_Regex    ^(log_source_id1|log_source_id2|test_syslog_source_id_tcp|test_syslog_source_id_udp)$
+    Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_fluent_bit_main.conf
@@ -30,9 +30,9 @@
 [INPUT]
     # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
     Name               tail
-    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-fluent-bit
-    Path               /var/log/google-cloud-ops-agent/subagents/logging-module.log
-    Tag                ops-agent-fluent-bit
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-collectd
+    Path               /var/log/google-cloud-ops-agent/subagents/metrics-module.log
+    Tag                ops-agent-collectd
     # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
     Buffer_Chunk_Size  512k
     # Set the max size a bit larger to accommodate for long log lines.
@@ -58,9 +58,9 @@
 [INPUT]
     # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
     Name               tail
-    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-collectd
-    Path               /var/log/google-cloud-ops-agent/subagents/metrics-module.log
-    Tag                ops-agent-collectd
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-fluent-bit
+    Path               /var/log/google-cloud-ops-agent/subagents/logging-module.log
+    Tag                ops-agent-fluent-bit
     # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
     Buffer_Chunk_Size  512k
     # Set the max size a bit larger to accommodate for long log lines.
@@ -279,7 +279,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name           stackdriver
     resource       gce_instance
-    Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
+    Match_Regex    ^(log_source_id1|log_source_id2|test_syslog_source_id_tcp|test_syslog_source_id_udp)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -295,7 +295,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name           stackdriver
     resource       gce_instance
-    Match_Regex    ^(log_source_id1|log_source_id2|test_syslog_source_id_tcp|test_syslog_source_id_udp)$
+    Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_fluent_bit_main.conf
@@ -30,9 +30,9 @@
 [INPUT]
     # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
     Name               tail
-    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-fluent-bit
-    Path               /var/log/google-cloud-ops-agent/subagents/logging-module.log
-    Tag                ops-agent-fluent-bit
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-collectd
+    Path               /var/log/google-cloud-ops-agent/subagents/metrics-module.log
+    Tag                ops-agent-collectd
     # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
     Buffer_Chunk_Size  512k
     # Set the max size a bit larger to accommodate for long log lines.
@@ -58,9 +58,9 @@
 [INPUT]
     # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
     Name               tail
-    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-collectd
-    Path               /var/log/google-cloud-ops-agent/subagents/metrics-module.log
-    Tag                ops-agent-collectd
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-fluent-bit
+    Path               /var/log/google-cloud-ops-agent/subagents/logging-module.log
+    Tag                ops-agent-fluent-bit
     # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
     Buffer_Chunk_Size  512k
     # Set the max size a bit larger to accommodate for long log lines.
@@ -322,7 +322,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name           stackdriver
     resource       gce_instance
-    Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
+    Match_Regex    ^(log_source_id1|log_source_id2|log_source_id3|log_source_id4|log_source_id5)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -338,7 +338,7 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name           stackdriver
     resource       gce_instance
-    Match_Regex    ^(log_source_id1|log_source_id2|log_source_id3|log_source_id4|log_source_id5)$
+    Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_fluent_bit_main.conf
@@ -30,9 +30,9 @@
 [INPUT]
     # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
     Name               tail
-    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-fluent-bit
-    Path               /var/log/google-cloud-ops-agent/subagents/logging-module.log
-    Tag                ops-agent-fluent-bit
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-collectd
+    Path               /var/log/google-cloud-ops-agent/subagents/metrics-module.log
+    Tag                ops-agent-collectd
     # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
     Buffer_Chunk_Size  512k
     # Set the max size a bit larger to accommodate for long log lines.
@@ -58,9 +58,9 @@
 [INPUT]
     # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
     Name               tail
-    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-collectd
-    Path               /var/log/google-cloud-ops-agent/subagents/metrics-module.log
-    Tag                ops-agent-collectd
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-fluent-bit
+    Path               /var/log/google-cloud-ops-agent/subagents/logging-module.log
+    Tag                ops-agent-fluent-bit
     # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
     Buffer_Chunk_Size  512k
     # Set the max size a bit larger to accommodate for long log lines.

--- a/confgenerator/testdata/valid/linux/logging-mutiple_google_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-mutiple_google_exporters/golden_fluent_bit_main.conf
@@ -30,9 +30,9 @@
 [INPUT]
     # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
     Name               tail
-    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-fluent-bit
-    Path               /var/log/google-cloud-ops-agent/subagents/logging-module.log
-    Tag                ops-agent-fluent-bit
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-collectd
+    Path               /var/log/google-cloud-ops-agent/subagents/metrics-module.log
+    Tag                ops-agent-collectd
     # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
     Buffer_Chunk_Size  512k
     # Set the max size a bit larger to accommodate for long log lines.
@@ -58,9 +58,9 @@
 [INPUT]
     # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
     Name               tail
-    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-collectd
-    Path               /var/log/google-cloud-ops-agent/subagents/metrics-module.log
-    Tag                ops-agent-collectd
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-fluent-bit
+    Path               /var/log/google-cloud-ops-agent/subagents/logging-module.log
+    Tag                ops-agent-fluent-bit
     # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
     Buffer_Chunk_Size  512k
     # Set the max size a bit larger to accommodate for long log lines.
@@ -322,22 +322,6 @@
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
     Name           stackdriver
     resource       gce_instance
-    Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
-
-    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-    Retry_Limit  3
-
-    # https://docs.fluentbit.io/manual/administration/security
-    # Enable TLS support.
-    tls         On
-    # Do not force certificate validation.
-    tls.verify  Off
-
-[OUTPUT]
-    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-    Name           stackdriver
-    resource       gce_instance
     Match_Regex    ^(log_source_id1|log_source_id3)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -355,6 +339,22 @@
     Name           stackdriver
     resource       gce_instance
     Match_Regex    ^(log_source_id2|log_source_id4|log_source_id5)$
+
+    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
+    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
+    Retry_Limit  3
+
+    # https://docs.fluentbit.io/manual/administration/security
+    # Enable TLS support.
+    tls         On
+    # Do not force certificate validation.
+    tls.verify  Off
+
+[OUTPUT]
+    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
+    Name           stackdriver
+    resource       gce_instance
+    Match_Regex    ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/linux/logging-no_conf/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-no_conf/golden_fluent_bit_main.conf
@@ -30,9 +30,9 @@
 [INPUT]
     # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
     Name               tail
-    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-fluent-bit
-    Path               /var/log/google-cloud-ops-agent/subagents/logging-module.log
-    Tag                ops-agent-fluent-bit
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-collectd
+    Path               /var/log/google-cloud-ops-agent/subagents/metrics-module.log
+    Tag                ops-agent-collectd
     # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
     Buffer_Chunk_Size  512k
     # Set the max size a bit larger to accommodate for long log lines.
@@ -58,9 +58,9 @@
 [INPUT]
     # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
     Name               tail
-    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-collectd
-    Path               /var/log/google-cloud-ops-agent/subagents/metrics-module.log
-    Tag                ops-agent-collectd
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-fluent-bit
+    Path               /var/log/google-cloud-ops-agent/subagents/logging-module.log
+    Tag                ops-agent-fluent-bit
     # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
     Buffer_Chunk_Size  512k
     # Set the max size a bit larger to accommodate for long log lines.

--- a/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_fluent_bit_main.conf
@@ -30,9 +30,9 @@
 [INPUT]
     # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
     Name               tail
-    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-fluent-bit
-    Path               /var/log/google-cloud-ops-agent/subagents/logging-module.log
-    Tag                ops-agent-fluent-bit
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/default_pipeline_syslog
+    Path               /var/log/messages,/var/log/syslog
+    Tag                default_pipeline.syslog
     # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
     Buffer_Chunk_Size  512k
     # Set the max size a bit larger to accommodate for long log lines.
@@ -86,9 +86,9 @@
 [INPUT]
     # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
     Name               tail
-    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/default_pipeline_syslog
-    Path               /var/log/messages,/var/log/syslog
-    Tag                default_pipeline.syslog
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-fluent-bit
+    Path               /var/log/google-cloud-ops-agent/subagents/logging-module.log
+    Tag                ops-agent-fluent-bit
     # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
     Buffer_Chunk_Size  512k
     # Set the max size a bit larger to accommodate for long log lines.

--- a/fluentbit/conf/conf.go
+++ b/fluentbit/conf/conf.go
@@ -18,6 +18,7 @@ package conf
 import (
 	"fmt"
 	"net"
+	"sort"
 	"strings"
 	"text/template"
 )
@@ -353,6 +354,17 @@ func GenerateFluentBitMainConfig(tails []*Tail, syslogs []*Syslog, wineventlogs 
 		}
 		stackdriverConfigSections = append(stackdriverConfigSections, configSection)
 	}
+
+	// make sure all collections are sorted so that generated configs are consistently generated
+	sort.Strings(tailConfigSections)
+	sort.Strings(syslogConfigSections)
+	sort.Strings(wineventlogConfigSections)
+	sort.Strings(filterParserConfigSections)
+	sort.Strings(filterModifyAddLogNameConfigSections)
+	sort.Strings(filterRewriteTagSections)
+	sort.Strings(filterModifyRemoveLogNameConfigSections)
+	sort.Strings(stackdriverConfigSections)
+
 	configSections := mainConfigSections{
 		TailConfigSections:                      tailConfigSections,
 		SyslogConfigSections:                    syslogConfigSections,

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/shirou/gopsutil v3.21.2+incompatible
-	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4
+	github.com/tklauser/go-sysconf v0.3.5 // indirect
+	golang.org/x/sys v0.0.0-20210316164454-77fc1eacc6aa
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,13 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/shirou/gopsutil v3.21.2+incompatible h1:U+YvJfjCh6MslYlIAXvPtzhW3YZEtc9uncueUNpD/0A=
 github.com/shirou/gopsutil v3.21.2+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+github.com/tklauser/go-sysconf v0.3.5 h1:uu3Xl4nkLzQfXNsWn15rPc/HQCJKObbt1dKJeWp3vU4=
+github.com/tklauser/go-sysconf v0.3.5/go.mod h1:MkWzOF4RMCshBAMXuhXJs64Rte09mITnppBXY/rYEFI=
+github.com/tklauser/numcpus v0.2.2/go.mod h1:x3qojaO3uyYt0i56EW/VUYs7uBvdl2fkfZFu0T9wgjM=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210316164454-77fc1eacc6aa h1:ZYxPR6aca/uhfRJyaOAtflSHjJYiktO7QnJC5ut7iY4=
+golang.org/x/sys v0.0.0-20210316164454-77fc1eacc6aa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
Because generator can be called on a map of values that are used to fill the template, the generator can generate the stanzas in different orders.  This causes unit tests, which test against a specific golden file, to fail sometimes.

To see the failures, rerun the unit tests 10 times in a row:

```
for i in 1 2 3 4 5 6 7 8 9 10; do go clean --testcache; go test -mod=mod ./...; done
```

With this change, there is a consistent order for the output, as well as an updated set of golden files, so that unit tests will pass all the time.