### PR TITLE
Scale up process/cpu_time from seconds to microseconds and ignore value for state=`wait`

### DIFF
--- a/confgenerator/testdata/valid/linux/default_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/default_config/golden_otel.conf
@@ -299,6 +299,11 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          - action: delete_label_value
+            label: state
+            label_value: wait
+          - action: experimental_scale_value
+            experimental_scale: 1000000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
           - action: add_label

--- a/confgenerator/testdata/valid/linux/default_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/default_config/golden_otel.conf
@@ -299,9 +299,6 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
-          - action: delete_label_value
-            label: state
-            label_value: wait
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -309,6 +306,9 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          - action: delete_label_value
+            label: state
+            label_value: wait
           # change label state -> user_or_syst
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/linux/default_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/default_config/golden_otel.conf
@@ -299,6 +299,7 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          # scale from seconds to microseconds
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -306,6 +307,7 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          # retain only user and syst state label values
           - action: delete_label_value
             label: state
             label_value: wait

--- a/confgenerator/testdata/valid/linux/empty_log_service/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/empty_log_service/golden_otel.conf
@@ -299,6 +299,11 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          - action: delete_label_value
+            label: state
+            label_value: wait
+          - action: experimental_scale_value
+            experimental_scale: 1000000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
           - action: add_label

--- a/confgenerator/testdata/valid/linux/empty_log_service/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/empty_log_service/golden_otel.conf
@@ -299,9 +299,6 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
-          - action: delete_label_value
-            label: state
-            label_value: wait
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -309,6 +306,9 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          - action: delete_label_value
+            label: state
+            label_value: wait
           # change label state -> user_or_syst
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/linux/empty_log_service/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/empty_log_service/golden_otel.conf
@@ -299,6 +299,7 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          # scale from seconds to microseconds
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -306,6 +307,7 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          # retain only user and syst state label values
           - action: delete_label_value
             label: state
             label_value: wait

--- a/confgenerator/testdata/valid/linux/logging-complex_logs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs/golden_otel.conf
@@ -299,6 +299,11 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          - action: delete_label_value
+            label: state
+            label_value: wait
+          - action: experimental_scale_value
+            experimental_scale: 1000000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
           - action: add_label

--- a/confgenerator/testdata/valid/linux/logging-complex_logs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs/golden_otel.conf
@@ -299,9 +299,6 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
-          - action: delete_label_value
-            label: state
-            label_value: wait
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -309,6 +306,9 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          - action: delete_label_value
+            label: state
+            label_value: wait
           # change label state -> user_or_syst
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/linux/logging-complex_logs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs/golden_otel.conf
@@ -299,6 +299,7 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          # scale from seconds to microseconds
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -306,6 +307,7 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          # retain only user and syst state label values
           - action: delete_label_value
             label: state
             label_value: wait

--- a/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_otel.conf
@@ -299,6 +299,11 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          - action: delete_label_value
+            label: state
+            label_value: wait
+          - action: experimental_scale_value
+            experimental_scale: 1000000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
           - action: add_label

--- a/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_otel.conf
@@ -299,9 +299,6 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
-          - action: delete_label_value
-            label: state
-            label_value: wait
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -309,6 +306,9 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          - action: delete_label_value
+            label: state
+            label_value: wait
           # change label state -> user_or_syst
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_otel.conf
@@ -299,6 +299,7 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          # scale from seconds to microseconds
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -306,6 +307,7 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          # retain only user and syst state label values
           - action: delete_label_value
             label: state
             label_value: wait

--- a/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_otel.conf
@@ -299,6 +299,11 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          - action: delete_label_value
+            label: state
+            label_value: wait
+          - action: experimental_scale_value
+            experimental_scale: 1000000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
           - action: add_label

--- a/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_otel.conf
@@ -299,9 +299,6 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
-          - action: delete_label_value
-            label: state
-            label_value: wait
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -309,6 +306,9 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          - action: delete_label_value
+            label: state
+            label_value: wait
           # change label state -> user_or_syst
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_otel.conf
@@ -299,6 +299,7 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          # scale from seconds to microseconds
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -306,6 +307,7 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          # retain only user and syst state label values
           - action: delete_label_value
             label: state
             label_value: wait

--- a/confgenerator/testdata/valid/linux/logging-multiple_google_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_google_exporters/golden_otel.conf
@@ -299,6 +299,11 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          - action: delete_label_value
+            label: state
+            label_value: wait
+          - action: experimental_scale_value
+            experimental_scale: 1000000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
           - action: add_label

