### PR TITLE
Remove requirement to uninstall standalone agents

### DIFF
--- a/cmd/ops_agent_windows/run_windows.go
+++ b/cmd/ops_agent_windows/run_windows.go
@@ -77,36 +77,6 @@ func (s *service) parseFlags(args []string) error {
 	return fs.Parse(allArgs)
 }
 
-func (s *service) checkForStandaloneAgents(unified *confgenerator.UnifiedConfig) error {
-	mgr, err := mgr.Connect()
-	if err != nil {
-		return fmt.Errorf("failed to connect to service manager: %s", err)
-	}
-	defer mgr.Disconnect()
-	services, err := mgr.ListServices()
-	if err != nil {
-		return fmt.Errorf("failed to list services: %s", err)
-	}
-
-	var errors string
-	if unified.HasLogging() && containsString(services, "StackdriverLogging") {
-		errors += "We detected an existing Windows service for the StackdriverLogging agent, " +
-			"which is not compatible with the Ops Agent when the Ops Agent configuration has a non-empty logging section. " +
-			"Please either remove the logging section from the Ops Agent configuration, " +
-			"or disable the StackdriverLogging agent, and then retry enabling the Ops Agent. "
-	}
-	if unified.HasMetrics() && containsString(services, "StackdriverMonitoring") {
-		errors += "We detected an existing Windows service for the StackdriverMonitoring agent, " +
-			"which is not compatible with the Ops Agent when the Ops Agent configuration has a non-empty metrics section. " +
-			"Please either remove the metrics section from the Ops Agent configuration, " +
-			"or disable the StackdriverMonitoring agent, and then retry enabling the Ops Agent. "
-	}
-	if errors != "" {
-		return fmt.Errorf("conflicts with existing agents: %s", errors)
-	}
-	return nil
-}
-
 func (s *service) generateConfigs() error {
 	data, err := ioutil.ReadFile(s.inFile)
 	if err != nil {
@@ -114,9 +84,6 @@ func (s *service) generateConfigs() error {
 	}
 	uc, err := confgenerator.ParseUnifiedConfig(data)
 	if err != nil {
-		return err
-	}
-	if err := s.checkForStandaloneAgents(&uc); err != nil {
 		return err
 	}
 	// TODO: Add flag for passing in log/run path?

--- a/pkg/deb/debian/control
+++ b/pkg/deb/debian/control
@@ -8,6 +8,5 @@ Standards-Version: 3.9.4
 Package: google-cloud-ops-agent
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Conflicts: stackdriver-agent, google-fluentd
 Description: Google Cloud Ops Agent
  The Google Cloud Ops Agent collects metrics and logs from the system.

--- a/pkg/rpm/google-cloud-ops-agent.spec
+++ b/pkg/rpm/google-cloud-ops-agent.spec
@@ -20,7 +20,6 @@ BuildRequires: systemd
 %else
 BuildRequires: systemd-rpm-macros
 %endif
-Conflicts: stackdriver-agent, google-fluentd
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 %description


### PR DESCRIPTION
In order to ease migration, remove the uninstallation of the standalone agents so that a customer can install the opsagent to run only a monitoring agent, while using that standalone logging agent, or vice versa.

This PR removes the uninstall for Linux and Windows.