### PR TITLE
Fix the tcp_connection metrics for the missing port and tcp_state labels

### DIFF
--- a/confgenerator/testdata/valid/linux/default_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/default_config/golden_otel.conf
@@ -243,8 +243,11 @@ processors:
             new_label: tcp_state
           # remove protocol label
           - action: aggregate_labels
-            label_set: [ state ]
+            label_set: [ tcp_state ]
             aggregation_type: sum
+	  - action: add_label
+	    new_label: port
+	    new_value: all
       # system.paging.usage -> swap/bytes_used
       - metric_name: system.paging.usage
         action: update

--- a/confgenerator/testdata/valid/linux/empty_log_service/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/empty_log_service/golden_otel.conf
@@ -243,8 +243,11 @@ processors:
             new_label: tcp_state
           # remove protocol label
           - action: aggregate_labels
-            label_set: [ state ]
+            label_set: [ tcp_state ]
             aggregation_type: sum
+	  - action: add_label
+	    new_label: port
+	    new_value: all
       # system.paging.usage -> swap/bytes_used
       - metric_name: system.paging.usage
         action: update

--- a/confgenerator/testdata/valid/linux/logging-complex_logs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs/golden_otel.conf
@@ -243,8 +243,11 @@ processors:
             new_label: tcp_state
           # remove protocol label
           - action: aggregate_labels
-            label_set: [ state ]
+            label_set: [ tcp_state ]
             aggregation_type: sum
+	  - action: add_label
+	    new_label: port
+	    new_value: all
       # system.paging.usage -> swap/bytes_used
       - metric_name: system.paging.usage
         action: update

--- a/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_otel.conf
@@ -243,8 +243,11 @@ processors:
             new_label: tcp_state
           # remove protocol label
           - action: aggregate_labels
-            label_set: [ state ]
+            label_set: [ tcp_state ]
             aggregation_type: sum
+	  - action: add_label
+	    new_label: port
+	    new_value: all
       # system.paging.usage -> swap/bytes_used
       - metric_name: system.paging.usage
         action: update

--- a/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_otel.conf
@@ -243,8 +243,11 @@ processors:
             new_label: tcp_state
           # remove protocol label
           - action: aggregate_labels
-            label_set: [ state ]
+            label_set: [ tcp_state ]
             aggregation_type: sum
+	  - action: add_label
+	    new_label: port
+	    new_value: all
       # system.paging.usage -> swap/bytes_used
       - metric_name: system.paging.usage
         action: update

--- a/confgenerator/testdata/valid/linux/logging-multiple_google_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_google_exporters/golden_otel.conf
@@ -243,8 +243,11 @@ processors:
             new_label: tcp_state
           # remove protocol label
           - action: aggregate_labels
-            label_set: [ state ]
+            label_set: [ tcp_state ]
             aggregation_type: sum
+	  - action: add_label
+	    new_label: port
+	    new_value: all
       # system.paging.usage -> swap/bytes_used
       - metric_name: system.paging.usage
         action: update

--- a/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_otel.conf
@@ -243,8 +243,11 @@ processors:
             new_label: tcp_state
           # remove protocol label
           - action: aggregate_labels
-            label_set: [ state ]
+            label_set: [ tcp_state ]
             aggregation_type: sum
+	  - action: add_label
+	    new_label: port
+	    new_value: all
       # system.paging.usage -> swap/bytes_used
       - metric_name: system.paging.usage
         action: update

--- a/confgenerator/testdata/valid/linux/logging-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-no_conf/golden_otel.conf
@@ -243,8 +243,11 @@ processors:
             new_label: tcp_state
           # remove protocol label
           - action: aggregate_labels
-            label_set: [ state ]
+            label_set: [ tcp_state ]
             aggregation_type: sum
+	  - action: add_label
+	    new_label: port
+	    new_value: all
       # system.paging.usage -> swap/bytes_used
       - metric_name: system.paging.usage
         action: update

--- a/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_otel.conf
@@ -243,8 +243,11 @@ processors:
             new_label: tcp_state
           # remove protocol label
           - action: aggregate_labels
-            label_set: [ state ]
+            label_set: [ tcp_state ]
             aggregation_type: sum
+	  - action: add_label
+	    new_label: port
+	    new_value: all
       # system.paging.usage -> swap/bytes_used
       - metric_name: system.paging.usage
         action: update

--- a/confgenerator/testdata/valid/linux/metrics-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-no_conf/golden_otel.conf
@@ -232,8 +232,11 @@ processors:
             new_label: tcp_state
           # remove protocol label
           - action: aggregate_labels
-            label_set: [ state ]
+            label_set: [ tcp_state ]
             aggregation_type: sum
+	  - action: add_label
+	    new_label: port
+	    new_value: all
       # system.paging.usage -> swap/bytes_used
       - metric_name: system.paging.usage
         action: update

