### PR TITLE
Use goimports to enforce codebase format style check.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,7 @@ before_install:
 
 script:
 - go test -mod=mod ./...
+
+after_success:
+# Check code test coverage.
 - $GOPATH/bin/goveralls -service=travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,12 @@ go:
 go_import_path: github.com/GoogleCloudPlatform/ops-agent
 
 before_install:
+- go get golang.org/x/tools/cmd/goimports
 - go get github.com/mattn/goveralls
 
 script:
+# Only enforce the format check on Linux to avoid the newline difference in Linux and Windows.
+- if [ "$TRAVIS_OS_NAME" = "linux" ] && [ $(goimports -l .) ]; then goimports -d .; echo 'Failed the goimports format check. Please format the code using "goimports -w ."'; exit 1; fi
 - go test -mod=mod ./...
 
 after_success:

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -20,13 +20,15 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
 	"github.com/GoogleCloudPlatform/ops-agent/collectd"
 	"github.com/GoogleCloudPlatform/ops-agent/fluentbit/conf"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/version"
 	"github.com/GoogleCloudPlatform/ops-agent/otel"
 	"github.com/shirou/gopsutil/host"
-	"github.com/GoogleCloudPlatform/ops-agent/internal/version"
 
 	"text/template"
+
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -227,14 +229,15 @@ func defaultStackdriverOutputs() (stackdrivers []*conf.Stackdriver) {
 }
 
 var userAgentTemplate = template.Must(template.New("useragent").Parse(`{{.Prefix}}/{{.AgentVersion}} (BuildDistro={{.BuildDistro}};Platform={{.Platform}};ShortName={{.ShortName}};ShortVersion={{.ShortVersion}},gzip(gfe))`))
+
 func getUserAgent(prefix string, hostInfo *host.InfoStat) (string, error) {
 	userAgent := map[string]string{
-	    "Prefix":     prefix,
-	    "AgentVersion": version.Version,
-	    "BuildDistro":   version.BuildDistro,
-	    "Platform": hostInfo.OS,
-	    "ShortName": hostInfo.Platform,
-	    "ShortVersion": hostInfo.PlatformVersion,
+		"Prefix":       prefix,
+		"AgentVersion": version.Version,
+		"BuildDistro":  version.BuildDistro,
+		"Platform":     hostInfo.OS,
+		"ShortName":    hostInfo.Platform,
+		"ShortVersion": hostInfo.PlatformVersion,
 	}
 	var userAgentBuilder strings.Builder
 	if err := userAgentTemplate.Execute(&userAgentBuilder, userAgent); err != nil {

--- a/confgenerator/files.go
+++ b/confgenerator/files.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
 	"github.com/shirou/gopsutil/host"
 )
 

--- a/fluentbit/conf/conf.go
+++ b/fluentbit/conf/conf.go
@@ -739,7 +739,7 @@ func (w WindowsEventlog) renderConfig() (string, error) {
 
 // A Stackdriver represents the configurable data for fluentBit's stackdriver output plugin.
 type Stackdriver struct {
-	Match string
+	Match     string
 	UserAgent string
 }
 
@@ -754,11 +754,11 @@ func (s Stackdriver) renderConfig() (string, error) {
 		}
 	}
 	if s.UserAgent == "" {
-                return "", emptyFieldErr{
-                        plugin: "stackdriver",
-                        field:  "stackdriver_agent",
-                }
-        }
+		return "", emptyFieldErr{
+			plugin: "stackdriver",
+			field:  "stackdriver_agent",
+		}
+	}
 
 	var renderedStackdriverConfig strings.Builder
 	if err := stackdriverTemplate.Execute(&renderedStackdriverConfig, s); err != nil {

--- a/fluentbit/conf/conf_test.go
+++ b/fluentbit/conf/conf_test.go
@@ -596,7 +596,7 @@ func TestWinlogErrors(t *testing.T) {
 
 func TestStackdriver(t *testing.T) {
 	s := Stackdriver{
-		Match: "test_match",
+		Match:     "test_match",
 		UserAgent: "user_agent",
 	}
 	want := `[OUTPUT]

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -19,4 +19,3 @@ var Version = "latest"
 
 // BuildDistro variable will be replaced at link time after `make` has been run.
 var BuildDistro = "build_distro"
-


### PR DESCRIPTION
Tip:

To run goimports (which the Go team highly recommends) as a save hook, put this in your `~/.vimrc` file:

```
Glug codefmt gofmt_executable="goimports"
Glug codefmt-google
autocmd FileType go AutoFormatBuffer gofmt
```