### PR TITLE
Update Fluent Bit default worker number to 8 to enable multithreading.

### DIFF
--- a/confgenerator/testdata/valid/linux/default_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/default_config/golden_fluent_bit_main.conf
@@ -133,6 +133,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -150,6 +151,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(syslog)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/linux/empty_log_service/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/empty_log_service/golden_fluent_bit_main.conf
@@ -88,6 +88,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/linux/logging-complex_logs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs/golden_fluent_bit_main.conf
@@ -268,6 +268,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(log_source_id1|log_source_id2|test_syslog_source_id_tcp|test_syslog_source_id_udp)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -285,6 +286,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_fluent_bit_main.conf
@@ -280,6 +280,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(log_source_id1|log_source_id2|test_syslog_source_id_tcp|test_syslog_source_id_udp)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -297,6 +298,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_fluent_bit_main.conf
@@ -323,6 +323,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(log_source_id1|log_source_id2|log_source_id3|log_source_id4|log_source_id5)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -340,6 +341,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_fluent_bit_main.conf
@@ -174,6 +174,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -191,6 +192,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(test_syslog_source_id_tcp|test_syslog_source_id_udp)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/linux/logging-mutiple_google_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-mutiple_google_exporters/golden_fluent_bit_main.conf
@@ -323,6 +323,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(log_source_id1|log_source_id3)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -340,6 +341,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(log_source_id2|log_source_id4|log_source_id5)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -357,6 +359,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/linux/logging-no_conf/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-no_conf/golden_fluent_bit_main.conf
@@ -88,6 +88,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_fluent_bit_main.conf
@@ -133,6 +133,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -150,6 +151,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(syslog)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/linux/metrics-no_conf/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-no_conf/golden_fluent_bit_main.conf
@@ -133,6 +133,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -150,6 +151,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(syslog)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/windows/default_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/default_config/golden_fluent_bit_main.conf
@@ -105,6 +105,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -122,6 +123,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(syslog)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_fluent_bit_main.conf
@@ -181,6 +181,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -198,6 +199,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(windows_event_log|log_source_id1|log_source_id2)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/windows/logging-no_conf/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-no_conf/golden_fluent_bit_main.conf
@@ -60,6 +60,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_fluent_bit_main.conf
@@ -85,6 +85,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -102,6 +103,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(windows_event_log)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/windows/metrics-no_conf/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-no_conf/golden_fluent_bit_main.conf
@@ -85,6 +85,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -102,6 +103,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(windows_event_log)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_fluent_bit_main.conf
@@ -85,6 +85,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -102,6 +103,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(windows_event_log)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_fluent_bit_main.conf
@@ -85,6 +85,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -102,6 +103,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(windows_event_log)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/windows/valid_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/valid_config/golden_fluent_bit_main.conf
@@ -85,6 +85,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -102,6 +103,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version,gzip(gfe))
+    workers           8
     Match_Regex       ^(windows_event_log)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/fluentbit/conf/conf.go
+++ b/fluentbit/conf/conf.go
@@ -256,6 +256,7 @@ const (
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent {{.UserAgent}}
+    workers           8
     Match_Regex       ^({{.Match}})$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/fluentbit/conf/conf_test.go
+++ b/fluentbit/conf/conf_test.go
@@ -604,6 +604,7 @@ func TestStackdriver(t *testing.T) {
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent user_agent
+    workers           8
     Match_Regex       ^(test_match)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries


### PR DESCRIPTION
The actual change is only in `fluentbit/conf/conf.go`.

Tested by b/182365367