### PR TITLE
Fix disk/operation_time to report average operation time

### DIFF
--- a/confgenerator/testdata/valid/linux/default_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/default_config/golden_otel.conf
@@ -39,6 +39,7 @@ processors:
           - system.filesystem.inodes.usage
           - system.paging.faults
           - system.disk.operation_time
+          - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:

--- a/confgenerator/testdata/valid/linux/default_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/default_config/golden_otel.conf
@@ -38,6 +38,7 @@ processors:
           - system.network.dropped
           - system.filesystem.inodes.usage
           - system.paging.faults
+          - system.disk.operation_time
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:
@@ -118,8 +119,8 @@ processors:
             experimental_scale: 1000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
-      # system.disk.operation_time -> disk/operation_time
-      - metric_name: system.disk.operation_time
+      # system.disk.average_operation_time -> disk/operation_time
+      - metric_name: system.disk.average_operation_time
         action: update
         new_name: disk/operation_time
         operations:

--- a/confgenerator/testdata/valid/linux/empty_log_service/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/empty_log_service/golden_otel.conf
@@ -39,6 +39,7 @@ processors:
           - system.filesystem.inodes.usage
           - system.paging.faults
           - system.disk.operation_time
+          - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:

--- a/confgenerator/testdata/valid/linux/empty_log_service/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/empty_log_service/golden_otel.conf
@@ -38,6 +38,7 @@ processors:
           - system.network.dropped
           - system.filesystem.inodes.usage
           - system.paging.faults
+          - system.disk.operation_time
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:
@@ -118,8 +119,8 @@ processors:
             experimental_scale: 1000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
-      # system.disk.operation_time -> disk/operation_time
-      - metric_name: system.disk.operation_time
+      # system.disk.average_operation_time -> disk/operation_time
+      - metric_name: system.disk.average_operation_time
         action: update
         new_name: disk/operation_time
         operations:

--- a/confgenerator/testdata/valid/linux/logging-complex_logs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs/golden_otel.conf
@@ -39,6 +39,7 @@ processors:
           - system.filesystem.inodes.usage
           - system.paging.faults
           - system.disk.operation_time
+          - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:

--- a/confgenerator/testdata/valid/linux/logging-complex_logs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs/golden_otel.conf
@@ -38,6 +38,7 @@ processors:
           - system.network.dropped
           - system.filesystem.inodes.usage
           - system.paging.faults
+          - system.disk.operation_time
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:
@@ -118,8 +119,8 @@ processors:
             experimental_scale: 1000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
-      # system.disk.operation_time -> disk/operation_time
-      - metric_name: system.disk.operation_time
+      # system.disk.average_operation_time -> disk/operation_time
+      - metric_name: system.disk.average_operation_time
         action: update
         new_name: disk/operation_time
         operations:

--- a/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_otel.conf
@@ -39,6 +39,7 @@ processors:
           - system.filesystem.inodes.usage
           - system.paging.faults
           - system.disk.operation_time
+          - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:

--- a/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_otel.conf
@@ -38,6 +38,7 @@ processors:
           - system.network.dropped
           - system.filesystem.inodes.usage
           - system.paging.faults
+          - system.disk.operation_time
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:
@@ -118,8 +119,8 @@ processors:
             experimental_scale: 1000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
-      # system.disk.operation_time -> disk/operation_time
-      - metric_name: system.disk.operation_time
+      # system.disk.average_operation_time -> disk/operation_time
+      - metric_name: system.disk.average_operation_time
         action: update
         new_name: disk/operation_time
         operations:

--- a/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_otel.conf
@@ -39,6 +39,7 @@ processors:
           - system.filesystem.inodes.usage
           - system.paging.faults
           - system.disk.operation_time
+          - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:

--- a/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_otel.conf
@@ -38,6 +38,7 @@ processors:
           - system.network.dropped
           - system.filesystem.inodes.usage
           - system.paging.faults
+          - system.disk.operation_time
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:
@@ -118,8 +119,8 @@ processors:
             experimental_scale: 1000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
-      # system.disk.operation_time -> disk/operation_time
-      - metric_name: system.disk.operation_time
+      # system.disk.average_operation_time -> disk/operation_time
+      - metric_name: system.disk.average_operation_time
         action: update
         new_name: disk/operation_time
         operations:

--- a/confgenerator/testdata/valid/linux/logging-multiple_google_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_google_exporters/golden_otel.conf
@@ -39,6 +39,7 @@ processors:
           - system.filesystem.inodes.usage
           - system.paging.faults
           - system.disk.operation_time
+          - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:

--- a/confgenerator/testdata/valid/linux/logging-multiple_google_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_google_exporters/golden_otel.conf
@@ -38,6 +38,7 @@ processors:
           - system.network.dropped
           - system.filesystem.inodes.usage
           - system.paging.faults