--- a/confgenerator/testdata/valid/linux/logging-multiple_google_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_google_exporters/golden_otel.conf
@@ -299,9 +299,6 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
-          - action: delete_label_value
-            label: state
-            label_value: wait
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -309,6 +306,9 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          - action: delete_label_value
+            label: state
+            label_value: wait
           # change label state -> user_or_syst
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/linux/logging-multiple_google_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_google_exporters/golden_otel.conf
@@ -299,6 +299,7 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          # scale from seconds to microseconds
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -306,6 +307,7 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          # retain only user and syst state label values
           - action: delete_label_value
             label: state
             label_value: wait

--- a/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_otel.conf
@@ -299,6 +299,11 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          - action: delete_label_value
+            label: state
+            label_value: wait
+          - action: experimental_scale_value
+            experimental_scale: 1000000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
           - action: add_label

--- a/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_otel.conf
@@ -299,9 +299,6 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
-          - action: delete_label_value
-            label: state
-            label_value: wait
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -309,6 +306,9 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          - action: delete_label_value
+            label: state
+            label_value: wait
           # change label state -> user_or_syst
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_otel.conf
@@ -299,6 +299,7 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          # scale from seconds to microseconds
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -306,6 +307,7 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          # retain only user and syst state label values
           - action: delete_label_value
             label: state
             label_value: wait

--- a/confgenerator/testdata/valid/linux/logging-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-no_conf/golden_otel.conf
@@ -299,6 +299,11 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          - action: delete_label_value
+            label: state
+            label_value: wait
+          - action: experimental_scale_value
+            experimental_scale: 1000000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
           - action: add_label

--- a/confgenerator/testdata/valid/linux/logging-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-no_conf/golden_otel.conf
@@ -299,9 +299,6 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
-          - action: delete_label_value
-            label: state
-            label_value: wait
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -309,6 +306,9 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          - action: delete_label_value
+            label: state
+            label_value: wait
           # change label state -> user_or_syst
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/linux/logging-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-no_conf/golden_otel.conf
@@ -299,6 +299,7 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          # scale from seconds to microseconds
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -306,6 +307,7 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          # retain only user and syst state label values
           - action: delete_label_value
             label: state
             label_value: wait

--- a/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_otel.conf
@@ -299,6 +299,11 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          - action: delete_label_value
+            label: state
+            label_value: wait
+          - action: experimental_scale_value
+            experimental_scale: 1000000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
           - action: add_label

--- a/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_otel.conf
@@ -299,9 +299,6 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
-          - action: delete_label_value
-            label: state
-            label_value: wait
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -309,6 +306,9 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          - action: delete_label_value
+            label: state
+            label_value: wait
           # change label state -> user_or_syst
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_otel.conf
@@ -299,6 +299,7 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          # scale from seconds to microseconds
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -306,6 +307,7 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          # retain only user and syst state label values
           - action: delete_label_value
             label: state
             label_value: wait

--- a/confgenerator/testdata/valid/linux/metrics-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-no_conf/golden_otel.conf
@@ -288,6 +288,11 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          - action: delete_label_value
+            label: state
+            label_value: wait
+          - action: experimental_scale_value
+            experimental_scale: 1000000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
           - action: add_label

--- a/confgenerator/testdata/valid/linux/metrics-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-no_conf/golden_otel.conf
@@ -288,9 +288,6 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
-          - action: delete_label_value
-            label: state
-            label_value: wait
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -298,6 +295,9 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          - action: delete_label_value
+            label: state
+            label_value: wait
           # change label state -> user_or_syst
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/linux/metrics-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-no_conf/golden_otel.conf
@@ -288,6 +288,7 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          # scale from seconds to microseconds
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -295,6 +296,7 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          # retain only user and syst state label values
           - action: delete_label_value
             label: state
             label_value: wait

--- a/confgenerator/testdata/valid/windows/default_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/default_config/golden_otel.conf
@@ -328,9 +328,6 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
-          - action: delete_label_value
-            label: state
-            label_value: wait
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -338,6 +335,9 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          - action: delete_label_value
+            label: state
+            label_value: wait
           # change label state -> user_or_syst
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/windows/default_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/default_config/golden_otel.conf
@@ -328,6 +328,7 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          # scale from seconds to microseconds
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -335,6 +336,7 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          # retain only user and syst state label values
           - action: delete_label_value
             label: state
             label_value: wait

--- a/confgenerator/testdata/valid/windows/default_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/default_config/golden_otel.conf
@@ -328,6 +328,11 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          - action: delete_label_value
+            label: state
+            label_value: wait
+          - action: experimental_scale_value
+            experimental_scale: 1000000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
           - action: add_label

