### PR TITLE
Disable multithreading on Windows by forcing the workers to be 1.

### DIFF
--- a/confgenerator/testdata/valid/windows/default_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/default_config/golden_fluent_bit_main.conf
@@ -85,7 +85,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    workers           8
+    workers           1
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -103,7 +103,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    workers           8
+    workers           1
     Match_Regex       ^(windows_event_log)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_fluent_bit_main.conf
@@ -181,7 +181,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    workers           8
+    workers           1
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -199,7 +199,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    workers           8
+    workers           1
     Match_Regex       ^(windows_event_log|log_source_id1|log_source_id2)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/windows/logging-no_conf/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-no_conf/golden_fluent_bit_main.conf
@@ -60,7 +60,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    workers           8
+    workers           1
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_fluent_bit_main.conf
@@ -85,7 +85,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    workers           8
+    workers           1
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -103,7 +103,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    workers           8
+    workers           1
     Match_Regex       ^(windows_event_log)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/windows/metrics-no_conf/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-no_conf/golden_fluent_bit_main.conf
@@ -85,7 +85,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    workers           8
+    workers           1
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -103,7 +103,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    workers           8
+    workers           1
     Match_Regex       ^(windows_event_log)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_fluent_bit_main.conf
@@ -85,7 +85,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    workers           8
+    workers           1
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -103,7 +103,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    workers           8
+    workers           1
     Match_Regex       ^(windows_event_log)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_fluent_bit_main.conf
@@ -85,7 +85,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    workers           8
+    workers           1
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -103,7 +103,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    workers           8
+    workers           1
     Match_Regex       ^(windows_event_log)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/confgenerator/testdata/valid/windows/valid_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/valid_config/golden_fluent_bit_main.conf
@@ -85,7 +85,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    workers           8
+    workers           1
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -103,7 +103,7 @@
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    workers           8
+    workers           1
     Match_Regex       ^(windows_event_log)$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries

--- a/fluentbit/conf/conf.go
+++ b/fluentbit/conf/conf.go
@@ -256,7 +256,7 @@ const (
     Name              stackdriver
     resource          gce_instance
     stackdriver_agent {{.UserAgent}}
-    workers           8
+    workers           {{.Workers}}
     Match_Regex       ^({{.Match}})$
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
@@ -742,11 +742,12 @@ func (w WindowsEventlog) renderConfig() (string, error) {
 type Stackdriver struct {
 	Match     string
 	UserAgent string
+	Workers   int
 }
 
 var stackdriverTemplate = template.Must(template.New("stackdriver").Parse(stackdriverConf))
 
-// renderConfig generates a section for configure fluentBit syslog input plugin.
+// renderConfig generates a section for configure fluentBit stackdriver output plugin.
 func (s Stackdriver) renderConfig() (string, error) {
 	if s.Match == "" {
 		return "", emptyFieldErr{
@@ -758,6 +759,12 @@ func (s Stackdriver) renderConfig() (string, error) {
 		return "", emptyFieldErr{
 			plugin: "stackdriver",
 			field:  "stackdriver_agent",
+		}
+	}
+	if s.Workers == 0 {
+		return "", emptyFieldErr{
+			plugin: "stackdriver",
+			field:  "workers",
 		}
 	}
 

--- a/fluentbit/conf/conf_test.go
+++ b/fluentbit/conf/conf_test.go
@@ -598,6 +598,7 @@ func TestStackdriver(t *testing.T) {
 	s := Stackdriver{
 		Match:     "test_match",
 		UserAgent: "user_agent",
+		Workers:   8,
 	}
 	want := `[OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver


### PR DESCRIPTION
Temporary workaround for b/190806301.