### PR TITLE
Add empty metrics_filter by default

### DIFF
--- a/confgenerator/built-in-config-linux.yaml
+++ b/confgenerator/built-in-config-linux.yaml
@@ -20,7 +20,10 @@ metrics:
     hostmetrics:
       type: hostmetrics
       collection_interval: 60s
-  processors: {}
+  processors:
+    metrics_filter:
+      type: exclude_metrics
+      metrics_pattern: []
   exporters:
     google:
       type: google_cloud_monitoring
@@ -29,6 +32,7 @@ metrics:
       default_pipeline:
         receivers:
         - hostmetrics
-        processors: []
+        processors:
+        - metrics_filter
         exporters:
         - google

--- a/confgenerator/built-in-config-windows.yaml
+++ b/confgenerator/built-in-config-windows.yaml
@@ -27,7 +27,10 @@ metrics:
     mssql:
       type: mssql
       collection_interval: 60s
-  processors: {}
+  processors:
+    metrics_filter:
+      type: exclude_metrics
+      metrics_pattern: []
   exporters:
     google:
       type: google_cloud_monitoring
@@ -38,6 +41,7 @@ metrics:
         - hostmetrics
         - iis
         - mssql
-        processors: []
+        processors:
+        - metrics_filter
         exporters:
         - google

--- a/confgenerator/confmerger.go
+++ b/confgenerator/confmerger.go
@@ -58,6 +58,11 @@ var (
 						CollectionInterval: "60s",
 					},
 				},
