### PR TITLE
Refactor and consolidate configuration validation.

### DIFF
--- a/cmd/ops_agent_windows/run_windows.go
+++ b/cmd/ops_agent_windows/run_windows.go
@@ -113,7 +113,7 @@ func (s *service) generateConfigs() error {
 	if err != nil {
 		return err
 	}
-	uc, err := config.ParseUnifiedConfig(data)
+	uc, err := config.ParseUnifiedConfig(data, "windows")
 	if err != nil {
 		return err
 	}

--- a/cmd/ops_agent_windows/run_windows.go
+++ b/cmd/ops_agent_windows/run_windows.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
+	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/config"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/debug"
 	"golang.org/x/sys/windows/svc/eventlog"
@@ -77,7 +78,7 @@ func (s *service) parseFlags(args []string) error {
 	return fs.Parse(allArgs)
 }
 
-func (s *service) checkForStandaloneAgents(unified *confgenerator.UnifiedConfig) error {
+func (s *service) checkForStandaloneAgents(unified *config.UnifiedConfig) error {
 	mgr, err := mgr.Connect()
 	if err != nil {
 		return fmt.Errorf("failed to connect to service manager: %s", err)
@@ -112,7 +113,7 @@ func (s *service) generateConfigs() error {
 	if err != nil {
 		return err
 	}
-	uc, err := confgenerator.ParseUnifiedConfig(data)
+	uc, err := config.ParseUnifiedConfig(data)
 	if err != nil {
 		return err
 	}
@@ -124,7 +125,8 @@ func (s *service) generateConfigs() error {
 		"otel",
 		"fluentbit",
 	} {
-		if err := uc.GenerateFiles(
+		if err := confgenerator.GenerateFilesFromConfig(
+			&uc,
 			subagent,
 			filepath.Join(os.Getenv("PROGRAMDATA"), dataDirectory, "log"),
 			filepath.Join(os.Getenv("PROGRAMDATA"), dataDirectory, "run"),

--- a/collectd/conf.go
+++ b/collectd/conf.go
@@ -22,33 +22,9 @@ import (
 	"strings"
 	"text/template"
 	"time"
+
+	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/config"
 )
-
-// Ops Agent config.
-// TODO(lingshi) Move these structs and the validation logic to the confgenerator folder. Make them pointers.
-type Metrics struct {
-	Receivers map[string]Receiver `yaml:"receivers"`
-	Exporters map[string]Exporter `yaml:"exporters"`
-	Service   Service             `yaml:"service"`
-}
-
-type Receiver struct {
-	Type               string `yaml:"type"`
-	CollectionInterval string `yaml:"collection_interval"` // time.Duration format
-}
-
-type Exporter struct {
-	Type string `yaml:"type"`
-}
-
-type Service struct {
-	Pipelines map[string]Pipeline `yaml:"pipelines"`
-}
-
-type Pipeline struct {
-	ReceiverIDs []string `yaml:"receivers"`
-	ExporterIDs []string `yaml:"exporters"`
-}
 
 // Collectd internal config related.
 type collectdConf struct {
@@ -152,7 +128,7 @@ func reservedIdPrefixError(component, id string) error {
 		component, id, component)
 }
 
-func GenerateCollectdConfig(metrics *Metrics, logsDir string) (string, error) {
+func GenerateCollectdConfig(metrics *config.Metrics, logsDir string) (string, error) {
 	var sb strings.Builder
 
 	collectdConf, err := validatedCollectdConfig(metrics)
@@ -176,7 +152,7 @@ func GenerateCollectdConfig(metrics *Metrics, logsDir string) (string, error) {
 	return sb.String(), nil
 }
 
-func validatedCollectdConfig(metrics *Metrics) (*collectdConf, error) {
+func validatedCollectdConfig(metrics *config.Metrics) (*collectdConf, error) {
 	collectdConf := collectdConf{
 		scrapeInternal:    defaultScrapeInterval,
 		enableHostMetrics: false,

--- a/collectd/conf.go
+++ b/collectd/conf.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strings"
 	"text/template"
-	"time"
 
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/config"
 )
@@ -180,13 +179,9 @@ func validatedCollectdConfig(metrics *config.Metrics) (*collectdConf, error) {
 		collectdConf.enableHostMetrics = true
 
 		if receiver.CollectionInterval != "" {
-			t, err := time.ParseDuration(receiver.CollectionInterval)
+			interval, err := config.ValidateCollectionInterval(receiverID, receiver.CollectionInterval)
 			if err != nil {
-				return nil, fmt.Errorf("parameter \"collection_interval\" in metrics receiver %q has invalid value %q that is not an interval (e.g. \"60s\"). Detailed error: %s", receiverID, receiver.CollectionInterval, err)
-			}
-			interval := t.Seconds()
-			if interval < 10 {
-				return nil, fmt.Errorf("parameter \"collection_interval\" in metrics receiver %q has invalid value \"%vs\" that is below the minimum threshold of \"10s\".", receiverID, interval)
+				return nil, err
 			}
 			collectdConf.scrapeInternal = interval
 		}

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -34,14 +34,16 @@ import (
 var (
 	// Supported component types.
 	supportedComponentTypes = map[string][]string{
-		"linux_logging_exporter":   []string{"google_cloud_logging"},
-		"linux_logging_receiver":   []string{"files", "syslog"},
-		"linux_metrics_exporter":   []string{"google_cloud_monitoring"},
-		"linux_metrics_receiver":   []string{"hostmetrics"},
-		"windows_logging_receiver": []string{"files", "syslog", "windows_event_log"},
-		"windows_logging_exporter": []string{"google_cloud_logging"},
-		"windows_metrics_receiver": []string{"hostmetrics", "iis", "mssql"},
-		"windows_metrics_exporter": []string{"google_cloud_monitoring"},
+		"linux_logging_receiver":    []string{"files", "syslog"},
+		"linux_logging_processor":   []string{"parse_json", "parse_regex"},
+		"linux_logging_exporter":    []string{"google_cloud_logging"},
+		"linux_metrics_receiver":    []string{"hostmetrics"},
+		"linux_metrics_exporter":    []string{"google_cloud_monitoring"},
+		"windows_logging_receiver":  []string{"files", "syslog", "windows_event_log"},
+		"windows_logging_processor": []string{"parse_json", "parse_regex"},
+		"windows_logging_exporter":  []string{"google_cloud_logging"},
+		"windows_metrics_receiver":  []string{"hostmetrics", "iis", "mssql"},
+		"windows_metrics_exporter":  []string{"google_cloud_monitoring"},
 	}
 
 	// Supported parameters.
@@ -808,7 +810,7 @@ func extractFluentBitParsers(processors map[string]*processor) ([]*conf.ParserJS
 			}
 			fbRegexParsers = append(fbRegexParsers, &fbRegexParser)
 		default:
-			return nil, nil, fmt.Errorf(`logging processor %q with type %q is not supported. Supported logging processor types: [parse_json, parse_regex].`, name, t)
+			return nil, nil, unsupportedComponentTypeError("linux", "logging", "processor", p.Type, name)
 		}
 	}
 	return fbJSONParsers, fbRegexParsers, nil

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -348,15 +348,6 @@ func generateOtelReceivers(receivers map[string]*config.MetricsReceiver, pipelin
 			}
 		}
 	}
-	if len(hostMetricsList) > 1 {
-		return nil, nil, nil, nil, fmt.Errorf(`at most one metrics receiver with type "hostmetrics" is allowed.`)
-	}
-	if len(mssqlList) > 1 {
-		return nil, nil, nil, nil, fmt.Errorf(`at most one metrics receiver with type "mssql" is allowed.`)
-	}
-	if len(iisList) > 1 {
-		return nil, nil, nil, nil, fmt.Errorf(`at most one metrics receiver with type "iis" is allowed.`)
-	}
 	return hostMetricsList, mssqlList, iisList, receiverNameMap, nil
 }
 
@@ -382,9 +373,6 @@ func generateOtelExporters(exporters map[string]*config.MetricsExporter, pipelin
 				}
 			}
 		}
-	}
-	if len(stackdriverList) > 1 {
-		return nil, nil, fmt.Errorf(`Only one exporter of the same type in [google_cloud_monitoring] is allowed.`)
 	}
 	return stackdriverList, exportNameMap, nil
 }

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -17,7 +17,6 @@ package confgenerator
 
 import (
 	"fmt"
-	"net"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -296,12 +295,6 @@ func extractReceiverFactories(receivers map[string]*config.LoggingReceiver) (map
 				ExcludePaths: r.ExcludePaths,
 			}
 		case "syslog":
-			if r.TransportProtocol != "tcp" && r.TransportProtocol != "udp" {
-				return nil, nil, nil, fmt.Errorf(`unknown transport_protocol %q in the logging receiver %q. Supported transport_protocol for %q type logging receiver: [tcp, udp].`, r.TransportProtocol, rID, r.Type)
-			}
-			if net.ParseIP(r.ListenHost) == nil {
-				return nil, nil, nil, fmt.Errorf(`unknown listen_host %q in the logging receiver %q. Value of listen_host for %q type logging receiver should be a valid IP.`, r.ListenHost, rID, r.Type)
-			}
 			syslogReceiverFactories[rID] = &syslogReceiverFactory{
 				TransportProtocol: r.TransportProtocol,
 				ListenHost:        r.ListenHost,

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -579,9 +579,6 @@ func generateFluentBitFilters(processors map[string]*config.LoggingProcessor, pi
 		pipeline := pipelines[pID]
 		for _, processorID := range pipeline.Processors {
 			p, ok := processors[processorID]
-			if !isDefaultProcessor(processorID) && !ok {
-				return nil, fmt.Errorf(`logging processor %q from pipeline %q is not defined.`, processorID, pID)
-			}
 			fbFilterParser := conf.FilterParser{
 				Match:   fmt.Sprintf("%s.*", pID),
 				Parser:  processorID,
@@ -594,16 +591,6 @@ func generateFluentBitFilters(processors map[string]*config.LoggingProcessor, pi
 		}
 	}
 	return fbFilterParsers, nil
-}
-
-func isDefaultProcessor(name string) bool {
-	switch name {
-	case "lib:apache", "lib:apache2", "lib:apache_error", "lib:mongodb", "lib:nginx",
-		"lib:syslog-rfc3164", "lib:syslog-rfc5424":
-		return true
-	default:
-		return false
-	}
 }
 
 func extractExporterPlugins(exporters map[string]*config.LoggingExporter, pipelines map[string]*config.LoggingPipeline, hostInfo *host.InfoStat) (
@@ -651,9 +638,6 @@ func extractExporterPlugins(exporters map[string]*config.LoggingExporter, pipeli
 func extractFluentBitParsers(processors map[string]*config.LoggingProcessor) ([]*conf.ParserJSON, []*conf.ParserRegex, error) {
 	fbJSONParsers := []*conf.ParserJSON{}
 	fbRegexParsers := []*conf.ParserRegex{}
-	if err := config.ValidateComponentIds(processors, "logging", "processor"); err != nil {
-		return nil, nil, err
-	}
 	for _, name := range config.SortedKeys(processors) {
 		p := processors[name]
 		cid := componentID{subagent: "logging", component: "processor", componentType: p.Type, id: name, platform: "linux"}

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
-	"sort"
 	"strings"
 	"text/template"
 
@@ -151,12 +150,7 @@ func generateOtelServices(receiverNameMap map[string]string, exporterNameMap map
 	if err := config.ValidateComponentIds(pipelines, "metrics", "pipeline"); err != nil {
 		return nil, err
 	}
-	var pipelineIDs []string
-	for p := range pipelines {
-		pipelineIDs = append(pipelineIDs, p)
-	}
-	sort.Strings(pipelineIDs)
-	for _, pID := range pipelineIDs {
+	for _, pID := range config.SortedKeys(pipelines) {
 		p := pipelines[pID]
 		for _, rID := range p.ReceiverIDs {
 			// TODO: Fix the platform. It should be "windows" for Windows and "linux" for Linux.
@@ -505,12 +499,7 @@ func generateOtelReceivers(receivers map[string]*config.MetricsReceiver, pipelin
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	var pipelineIDs []string
-	for p := range pipelines {
-		pipelineIDs = append(pipelineIDs, p)
-	}
-	sort.Strings(pipelineIDs)
-	for _, pID := range pipelineIDs {
+	for _, pID := range config.SortedKeys(pipelines) {
 		p := pipelines[pID]
 		for _, rID := range p.ReceiverIDs {
 			if _, ok := receiverNameMap[rID]; ok {
@@ -560,12 +549,7 @@ func generateOtelExporters(exporters map[string]*config.MetricsExporter, pipelin
 	if err := config.ValidateComponentIds(exporters, "metrics", "exporter"); err != nil {
 		return nil, nil, err
 	}
-	var pipelineIDs []string
-	for p := range pipelines {
-		pipelineIDs = append(pipelineIDs, p)
-	}
-	sort.Strings(pipelineIDs)
-	for _, pID := range pipelineIDs {
+	for _, pID := range config.SortedKeys(pipelines) {
 		p := pipelines[pID]
 		for _, eID := range p.ExporterIDs {
 			if _, ok := exporters[eID]; !ok {
@@ -603,12 +587,7 @@ func generateFluentBitInputs(receivers map[string]*config.LoggingReceiver, pipel
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	var pipelineIDs []string
-	for p := range pipelines {
-		pipelineIDs = append(pipelineIDs, p)
-	}
-	sort.Strings(pipelineIDs)
-	for _, pID := range pipelineIDs {
+	for _, pID := range config.SortedKeys(pipelines) {
 		p := pipelines[pID]
 		for _, rID := range p.Receivers {
 			if f, ok := fileReceiverFactories[rID]; ok {
@@ -651,12 +630,7 @@ func generateFluentBitInputs(receivers map[string]*config.LoggingReceiver, pipel
 
 func generateFluentBitFilters(processors map[string]*config.LoggingProcessor, pipelines map[string]*config.LoggingPipeline) ([]*conf.FilterParser, error) {
 	fbFilterParsers := []*conf.FilterParser{}
-	var pipelineIDs []string
-	for p := range pipelines {
-		pipelineIDs = append(pipelineIDs, p)
-	}
-	sort.Strings(pipelineIDs)
-	for _, pID := range pipelineIDs {
+	for _, pID := range config.SortedKeys(pipelines) {
 		pipeline := pipelines[pID]
 		for _, processorID := range pipeline.Processors {
 			p, ok := processors[processorID]
@@ -699,13 +673,8 @@ func extractExporterPlugins(exporters map[string]*config.LoggingExporter, pipeli
 	if err := config.ValidateComponentIds(exporters, "logging", "exporter"); err != nil {
 		return nil, nil, nil, nil, err
 	}
-	var pipelineIDs []string
-	for p := range pipelines {
-		pipelineIDs = append(pipelineIDs, p)
-	}
-	sort.Strings(pipelineIDs)
 	stackdriverExporters := make(map[string][]string)
-	for _, pID := range pipelineIDs {
+	for _, pID := range config.SortedKeys(pipelines) {
 		pipeline := pipelines[pID]
 		for _, exporterID := range pipeline.Exporters {
 			e, ok := exporters[exporterID]
@@ -748,13 +717,7 @@ func extractFluentBitParsers(processors map[string]*config.LoggingProcessor) ([]
 	if err := config.ValidateComponentIds(processors, "logging", "processor"); err != nil {
 		return nil, nil, err
 	}
-	var names []string
-	for n := range processors {
-		names = append(names, n)
-	}
-	sort.Strings(names)
-
-	for _, name := range names {
+	for _, name := range config.SortedKeys(processors) {
 		p := processors[name]
 		cid := componentID{subagent: "logging", component: "processor", componentType: p.Type, id: name, platform: "linux"}
 		switch t := p.Type; t {

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -17,6 +17,7 @@ package confgenerator
 
 import (
 	"fmt"
+	"net"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -497,7 +498,13 @@ func extractReceiverFactories(receivers map[string]*receiver) (map[string]*fileR
 				return nil, nil, nil, unsupportedParameterError("logging", "receiver", r.Type, rID, "exclude_paths")
 			}
 			if r.TransportProtocol != "tcp" && r.TransportProtocol != "udp" {
-				return nil, nil, nil, fmt.Errorf(`unknown transport protocol %q in the logging receiver %q. Supported transport protocol for %q type logging receiver: [tcp, udp].`, r.TransportProtocol, rID, r.Type)
+				return nil, nil, nil, fmt.Errorf(`unknown transport_protocol %q in the logging receiver %q. Supported transport_protocol for %q type logging receiver: [tcp, udp].`, r.TransportProtocol, rID, r.Type)
+			}
+			if net.ParseIP(r.ListenHost) == nil {
+				return nil, nil, nil, fmt.Errorf(`unknown listen_host %q in the logging receiver %q. Value of listen_host for %q type logging receiver should be a valid IP.`, r.ListenHost, rID, r.Type)
+			}
+			if r.ListenPort == 0 {
+				return nil, nil, nil, missingRequiredParameterError("logging", "receiver", r.Type, rID, "listen_port")
 			}
 			if r.Channels != nil {
 				return nil, nil, nil, unsupportedParameterError("logging", "receiver", r.Type, rID, "channels")

--- a/confgenerator/confgenerator_test.go
+++ b/confgenerator/confgenerator_test.go
@@ -36,12 +36,13 @@ var (
 	//   ops-agent$ go test -mod=mod github.com/GoogleCloudPlatform/ops-agent/confgenerator -update_golden
 	// Add "-v" to show details for which files are updated with what:
 	//   ops-agent$ go test -mod=mod github.com/GoogleCloudPlatform/ops-agent/confgenerator -update_golden -v
-	updateGolden     = flag.Bool("update_golden", false, "Whether to update the expected golden confs if they differ from the actual generated confs.")
-	goldenMainPath   = validTestdataDir + "/%s/%s/golden_fluent_bit_main.conf"
-	goldenParserPath = validTestdataDir + "/%s/%s/golden_fluent_bit_parser.conf"
-	goldenOtelPath   = validTestdataDir + "/%s/%s/golden_otel.conf"
-	goldenErrorPath  = invalidTestdataDir + "/%s/%s/golden_error"
-	invalidInputPath = invalidTestdataDir + "/%s/%s/input.yaml"
+	updateGolden       = flag.Bool("update_golden", false, "Whether to update the expected golden confs if they differ from the actual generated confs.")
+	goldenMainPath     = validTestdataDir + "/%s/%s/golden_fluent_bit_main.conf"
+	goldenParserPath   = validTestdataDir + "/%s/%s/golden_fluent_bit_parser.conf"
+	goldenCollectdPath = validTestdataDir + "/%s/%s/golden_collectd.conf"
+	goldenOtelPath     = validTestdataDir + "/%s/%s/golden_otel.conf"
+	goldenErrorPath    = invalidTestdataDir + "/%s/%s/golden_error"
+	invalidInputPath   = invalidTestdataDir + "/%s/%s/input.yaml"
 )
 
 type platformConfig struct {
@@ -154,6 +155,16 @@ func testGenerateConfsWithValidInput(t *testing.T, platform platformConfig) {
 			updateOrCompareGolden(t, testName, platform.OS, expectedMainConfig, mainConf, goldenMainPath)
 			updateOrCompareGolden(t, testName, platform.OS, expectedParserConfig, parserConf, goldenParserPath)
 
+			if platform.OS != "windows" {
+				expectedCollectdConfig := readFileContent(t, testName, platform.OS, goldenCollectdPath, true)
+				collectdConf, err := uc.GenerateCollectdConfig(platform.defaultLogsDir)
+				if err != nil {
+					t.Fatalf("GenerateCollectdConfig got %v", err)
+				}
+				// Compare the expected and actual and error out in case of diff.
+				updateOrCompareGolden(t, testName, platform.OS, expectedCollectdConfig, collectdConf, goldenCollectdPath)
+			}
+
 			expectedOtelConfig := readFileContent(t, testName, platform.OS, goldenOtelPath, true)
 			otelConf, err := uc.GenerateOtelConfig(platform.InfoStat)
 			if err != nil {
@@ -243,6 +254,12 @@ func generateConfigs(invalidInput []byte, platform platformConfig) (err error) {
 
 	if _, _, err := uc.GenerateFluentBitConfigs(platform.defaultLogsDir, platform.defaultStateDir, platform.InfoStat); err != nil {
 		return err
+	}
+
+	if platform.OS != "windows" {
+		if _, err := uc.GenerateCollectdConfig(platform.defaultLogsDir); err != nil {
+			return err
+		}
 	}
 
 	if _, err = uc.GenerateOtelConfig(platform.InfoStat); err != nil {

--- a/confgenerator/confgenerator_test.go
+++ b/confgenerator/confgenerator_test.go
@@ -139,7 +139,7 @@ func testGenerateConfsWithValidInput(t *testing.T, platform platformConfig) {
 			if err != nil {
 				t.Fatalf("ReadFile(%q) got %v", unifiedConfigFilePath, err)
 			}
-			uc, err := config.ParseUnifiedConfig(data)
+			uc, err := config.ParseUnifiedConfig(data, platform.OS)
 			if err != nil {
 				t.Fatalf("ParseUnifiedConfig got %v", err)
 			}
@@ -249,7 +249,7 @@ func testGenerateConfigsWithInvalidInput(t *testing.T, platform platformConfig) 
 // 2. Config generation phase when the config is invalid.
 // If at any point, an error is generated, immediately return it for validation.
 func generateConfigs(invalidInput []byte, platform platformConfig) (err error) {
-	uc, err := config.ParseUnifiedConfig(invalidInput)
+	uc, err := config.ParseUnifiedConfig(invalidInput, platform.OS)
 	if err != nil {
 		return err
 	}

--- a/confgenerator/config/config.go
+++ b/confgenerator/config/config.go
@@ -1,0 +1,41 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package config represents the Ops Agent configuration.
+package config
+
+// Ops Agent metrics config.
+type Metrics struct {
+	Receivers map[string]*MetricsReceiver `yaml:"receivers"`
+	Exporters map[string]*MetricsExporter `yaml:"exporters"`
+	Service   *MetricsService             `yaml:"service"`
+}
+
+type MetricsReceiver struct {
+	Type               string `yaml:"type"`
+	CollectionInterval string `yaml:"collection_interval"` // time.Duration format
+}
+
+type MetricsExporter struct {
+	Type string `yaml:"type"`
+}
+
+type MetricsService struct {
+	Pipelines map[string]*MetricsPipeline `yaml:"pipelines"`
+}
+
+type MetricsPipeline struct {
+	ReceiverIDs []string `yaml:"receivers"`
+	ExporterIDs []string `yaml:"exporters"`
+}

--- a/confgenerator/config/config.go
+++ b/confgenerator/config/config.go
@@ -21,6 +21,59 @@ import (
 	"time"
 )
 
+// Ops Agent logging config.
+type Logging struct {
+	Receivers  map[string]*LoggingReceiver  `yaml:"receivers"`
+	Processors map[string]*LoggingProcessor `yaml:"processors"`
+	Exporters  map[string]*LoggingExporter  `yaml:"exporters"`
+	Service    *LoggingService              `yaml:"service"`
+}
+
+type LoggingReceiver struct {
+	// Required. It is either file or syslog.
+	Type string `yaml:"type"`
+
+	// Valid for type "files".
+	IncludePaths []string `yaml:"include_paths"`
+	ExcludePaths []string `yaml:"exclude_paths"`
+
+	// Valid for type "syslog".
+	TransportProtocol string `yaml:"transport_protocol"`
+	ListenHost        string `yaml:"listen_host"`
+	ListenPort        uint16 `yaml:"listen_port"`
+
+	// Valid for type "windows_event_log".
+	Channels []string `yaml:"channels"`
+}
+
+type LoggingProcessor struct {
+	// Required. It is either parse_json or parse_regex.
+	Type string `yaml:"type"`
+
+	// Valid for parse_regex only.
+	Regex string `yaml:"regex"`
+
+	// Valid for type parse_json and parse_regex.
+	Field      string `yaml:"field"`       // optional, default to "message"
+	TimeKey    string `yaml:"time_key"`    // optional, by default does not parse timestamp
+	TimeFormat string `yaml:"time_format"` // optional, must be provided if time_key is present
+}
+
+type LoggingExporter struct {
+	// Required. It can only be `google_cloud_logging` now. More type may be supported later.
+	Type string `yaml:"type"`
+}
+
+type LoggingService struct {
+	Pipelines map[string]*LoggingPipeline
+}
+
+type LoggingPipeline struct {
+	Receivers  []string `yaml:"receivers"`
+	Processors []string `yaml:"processors"`
+	Exporters  []string `yaml:"exporters"`
+}
+
 // Ops Agent metrics config.
 type Metrics struct {
 	Receivers map[string]*MetricsReceiver `yaml:"receivers"`

--- a/confgenerator/config/config.go
+++ b/confgenerator/config/config.go
@@ -129,8 +129,8 @@ func mapKeys(m interface{}) map[string]interface{} {
 	return keys
 }
 
-// sortedKeys returns keys from a map[string]Any as a sorted string slice.
-func sortedKeys(m interface{}) []string {
+// SortedKeys returns keys from a map[string]Any as a sorted string slice.
+func SortedKeys(m interface{}) []string {
 	var r []string
 	for k := range mapKeys(m) {
 		r = append(r, k)
@@ -140,7 +140,7 @@ func sortedKeys(m interface{}) []string {
 }
 
 func ValidateComponentIds(components interface{}, subagent string, component string) error {
-	for _, id := range sortedKeys(components) {
+	for _, id := range SortedKeys(components) {
 		if strings.HasPrefix(id, "lib:") {
 			return reservedIdPrefixError(subagent, component, id)
 		}

--- a/confgenerator/config/config.go
+++ b/confgenerator/config/config.go
@@ -478,15 +478,40 @@ var (
 	}
 )
 
-// mapKeys returns keys from a map[string]Any as a map[string]interface{}.
-func mapKeys(m interface{}) map[string]interface{} {
-	keys := map[string]interface{}{}
-	for iter := reflect.ValueOf(m).MapRange(); iter.Next(); {
-		k := iter.Key()
-		if k.Kind() != reflect.String {
-			panic(fmt.Sprintf("key %v not a string", k))
+// mapKeys returns keys from a map[string]Any as a map[string]bool.
+func mapKeys(m interface{}) map[string]bool {
+	keys := map[string]bool{}
+	switch m := m.(type) {
+	case map[string]*LoggingReceiver:
+		for k := range m {
+			keys[k] = true
 		}
-		keys[k.String()] = nil
+	case map[string]*LoggingProcessor:
+		for k := range m {
+			keys[k] = true
+		}
+	case map[string]*LoggingExporter:
+		for k := range m {
+			keys[k] = true
+		}
+	case map[string]*LoggingPipeline:
+		for k := range m {
+			keys[k] = true
+		}
+	case map[string]*MetricsReceiver:
+		for k := range m {
+			keys[k] = true
+		}
+	case map[string]*MetricsExporter:
+		for k := range m {
+			keys[k] = true
+		}
+	case map[string]*MetricsPipeline:
+		for k := range m {
+			keys[k] = true
+		}
+	default:
+		panic(fmt.Sprintf("Unknown type: %T", m))
 	}
 	return keys
 }
@@ -502,10 +527,10 @@ func SortedKeys(m interface{}) []string {
 }
 
 // findInvalid returns all strings from a slice that are not in allowed.
-func findInvalid(actual []string, allowed map[string]interface{}) []string {
+func findInvalid(actual []string, allowed map[string]bool) []string {
 	var invalid []string
 	for _, v := range actual {
-		if _, ok := allowed[v]; !ok {
+		if !allowed[v] {
 			invalid = append(invalid, v)
 		}
 	}

--- a/confgenerator/config/config.go
+++ b/confgenerator/config/config.go
@@ -21,6 +21,10 @@ import (
 	"time"
 )
 
+type configComponent struct {
+	Type string `yaml:"type"`
+}
+
 // Ops Agent logging config.
 type Logging struct {
 	Receivers  map[string]*LoggingReceiver  `yaml:"receivers"`
@@ -30,8 +34,7 @@ type Logging struct {
 }
 
 type LoggingReceiver struct {
-	// Required. It is either file or syslog.
-	Type string `yaml:"type"`
+	configComponent `yaml:",inline"`
 
 	// Valid for type "files".
 	IncludePaths []string `yaml:"include_paths"`
@@ -47,8 +50,7 @@ type LoggingReceiver struct {
 }
 
 type LoggingProcessor struct {
-	// Required. It is either parse_json or parse_regex.
-	Type string `yaml:"type"`
+	configComponent `yaml:",inline"`
 
 	// Valid for parse_regex only.
 	Regex string `yaml:"regex"`
@@ -60,8 +62,7 @@ type LoggingProcessor struct {
 }
 
 type LoggingExporter struct {
-	// Required. It can only be `google_cloud_logging` now. More type may be supported later.
-	Type string `yaml:"type"`
+	configComponent `yaml:",inline"`
 }
 
 type LoggingService struct {
@@ -82,12 +83,13 @@ type Metrics struct {
 }
 
 type MetricsReceiver struct {
-	Type               string `yaml:"type"`
+	configComponent `yaml:",inline"`
+
 	CollectionInterval string `yaml:"collection_interval"` // time.Duration format
 }
 
 type MetricsExporter struct {
-	Type string `yaml:"type"`
+	configComponent `yaml:",inline"`
 }
 
 type MetricsService struct {

--- a/confgenerator/config/config.go
+++ b/confgenerator/config/config.go
@@ -15,6 +15,12 @@
 // Package config represents the Ops Agent configuration.
 package config
 
+import (
+	"fmt"
+	"math"
+	"time"
+)
+
 // Ops Agent metrics config.
 type Metrics struct {
 	Receivers map[string]*MetricsReceiver `yaml:"receivers"`
@@ -38,4 +44,16 @@ type MetricsService struct {
 type MetricsPipeline struct {
 	ReceiverIDs []string `yaml:"receivers"`
 	ExporterIDs []string `yaml:"exporters"`
+}
+
+func ValidateCollectionInterval(receiverID string, collectionInterval string) (float64, error) {
+	t, err := time.ParseDuration(collectionInterval)
+	if err != nil {
+		return math.NaN(), fmt.Errorf("parameter \"collection_interval\" in metrics receiver %q has invalid value %q that is not an interval (e.g. \"60s\"). Detailed error: %s", receiverID, collectionInterval, err)
+	}
+	interval := t.Seconds()
+	if interval < 10 {
+		return math.NaN(), fmt.Errorf("parameter \"collection_interval\" in metrics receiver %q has invalid value \"%vs\" that is below the minimum threshold of \"10s\".", receiverID, interval)
+	}
+	return interval, nil
 }

--- a/confgenerator/config/config.go
+++ b/confgenerator/config/config.go
@@ -345,7 +345,7 @@ func collectYamlFields(s interface{}) []yamlField {
 			if sliceContains(annotations, "inline") {
 				// Expand inline structs.
 				parameters = append(parameters, recurse(v)...)
-			} else if f.Name[:1] != strings.ToLower(f.Name[:1]) { // skip private non-struct fields
+			} else if f.PkgPath == "" { // skip private non-struct fields
 				parameters = append(parameters, yamlField{
 					Name:     n,
 					Required: !sliceContains(annotations, "omitempty"),

--- a/confgenerator/config/config.go
+++ b/confgenerator/config/config.go
@@ -22,7 +22,32 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	yaml "gopkg.in/yaml.v2"
 )
+
+// Ops Agent config.
+type UnifiedConfig struct {
+	Logging *Logging `yaml:"logging"`
+	Metrics *Metrics `yaml:"metrics"`
+}
+
+func (uc *UnifiedConfig) HasLogging() bool {
+	return uc.Logging != nil
+}
+
+func (uc *UnifiedConfig) HasMetrics() bool {
+	return uc.Metrics != nil
+}
+
+func ParseUnifiedConfig(input []byte) (UnifiedConfig, error) {
+	config := UnifiedConfig{}
+	err := yaml.UnmarshalStrict(input, &config)
+	if err != nil {
+		return UnifiedConfig{}, fmt.Errorf("the agent config file is not valid YAML. detailed error: %s", err)
+	}
+	return config, nil
+}
 
 type configComponent struct {
 	Type string `yaml:"type"`

--- a/confgenerator/config/config.go
+++ b/confgenerator/config/config.go
@@ -36,32 +36,45 @@ type Logging struct {
 	Service    *LoggingService              `yaml:"service"`
 }
 
+type LoggingReceiverFiles struct {
+	IncludePaths []string `yaml:"include_paths"`
+	ExcludePaths []string `yaml:"exclude_paths"` // optional
+}
+
+type LoggingReceiverSyslog struct {
+	TransportProtocol string `yaml:"transport_protocol"` // one of "tcp" or "udp"
+	ListenHost        string `yaml:"listen_host"`
+	ListenPort        uint16 `yaml:"listen_port"`
+}
+
+type LoggingReceiverWinevtlog struct {
+	Channels []string `yaml:"channels"`
+}
+
 type LoggingReceiver struct {
 	configComponent `yaml:",inline"`
 
-	// Valid for type "files".
-	IncludePaths []string `yaml:"include_paths"`
-	ExcludePaths []string `yaml:"exclude_paths"`
+	LoggingReceiverFiles     `yaml:",inline"` // Type "files"
+	LoggingReceiverSyslog    `yaml:",inline"` // Type "syslog"
+	LoggingReceiverWinevtlog `yaml:",inline"` // Type "windows_event_log"
+}
 
-	// Valid for type "syslog".
-	TransportProtocol string `yaml:"transport_protocol"`
-	ListenHost        string `yaml:"listen_host"`
-	ListenPort        uint16 `yaml:"listen_port"`
+type LoggingProcessorParseJson struct {
+	Field      string `yaml:"field"`       // optional, default to "message"
+	TimeKey    string `yaml:"time_key"`    // optional, by default does not parse timestamp
+	TimeFormat string `yaml:"time_format"` // optional, must be provided if time_key is present
+}
 
-	// Valid for type "windows_event_log".
-	Channels []string `yaml:"channels"`
+type LoggingProcessorParseRegex struct {
+	Regex string `yaml:"regex"`
+
+	LoggingProcessorParseJson `yaml:",inline"` // Type "parse_json"
 }
 
 type LoggingProcessor struct {
 	configComponent `yaml:",inline"`
 
-	// Valid for parse_regex only.
-	Regex string `yaml:"regex"`
-
-	// Valid for type parse_json and parse_regex.
-	Field      string `yaml:"field"`       // optional, default to "message"
-	TimeKey    string `yaml:"time_key"`    // optional, by default does not parse timestamp
-	TimeFormat string `yaml:"time_format"` // optional, must be provided if time_key is present
+	LoggingProcessorParseRegex `yaml:",inline"` // Type "parse_json" or "parse_regex"
 }
 
 type LoggingExporter struct {

--- a/confgenerator/config/config.go
+++ b/confgenerator/config/config.go
@@ -160,19 +160,19 @@ func (uc *UnifiedConfig) Validate() error {
 
 func (l *Logging) Validate() error {
 	subagent := "logging"
-	if err := ValidateComponentIds(l.Receivers, subagent, "receiver"); err != nil {
+	if err := validateComponentIds(l.Receivers, subagent, "receiver"); err != nil {
 		return err
 	}
-	if err := ValidateComponentIds(l.Processors, subagent, "processor"); err != nil {
+	if err := validateComponentIds(l.Processors, subagent, "processor"); err != nil {
 		return err
 	}
-	if err := ValidateComponentIds(l.Exporters, subagent, "exporter"); err != nil {
+	if err := validateComponentIds(l.Exporters, subagent, "exporter"); err != nil {
 		return err
 	}
 	if l.Service == nil {
 		return nil
 	}
-	if err := ValidateComponentIds(l.Service.Pipelines, subagent, "pipeline"); err != nil {
+	if err := validateComponentIds(l.Service.Pipelines, subagent, "pipeline"); err != nil {
 		return err
 	}
 	for _, id := range SortedKeys(l.Service.Pipelines) {
@@ -199,16 +199,16 @@ func (l *Logging) Validate() error {
 
 func (m *Metrics) Validate() error {
 	subagent := "metrics"
-	if err := ValidateComponentIds(m.Receivers, subagent, "receiver"); err != nil {
+	if err := validateComponentIds(m.Receivers, subagent, "receiver"); err != nil {
 		return err
 	}
-	if err := ValidateComponentIds(m.Exporters, subagent, "exporter"); err != nil {
+	if err := validateComponentIds(m.Exporters, subagent, "exporter"); err != nil {
 		return err
 	}
 	if m.Service == nil {
 		return nil
 	}
-	if err := ValidateComponentIds(m.Service.Pipelines, subagent, "pipeline"); err != nil {
+	if err := validateComponentIds(m.Service.Pipelines, subagent, "pipeline"); err != nil {
 		return err
 	}
 	for _, id := range SortedKeys(m.Service.Pipelines) {
@@ -273,7 +273,7 @@ func findInvalid(actual []string, allowed map[string]interface{}) []string {
 	return invalid
 }
 
-func ValidateComponentIds(components interface{}, subagent string, component string) error {
+func validateComponentIds(components interface{}, subagent string, component string) error {
 	for _, id := range SortedKeys(components) {
 		if strings.HasPrefix(id, "lib:") {
 			return reservedIdPrefixError(subagent, component, id)

--- a/confgenerator/files.go
+++ b/confgenerator/files.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package confgenerator
 
 import (

--- a/confgenerator/files.go
+++ b/confgenerator/files.go
@@ -26,11 +26,12 @@ import (
 )
 
 func GenerateFiles(input, service, logsDir, stateDir, outDir string) error {
+	hostInfo, _ := host.Info()
 	data, err := ioutil.ReadFile(input)
 	if err != nil {
 		return err
 	}
-	uc, err := config.ParseUnifiedConfig(data)
+	uc, err := config.ParseUnifiedConfig(data, hostInfo.OS)
 	if err != nil {
 		return err
 	}

--- a/confgenerator/testdata/invalid/linux/logging-processor_parse_regex_type_missing_required_parameter_regex/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-processor_parse_regex_type_missing_required_parameter_regex/golden_error
@@ -1,1 +1,1 @@
-parameter "regex" is required in logging processor "processor_1" because its type is "parse_regex".
+parameter "regex" in "parse_regex" type logging processor "processor_1" is required.

--- a/confgenerator/testdata/invalid/linux/logging-receiver_files_type_invalid_parameter_include_paths_is_empty/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_files_type_invalid_parameter_include_paths_is_empty/golden_error
@@ -1,1 +1,1 @@
-parameter "include_paths" is required in logging receiver "receiver_1" because its type is "files".
+parameter "include_paths" in "files" type logging receiver "receiver_1" is required.

--- a/confgenerator/testdata/invalid/linux/logging-receiver_files_type_missing_required_parameter_include_paths/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_files_type_missing_required_parameter_include_paths/golden_error
@@ -1,1 +1,1 @@
-parameter "include_paths" is required in logging receiver "receiver_1" because its type is "files".
+parameter "include_paths" in "files" type logging receiver "receiver_1" is required.

--- a/confgenerator/testdata/invalid/linux/logging-receiver_files_type_unsupported_parameter_channels/input.yaml
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_files_type_unsupported_parameter_channels/input.yaml
@@ -12,5 +12,5 @@ logging:
   service:
     pipelines:
       default_pipeline:
-        receivers: [syslog]
+        receivers: [receiver_1]
         exporters: [google]

--- a/confgenerator/testdata/invalid/linux/logging-receiver_files_type_unsupported_parameter_listen_host/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_files_type_unsupported_parameter_listen_host/golden_error
@@ -1,1 +1,1 @@
-parameter "listen_host" in logging receiver "receiver_1" is not supported. Supported parameters for "files" type logging receiver: [include_paths, exclude_paths].
+parameter "listen_host" in "files" type logging receiver "receiver_1" is not supported. Supported parameters: [include_paths, exclude_paths].

--- a/confgenerator/testdata/invalid/linux/logging-receiver_files_type_unsupported_parameter_listen_host/input.yaml
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_files_type_unsupported_parameter_listen_host/input.yaml
@@ -12,5 +12,5 @@ logging:
   service:
     pipelines:
       default_pipeline:
-        receivers: [syslog]
+        receivers: [receiver_1]
         exporters: [google]

--- a/confgenerator/testdata/invalid/linux/logging-receiver_files_type_unsupported_parameter_listen_port/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_files_type_unsupported_parameter_listen_port/golden_error
@@ -1,1 +1,1 @@
-parameter "listen_port" in logging receiver "receiver_1" is not supported. Supported parameters for "files" type logging receiver: [include_paths, exclude_paths].
+parameter "listen_port" in "files" type logging receiver "receiver_1" is not supported. Supported parameters: [include_paths, exclude_paths].

--- a/confgenerator/testdata/invalid/linux/logging-receiver_files_type_unsupported_parameter_listen_port/input.yaml
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_files_type_unsupported_parameter_listen_port/input.yaml
@@ -12,5 +12,5 @@ logging:
   service:
     pipelines:
       default_pipeline:
-        receivers: [syslog]
+        receivers: [receiver_1]
         exporters: [google]

--- a/confgenerator/testdata/invalid/linux/logging-receiver_files_type_unsupported_parameter_random/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_files_type_unsupported_parameter_random/golden_error
@@ -1,2 +1,2 @@
 the agent config file is not valid YAML. detailed error: yaml: unmarshal errors:
-  line 8: field field_1 not found in type confgenerator.receiver
+  line 8: field field_1 not found in type config.LoggingReceiver

--- a/confgenerator/testdata/invalid/linux/logging-receiver_files_type_unsupported_parameter_random/input.yaml
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_files_type_unsupported_parameter_random/input.yaml
@@ -1,6 +1,6 @@
 logging:
   receivers:
-    syslog:
+    receiver_1:
       type: files
       include_paths:
       - /var/log/messages
@@ -12,5 +12,5 @@ logging:
   service:
     pipelines:
       default_pipeline:
-        receivers: [syslog]
+        receivers: [receiver_1]
         exporters: [google]

--- a/confgenerator/testdata/invalid/linux/logging-receiver_files_type_unsupported_parameter_transport_protocol/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_files_type_unsupported_parameter_transport_protocol/golden_error
@@ -1,1 +1,1 @@
-parameter "transport_protocol" in logging receiver "receiver_1" is not supported. Supported parameters for "files" type logging receiver: [include_paths, exclude_paths].
+parameter "transport_protocol" in "files" type logging receiver "receiver_1" is not supported. Supported parameters: [include_paths, exclude_paths].

--- a/confgenerator/testdata/invalid/linux/logging-receiver_files_type_unsupported_parameter_transport_protocol/input.yaml
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_files_type_unsupported_parameter_transport_protocol/input.yaml
@@ -12,5 +12,5 @@ logging:
   service:
     pipelines:
       default_pipeline:
-        receivers: [syslog]
+        receivers: [receiver_1]
         exporters: [google]

--- a/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_invalid_parameter_listen_host_is_empty_string/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_invalid_parameter_listen_host_is_empty_string/golden_error
@@ -1,1 +1,1 @@
-parameter "listen_host" is required in logging receiver "receiver_1" because its type is "syslog".
+parameter "listen_host" in "syslog" type logging receiver "receiver_1" is required.

--- a/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_invalid_parameter_listen_host_is_empty_string/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_invalid_parameter_listen_host_is_empty_string/golden_error
@@ -1,1 +1,1 @@
-got invalid value for "syslog" plugin's field "Listen", should be a valid IP
+unknown listen_host "" in the logging receiver "receiver_1". Value of listen_host for "syslog" type logging receiver should be a valid IP.

--- a/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_invalid_parameter_listen_host_is_empty_string/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_invalid_parameter_listen_host_is_empty_string/golden_error
@@ -1,1 +1,1 @@
-unknown listen_host "" in the logging receiver "receiver_1". Value of listen_host for "syslog" type logging receiver should be a valid IP.
+parameter "listen_host" is required in logging receiver "receiver_1" because its type is "syslog".

--- a/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_invalid_parameter_listen_host_is_not_an_ip/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_invalid_parameter_listen_host_is_not_an_ip/golden_error
@@ -1,0 +1,1 @@
+unknown listen_host "abc" in the logging receiver "receiver_1". Value of listen_host for "syslog" type logging receiver should be a valid IP.

--- a/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_invalid_parameter_listen_host_is_not_an_ip/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_invalid_parameter_listen_host_is_not_an_ip/golden_error
@@ -1,1 +1,1 @@
-unknown listen_host "abc" in the logging receiver "receiver_1". Value of listen_host for "syslog" type logging receiver should be a valid IP.
+parameter "listen_host" in "syslog" type logging receiver "receiver_1" has invalid value "abc": must be a valid IP.

--- a/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_invalid_parameter_listen_host_is_not_an_ip/input.yaml
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_invalid_parameter_listen_host_is_not_an_ip/input.yaml
@@ -1,0 +1,15 @@
+logging:
+  receivers:
+    receiver_1:
+      type: syslog
+      listen_host: abc
+      listen_port: 1111
+      transport_protocol: tcp
+  exporters:
+    google:
+      type: google_cloud_logging
+  service:
+    pipelines:
+      default_pipeline:
+        receivers: [receiver_1]
+        exporters: [google]

--- a/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_invalid_parameter_listen_port_is_zero/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_invalid_parameter_listen_port_is_zero/golden_error
@@ -1,1 +1,1 @@
-parameter "listen_port" is required in logging receiver "receiver_1" because its type is "syslog".
+parameter "listen_port" in "syslog" type logging receiver "receiver_1" is required.

--- a/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_invalid_parameter_listen_port_is_zero/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_invalid_parameter_listen_port_is_zero/golden_error
@@ -1,1 +1,1 @@
-"syslog" plugin should not have empty field: "Port"
+parameter "listen_port" is required in logging receiver "receiver_1" because its type is "syslog".

--- a/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_invalid_parameter_unknown_transport_protocol/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_invalid_parameter_unknown_transport_protocol/golden_error
@@ -1,1 +1,1 @@
-unknown transport_protocol "unknown_protocol" in the logging receiver "receiver_1". Supported transport_protocol for "syslog" type logging receiver: [tcp, udp].
+parameter "transport_protocol" in "syslog" type logging receiver "receiver_1" has invalid value "unknown_protocol": must be one of [tcp, udp].

--- a/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_invalid_parameter_unknown_transport_protocol/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_invalid_parameter_unknown_transport_protocol/golden_error
@@ -1,1 +1,1 @@
-unknown transport protocol "unknown_protocol" in the logging receiver "receiver_1". Supported transport protocol for "syslog" type logging receiver: [tcp, udp].
+unknown transport_protocol "unknown_protocol" in the logging receiver "receiver_1". Supported transport_protocol for "syslog" type logging receiver: [tcp, udp].

--- a/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_unsupported_parameter_channels/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_unsupported_parameter_channels/golden_error
@@ -1,1 +1,1 @@
-parameter "channels" in logging receiver "receiver_1" is not supported. Supported parameters for "syslog" type logging receiver: [transport_protocol, listen_host, listen_port].
+parameter "channels" in "syslog" type logging receiver "receiver_1" is not supported. Supported parameters: [transport_protocol, listen_host, listen_port].

--- a/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_unsupported_parameter_channels/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_unsupported_parameter_channels/golden_error
@@ -1,1 +1,1 @@
-parameter "channels" in logging receiver "reciever_1" is not supported. Supported parameters for "syslog" type logging receiver: [transport_protocol, listen_host, listen_port].
+parameter "channels" in logging receiver "receiver_1" is not supported. Supported parameters for "syslog" type logging receiver: [transport_protocol, listen_host, listen_port].

--- a/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_unsupported_parameter_channels/input.yaml
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_unsupported_parameter_channels/input.yaml
@@ -1,6 +1,6 @@
 logging:
   receivers:
-    reciever_1:
+    receiver_1:
       type: syslog
       listen_host: 1.1.1.1
       listen_port: 1111
@@ -12,5 +12,5 @@ logging:
   service:
     pipelines:
       default_pipeline:
-        receivers: [syslog]
+        receivers: [receiver_1]
         exporters: [google]

--- a/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_unsupported_parameter_exclude_paths/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_unsupported_parameter_exclude_paths/golden_error
@@ -1,1 +1,1 @@
-parameter "exclude_paths" in logging receiver "receiver_1" is not supported. Supported parameters for "syslog" type logging receiver: [transport_protocol, listen_host, listen_port].
+parameter "exclude_paths" in "syslog" type logging receiver "receiver_1" is not supported. Supported parameters: [transport_protocol, listen_host, listen_port].

--- a/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_unsupported_parameter_exclude_paths/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_unsupported_parameter_exclude_paths/golden_error
@@ -1,1 +1,1 @@
-parameter "exclude_paths" in logging receiver "reciever_1" is not supported. Supported parameters for "syslog" type logging receiver: [transport_protocol, listen_host, listen_port].
+parameter "exclude_paths" in logging receiver "receiver_1" is not supported. Supported parameters for "syslog" type logging receiver: [transport_protocol, listen_host, listen_port].

--- a/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_unsupported_parameter_exclude_paths/input.yaml
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_unsupported_parameter_exclude_paths/input.yaml
@@ -1,6 +1,6 @@
 logging:
   receivers:
-    reciever_1:
+    receiver_1:
       type: syslog
       listen_host: 1.1.1.1
       listen_port: 1111
@@ -12,5 +12,5 @@ logging:
   service:
     pipelines:
       default_pipeline:
-        receivers: [syslog]
+        receivers: [receiver_1]
         exporters: [google]

--- a/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_unsupported_parameter_include_paths/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_unsupported_parameter_include_paths/golden_error
@@ -1,1 +1,1 @@
-parameter "include_paths" in logging receiver "reciever_1" is not supported. Supported parameters for "syslog" type logging receiver: [transport_protocol, listen_host, listen_port].
+parameter "include_paths" in logging receiver "receiver_1" is not supported. Supported parameters for "syslog" type logging receiver: [transport_protocol, listen_host, listen_port].

--- a/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_unsupported_parameter_include_paths/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_unsupported_parameter_include_paths/golden_error
@@ -1,1 +1,1 @@
-parameter "include_paths" in logging receiver "receiver_1" is not supported. Supported parameters for "syslog" type logging receiver: [transport_protocol, listen_host, listen_port].
+parameter "include_paths" in "syslog" type logging receiver "receiver_1" is not supported. Supported parameters: [transport_protocol, listen_host, listen_port].

--- a/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_unsupported_parameter_include_paths/input.yaml
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_unsupported_parameter_include_paths/input.yaml
@@ -1,6 +1,6 @@
 logging:
   receivers:
-    reciever_1:
+    receiver_1:
       type: syslog
       listen_host: 1.1.1.1
       listen_port: 1111
@@ -12,5 +12,5 @@ logging:
   service:
     pipelines:
       default_pipeline:
-        receivers: [syslog]
+        receivers: [receiver_1]
         exporters: [google]

--- a/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_unsupported_parameter_random/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_unsupported_parameter_random/golden_error
@@ -1,2 +1,2 @@
 the agent config file is not valid YAML. detailed error: yaml: unmarshal errors:
-  line 8: field unsupported_paramater not found in type confgenerator.receiver
+  line 8: field unsupported_paramater not found in type config.LoggingReceiver

--- a/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_unsupported_parameter_random/input.yaml
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_syslog_type_unsupported_parameter_random/input.yaml
@@ -1,6 +1,6 @@
 logging:
   receivers:
-    reciever_1:
+    receiver_1:
       type: syslog
       listen_host: 1.1.1.1
       listen_port: 1111
@@ -12,5 +12,5 @@ logging:
   service:
     pipelines:
       default_pipeline:
-        receivers: [syslog]
+        receivers: [receiver_1]
         exporters: [google]

--- a/confgenerator/testdata/invalid/linux/logging-receiver_unsupported_type/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_unsupported_type/golden_error
@@ -1,1 +1,1 @@
-logging receiver "receiver_1" with type "unsupported_type" is not supported. Supported logging receiver types: [files, syslog, windows_event_log].
+logging receiver "receiver_1" with type "unsupported_type" is not supported. Supported logging receiver types: [files, syslog].

--- a/confgenerator/testdata/invalid/linux/metrics-processor_unsupported_type/golden_error
+++ b/confgenerator/testdata/invalid/linux/metrics-processor_unsupported_type/golden_error
@@ -1,2 +1,2 @@
 the agent config file is not valid YAML. detailed error: yaml: unmarshal errors:
-  line 6: field processors not found in type collectd.Metrics
+  line 6: field processors not found in type config.Metrics

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_invalid_parameter_collection_interval_below_minimum/golden_error
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_invalid_parameter_collection_interval_below_minimum/golden_error
@@ -1,1 +1,1 @@
-parameter "collection_interval" in metrics receiver "receiver_1" has invalid value "2s" that is below the minimum threshold of "10s".
+parameter "collection_interval" in "hostmetrics" type metrics receiver "receiver_1" has invalid value "2s": below the minimum threshold of "10s".

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_invalid_parameter_malformed_collection_interval/golden_error
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_invalid_parameter_malformed_collection_interval/golden_error
@@ -1,1 +1,1 @@
-parameter "collection_interval" in metrics receiver "receiver_1" has invalid value "24" that is not an interval (e.g. "60s"). Detailed error: time: missing unit in duration "24"
+parameter "collection_interval" in "hostmetrics" type metrics receiver "receiver_1" has invalid value "24": not an interval (e.g. "60s"). Detailed error: time: missing unit in duration "24"

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_unsupported_type/golden_error
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_unsupported_type/golden_error
@@ -1,1 +1,1 @@
-metrics receiver "receiver_1" with type "unsupported_type" is not supported. Supported metrics receiver types: [hostmetrics, iis, mssql].
+metrics receiver "receiver_1" with type "unsupported_type" is not supported. Supported metrics receiver types: [hostmetrics].

--- a/confgenerator/testdata/invalid/windows/all-not_in_yaml_format/golden_error
+++ b/confgenerator/testdata/invalid/windows/all-not_in_yaml_format/golden_error
@@ -1,2 +1,2 @@
 the agent config file is not valid YAML. detailed error: yaml: unmarshal errors:
-  line 1: cannot unmarshal !!str `sdfd` into confgenerator.UnifiedConfig
+  line 1: cannot unmarshal !!str `sdfd` into config.UnifiedConfig

--- a/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_missing_required_parameter_channels/golden_error
+++ b/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_missing_required_parameter_channels/golden_error
@@ -1,1 +1,1 @@
-parameter "channels" is required in logging receiver "receiver_1" because its type is "windows_event_log".
+parameter "channels" in "windows_event_log" type logging receiver "receiver_1" is required.

--- a/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_exclude_paths/golden_error
+++ b/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_exclude_paths/golden_error
@@ -1,1 +1,1 @@
-parameter "exclude_paths" in logging receiver "receiver_1" is not supported. Supported parameters for "windows_event_log" type logging receiver: [channels].
+parameter "exclude_paths" in "windows_event_log" type logging receiver "receiver_1" is not supported. Supported parameters: [channels].

--- a/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_exclude_paths/input.yaml
+++ b/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_exclude_paths/input.yaml
@@ -10,5 +10,5 @@ logging:
   service:
     pipelines:
       default_pipeline:
-        receivers: [windows_event_log]
+        receivers: [receiver_1]
         exporters: [google]

--- a/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_include_paths/golden_error
+++ b/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_include_paths/golden_error
@@ -1,1 +1,1 @@
-parameter "include_paths" in logging receiver "receiver_1" is not supported. Supported parameters for "windows_event_log" type logging receiver: [channels].
+parameter "include_paths" in "windows_event_log" type logging receiver "receiver_1" is not supported. Supported parameters: [channels].

--- a/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_include_paths/input.yaml
+++ b/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_include_paths/input.yaml
@@ -10,5 +10,5 @@ logging:
   service:
     pipelines:
       default_pipeline:
-        receivers: [windows_event_log]
+        receivers: [receiver_1]
         exporters: [google]

--- a/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_listen_host/golden_error
+++ b/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_listen_host/golden_error
@@ -1,1 +1,1 @@
-parameter "listen_host" in logging receiver "receiver_1" is not supported. Supported parameters for "windows_event_log" type logging receiver: [channels].
+parameter "listen_host" in "windows_event_log" type logging receiver "receiver_1" is not supported. Supported parameters: [channels].

--- a/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_listen_host/input.yaml
+++ b/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_listen_host/input.yaml
@@ -10,5 +10,5 @@ logging:
   service:
     pipelines:
       default_pipeline:
-        receivers: [windows_event_log]
+        receivers: [receiver_1]
         exporters: [google]

--- a/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_listen_port/golden_error
+++ b/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_listen_port/golden_error
@@ -1,1 +1,1 @@
-parameter "listen_port" in logging receiver "receiver_1" is not supported. Supported parameters for "windows_event_log" type logging receiver: [channels].
+parameter "listen_port" in "windows_event_log" type logging receiver "receiver_1" is not supported. Supported parameters: [channels].

--- a/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_listen_port/input.yaml
+++ b/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_listen_port/input.yaml
@@ -10,5 +10,5 @@ logging:
   service:
     pipelines:
       default_pipeline:
-        receivers: [windows_event_log]
+        receivers: [receiver_1]
         exporters: [google]

--- a/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_random/golden_error
+++ b/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_random/golden_error
@@ -1,2 +1,2 @@
 the agent config file is not valid YAML. detailed error: yaml: unmarshal errors:
-  line 6: field unsupported_parameter not found in type confgenerator.receiver
+  line 6: field unsupported_parameter not found in type config.LoggingReceiver

--- a/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_random/input.yaml
+++ b/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_random/input.yaml
@@ -10,5 +10,5 @@ logging:
   service:
     pipelines:
       default_pipeline:
-        receivers: [windows_event_log]
+        receivers: [receiver_1]
         exporters: [google]

--- a/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_transport_protocol/golden_error
+++ b/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_transport_protocol/golden_error
@@ -1,1 +1,1 @@
-parameter "transport_protocol" in logging receiver "receiver_1" is not supported. Supported parameters for "windows_event_log" type logging receiver: [channels].
+parameter "transport_protocol" in "windows_event_log" type logging receiver "receiver_1" is not supported. Supported parameters: [channels].

--- a/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_transport_protocol/input.yaml
+++ b/confgenerator/testdata/invalid/windows/logging-receiver_windows_event_log_type_unsupported_parameter_transport_protocol/input.yaml
@@ -10,5 +10,5 @@ logging:
   service:
     pipelines:
       default_pipeline:
-        receivers: [windows_event_log]
+        receivers: [receiver_1]
         exporters: [google]

--- a/confgenerator/testdata/invalid/windows/metrics-receiver_invalid_parameter_collection_interval_below_minimum/golden_error
+++ b/confgenerator/testdata/invalid/windows/metrics-receiver_invalid_parameter_collection_interval_below_minimum/golden_error
@@ -1,1 +1,1 @@
-parameter "collection_interval" in metrics receiver "receiver_1" has invalid value "2s" that is below the minimum threshold of "10s".
+parameter "collection_interval" in "hostmetrics" type metrics receiver "receiver_1" has invalid value "2s": below the minimum threshold of "10s".

--- a/confgenerator/testdata/invalid/windows/metrics-receiver_invalid_parameter_malformed_collection_interval/golden_error
+++ b/confgenerator/testdata/invalid/windows/metrics-receiver_invalid_parameter_malformed_collection_interval/golden_error
@@ -1,1 +1,1 @@
-parameter "collection_interval" in metrics receiver "receiver_1" has invalid value "24" that is not an interval (e.g. "60s"). Detailed error: time: missing unit in duration "24"
+parameter "collection_interval" in "hostmetrics" type metrics receiver "receiver_1" has invalid value "24": not an interval (e.g. "60s"). Detailed error: time: missing unit in duration "24"

--- a/fluentbit/conf/conf.go
+++ b/fluentbit/conf/conf.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//Package conf provides data structures to represent and generate fluentBit configuration.
+// Package conf provides data structures to represent and generate fluentBit configuration.
 package conf
 
 import (

--- a/otel/conf.go
+++ b/otel/conf.go
@@ -20,11 +20,11 @@ import (
 	"regexp"
 	"strings"
 	"text/template"
-	"time"
+
+	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/config"
 )
 
 var templateFunctions = template.FuncMap{
-	"notEmpty":                   notEmpty,
 	"validateCollectionInterval": validateCollectionInterval,
 }
 
@@ -581,17 +581,12 @@ func notEmpty(plugin, field, value string) (string, error) {
 	return value, nil
 }
 
-func validateCollectionInterval(pluginName, collectionInterval string) (string, error) {
-	if _, err := notEmpty(pluginName, "collection_interval", collectionInterval); err != nil {
+func validateCollectionInterval(receiverID, collectionInterval string) (string, error) {
+	if _, err := notEmpty(receiverID, "collection_interval", collectionInterval); err != nil {
 		return "", err
 	}
-	t, err := time.ParseDuration(collectionInterval)
-	if err != nil {
-		return "", fmt.Errorf("parameter \"collection_interval\" in metrics receiver %q has invalid value %q that is not an interval (e.g. \"60s\"). Detailed error: %s", pluginName, collectionInterval, err)
-	}
-	interval := t.Seconds()
-	if interval < 10 {
-		return "", fmt.Errorf("parameter \"collection_interval\" in metrics receiver %q has invalid value \"%vs\" that is below the minimum threshold of \"10s\".", pluginName, interval)
+	if _, err := config.ValidateCollectionInterval(receiverID, collectionInterval); err != nil {
+		return "", err
 	}
 	return collectionInterval, nil
 }


### PR DESCRIPTION
This pulls out all of the config representation data structures, as well as the Ops Agent-level config validation, into the `confgenerator/config` package.
Also fixes some test case inconsistencies and temporarily reinstates collectd config generation tests.