--- a/confgenerator/testdata/valid/windows/default_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/default_config/golden_otel.conf
@@ -272,8 +272,11 @@ processors:
             new_label: tcp_state
           # remove protocol label
           - action: aggregate_labels
-            label_set: [ state ]
+            label_set: [ tcp_state ]
             aggregation_type: sum
+	  - action: add_label
+	    new_label: port
+	    new_value: all
       # system.paging.usage -> swap/bytes_used
       - metric_name: system.paging.usage
         action: update

--- a/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_otel.conf
@@ -272,8 +272,11 @@ processors:
             new_label: tcp_state
           # remove protocol label
           - action: aggregate_labels
-            label_set: [ state ]
+            label_set: [ tcp_state ]
             aggregation_type: sum
+	  - action: add_label
+	    new_label: port
+	    new_value: all
       # system.paging.usage -> swap/bytes_used
       - metric_name: system.paging.usage
         action: update

--- a/confgenerator/testdata/valid/windows/logging-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-no_conf/golden_otel.conf
@@ -272,8 +272,11 @@ processors:
             new_label: tcp_state
           # remove protocol label
           - action: aggregate_labels
-            label_set: [ state ]
+            label_set: [ tcp_state ]
             aggregation_type: sum
+	  - action: add_label
+	    new_label: port
+	    new_value: all
       # system.paging.usage -> swap/bytes_used
       - metric_name: system.paging.usage
         action: update

--- a/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_otel.conf
@@ -243,8 +243,11 @@ processors:
             new_label: tcp_state
           # remove protocol label
           - action: aggregate_labels
-            label_set: [ state ]
+            label_set: [ tcp_state ]
             aggregation_type: sum
+	  - action: add_label
+	    new_label: port
+	    new_value: all
       # system.paging.usage -> swap/bytes_used
       - metric_name: system.paging.usage
         action: update

--- a/confgenerator/testdata/valid/windows/metrics-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-no_conf/golden_otel.conf
@@ -232,8 +232,11 @@ processors:
             new_label: tcp_state
           # remove protocol label
           - action: aggregate_labels
-            label_set: [ state ]
+            label_set: [ tcp_state ]
             aggregation_type: sum
+	  - action: add_label
+	    new_label: port
+	    new_value: all
       # system.paging.usage -> swap/bytes_used
       - metric_name: system.paging.usage
         action: update

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_otel.conf
@@ -255,8 +255,11 @@ processors:
             new_label: tcp_state
           # remove protocol label
           - action: aggregate_labels
-            label_set: [ state ]
+            label_set: [ tcp_state ]
             aggregation_type: sum
+	  - action: add_label
+	    new_label: port
+	    new_value: all
       # system.paging.usage -> swap/bytes_used
       - metric_name: system.paging.usage
         action: update

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_otel.conf
@@ -260,8 +260,11 @@ processors:
             new_label: tcp_state
           # remove protocol label
           - action: aggregate_labels
-            label_set: [ state ]
+            label_set: [ tcp_state ]
             aggregation_type: sum
+	  - action: add_label
+	    new_label: port
+	    new_value: all
       # system.paging.usage -> swap/bytes_used
       - metric_name: system.paging.usage
         action: update

--- a/confgenerator/testdata/valid/windows/valid_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/valid_config/golden_otel.conf
@@ -272,8 +272,11 @@ processors:
             new_label: tcp_state
           # remove protocol label
           - action: aggregate_labels
-            label_set: [ state ]
+            label_set: [ tcp_state ]
             aggregation_type: sum
+	  - action: add_label
+	    new_label: port
+	    new_value: all
       # system.paging.usage -> swap/bytes_used
       - metric_name: system.paging.usage
         action: update

--- a/otel/conf.go
+++ b/otel/conf.go
@@ -365,8 +365,11 @@ windowsperfcounters/mssql_{{.MSSQLID}}:
             new_label: tcp_state
           # remove protocol label
           - action: aggregate_labels
-            label_set: [ state ]
+            label_set: [ tcp_state ]
             aggregation_type: sum
+	  - action: add_label
+	    new_label: port
+	    new_value: all
       # system.paging.usage -> swap/bytes_used
       - metric_name: system.paging.usage
         action: update

--- a/otel/conf_test.go
+++ b/otel/conf_test.go
@@ -466,8 +466,11 @@ processors:
             new_label: tcp_state
           # remove protocol label
           - action: aggregate_labels
-            label_set: [ state ]
+            label_set: [ tcp_state ]
             aggregation_type: sum
+	  - action: add_label
+	    new_label: port
+	    new_value: all
       # system.paging.usage -> swap/bytes_used
       - metric_name: system.paging.usage
         action: update


### PR DESCRIPTION
Test evidence:
[
![Screen Shot 2021-06-14 at 4 35 10 PM](https://user-images.githubusercontent.com/8354694/121955963-8f390300-cd2e-11eb-96f3-696883137246.png)
](url)