### PR TITLE
ops-agent.service after subagents service

### DIFF
--- a/systemd/google-cloud-ops-agent.service
+++ b/systemd/google-cloud-ops-agent.service
@@ -15,6 +15,7 @@
 [Unit]
 Description=Google Cloud Ops Agent
 Requires=google-cloud-ops-agent-fluent-bit.service google-cloud-ops-agent-opentelemetry-collector.service
+After=google-cloud-ops-agent-fluent-bit.service google-cloud-ops-agent-opentelemetry-collector.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
### TL,DR: Add `After=google-cloud-ops-agent-fluent-bit.service google-cloud-ops-agent-opentelemetry-collector.service` inside `ops-agent.service` file helps making the `restart service` on invalid conf consistently fail


### Problem

By 50% chance(because of the inconsistency), on restarting the agent on an invalid conf, client now finds out that agent not running only after missing metrics or logs for a while. I think this might cause some support pain on us considering customizing conf is allowed and sometimes it can go wrong by client.

### Background

While working with jimmy park on re-confirming the behavior of Troubleshooting invalid conf in GA, we realized sometimes `restart` on invalid conf doesn't emit any error msgs and echo $? also says 0. As the document we wrote for beta said it would have error msg if the agent didn't restart right. But we smartly use *might*. 

### `target` behaves consistently with invalid conf
 
- To confirm if `target` behaves differently with `service`. I installed `1.*.* the latest` where we still use `sudo systemctl restart google-cloud-ops-agent.target`. If the conf is invalid on restart, `echo $?` constantly show `1`. See: ![image](https://user-images.githubusercontent.com/8354694/124135110-8136f200-da51-11eb-8393-c28a3b4bfd5a.png)

#### V.S.

### `service` behave inconsistently on invalid conf
![image](https://user-images.githubusercontent.com/8354694/124135172-927ffe80-da51-11eb-8434-6f33fa884862.png)

## Solution

After reading the code and some doc, I think the inconsistent behavior of `restart service` on invalid conf is because ops-agent.service doesn't wait for `fluentbit.service` and `otel.service`. The conversion code is triggered in `ExecStartPre=` in those two subagents `service` file. When the conversion fails, it happens in those two subagents service. If we let `ops-agent.service` to wait for those two subagents service, it might work. Therefor, I tried putting back this line `After=google-cloud-ops-agent-fluent-bit.service google-cloud-ops-agent-opentelemetry-collector.service` inside `ops-agent.service` file. And restarting service on invalid configuration now consistently emit error.

### Test evidence:
![image](https://user-images.githubusercontent.com/8354694/124135217-9b70d000-da51-11eb-9177-7d492fff33ab.png) 