+				Processors: map[string]*MetricsProcessor{
+					"metrics_filter": &MetricsProcessor{
+						configComponent: configComponent{Type: "exclude_metrics"},
+					},
+				},
 				Exporters: map[string]*MetricsExporter{
 					"google": &MetricsExporter{
 						configComponent: configComponent{Type: "google_cloud_monitoring"},
@@ -66,8 +71,9 @@ var (
 				Service: &MetricsService{
 					Pipelines: map[string]*MetricsPipeline{
 						"default_pipeline": &MetricsPipeline{
-							ReceiverIDs: []string{"hostmetrics"},
-							ExporterIDs: []string{"google"},
+							ReceiverIDs:  []string{"hostmetrics"},
+							ProcessorIDs: []string{"metrics_filter"},
+							ExporterIDs:  []string{"google"},
 						},
 					},
 				},
@@ -113,6 +119,11 @@ var (
 						CollectionInterval: "60s",
 					},
 				},
+				Processors: map[string]*MetricsProcessor{
+					"metrics_filter": &MetricsProcessor{
+						configComponent: configComponent{Type: "exclude_metrics"},
+					},
+				},
 				Exporters: map[string]*MetricsExporter{
 					"google": &MetricsExporter{
 						configComponent: configComponent{Type: "google_cloud_monitoring"},
@@ -121,8 +132,9 @@ var (
 				Service: &MetricsService{
 					Pipelines: map[string]*MetricsPipeline{
 						"default_pipeline": &MetricsPipeline{
-							ReceiverIDs: []string{"hostmetrics", "iis", "mssql"},
-							ExporterIDs: []string{"google"},
+							ReceiverIDs:  []string{"hostmetrics", "iis", "mssql"},
+							ProcessorIDs: []string{"metrics_filter"},
+							ExporterIDs:  []string{"google"},
 						},
 					},
 				},
@@ -240,7 +252,6 @@ func mergeConfigs(original, overrides *UnifiedConfig) {
 		}
 
 		// Overrides metrics.processors.
-		original.Metrics.Processors = map[string]*MetricsProcessor{}
 		for k, v := range overrides.Metrics.Processors {
 			original.Metrics.Processors[k] = v
 		}
@@ -252,26 +263,8 @@ func mergeConfigs(original, overrides *UnifiedConfig) {
 
 		if overrides.Metrics.Service != nil {
 			for name, pipeline := range overrides.Metrics.Service.Pipelines {
-				if name == "default_pipeline" {
-					// overrides metrics.service.pipelines.default_pipeline.receivers
-					if ids := pipeline.ReceiverIDs; ids != nil {
-						original.Metrics.Service.Pipelines["default_pipeline"].ReceiverIDs = ids
-					}
-
-					//
-					// overrides metrics.service.pipelines.default_pipeline.processors
-					if ids := pipeline.ProcessorIDs; ids != nil {
-						original.Metrics.Service.Pipelines["default_pipeline"].ProcessorIDs = ids
-					}
-
-					// Overrides metrics.service.pipelines.default_pipeline.exporters
-					if ids := pipeline.ExporterIDs; ids != nil {
-						original.Metrics.Service.Pipelines["default_pipeline"].ExporterIDs = ids
-					}
-				} else {
-					// Overrides metrics.service.pipelines.<non_default_pipelines>
-					original.Metrics.Service.Pipelines[name] = pipeline
-				}
+				// Overrides metrics.service.pipelines.<non_default_pipelines>
+				original.Metrics.Service.Pipelines[name] = pipeline
 			}
 		}
 	}

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
@@ -458,6 +458,11 @@ processors:
         operations:
           # change data type from double -> int64
           - action: toggle_scalar_data_type
+  filter/exclude_metrics_filter:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names:
 exporters:
   googlecloud/google:
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
@@ -482,5 +487,5 @@ service:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection]
+      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/default_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/default_config/golden_otel.conf
@@ -458,6 +458,11 @@ processors:
         operations:
           # change data type from double -> int64
           - action: toggle_scalar_data_type
+  filter/exclude_metrics_filter:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names:
 exporters:
   googlecloud/google:
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
@@ -482,5 +487,5 @@ service:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection]
+      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/logging-complex_logs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs/golden_otel.conf
@@ -458,6 +458,11 @@ processors:
         operations:
           # change data type from double -> int64
           - action: toggle_scalar_data_type
+  filter/exclude_metrics_filter:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names:
 exporters:
   googlecloud/google:
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
@@ -482,5 +487,5 @@ service:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection]
+      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_otel.conf
@@ -458,6 +458,11 @@ processors:
         operations:
           # change data type from double -> int64
           - action: toggle_scalar_data_type
+  filter/exclude_metrics_filter:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names:
 exporters:
   googlecloud/google:
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
@@ -482,5 +487,5 @@ service:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection]
+      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_otel.conf
@@ -458,6 +458,11 @@ processors:
         operations:
           # change data type from double -> int64
           - action: toggle_scalar_data_type
+  filter/exclude_metrics_filter:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names:
 exporters:
   googlecloud/google:
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
@@ -482,5 +487,5 @@ service:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection]
+      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/logging-multiple_google_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_google_exporters/golden_otel.conf
@@ -458,6 +458,11 @@ processors:
         operations:
           # change data type from double -> int64
           - action: toggle_scalar_data_type
+  filter/exclude_metrics_filter:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names:
 exporters:
   googlecloud/google:
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
@@ -482,5 +487,5 @@ service:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection]
+      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_otel.conf
@@ -458,6 +458,11 @@ processors:
         operations:
           # change data type from double -> int64
           - action: toggle_scalar_data_type
+  filter/exclude_metrics_filter:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names:
 exporters:
   googlecloud/google:
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
@@ -482,5 +487,5 @@ service:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection]
+      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/logging-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-no_conf/golden_otel.conf
@@ -458,6 +458,11 @@ processors:
         operations:
           # change data type from double -> int64
           - action: toggle_scalar_data_type
+  filter/exclude_metrics_filter:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names:
 exporters:
   googlecloud/google:
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
@@ -482,5 +487,5 @@ service:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection]
+      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_on_default_pipeline/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_on_default_pipeline/golden_otel.conf
@@ -458,6 +458,11 @@ processors:
         operations:
           # change data type from double -> int64
           - action: toggle_scalar_data_type