--- a/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_otel.conf
@@ -328,9 +328,6 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
-          - action: delete_label_value
-            label: state
-            label_value: wait
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -338,6 +335,9 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          - action: delete_label_value
+            label: state
+            label_value: wait
           # change label state -> user_or_syst
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_otel.conf
@@ -328,6 +328,7 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          # scale from seconds to microseconds
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -335,6 +336,7 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          # retain only user and syst state label values
           - action: delete_label_value
             label: state
             label_value: wait

--- a/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_otel.conf
@@ -328,6 +328,11 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          - action: delete_label_value
+            label: state
+            label_value: wait
+          - action: experimental_scale_value
+            experimental_scale: 1000000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
           - action: add_label

--- a/confgenerator/testdata/valid/windows/logging-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-no_conf/golden_otel.conf
@@ -328,9 +328,6 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
-          - action: delete_label_value
-            label: state
-            label_value: wait
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -338,6 +335,9 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          - action: delete_label_value
+            label: state
+            label_value: wait
           # change label state -> user_or_syst
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/windows/logging-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-no_conf/golden_otel.conf
@@ -328,6 +328,7 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          # scale from seconds to microseconds
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -335,6 +336,7 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          # retain only user and syst state label values
           - action: delete_label_value
             label: state
             label_value: wait

--- a/confgenerator/testdata/valid/windows/logging-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-no_conf/golden_otel.conf
@@ -328,6 +328,11 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          - action: delete_label_value
+            label: state
+            label_value: wait
+          - action: experimental_scale_value
+            experimental_scale: 1000000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
           - action: add_label

--- a/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_otel.conf
@@ -299,6 +299,11 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          - action: delete_label_value
+            label: state
+            label_value: wait
+          - action: experimental_scale_value
+            experimental_scale: 1000000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
           - action: add_label

--- a/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_otel.conf
@@ -299,9 +299,6 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
-          - action: delete_label_value
-            label: state
-            label_value: wait
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -309,6 +306,9 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          - action: delete_label_value
+            label: state
+            label_value: wait
           # change label state -> user_or_syst
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_otel.conf
@@ -299,6 +299,7 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          # scale from seconds to microseconds
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -306,6 +307,7 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          # retain only user and syst state label values
           - action: delete_label_value
             label: state
             label_value: wait

--- a/confgenerator/testdata/valid/windows/metrics-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-no_conf/golden_otel.conf
@@ -288,6 +288,11 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          - action: delete_label_value
+            label: state
+            label_value: wait
+          - action: experimental_scale_value
+            experimental_scale: 1000000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
           - action: add_label

--- a/confgenerator/testdata/valid/windows/metrics-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-no_conf/golden_otel.conf
@@ -288,9 +288,6 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
-          - action: delete_label_value
-            label: state
-            label_value: wait
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -298,6 +295,9 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          - action: delete_label_value
+            label: state
+            label_value: wait
           # change label state -> user_or_syst
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/windows/metrics-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-no_conf/golden_otel.conf
@@ -288,6 +288,7 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          # scale from seconds to microseconds
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -295,6 +296,7 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          # retain only user and syst state label values
           - action: delete_label_value
             label: state
             label_value: wait

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_otel.conf
@@ -311,6 +311,7 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          # scale from seconds to microseconds
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -318,6 +319,7 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          # retain only user and syst state label values
           - action: delete_label_value
             label: state
             label_value: wait

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_otel.conf
@@ -311,6 +311,11 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          - action: delete_label_value
+            label: state
+            label_value: wait
+          - action: experimental_scale_value
+            experimental_scale: 1000000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
           - action: add_label

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_otel.conf
@@ -311,9 +311,6 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
-          - action: delete_label_value
-            label: state
-            label_value: wait
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -321,6 +318,9 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          - action: delete_label_value
+            label: state
+            label_value: wait
           # change label state -> user_or_syst
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_otel.conf
@@ -316,9 +316,6 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
-          - action: delete_label_value
-            label: state
-            label_value: wait
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -326,6 +323,9 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          - action: delete_label_value
+            label: state
+            label_value: wait
           # change label state -> user_or_syst
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_otel.conf
@@ -316,6 +316,11 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          - action: delete_label_value
+            label: state
+            label_value: wait
+          - action: experimental_scale_value
+            experimental_scale: 1000000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
           - action: add_label

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_otel.conf
@@ -316,6 +316,7 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          # scale from seconds to microseconds
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -323,6 +324,7 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          # retain only user and syst state label values
           - action: delete_label_value
             label: state
             label_value: wait

