### PR TITLE
More permanent workaround for zypper segfaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM debian:buster AS buster
 
 # TODO: Factor out the common code without rerunning apt-get on every build.
 
-RUN apt-get update && \
+RUN set -x; apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install golang git systemd \
     autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
     build-essential cmake bison flex file libsystemd-dev \
@@ -33,7 +33,7 @@ FROM debian:stretch AS stretch
 
 # TODO: Factor out the common code without rerunning apt-get on every build.
 
-RUN echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list && \
+RUN set -x; echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y -t stretch-backports install golang && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
@@ -47,7 +47,7 @@ RUN ./pkg/deb/build.sh
 
 FROM ubuntu:focal AS focal
 
-RUN apt-get update && \
+RUN set -x; apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install golang git systemd \
     autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
     build-essential cmake bison flex file libsystemd-dev \
@@ -59,7 +59,7 @@ RUN ./pkg/deb/build.sh
 
 FROM ubuntu:bionic AS bionic
 
-RUN apt-get update && \
+RUN set -x; apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install software-properties-common && \
     add-apt-repository ppa:longsleep/golang-backports && \
     apt-get update && \
@@ -74,7 +74,7 @@ RUN ./pkg/deb/build.sh
 
 FROM ubuntu:xenial AS xenial
 
-RUN apt-get update && \
+RUN set -x; apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install software-properties-common && \
     add-apt-repository ppa:gophers/archive && \
     apt-get update && \
@@ -95,7 +95,7 @@ RUN echo DEBUILD_PREPEND_PATH=/usr/lib/go-1.11/bin >> /etc/devscripts.conf && \
 
 FROM centos:7 AS centos7
 
-RUN yum -y update && \
+RUN set -x; yum -y update && \
     yum -y install git systemd \
     autoconf libtool libcurl-devel libtool-ltdl-devel openssl-devel yajl-devel \
     gcc gcc-c++ make bison flex file systemd-devel zlib-devel gtest-devel rpm-build \
@@ -110,7 +110,7 @@ RUN ./pkg/rpm/build.sh
 
 FROM centos:8 AS centos8
 
-RUN yum -y update && \
+RUN set -x; yum -y update && \
     dnf -y install 'dnf-command(config-manager)' && \
     yum config-manager --set-enabled powertools && \
     yum -y install golang git systemd \
@@ -126,7 +126,7 @@ RUN ./pkg/rpm/build.sh
 # Use OpenSUSE Leap 42.3 to emulate SLES 12: https://en.opensuse.org/openSUSE:Build_Service_cross_distribution_howto#Detect_a_distribution_flavor_for_special_code
 FROM opensuse/leap:42.3 as sles12
 
-RUN zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros \
+RUN set -x; zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros \
 # Add home:Ledest:devel repo to install >3.4 bison
 && zypper addrepo https://download.opensuse.org/repositories/home:Ledest:devel/openSUSE_Leap_42.3/home:Ledest:devel.repo \
 && zypper addrepo https://download.opensuse.org/repositories/devel:languages:go/openSUSE_Leap_42.3/devel:languages:go.repo \
@@ -148,7 +148,7 @@ RUN ./pkg/rpm/build.sh
 
 FROM opensuse/leap:15.1 as sles15
 
-RUN zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros \
+RUN set -x; zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros \
 # Add home:ptrommler:formal repo to install >3.4 bison
 && zypper addrepo https://download.opensuse.org/repositories/home:ptrommler:formal/openSUSE_Leap_15.1/home:ptrommler:formal.repo \
 && zypper addrepo https://download.opensuse.org/repositories/devel:languages:go/openSUSE_Leap_15.1/devel:languages:go.repo \

--- a/Dockerfile
+++ b/Dockerfile
@@ -131,9 +131,14 @@ RUN zypper -n install git systemd autoconf automake flex libtool libcurl-devel l
 && zypper addrepo https://download.opensuse.org/repositories/home:Ledest:devel/openSUSE_Leap_42.3/home:Ledest:devel.repo \
 && zypper addrepo https://download.opensuse.org/repositories/devel:languages:go/openSUSE_Leap_42.3/devel:languages:go.repo \
 && zypper -n --gpg-auto-import-keys refresh \
-&& zypper update \
-# Pin Golang version to 1.14 to bypass b/182517088#comment14. The long-term solution is tracked by b/184743026.
-&& zypper -n install bison>3.4 go1.14 \
+&& zypper -n update \
+# Temporary workaround for https://bugzilla.opensuse.org/show_bug.cgi?id=1127849
+# zypper/libcurl has a use-after-free bug that causes segfaults for particular download sequences.
+# Installing "go" currently produces one such solution.
+# By downloading go separately, the RPM will be cached and not downloaded again by the install, thereby permuting the sequence enough to (curently) avoid the segfault.
+# This can happen again in the future if any other changes happen to the packages in the solution.
+&& zypper -n download go \
+&& zypper -n install bison>3.4 go \
 # Allow fluent-bit to find systemd
 && ln -fs /usr/lib/systemd /lib/systemd
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -153,7 +153,7 @@ RUN zypper -n install git systemd autoconf automake flex libtool libcurl-devel l
 && zypper addrepo https://download.opensuse.org/repositories/home:ptrommler:formal/openSUSE_Leap_15.1/home:ptrommler:formal.repo \
 && zypper addrepo https://download.opensuse.org/repositories/devel:languages:go/openSUSE_Leap_15.1/devel:languages:go.repo \
 && zypper -n --gpg-auto-import-keys refresh \
-&& zypper update \
+&& zypper -n update \
 && zypper -n install bison>3.4 go \
 # Allow fluent-bit to find systemd
 && ln -fs /usr/lib/systemd /lib/systemd


### PR DESCRIPTION
zypper has a bug that causes random segfaults when downloading packages:
https://bugzilla.opensuse.org/show_bug.cgi?id=1127849

We get unlucky and trigger this when we try to install our
packages. Downloading go separately seems to avoid a segfault with our
exact package set.

(This could happen with any package, so there's no guarantee this won't
break again in the future if the packages change again in the upstream
repos. Unless we can get opensuse to release a new container or zypper,
we'll just have to experiment until we find another reliable sequence of
package installs.)