### PR TITLE
Revert "Stop ignoring errors in sub-agent startup (#59)"

### DIFF
--- a/cmd/ops_agent_windows/run_windows.go
+++ b/cmd/ops_agent_windows/run_windows.go
@@ -45,8 +45,7 @@ func (s *service) Execute(args []string, r <-chan svc.ChangeRequest, changes cha
 	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
 	if err := s.startSubagents(); err != nil {
 		s.log.Error(1, fmt.Sprintf("failed to start subagents: %v", err))
-		// ERROR_SERVICE_DEPENDENCY_FAIL
-		return false, 0x0000042C
+		// TODO: Ignore failures for partial startup?
 	}
 	s.log.Info(1, "started subagents")
 	defer func() {
@@ -150,7 +149,8 @@ func (s *service) startSubagents() error {
 		}
 		defer handle.Close()
 		if err := handle.Start(); err != nil {
-			return fmt.Errorf("failed to start %q: %v", svc.name, err)
+			// TODO: Should we be ignoring failures for partial startup?
+			s.log.Error(1, fmt.Sprintf("failed to start %q: %v", svc.name, err))
 		}
 	}
 	return nil


### PR DESCRIPTION
This reverts commit e2cb848fb2af597d16f79b0bf892acfc9bc0fa4c.

Fixes b/186138997. We need to figure out a more robust way to solve the original problem https://github.com/GoogleCloudPlatform/ops-agent/pull/59 tried to solve. Reverting it first to unblock releases.

**Issue**
The parent process and child process enter a dependency loop and neither is able to start.

**Error**
```
setupOpsAgent() failed to restart ops agent: exit status 1 stdout:
stderr: #< CLIXML <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04"><Obj S="progress" RefId="0"><TN RefId="0"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS><I64 N="SourceId">1</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj><S S="Error">Restart-Service : Failed to start service 'Google Cloud Ops Agent (google-cloud-ops-agent)'.x000D__x000A</S><S S="Error">At line:1 char:1_x000D__x000A_</S><S S="Error">+ Restart-Service google-cloud-ops-agent -Force_x000D__x000A_</S><S S="Error">+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~x000D__x000A</S><S S="Error"> + CategoryInfo : OpenError: (System.ServiceProcess.ServiceController:ServiceController) [Restart-Service] x000D__x000A</S><S S="Error"> , ServiceCommandException_x000D__x000A_</S><S S="Error"> + FullyQualifiedErrorId : StartServiceFailed,Microsoft.PowerShell.Commands.RestartServiceCommand_x000D__x000A_</S><S S="Error"> x000D__x000A</S></Objs>
```