+          - system.disk.operation_time
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:
@@ -118,8 +119,8 @@ processors:
             experimental_scale: 1000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
-      # system.disk.operation_time -> disk/operation_time
-      - metric_name: system.disk.operation_time
+      # system.disk.average_operation_time -> disk/operation_time
+      - metric_name: system.disk.average_operation_time
         action: update
         new_name: disk/operation_time
         operations:

--- a/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_otel.conf
@@ -39,6 +39,7 @@ processors:
           - system.filesystem.inodes.usage
           - system.paging.faults
           - system.disk.operation_time
+          - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:

--- a/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_otel.conf
@@ -38,6 +38,7 @@ processors:
           - system.network.dropped
           - system.filesystem.inodes.usage
           - system.paging.faults
+          - system.disk.operation_time
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:
@@ -118,8 +119,8 @@ processors:
             experimental_scale: 1000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
-      # system.disk.operation_time -> disk/operation_time
-      - metric_name: system.disk.operation_time
+      # system.disk.average_operation_time -> disk/operation_time
+      - metric_name: system.disk.average_operation_time
         action: update
         new_name: disk/operation_time
         operations:

--- a/confgenerator/testdata/valid/linux/logging-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-no_conf/golden_otel.conf
@@ -39,6 +39,7 @@ processors:
           - system.filesystem.inodes.usage
           - system.paging.faults
           - system.disk.operation_time
+          - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:

--- a/confgenerator/testdata/valid/linux/logging-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-no_conf/golden_otel.conf
@@ -38,6 +38,7 @@ processors:
           - system.network.dropped
           - system.filesystem.inodes.usage
           - system.paging.faults
+          - system.disk.operation_time
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:
@@ -118,8 +119,8 @@ processors:
             experimental_scale: 1000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
-      # system.disk.operation_time -> disk/operation_time
-      - metric_name: system.disk.operation_time
+      # system.disk.average_operation_time -> disk/operation_time
+      - metric_name: system.disk.average_operation_time
         action: update
         new_name: disk/operation_time
         operations:

--- a/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_otel.conf
@@ -39,6 +39,7 @@ processors:
           - system.filesystem.inodes.usage
           - system.paging.faults
           - system.disk.operation_time
+          - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:

--- a/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_otel.conf
@@ -38,6 +38,7 @@ processors:
           - system.network.dropped
           - system.filesystem.inodes.usage
           - system.paging.faults
+          - system.disk.operation_time
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:
@@ -118,8 +119,8 @@ processors:
             experimental_scale: 1000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
-      # system.disk.operation_time -> disk/operation_time
-      - metric_name: system.disk.operation_time
+      # system.disk.average_operation_time -> disk/operation_time
+      - metric_name: system.disk.average_operation_time
         action: update
         new_name: disk/operation_time
         operations:

--- a/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes/golden_otel.conf
@@ -39,6 +39,7 @@ processors:
           - system.filesystem.inodes.usage
           - system.paging.faults
           - system.disk.operation_time
+          - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:

--- a/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes/golden_otel.conf
@@ -38,6 +38,7 @@ processors:
           - system.network.dropped
           - system.filesystem.inodes.usage
           - system.paging.faults
+          - system.disk.operation_time
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:
@@ -118,8 +119,8 @@ processors:
             experimental_scale: 1000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
-      # system.disk.operation_time -> disk/operation_time
-      - metric_name: system.disk.operation_time
+      # system.disk.average_operation_time -> disk/operation_time
+      - metric_name: system.disk.average_operation_time
         action: update
         new_name: disk/operation_time
         operations:

--- a/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes_with_glob/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes_with_glob/golden_otel.conf
@@ -39,6 +39,7 @@ processors:
           - system.filesystem.inodes.usage
           - system.paging.faults
           - system.disk.operation_time
+          - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:

--- a/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes_with_glob/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes_with_glob/golden_otel.conf
@@ -38,6 +38,7 @@ processors:
           - system.network.dropped
           - system.filesystem.inodes.usage
           - system.paging.faults
+          - system.disk.operation_time
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:
@@ -118,8 +119,8 @@ processors:
             experimental_scale: 1000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
-      # system.disk.operation_time -> disk/operation_time
-      - metric_name: system.disk.operation_time
+      # system.disk.average_operation_time -> disk/operation_time
+      - metric_name: system.disk.average_operation_time
         action: update
         new_name: disk/operation_time
         operations:

--- a/confgenerator/testdata/valid/linux/metrics-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-no_conf/golden_otel.conf
@@ -27,6 +27,7 @@ processors:
           - system.filesystem.inodes.usage
           - system.paging.faults
           - system.disk.operation_time