+  filter/exclude_metrics_filter:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names:
 exporters:
   googlecloud/google:
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
@@ -482,5 +487,5 @@ service:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection]
+      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_otel.conf
@@ -458,6 +458,11 @@ processors:
         operations:
           # change data type from double -> int64
           - action: toggle_scalar_data_type
+  filter/exclude_metrics_filter:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names:
 exporters:
   googlecloud/google:
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
@@ -482,5 +487,5 @@ service:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection]
+      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes/input.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes/input.yaml
@@ -19,7 +19,3 @@ metrics:
       metrics_pattern:
       - agent.googleapis.com/processes/*
       - agent.googleapis.com/cpu/*
-  service:
-    pipelines:
-      default_pipeline:
-        processors: [metrics_filter]

--- a/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes_with_glob/input.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes_with_glob/input.yaml
@@ -19,7 +19,3 @@ metrics:
       metrics_pattern:
       - agent.googleapis.com/proce*ses/*
       - agent.googleapis.com/c*u/*
-  service:
-    pipelines:
-      default_pipeline:
-        processors: [metrics_filter]

--- a/confgenerator/testdata/valid/linux/metrics-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-no_conf/golden_otel.conf
@@ -6,6 +6,18 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets: ['0.0.0.0:8888']
+  hostmetrics/hostmetrics:
+    collection_interval: 60s
+    scrapers:
+      cpu:
+      load:
+      memory:
+      disk:
+      filesystem:
+      network:
+      paging:
+      process:
+      processes:
 processors:
   resourcedetection:
     detectors: [gce]
@@ -446,7 +458,17 @@ processors:
         operations:
           # change data type from double -> int64
           - action: toggle_scalar_data_type
+  filter/exclude_metrics_filter:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names:
+          - "^.*$"
 exporters:
+  googlecloud/google:
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    metric:
+      prefix: agent.googleapis.com/
   googlecloud/agent:
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
     metric:
@@ -464,3 +486,7 @@ service:
         - resourcedetection
       exporters:
         - googlecloud/agent
+    metrics/system:
+      receivers:  [hostmetrics/hostmetrics]
+      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/metrics-no_conf/input.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-no_conf/input.yaml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 metrics:
-  service:
-    pipelines:
-      default_pipeline:
-        receivers: []
-        exporters: []
+  processors:
+    metrics_filter:
+      type: exclude_metrics
+      metrics_pattern:
+        - agent.googleapis.com/*

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
@@ -487,6 +487,11 @@ processors:
         operations:
           # change data type from double -> int64
           - action: toggle_scalar_data_type
+  filter/exclude_metrics_filter:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names:
 exporters:
   googlecloud/google:
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
@@ -511,13 +516,13 @@ service:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection]
+      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/iis:
       receivers:  [windowsperfcounters/iis_iis]
-      processors: [googlemetricstransform/iis,resourcedetection]
+      processors: [googlemetricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/mssql:
       receivers:  [windowsperfcounters/mssql_mssql]
-      processors: [googlemetricstransform/mssql,resourcedetection]
+      processors: [googlemetricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/windows/default_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/default_config/golden_otel.conf
@@ -487,6 +487,11 @@ processors:
         operations:
           # change data type from double -> int64
           - action: toggle_scalar_data_type
+  filter/exclude_metrics_filter:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names:
 exporters:
   googlecloud/google:
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
@@ -511,13 +516,13 @@ service:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection]
+      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/iis:
       receivers:  [windowsperfcounters/iis_iis]
-      processors: [googlemetricstransform/iis,resourcedetection]
+      processors: [googlemetricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/mssql:
       receivers:  [windowsperfcounters/mssql_mssql]
-      processors: [googlemetricstransform/mssql,resourcedetection]
+      processors: [googlemetricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_otel.conf
@@ -487,6 +487,11 @@ processors:
         operations:
           # change data type from double -> int64
           - action: toggle_scalar_data_type
+  filter/exclude_metrics_filter:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names:
 exporters:
   googlecloud/google:
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
@@ -511,13 +516,13 @@ service:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection]
+      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/iis:
       receivers:  [windowsperfcounters/iis_iis]
-      processors: [googlemetricstransform/iis,resourcedetection]
+      processors: [googlemetricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/mssql:
       receivers:  [windowsperfcounters/mssql_mssql]
-      processors: [googlemetricstransform/mssql,resourcedetection]
+      processors: [googlemetricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/windows/logging-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-no_conf/golden_otel.conf
@@ -487,6 +487,11 @@ processors:
         operations:
           # change data type from double -> int64
           - action: toggle_scalar_data_type
+  filter/exclude_metrics_filter:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names:
 exporters:
   googlecloud/google:
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
@@ -511,13 +516,13 @@ service:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection]
+      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/iis:
       receivers:  [windowsperfcounters/iis_iis]
-      processors: [googlemetricstransform/iis,resourcedetection]
+      processors: [googlemetricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/mssql:
       receivers:  [windowsperfcounters/mssql_mssql]
-      processors: [googlemetricstransform/mssql,resourcedetection]
+      processors: [googlemetricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_otel.conf
@@ -487,6 +487,11 @@ processors:
         operations:
           # change data type from double -> int64
           - action: toggle_scalar_data_type
+  filter/exclude_metrics_filter:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names:
 exporters:
   googlecloud/google:
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
@@ -511,13 +516,13 @@ service:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection]
+      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/iis:
       receivers:  [windowsperfcounters/iis_iis]
-      processors: [googlemetricstransform/iis,resourcedetection]
+      processors: [googlemetricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/mssql:
       receivers:  [windowsperfcounters/mssql_mssql]
-      processors: [googlemetricstransform/mssql,resourcedetection]
+      processors: [googlemetricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/windows/metrics-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-no_conf/golden_otel.conf
@@ -6,6 +6,47 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets: ['0.0.0.0:8888']
+  hostmetrics/hostmetrics:
+    collection_interval: 60s
+    scrapers:
+      cpu:
+      load:
+      memory:
+      disk:
+      filesystem:
+      network:
+      paging:
+      process:
+      processes:
+  windowsperfcounters/mssql_mssql:
+    collection_interval: 60s
+    perfcounters:
+      - object: SQLServer:General Statistics
+        instances: _Total
+        counters:
+          - User Connections
+      - object: SQLServer:Databases
+        instances: _Total
+        counters:
+          - Transactions/sec
+          - Write Transactions/sec
+  windowsperfcounters/iis_iis:
+    collection_interval: 60s
+    perfcounters:
+      - object: Web Service
+        instances: _Total
+        counters:
+          - Current Connections
+          - Total Bytes Received
+          - Total Bytes Sent
+          - Total Connection Attempts (all instances)
+          - Total Delete Requests
+          - Total Get Requests
+          - Total Head Requests
+          - Total Options Requests
+          - Total Post Requests
+          - Total Put Requests
+          - Total Trace Requests
 processors:
   resourcedetection:
     detectors: [gce]
@@ -446,7 +487,17 @@ processors:
         operations:
           # change data type from double -> int64
           - action: toggle_scalar_data_type
+  filter/exclude_metrics_filter:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names:
+          - "^.*$"
 exporters:
+  googlecloud/google:
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    metric:
+      prefix: agent.googleapis.com/
   googlecloud/agent:
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
     metric:
@@ -464,3 +515,15 @@ service:
         - resourcedetection
       exporters:
         - googlecloud/agent
+    metrics/system:
+      receivers:  [hostmetrics/hostmetrics]
+      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      exporters: [googlecloud/google]
+    metrics/iis:
+      receivers:  [windowsperfcounters/iis_iis]
+      processors: [googlemetricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
+      exporters: [googlecloud/google]
+    metrics/mssql:
+      receivers:  [windowsperfcounters/mssql_mssql]
+      processors: [googlemetricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
+      exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/windows/metrics-no_conf/input.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-no_conf/input.yaml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 metrics:
-  service:
-    pipelines:
-      default_pipeline:
-        receivers: []
-        exporters: []
+  processors:
+    metrics_filter:
+      type: exclude_metrics
+      metrics_pattern:
+        - agent.googleapis.com/*

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_otel.conf
@@ -30,6 +30,23 @@ receivers:
         counters:
           - Transactions/sec
           - Write Transactions/sec
+  windowsperfcounters/iis_iis:
+    collection_interval: 60s
+    perfcounters:
+      - object: Web Service
+        instances: _Total
+        counters:
+          - Current Connections
+          - Total Bytes Received
+          - Total Bytes Sent
+          - Total Connection Attempts (all instances)
+          - Total Delete Requests
+          - Total Get Requests
+          - Total Head Requests
+          - Total Options Requests
+          - Total Post Requests
+          - Total Put Requests
+          - Total Trace Requests
 processors:
   resourcedetection:
     detectors: [gce]
@@ -470,6 +487,12 @@ processors:
         operations:
           # change data type from double -> int64
           - action: toggle_scalar_data_type
+  filter/exclude_metrics_filter:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names:
+          - "^iis/.*$"
 exporters:
   googlecloud/google:
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
@@ -494,9 +517,13 @@ service:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection]
+      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      exporters: [googlecloud/google]
+    metrics/iis:
+      receivers:  [windowsperfcounters/iis_iis]
+      processors: [googlemetricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/mssql:
       receivers:  [windowsperfcounters/mssql_mssql]
-      processors: [googlemetricstransform/mssql,resourcedetection]
+      processors: [googlemetricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_iis/input.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_iis/input.yaml
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 metrics:
-  service:
-    pipelines:
-      default_pipeline:
-        receivers: [hostmetrics,mssql]
+  processors:
+    metrics_filter:
+      type: exclude_metrics
+      metrics_pattern:
+        - agent.googleapis.com/iis/*

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_otel.conf
@@ -18,6 +18,18 @@ receivers:
       paging:
       process:
       processes:
+  windowsperfcounters/mssql_mssql:
+    collection_interval: 60s
+    perfcounters:
+      - object: SQLServer:General Statistics
+        instances: _Total
+        counters:
+          - User Connections
+      - object: SQLServer:Databases
+        instances: _Total
+        counters:
+          - Transactions/sec
+          - Write Transactions/sec
   windowsperfcounters/iis_iis:
     collection_interval: 60s
     perfcounters:
@@ -475,6 +487,12 @@ processors:
         operations:
           # change data type from double -> int64
           - action: toggle_scalar_data_type
+  filter/exclude_metrics_filter:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names:
+          - "^mssql/.*$"
 exporters:
   googlecloud/google:
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
@@ -499,9 +517,13 @@ service:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection]
+      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/iis:
       receivers:  [windowsperfcounters/iis_iis]
-      processors: [googlemetricstransform/iis,resourcedetection]
+      processors: [googlemetricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
+      exporters: [googlecloud/google]
+    metrics/mssql:
+      receivers:  [windowsperfcounters/mssql_mssql]
+      processors: [googlemetricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/input.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/input.yaml
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 metrics:
-  service:
-    pipelines:
-      default_pipeline:
-        receivers: [hostmetrics,iis]
+  processors:
+    metrics_filter:
+      type: exclude_metrics
+      metrics_pattern:
+        - agent.googleapis.com/mssql/*


### PR DESCRIPTION
This allows user configs to never need a pipelines section.

No changes to config validation, so users can still specify a pipeline if they choose to (but there is no longer any reason they would ever have a need to do that, with today's config options).