--- a/confgenerator/testdata/valid/windows/valid_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/valid_config/golden_otel.conf
@@ -328,9 +328,6 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
-          - action: delete_label_value
-            label: state
-            label_value: wait
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -338,6 +335,9 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          - action: delete_label_value
+            label: state
+            label_value: wait
           # change label state -> user_or_syst
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/windows/valid_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/valid_config/golden_otel.conf
@@ -328,6 +328,7 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          # scale from seconds to microseconds
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -335,6 +336,7 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          # retain only user and syst state label values
           - action: delete_label_value
             label: state
             label_value: wait

--- a/confgenerator/testdata/valid/windows/valid_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/valid_config/golden_otel.conf
@@ -328,6 +328,11 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          - action: delete_label_value
+            label: state
+            label_value: wait
+          - action: experimental_scale_value
+            experimental_scale: 1000000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
           - action: add_label

--- a/otel/conf.go
+++ b/otel/conf.go
@@ -421,9 +421,6 @@ windowsperfcounters/mssql_{{.MSSQLID}}:
         action: update
         new_name: processes/cpu_time
         operations:
-          - action: delete_label_value
-            label: state
-            label_value: wait
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -431,6 +428,9 @@ windowsperfcounters/mssql_{{.MSSQLID}}:
           - action: add_label
             new_label: process
             new_value: all
+          - action: delete_label_value
+            label: state
+            label_value: wait
           # change label state -> user_or_syst
           - action: update_label
             label: state

--- a/otel/conf.go
+++ b/otel/conf.go
@@ -421,6 +421,11 @@ windowsperfcounters/mssql_{{.MSSQLID}}:
         action: update
         new_name: processes/cpu_time
         operations:
+          - action: delete_label_value
+            label: state
+            label_value: wait
+          - action: experimental_scale_value
+            experimental_scale: 1000000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
           - action: add_label

--- a/otel/conf.go
+++ b/otel/conf.go
@@ -421,6 +421,7 @@ windowsperfcounters/mssql_{{.MSSQLID}}:
         action: update
         new_name: processes/cpu_time
         operations:
+          # scale from seconds to microseconds
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -428,6 +429,7 @@ windowsperfcounters/mssql_{{.MSSQLID}}:
           - action: add_label
             new_label: process
             new_value: all
+          # retain only user and syst state label values
           - action: delete_label_value
             label: state
             label_value: wait

--- a/otel/conf_test.go
+++ b/otel/conf_test.go
@@ -522,9 +522,6 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
-          - action: delete_label_value
-            label: state
-            label_value: wait
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -532,6 +529,9 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          - action: delete_label_value
+            label: state
+            label_value: wait
           # change label state -> user_or_syst
           - action: update_label
             label: state

--- a/otel/conf_test.go
+++ b/otel/conf_test.go
@@ -522,6 +522,11 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          - action: delete_label_value
+            label: state
+            label_value: wait
+          - action: experimental_scale_value
+            experimental_scale: 1000000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
           - action: add_label

--- a/otel/conf_test.go
+++ b/otel/conf_test.go
@@ -522,6 +522,7 @@ processors:
         action: update
         new_name: processes/cpu_time
         operations:
+          # scale from seconds to microseconds
           - action: experimental_scale_value
             experimental_scale: 1000000
           # change data type from double -> int64
@@ -529,6 +530,7 @@ processors:
           - action: add_label
             new_label: process
             new_value: all
+          # retain only user and syst state label values
           - action: delete_label_value
             label: state
             label_value: wait


### PR DESCRIPTION
Test Evidence
```
Metric #24
Descriptor:
     -> Name: processes/cpu_time
     -> Description: Total CPU seconds broken down by different states.
     -> Unit: s
     -> DataType: IntSum
     -> IsMonotonic: true
     -> AggregationTemporality: AGGREGATION_TEMPORALITY_CUMULATIVE
IntDataPoints #0
Data point labels:
     -> command: systemd
     -> command_line: /sbin/init
     -> owner: root
     -> pid: 1
     -> user_or_syst: user
StartTimestamp: 2021-04-29 23:56:14 +0000 UTC
Timestamp: 2021-06-21 20:05:00.068115162 +0000 UTC
Value: 14000000
IntDataPoints #1
Data point labels:
     -> command: systemd
     -> command_line: /sbin/init
     -> owner: root
     -> pid: 1
     -> user_or_syst: syst
StartTimestamp: 2021-04-29 23:56:14 +0000 UTC
Timestamp: 2021-06-21 20:05:00.068115162 +0000 UTC
Value: 15100000
IntDataPoints #2
Data point labels:
     -> command: systemd-journald
     -> command_line: /lib/systemd/systemd-journald
     -> owner: root
     -> pid: 416
     -> user_or_syst: user
StartTimestamp: 2021-04-29 23:56:14 +0000 UTC
Timestamp: 2021-06-21 20:05:00.068234149 +0000 UTC
Value: 162320000
```