+          - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:

--- a/confgenerator/testdata/valid/linux/metrics-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-no_conf/golden_otel.conf
@@ -26,6 +26,7 @@ processors:
           - system.network.dropped
           - system.filesystem.inodes.usage
           - system.paging.faults
+          - system.disk.operation_time
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:
@@ -106,8 +107,8 @@ processors:
             experimental_scale: 1000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
-      # system.disk.operation_time -> disk/operation_time
-      - metric_name: system.disk.operation_time
+      # system.disk.average_operation_time -> disk/operation_time
+      - metric_name: system.disk.average_operation_time
         action: update
         new_name: disk/operation_time
         operations:

--- a/confgenerator/testdata/valid/windows/default_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/default_config/golden_otel.conf
@@ -67,6 +67,7 @@ processors:
           - system.network.dropped
           - system.filesystem.inodes.usage
           - system.paging.faults
+          - system.disk.operation_time
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:
@@ -147,8 +148,8 @@ processors:
             experimental_scale: 1000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
-      # system.disk.operation_time -> disk/operation_time
-      - metric_name: system.disk.operation_time
+      # system.disk.average_operation_time -> disk/operation_time
+      - metric_name: system.disk.average_operation_time
         action: update
         new_name: disk/operation_time
         operations:

--- a/confgenerator/testdata/valid/windows/default_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/default_config/golden_otel.conf
@@ -68,6 +68,7 @@ processors:
           - system.filesystem.inodes.usage
           - system.paging.faults
           - system.disk.operation_time
+          - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:

--- a/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_otel.conf
@@ -67,6 +67,7 @@ processors:
           - system.network.dropped
           - system.filesystem.inodes.usage
           - system.paging.faults
+          - system.disk.operation_time
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:
@@ -147,8 +148,8 @@ processors:
             experimental_scale: 1000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
-      # system.disk.operation_time -> disk/operation_time
-      - metric_name: system.disk.operation_time
+      # system.disk.average_operation_time -> disk/operation_time
+      - metric_name: system.disk.average_operation_time
         action: update
         new_name: disk/operation_time
         operations:

--- a/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_otel.conf
@@ -68,6 +68,7 @@ processors:
           - system.filesystem.inodes.usage
           - system.paging.faults
           - system.disk.operation_time
+          - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:

--- a/confgenerator/testdata/valid/windows/logging-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-no_conf/golden_otel.conf
@@ -67,6 +67,7 @@ processors:
           - system.network.dropped
           - system.filesystem.inodes.usage
           - system.paging.faults
+          - system.disk.operation_time
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:
@@ -147,8 +148,8 @@ processors:
             experimental_scale: 1000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
-      # system.disk.operation_time -> disk/operation_time
-      - metric_name: system.disk.operation_time
+      # system.disk.average_operation_time -> disk/operation_time
+      - metric_name: system.disk.average_operation_time
         action: update
         new_name: disk/operation_time
         operations:

--- a/confgenerator/testdata/valid/windows/logging-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-no_conf/golden_otel.conf
@@ -68,6 +68,7 @@ processors:
           - system.filesystem.inodes.usage
           - system.paging.faults
           - system.disk.operation_time
+          - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:

--- a/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_otel.conf
@@ -39,6 +39,7 @@ processors:
           - system.filesystem.inodes.usage
           - system.paging.faults
           - system.disk.operation_time
+          - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:

--- a/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_otel.conf
@@ -38,6 +38,7 @@ processors:
           - system.network.dropped
           - system.filesystem.inodes.usage
           - system.paging.faults
+          - system.disk.operation_time
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:
@@ -118,8 +119,8 @@ processors:
             experimental_scale: 1000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
-      # system.disk.operation_time -> disk/operation_time
-      - metric_name: system.disk.operation_time
+      # system.disk.average_operation_time -> disk/operation_time
+      - metric_name: system.disk.average_operation_time
         action: update
         new_name: disk/operation_time
         operations:

--- a/confgenerator/testdata/valid/windows/metrics-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-no_conf/golden_otel.conf
@@ -27,6 +27,7 @@ processors:
           - system.filesystem.inodes.usage
           - system.paging.faults
           - system.disk.operation_time
+          - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:

--- a/confgenerator/testdata/valid/windows/metrics-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-no_conf/golden_otel.conf
@@ -26,6 +26,7 @@ processors:
           - system.network.dropped
           - system.filesystem.inodes.usage
           - system.paging.faults
+          - system.disk.operation_time
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:
@@ -106,8 +107,8 @@ processors:
             experimental_scale: 1000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
