### PR TITLE
use bin subdir for fluent-bit

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,12 +52,12 @@ function build_fluentbit() {
   cd submodules/fluent-bit
   mkdir -p build
   cd build
-  # CMAKE_INSTALL_PREFIX and CMAKE_INSTALL_BINDIR here will cause the binary to
-  # be put at /usr/lib/google-cloud-ops-agent/./fluent-bit
+  # CMAKE_INSTALL_PREFIX here will cause the binary to be put at
+  # /usr/lib/google-cloud-ops-agent/bin/fluent-bit
   # Additionally, -DFLB_SHARED_LIB=OFF skips building libfluent-bit.so
   cmake .. -DCMAKE_INSTALL_PREFIX=/usr/lib/google-cloud-ops-agent \
-    -DCMAKE_INSTALL_BINDIR=. -DFLB_HTTP_SERVER=ON -DFLB_DEBUG=OFF \
-    -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITHOUT_HEADERS=ON -DFLB_SHARED_LIB=OFF
+    -DFLB_HTTP_SERVER=ON -DFLB_DEBUG=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DWITHOUT_HEADERS=ON -DFLB_SHARED_LIB=OFF
   make -j8
   make DESTDIR="$DESTDIR" install
   # We don't want fluent-bit's service or configuration, but there are no cmake

--- a/systemd/google-cloud-ops-agent-fluent-bit.service
+++ b/systemd/google-cloud-ops-agent-fluent-bit.service
@@ -27,7 +27,7 @@ StateDirectory=google-cloud-ops-agent/fluent-bit
 LogsDirectory=google-cloud-ops-agent/subagents
 Type=simple
 ExecStartPre=@PREFIX@/libexec/google_cloud_ops_agent_engine -service=fluentbit -in @SYSCONFDIR@/google-cloud-ops-agent/config.yaml -logs ${LOGS_DIRECTORY} -state ${STATE_DIRECTORY}
-ExecStart=/usr/lib/google-cloud-ops-agent/fluent-bit --config ${RUNTIME_DIRECTORY}/fluent_bit_main.conf --parser ${RUNTIME_DIRECTORY}/fluent_bit_parser.conf --log_file ${LOGS_DIRECTORY}/logging-module.log --storage_path ${STATE_DIRECTORY}/buffers
+ExecStart=/usr/lib/google-cloud-ops-agent/bin/fluent-bit --config ${RUNTIME_DIRECTORY}/fluent_bit_main.conf --parser ${RUNTIME_DIRECTORY}/fluent_bit_parser.conf --log_file ${LOGS_DIRECTORY}/logging-module.log --storage_path ${STATE_DIRECTORY}/buffers
 Restart=always
 # For debugging:
 RuntimeDirectoryPreserve=yes


### PR DESCRIPTION
SELinux rules on EL8 systems mean that we need to place our binaries in a bin/ subdirectory to receive the appropriate file context. This has been causing test failures.