### PR TITLE
no fluentbit include/ dir

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,13 +52,12 @@ function build_fluentbit() {
   cd submodules/fluent-bit
   mkdir -p build
   cd build
-  cmake .. -DCMAKE_INSTALL_PREFIX=$subagentdir/fluent-bit -DFLB_HTTP_SERVER=ON -DFLB_DEBUG=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo
+  cmake .. -DCMAKE_INSTALL_PREFIX=$subagentdir/fluent-bit -DFLB_HTTP_SERVER=ON -DFLB_DEBUG=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITHOUT_HEADERS=ON
   make -j8
   make DESTDIR="$DESTDIR" install
   # We don't want fluent-bit's service
   rm "$DESTDIR/lib/systemd/system/fluent-bit.service"
   rm -r "${DESTDIR}${subagentdir}/fluent-bit/etc"
-  rm -r "${DESTDIR}${subagentdir}/fluent-bit/include"
 }
 
 function build_opsagent() {

--- a/build.sh
+++ b/build.sh
@@ -52,12 +52,13 @@ function build_fluentbit() {
   cd submodules/fluent-bit
   mkdir -p build
   cd build
-  cmake .. -DCMAKE_INSTALL_PREFIX=$subagentdir/fluent-bit -DFLB_HTTP_SERVER=On -DCMAKE_BUILD_TYPE=RELWITHDEBINFO
+  cmake .. -DCMAKE_INSTALL_PREFIX=$subagentdir/fluent-bit -DFLB_HTTP_SERVER=ON -DFLB_DEBUG=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo
   make -j8
   make DESTDIR="$DESTDIR" install
   # We don't want fluent-bit's service
   rm "$DESTDIR/lib/systemd/system/fluent-bit.service"
-  rm -r "$DESTDIR$subagentdir/fluent-bit/etc"
+  rm -r "${DESTDIR}${subagentdir}/fluent-bit/etc"
+  rm -r "${DESTDIR}${subagentdir}/fluent-bit/include"
 }
 
 function build_opsagent() {


### PR DESCRIPTION
The include dir should not be included in the main ops-agent package. If we needed this, the norm would be to ship it in a -devel package. I don't think we need it at all, though.

FLB_DEBUG defaults to true, and if set it overrides CMAKE_BUILD_TYPE to 'Debug'. Since I infer from the line that RelWithDebInfo is the desired target, this PR also sets FLB_DEBUG to false.