### PR TITLE
Stop ignoring errors in sub-agent startup

### DIFF
--- a/cmd/ops_agent_windows/run_windows.go
+++ b/cmd/ops_agent_windows/run_windows.go
@@ -150,9 +150,7 @@ func (s *service) startSubagents() error {
 		}
 		defer handle.Close()
 		if err := handle.Start(); err != nil {
-			err = fmt.Errorf("failed to start %q: %v", svc.name, err)
-			s.log.Error(1, err.Error())
-			return err
+			return fmt.Errorf("failed to start %q: %v", svc.name, err)
 		}
 	}
 	return nil

--- a/cmd/ops_agent_windows/run_windows.go
+++ b/cmd/ops_agent_windows/run_windows.go
@@ -45,7 +45,8 @@ func (s *service) Execute(args []string, r <-chan svc.ChangeRequest, changes cha
 	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
 	if err := s.startSubagents(); err != nil {
 		s.log.Error(1, fmt.Sprintf("failed to start subagents: %v", err))
-		// TODO: Ignore failures for partial startup?
+		// ERROR_SERVICE_DEPENDENCY_FAIL
+		return false, 0x0000042C
 	}
 	s.log.Info(1, "started subagents")
 	defer func() {
@@ -149,8 +150,9 @@ func (s *service) startSubagents() error {
 		}
 		defer handle.Close()
 		if err := handle.Start(); err != nil {
-			// TODO: Should we be ignoring failures for partial startup?
-			s.log.Error(1, fmt.Sprintf("failed to start %q: %v", svc.name, err))
+			err = fmt.Errorf("failed to start %q: %v", svc.name, err)
+			s.log.Error(1, err.Error())
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
Previously, when a subagent couldn't be started, the install process would claim that the ops agent was installed successfully and would simply skip the failing agent. This is confusing and hides problems. The way I ran into this was in the case of a flaky install error, which is supposed to be handled by OS Config via a retry loop. However, the retry loop doesn't kick in because it thinks the install succeeded. After this PR, it should at least notice the error and try again.

Additional context is in b/182388102 and b/182387975.