-      # system.disk.operation_time -> disk/operation_time
-      - metric_name: system.disk.operation_time
+      # system.disk.average_operation_time -> disk/operation_time
+      - metric_name: system.disk.average_operation_time
         action: update
         new_name: disk/operation_time
         operations:

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_otel.conf
@@ -50,6 +50,7 @@ processors:
           - system.network.dropped
           - system.filesystem.inodes.usage
           - system.paging.faults
+          - system.disk.operation_time
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:
@@ -130,8 +131,8 @@ processors:
             experimental_scale: 1000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
-      # system.disk.operation_time -> disk/operation_time
-      - metric_name: system.disk.operation_time
+      # system.disk.average_operation_time -> disk/operation_time
+      - metric_name: system.disk.average_operation_time
         action: update
         new_name: disk/operation_time
         operations:

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_otel.conf
@@ -51,6 +51,7 @@ processors:
           - system.filesystem.inodes.usage
           - system.paging.faults
           - system.disk.operation_time
+          - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_otel.conf
@@ -56,6 +56,7 @@ processors:
           - system.filesystem.inodes.usage
           - system.paging.faults
           - system.disk.operation_time
+          - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_otel.conf
@@ -55,6 +55,7 @@ processors:
           - system.network.dropped
           - system.filesystem.inodes.usage
           - system.paging.faults
+          - system.disk.operation_time
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:
@@ -135,8 +136,8 @@ processors:
             experimental_scale: 1000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
-      # system.disk.operation_time -> disk/operation_time
-      - metric_name: system.disk.operation_time
+      # system.disk.average_operation_time -> disk/operation_time
+      - metric_name: system.disk.average_operation_time
         action: update
         new_name: disk/operation_time
         operations:

--- a/confgenerator/testdata/valid/windows/valid_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/valid_config/golden_otel.conf
@@ -67,6 +67,7 @@ processors:
           - system.network.dropped
           - system.filesystem.inodes.usage
           - system.paging.faults
+          - system.disk.operation_time
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:
@@ -147,8 +148,8 @@ processors:
             experimental_scale: 1000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
-      # system.disk.operation_time -> disk/operation_time
-      - metric_name: system.disk.operation_time
+      # system.disk.average_operation_time -> disk/operation_time
+      - metric_name: system.disk.average_operation_time
         action: update
         new_name: disk/operation_time
         operations:

--- a/confgenerator/testdata/valid/windows/valid_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/valid_config/golden_otel.conf
@@ -68,6 +68,7 @@ processors:
           - system.filesystem.inodes.usage
           - system.paging.faults
           - system.disk.operation_time
+          - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:

--- a/otel/conf.go
+++ b/otel/conf.go
@@ -167,6 +167,7 @@ windowsperfcounters/mssql_{{.MSSQLID}}:
           - system.filesystem.inodes.usage
           - system.paging.faults
           - system.disk.operation_time
+          - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:

--- a/otel/conf.go
+++ b/otel/conf.go
@@ -166,6 +166,7 @@ windowsperfcounters/mssql_{{.MSSQLID}}:
           - system.network.dropped
           - system.filesystem.inodes.usage
           - system.paging.faults
+          - system.disk.operation_time
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:
@@ -246,8 +247,8 @@ windowsperfcounters/mssql_{{.MSSQLID}}:
             experimental_scale: 1000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
-      # system.disk.operation_time -> disk/operation_time
-      - metric_name: system.disk.operation_time
+      # system.disk.average_operation_time -> disk/operation_time
+      - metric_name: system.disk.average_operation_time
         action: update
         new_name: disk/operation_time
         operations:

--- a/otel/conf_test.go
+++ b/otel/conf_test.go
@@ -242,6 +242,7 @@ processors:
           - system.filesystem.inodes.usage
           - system.paging.faults
           - system.disk.operation_time
+          - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:

--- a/otel/conf_test.go
+++ b/otel/conf_test.go
@@ -241,6 +241,7 @@ processors:
           - system.network.dropped
           - system.filesystem.inodes.usage
           - system.paging.faults
+          - system.disk.operation_time
 
   # convert from opentelemetry metric formats to cloud monitoring formats
   googlemetricstransform/system:
@@ -321,8 +322,8 @@ processors:
             experimental_scale: 1000
           # change data type from double -> int64
           - action: toggle_scalar_data_type
-      # system.disk.operation_time -> disk/operation_time
-      - metric_name: system.disk.operation_time
+      # system.disk.average_operation_time -> disk/operation_time
+      - metric_name: system.disk.average_operation_time
         action: update
         new_name: disk/operation_time
         operations:


### PR DESCRIPTION
collectd reported average operation time; OT reports total operation time, so we need to introduce a new metric for average operation time and divide the existing metrics.

Before this can be merged we need to merge https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/pull/49 and update the submodule in this PR.