### PR TITLE
Unfork metricstransformprocessor

### DIFF
--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -94,13 +94,13 @@ func generateOtelServices(receiverNameMap map[string]string, exporterNameMap map
 			var pipelineID string
 			var defaultProcessors []string
 			if strings.HasPrefix(receiverNameMap[rID], "hostmetrics/") {
-				defaultProcessors = []string{"agentmetrics/system", "filter/system", "googlemetricstransform/system", "resourcedetection"}
+				defaultProcessors = []string{"agentmetrics/system", "filter/system", "metricstransform/system", "resourcedetection"}
 				pipelineID = "system"
 			} else if strings.HasPrefix(receiverNameMap[rID], "windowsperfcounters/mssql") {
-				defaultProcessors = []string{"googlemetricstransform/mssql", "resourcedetection"}
+				defaultProcessors = []string{"metricstransform/mssql", "resourcedetection"}
 				pipelineID = "mssql"
 			} else if strings.HasPrefix(receiverNameMap[rID], "windowsperfcounters/iis") {
-				defaultProcessors = []string{"googlemetricstransform/iis", "resourcedetection"}
+				defaultProcessors = []string{"metricstransform/iis", "resourcedetection"}
 				pipelineID = "iis"
 			}
 

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
@@ -73,7 +73,7 @@ processors:
           # add blank cpu_number label
           - action: add_label
             new_label: cpu_number
-            new_value: ""
+            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
@@ -24,11 +24,8 @@ processors:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
@@ -28,6 +28,8 @@ processors:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -66,9 +68,13 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
@@ -22,7 +22,7 @@ processors:
   resourcedetection:
     detectors: [gce]
 
-  # perform custom transformations that aren't supported by the googlemetricstransform processor
+  # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
     # 1. converts up down sum types to gauges
     # 2. combines resource process metrics into metrics with processes as labels
@@ -44,7 +44,7 @@ processors:
           - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/system:
+  metricstransform/system:
     transforms:
       # system.cpu.time -> cpu/usage_time
       - metric_name: system.cpu.time
@@ -66,14 +66,10 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # take avg over cpu dimension, retaining only state label
-          - action: aggregate_labels
-            label_set: [state]
-            aggregation_type: mean
-          # add blank cpu_number label
-          - action: add_label
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
             new_label: cpu_number
-            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state
@@ -381,7 +377,7 @@ processors:
           - otelcol_googlecloudmonitoring_point_count
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/iis:
+  metricstransform/iis:
     transforms:
       - include: \Web Service(_Total)\Current Connections
         action: update
@@ -401,7 +397,7 @@ processors:
         submatch_case: lower
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/mssql:
+  metricstransform/mssql:
     transforms:
       - include: \SQLServer:General Statistics(_Total)\User Connections
         action: update
@@ -414,7 +410,7 @@ processors:
         new_name: mssql/write_transaction_rate
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/agent:
+  metricstransform/agent:
     transforms:
       # otelcol_process_uptime -> agent/uptime
       - metric_name: otelcol_process_uptime
@@ -481,11 +477,11 @@ service:
         - prometheus/agent
       processors:
         - filter/agent
-        - googlemetricstransform/agent
+        - metricstransform/agent
         - resourcedetection
       exporters:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      processors: [agentmetrics/system,filter/system,metricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/default_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/default_config/golden_otel.conf
@@ -73,7 +73,7 @@ processors:
           # add blank cpu_number label
           - action: add_label
             new_label: cpu_number
-            new_value: ""
+            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/linux/default_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/default_config/golden_otel.conf
@@ -24,11 +24,8 @@ processors:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring

--- a/confgenerator/testdata/valid/linux/default_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/default_config/golden_otel.conf
@@ -28,6 +28,8 @@ processors:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -66,9 +68,13 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/confgenerator/testdata/valid/linux/default_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/default_config/golden_otel.conf
@@ -22,7 +22,7 @@ processors:
   resourcedetection:
     detectors: [gce]
 
-  # perform custom transformations that aren't supported by the googlemetricstransform processor
+  # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
     # 1. converts up down sum types to gauges
     # 2. combines resource process metrics into metrics with processes as labels
@@ -44,7 +44,7 @@ processors:
           - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/system:
+  metricstransform/system:
     transforms:
       # system.cpu.time -> cpu/usage_time
       - metric_name: system.cpu.time
@@ -66,14 +66,10 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # take avg over cpu dimension, retaining only state label
-          - action: aggregate_labels
-            label_set: [state]
-            aggregation_type: mean
-          # add blank cpu_number label
-          - action: add_label
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
             new_label: cpu_number
-            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state
@@ -381,7 +377,7 @@ processors:
           - otelcol_googlecloudmonitoring_point_count
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/iis:
+  metricstransform/iis:
     transforms:
       - include: \Web Service(_Total)\Current Connections
         action: update
@@ -401,7 +397,7 @@ processors:
         submatch_case: lower
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/mssql:
+  metricstransform/mssql:
     transforms:
       - include: \SQLServer:General Statistics(_Total)\User Connections
         action: update
@@ -414,7 +410,7 @@ processors:
         new_name: mssql/write_transaction_rate
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/agent:
+  metricstransform/agent:
     transforms:
       # otelcol_process_uptime -> agent/uptime
       - metric_name: otelcol_process_uptime
@@ -481,11 +477,11 @@ service:
         - prometheus/agent
       processors:
         - filter/agent
-        - googlemetricstransform/agent
+        - metricstransform/agent
         - resourcedetection
       exporters:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      processors: [agentmetrics/system,filter/system,metricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/logging-complex_logs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs/golden_otel.conf
@@ -73,7 +73,7 @@ processors:
           # add blank cpu_number label
           - action: add_label
             new_label: cpu_number
-            new_value: ""
+            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/linux/logging-complex_logs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs/golden_otel.conf
@@ -24,11 +24,8 @@ processors:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring

--- a/confgenerator/testdata/valid/linux/logging-complex_logs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs/golden_otel.conf
@@ -28,6 +28,8 @@ processors:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -66,9 +68,13 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-complex_logs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs/golden_otel.conf
@@ -22,7 +22,7 @@ processors:
   resourcedetection:
     detectors: [gce]
 
-  # perform custom transformations that aren't supported by the googlemetricstransform processor
+  # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
     # 1. converts up down sum types to gauges
     # 2. combines resource process metrics into metrics with processes as labels
@@ -44,7 +44,7 @@ processors:
           - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/system:
+  metricstransform/system:
     transforms:
       # system.cpu.time -> cpu/usage_time
       - metric_name: system.cpu.time
@@ -66,14 +66,10 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # take avg over cpu dimension, retaining only state label
-          - action: aggregate_labels
-            label_set: [state]
-            aggregation_type: mean
-          # add blank cpu_number label
-          - action: add_label
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
             new_label: cpu_number
-            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state
@@ -381,7 +377,7 @@ processors:
           - otelcol_googlecloudmonitoring_point_count
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/iis:
+  metricstransform/iis:
     transforms:
       - include: \Web Service(_Total)\Current Connections
         action: update
@@ -401,7 +397,7 @@ processors:
         submatch_case: lower
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/mssql:
+  metricstransform/mssql:
     transforms:
       - include: \SQLServer:General Statistics(_Total)\User Connections
         action: update
@@ -414,7 +410,7 @@ processors:
         new_name: mssql/write_transaction_rate
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/agent:
+  metricstransform/agent:
     transforms:
       # otelcol_process_uptime -> agent/uptime
       - metric_name: otelcol_process_uptime
@@ -481,11 +477,11 @@ service:
         - prometheus/agent
       processors:
         - filter/agent
-        - googlemetricstransform/agent
+        - metricstransform/agent
         - resourcedetection
       exporters:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      processors: [agentmetrics/system,filter/system,metricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_otel.conf
@@ -73,7 +73,7 @@ processors:
           # add blank cpu_number label
           - action: add_label
             new_label: cpu_number
-            new_value: ""
+            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_otel.conf
@@ -24,11 +24,8 @@ processors:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring

--- a/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_otel.conf
@@ -28,6 +28,8 @@ processors:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -66,9 +68,13 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-complex_logs_with_processors/golden_otel.conf
@@ -22,7 +22,7 @@ processors:
   resourcedetection:
     detectors: [gce]
 
-  # perform custom transformations that aren't supported by the googlemetricstransform processor
+  # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
     # 1. converts up down sum types to gauges
     # 2. combines resource process metrics into metrics with processes as labels
@@ -44,7 +44,7 @@ processors:
           - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/system:
+  metricstransform/system:
     transforms:
       # system.cpu.time -> cpu/usage_time
       - metric_name: system.cpu.time
@@ -66,14 +66,10 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # take avg over cpu dimension, retaining only state label
-          - action: aggregate_labels
-            label_set: [state]
-            aggregation_type: mean
-          # add blank cpu_number label
-          - action: add_label
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
             new_label: cpu_number
-            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state
@@ -381,7 +377,7 @@ processors:
           - otelcol_googlecloudmonitoring_point_count
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/iis:
+  metricstransform/iis:
     transforms:
       - include: \Web Service(_Total)\Current Connections
         action: update
@@ -401,7 +397,7 @@ processors:
         submatch_case: lower
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/mssql:
+  metricstransform/mssql:
     transforms:
       - include: \SQLServer:General Statistics(_Total)\User Connections
         action: update
@@ -414,7 +410,7 @@ processors:
         new_name: mssql/write_transaction_rate
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/agent:
+  metricstransform/agent:
     transforms:
       # otelcol_process_uptime -> agent/uptime
       - metric_name: otelcol_process_uptime
@@ -481,11 +477,11 @@ service:
         - prometheus/agent
       processors:
         - filter/agent
-        - googlemetricstransform/agent
+        - metricstransform/agent
         - resourcedetection
       exporters:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      processors: [agentmetrics/system,filter/system,metricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_otel.conf
@@ -73,7 +73,7 @@ processors:
           # add blank cpu_number label
           - action: add_label
             new_label: cpu_number
-            new_value: ""
+            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_otel.conf
@@ -24,11 +24,8 @@ processors:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring

--- a/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_otel.conf
@@ -28,6 +28,8 @@ processors:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -66,9 +68,13 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_file_sources/golden_otel.conf
@@ -22,7 +22,7 @@ processors:
   resourcedetection:
     detectors: [gce]
 
-  # perform custom transformations that aren't supported by the googlemetricstransform processor
+  # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
     # 1. converts up down sum types to gauges
     # 2. combines resource process metrics into metrics with processes as labels
@@ -44,7 +44,7 @@ processors:
           - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/system:
+  metricstransform/system:
     transforms:
       # system.cpu.time -> cpu/usage_time
       - metric_name: system.cpu.time
@@ -66,14 +66,10 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # take avg over cpu dimension, retaining only state label
-          - action: aggregate_labels
-            label_set: [state]
-            aggregation_type: mean
-          # add blank cpu_number label
-          - action: add_label
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
             new_label: cpu_number
-            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state
@@ -381,7 +377,7 @@ processors:
           - otelcol_googlecloudmonitoring_point_count
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/iis:
+  metricstransform/iis:
     transforms:
       - include: \Web Service(_Total)\Current Connections
         action: update
@@ -401,7 +397,7 @@ processors:
         submatch_case: lower
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/mssql:
+  metricstransform/mssql:
     transforms:
       - include: \SQLServer:General Statistics(_Total)\User Connections
         action: update
@@ -414,7 +410,7 @@ processors:
         new_name: mssql/write_transaction_rate
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/agent:
+  metricstransform/agent:
     transforms:
       # otelcol_process_uptime -> agent/uptime
       - metric_name: otelcol_process_uptime
@@ -481,11 +477,11 @@ service:
         - prometheus/agent
       processors:
         - filter/agent
-        - googlemetricstransform/agent
+        - metricstransform/agent
         - resourcedetection
       exporters:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      processors: [agentmetrics/system,filter/system,metricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/logging-multiple_google_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_google_exporters/golden_otel.conf
@@ -73,7 +73,7 @@ processors:
           # add blank cpu_number label
           - action: add_label
             new_label: cpu_number
-            new_value: ""
+            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/linux/logging-multiple_google_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_google_exporters/golden_otel.conf
@@ -24,11 +24,8 @@ processors:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring

--- a/confgenerator/testdata/valid/linux/logging-multiple_google_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_google_exporters/golden_otel.conf
@@ -28,6 +28,8 @@ processors:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -66,9 +68,13 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-multiple_google_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_google_exporters/golden_otel.conf
@@ -22,7 +22,7 @@ processors:
   resourcedetection:
     detectors: [gce]
 
-  # perform custom transformations that aren't supported by the googlemetricstransform processor
+  # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
     # 1. converts up down sum types to gauges
     # 2. combines resource process metrics into metrics with processes as labels
@@ -44,7 +44,7 @@ processors:
           - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/system:
+  metricstransform/system:
     transforms:
       # system.cpu.time -> cpu/usage_time
       - metric_name: system.cpu.time
@@ -66,14 +66,10 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # take avg over cpu dimension, retaining only state label
-          - action: aggregate_labels
-            label_set: [state]
-            aggregation_type: mean
-          # add blank cpu_number label
-          - action: add_label
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
             new_label: cpu_number
-            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state
@@ -381,7 +377,7 @@ processors:
           - otelcol_googlecloudmonitoring_point_count
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/iis:
+  metricstransform/iis:
     transforms:
       - include: \Web Service(_Total)\Current Connections
         action: update
@@ -401,7 +397,7 @@ processors:
         submatch_case: lower
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/mssql:
+  metricstransform/mssql:
     transforms:
       - include: \SQLServer:General Statistics(_Total)\User Connections
         action: update
@@ -414,7 +410,7 @@ processors:
         new_name: mssql/write_transaction_rate
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/agent:
+  metricstransform/agent:
     transforms:
       # otelcol_process_uptime -> agent/uptime
       - metric_name: otelcol_process_uptime
@@ -481,11 +477,11 @@ service:
         - prometheus/agent
       processors:
         - filter/agent
-        - googlemetricstransform/agent
+        - metricstransform/agent
         - resourcedetection
       exporters:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      processors: [agentmetrics/system,filter/system,metricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_otel.conf
@@ -73,7 +73,7 @@ processors:
           # add blank cpu_number label
           - action: add_label
             new_label: cpu_number
-            new_value: ""
+            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_otel.conf
@@ -24,11 +24,8 @@ processors:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring

--- a/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_otel.conf
@@ -28,6 +28,8 @@ processors:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -66,9 +68,13 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-multiple_syslog_sources/golden_otel.conf
@@ -22,7 +22,7 @@ processors:
   resourcedetection:
     detectors: [gce]
 
-  # perform custom transformations that aren't supported by the googlemetricstransform processor
+  # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
     # 1. converts up down sum types to gauges
     # 2. combines resource process metrics into metrics with processes as labels
@@ -44,7 +44,7 @@ processors:
           - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/system:
+  metricstransform/system:
     transforms:
       # system.cpu.time -> cpu/usage_time
       - metric_name: system.cpu.time
@@ -66,14 +66,10 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # take avg over cpu dimension, retaining only state label
-          - action: aggregate_labels
-            label_set: [state]
-            aggregation_type: mean
-          # add blank cpu_number label
-          - action: add_label
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
             new_label: cpu_number
-            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state
@@ -381,7 +377,7 @@ processors:
           - otelcol_googlecloudmonitoring_point_count
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/iis:
+  metricstransform/iis:
     transforms:
       - include: \Web Service(_Total)\Current Connections
         action: update
@@ -401,7 +397,7 @@ processors:
         submatch_case: lower
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/mssql:
+  metricstransform/mssql:
     transforms:
       - include: \SQLServer:General Statistics(_Total)\User Connections
         action: update
@@ -414,7 +410,7 @@ processors:
         new_name: mssql/write_transaction_rate
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/agent:
+  metricstransform/agent:
     transforms:
       # otelcol_process_uptime -> agent/uptime
       - metric_name: otelcol_process_uptime
@@ -481,11 +477,11 @@ service:
         - prometheus/agent
       processors:
         - filter/agent
-        - googlemetricstransform/agent
+        - metricstransform/agent
         - resourcedetection
       exporters:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      processors: [agentmetrics/system,filter/system,metricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/logging-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-no_conf/golden_otel.conf
@@ -73,7 +73,7 @@ processors:
           # add blank cpu_number label
           - action: add_label
             new_label: cpu_number
-            new_value: ""
+            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/linux/logging-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-no_conf/golden_otel.conf
@@ -24,11 +24,8 @@ processors:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring

--- a/confgenerator/testdata/valid/linux/logging-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-no_conf/golden_otel.conf
@@ -28,6 +28,8 @@ processors:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -66,9 +68,13 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-no_conf/golden_otel.conf
@@ -22,7 +22,7 @@ processors:
   resourcedetection:
     detectors: [gce]
 
-  # perform custom transformations that aren't supported by the googlemetricstransform processor
+  # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
     # 1. converts up down sum types to gauges
     # 2. combines resource process metrics into metrics with processes as labels
@@ -44,7 +44,7 @@ processors:
           - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/system:
+  metricstransform/system:
     transforms:
       # system.cpu.time -> cpu/usage_time
       - metric_name: system.cpu.time
@@ -66,14 +66,10 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # take avg over cpu dimension, retaining only state label
-          - action: aggregate_labels
-            label_set: [state]
-            aggregation_type: mean
-          # add blank cpu_number label
-          - action: add_label
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
             new_label: cpu_number
-            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state
@@ -381,7 +377,7 @@ processors:
           - otelcol_googlecloudmonitoring_point_count
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/iis:
+  metricstransform/iis:
     transforms:
       - include: \Web Service(_Total)\Current Connections
         action: update
@@ -401,7 +397,7 @@ processors:
         submatch_case: lower
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/mssql:
+  metricstransform/mssql:
     transforms:
       - include: \SQLServer:General Statistics(_Total)\User Connections
         action: update
@@ -414,7 +410,7 @@ processors:
         new_name: mssql/write_transaction_rate
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/agent:
+  metricstransform/agent:
     transforms:
       # otelcol_process_uptime -> agent/uptime
       - metric_name: otelcol_process_uptime
@@ -481,11 +477,11 @@ service:
         - prometheus/agent
       processors:
         - filter/agent
-        - googlemetricstransform/agent
+        - metricstransform/agent
         - resourcedetection
       exporters:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      processors: [agentmetrics/system,filter/system,metricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_on_default_pipeline/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_on_default_pipeline/golden_otel.conf
@@ -22,7 +22,7 @@ processors:
   resourcedetection:
     detectors: [gce]
 
-  # perform custom transformations that aren't supported by the googlemetricstransform processor
+  # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
     # 1. converts up down sum types to gauges
     # 2. combines resource process metrics into metrics with processes as labels
@@ -44,7 +44,7 @@ processors:
           - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/system:
+  metricstransform/system:
     transforms:
       # system.cpu.time -> cpu/usage_time
       - metric_name: system.cpu.time
@@ -66,14 +66,10 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # take avg over cpu dimension, retaining only state label
-          - action: aggregate_labels
-            label_set: [state]
-            aggregation_type: mean
-          # add blank cpu_number label
-          - action: add_label
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
             new_label: cpu_number
-            new_value: ""
           # change label state -> cpu_state
           - action: update_label
             label: state
@@ -381,7 +377,7 @@ processors:
           - otelcol_googlecloudmonitoring_point_count
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/iis:
+  metricstransform/iis:
     transforms:
       - include: \Web Service(_Total)\Current Connections
         action: update
@@ -401,7 +397,7 @@ processors:
         submatch_case: lower
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/mssql:
+  metricstransform/mssql:
     transforms:
       - include: \SQLServer:General Statistics(_Total)\User Connections
         action: update
@@ -414,7 +410,7 @@ processors:
         new_name: mssql/write_transaction_rate
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/agent:
+  metricstransform/agent:
     transforms:
       # otelcol_process_uptime -> agent/uptime
       - metric_name: otelcol_process_uptime
@@ -481,11 +477,11 @@ service:
         - prometheus/agent
       processors:
         - filter/agent
-        - googlemetricstransform/agent
+        - metricstransform/agent
         - resourcedetection
       exporters:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      processors: [agentmetrics/system,filter/system,metricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_on_default_pipeline/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_on_default_pipeline/golden_otel.conf
@@ -24,11 +24,8 @@ processors:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_on_default_pipeline/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_on_default_pipeline/golden_otel.conf
@@ -28,6 +28,8 @@ processors:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -66,9 +68,13 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_otel.conf
@@ -73,7 +73,7 @@ processors:
           # add blank cpu_number label
           - action: add_label
             new_label: cpu_number
-            new_value: ""
+            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_otel.conf
@@ -24,11 +24,8 @@ processors:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring

--- a/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_otel.conf
@@ -28,6 +28,8 @@ processors:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -66,9 +68,13 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_collection_interval/golden_otel.conf
@@ -22,7 +22,7 @@ processors:
   resourcedetection:
     detectors: [gce]
 
-  # perform custom transformations that aren't supported by the googlemetricstransform processor
+  # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
     # 1. converts up down sum types to gauges
     # 2. combines resource process metrics into metrics with processes as labels
@@ -44,7 +44,7 @@ processors:
           - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/system:
+  metricstransform/system:
     transforms:
       # system.cpu.time -> cpu/usage_time
       - metric_name: system.cpu.time
@@ -66,14 +66,10 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # take avg over cpu dimension, retaining only state label
-          - action: aggregate_labels
-            label_set: [state]
-            aggregation_type: mean
-          # add blank cpu_number label
-          - action: add_label
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
             new_label: cpu_number
-            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state
@@ -381,7 +377,7 @@ processors:
           - otelcol_googlecloudmonitoring_point_count
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/iis:
+  metricstransform/iis:
     transforms:
       - include: \Web Service(_Total)\Current Connections
         action: update
@@ -401,7 +397,7 @@ processors:
         submatch_case: lower
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/mssql:
+  metricstransform/mssql:
     transforms:
       - include: \SQLServer:General Statistics(_Total)\User Connections
         action: update
@@ -414,7 +410,7 @@ processors:
         new_name: mssql/write_transaction_rate
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/agent:
+  metricstransform/agent:
     transforms:
       # otelcol_process_uptime -> agent/uptime
       - metric_name: otelcol_process_uptime
@@ -481,11 +477,11 @@ service:
         - prometheus/agent
       processors:
         - filter/agent
-        - googlemetricstransform/agent
+        - metricstransform/agent
         - resourcedetection
       exporters:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      processors: [agentmetrics/system,filter/system,metricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes/golden_otel.conf
@@ -73,7 +73,7 @@ processors:
           # add blank cpu_number label
           - action: add_label
             new_label: cpu_number
-            new_value: ""
+            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes/golden_otel.conf
@@ -24,11 +24,8 @@ processors:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring

--- a/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes/golden_otel.conf
@@ -28,6 +28,8 @@ processors:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -66,9 +68,13 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes/golden_otel.conf
@@ -22,7 +22,7 @@ processors:
   resourcedetection:
     detectors: [gce]
 
-  # perform custom transformations that aren't supported by the googlemetricstransform processor
+  # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
     # 1. converts up down sum types to gauges
     # 2. combines resource process metrics into metrics with processes as labels
@@ -44,7 +44,7 @@ processors:
           - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/system:
+  metricstransform/system:
     transforms:
       # system.cpu.time -> cpu/usage_time
       - metric_name: system.cpu.time
@@ -66,14 +66,10 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # take avg over cpu dimension, retaining only state label
-          - action: aggregate_labels
-            label_set: [state]
-            aggregation_type: mean
-          # add blank cpu_number label
-          - action: add_label
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
             new_label: cpu_number
-            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state
@@ -381,7 +377,7 @@ processors:
           - otelcol_googlecloudmonitoring_point_count
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/iis:
+  metricstransform/iis:
     transforms:
       - include: \Web Service(_Total)\Current Connections
         action: update
@@ -401,7 +397,7 @@ processors:
         submatch_case: lower
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/mssql:
+  metricstransform/mssql:
     transforms:
       - include: \SQLServer:General Statistics(_Total)\User Connections
         action: update
@@ -414,7 +410,7 @@ processors:
         new_name: mssql/write_transaction_rate
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/agent:
+  metricstransform/agent:
     transforms:
       # otelcol_process_uptime -> agent/uptime
       - metric_name: otelcol_process_uptime
@@ -483,11 +479,11 @@ service:
         - prometheus/agent
       processors:
         - filter/agent
-        - googlemetricstransform/agent
+        - metricstransform/agent
         - resourcedetection
       exporters:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      processors: [agentmetrics/system,filter/system,metricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes_with_glob/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes_with_glob/golden_otel.conf
@@ -73,7 +73,7 @@ processors:
           # add blank cpu_number label
           - action: add_label
             new_label: cpu_number
-            new_value: ""
+            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes_with_glob/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes_with_glob/golden_otel.conf
@@ -24,11 +24,8 @@ processors:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring

--- a/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes_with_glob/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes_with_glob/golden_otel.conf
@@ -28,6 +28,8 @@ processors:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -66,9 +68,13 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes_with_glob/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-exclude_metrics_by_prefixes_with_glob/golden_otel.conf
@@ -22,7 +22,7 @@ processors:
   resourcedetection:
     detectors: [gce]
 
-  # perform custom transformations that aren't supported by the googlemetricstransform processor
+  # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
     # 1. converts up down sum types to gauges
     # 2. combines resource process metrics into metrics with processes as labels
@@ -44,7 +44,7 @@ processors:
           - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/system:
+  metricstransform/system:
     transforms:
       # system.cpu.time -> cpu/usage_time
       - metric_name: system.cpu.time
@@ -66,14 +66,10 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # take avg over cpu dimension, retaining only state label
-          - action: aggregate_labels
-            label_set: [state]
-            aggregation_type: mean
-          # add blank cpu_number label
-          - action: add_label
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
             new_label: cpu_number
-            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state
@@ -381,7 +377,7 @@ processors:
           - otelcol_googlecloudmonitoring_point_count
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/iis:
+  metricstransform/iis:
     transforms:
       - include: \Web Service(_Total)\Current Connections
         action: update
@@ -401,7 +397,7 @@ processors:
         submatch_case: lower
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/mssql:
+  metricstransform/mssql:
     transforms:
       - include: \SQLServer:General Statistics(_Total)\User Connections
         action: update
@@ -414,7 +410,7 @@ processors:
         new_name: mssql/write_transaction_rate
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/agent:
+  metricstransform/agent:
     transforms:
       # otelcol_process_uptime -> agent/uptime
       - metric_name: otelcol_process_uptime
@@ -483,11 +479,11 @@ service:
         - prometheus/agent
       processors:
         - filter/agent
-        - googlemetricstransform/agent
+        - metricstransform/agent
         - resourcedetection
       exporters:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      processors: [agentmetrics/system,filter/system,metricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/metrics-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-no_conf/golden_otel.conf
@@ -73,7 +73,7 @@ processors:
           # add blank cpu_number label
           - action: add_label
             new_label: cpu_number
-            new_value: ""
+            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/linux/metrics-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-no_conf/golden_otel.conf
@@ -24,11 +24,8 @@ processors:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring

--- a/confgenerator/testdata/valid/linux/metrics-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-no_conf/golden_otel.conf
@@ -28,6 +28,8 @@ processors:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -66,9 +68,13 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-no_conf/golden_otel.conf
@@ -22,7 +22,7 @@ processors:
   resourcedetection:
     detectors: [gce]
 
-  # perform custom transformations that aren't supported by the googlemetricstransform processor
+  # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
     # 1. converts up down sum types to gauges
     # 2. combines resource process metrics into metrics with processes as labels
@@ -44,7 +44,7 @@ processors:
           - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/system:
+  metricstransform/system:
     transforms:
       # system.cpu.time -> cpu/usage_time
       - metric_name: system.cpu.time
@@ -66,14 +66,10 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # take avg over cpu dimension, retaining only state label
-          - action: aggregate_labels
-            label_set: [state]
-            aggregation_type: mean
-          # add blank cpu_number label
-          - action: add_label
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
             new_label: cpu_number
-            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state
@@ -381,7 +377,7 @@ processors:
           - otelcol_googlecloudmonitoring_point_count
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/iis:
+  metricstransform/iis:
     transforms:
       - include: \Web Service(_Total)\Current Connections
         action: update
@@ -401,7 +397,7 @@ processors:
         submatch_case: lower
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/mssql:
+  metricstransform/mssql:
     transforms:
       - include: \SQLServer:General Statistics(_Total)\User Connections
         action: update
@@ -414,7 +410,7 @@ processors:
         new_name: mssql/write_transaction_rate
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/agent:
+  metricstransform/agent:
     transforms:
       # otelcol_process_uptime -> agent/uptime
       - metric_name: otelcol_process_uptime
@@ -482,11 +478,11 @@ service:
         - prometheus/agent
       processors:
         - filter/agent
-        - googlemetricstransform/agent
+        - metricstransform/agent
         - resourcedetection
       exporters:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      processors: [agentmetrics/system,filter/system,metricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
@@ -53,11 +53,8 @@ processors:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
@@ -57,6 +57,8 @@ processors:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -95,9 +97,13 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
@@ -51,7 +51,7 @@ processors:
   resourcedetection:
     detectors: [gce]
 
-  # perform custom transformations that aren't supported by the googlemetricstransform processor
+  # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
     # 1. converts up down sum types to gauges
     # 2. combines resource process metrics into metrics with processes as labels
@@ -73,7 +73,7 @@ processors:
           - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/system:
+  metricstransform/system:
     transforms:
       # system.cpu.time -> cpu/usage_time
       - metric_name: system.cpu.time
@@ -95,14 +95,10 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # take avg over cpu dimension, retaining only state label
-          - action: aggregate_labels
-            label_set: [state]
-            aggregation_type: mean
-          # add blank cpu_number label
-          - action: add_label
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
             new_label: cpu_number
-            new_value: ""
           # change label state -> cpu_state
           - action: update_label
             label: state
@@ -410,7 +406,7 @@ processors:
           - otelcol_googlecloudmonitoring_point_count
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/iis:
+  metricstransform/iis:
     transforms:
       - include: \Web Service(_Total)\Current Connections
         action: update
@@ -430,7 +426,7 @@ processors:
         submatch_case: lower
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/mssql:
+  metricstransform/mssql:
     transforms:
       - include: \SQLServer:General Statistics(_Total)\User Connections
         action: update
@@ -443,7 +439,7 @@ processors:
         new_name: mssql/write_transaction_rate
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/agent:
+  metricstransform/agent:
     transforms:
       # otelcol_process_uptime -> agent/uptime
       - metric_name: otelcol_process_uptime
@@ -510,19 +506,19 @@ service:
         - prometheus/agent
       processors:
         - filter/agent
-        - googlemetricstransform/agent
+        - metricstransform/agent
         - resourcedetection
       exporters:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      processors: [agentmetrics/system,filter/system,metricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/iis:
       receivers:  [windowsperfcounters/iis_iis]
-      processors: [googlemetricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
+      processors: [metricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/mssql:
       receivers:  [windowsperfcounters/mssql_mssql]
-      processors: [googlemetricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
+      processors: [metricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/windows/default_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/default_config/golden_otel.conf
@@ -53,11 +53,8 @@ processors:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring

--- a/confgenerator/testdata/valid/windows/default_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/default_config/golden_otel.conf
@@ -57,6 +57,8 @@ processors:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -95,9 +97,13 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/confgenerator/testdata/valid/windows/default_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/default_config/golden_otel.conf
@@ -51,7 +51,7 @@ processors:
   resourcedetection:
     detectors: [gce]
 
-  # perform custom transformations that aren't supported by the googlemetricstransform processor
+  # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
     # 1. converts up down sum types to gauges
     # 2. combines resource process metrics into metrics with processes as labels
@@ -73,7 +73,7 @@ processors:
           - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/system:
+  metricstransform/system:
     transforms:
       # system.cpu.time -> cpu/usage_time
       - metric_name: system.cpu.time
@@ -95,14 +95,10 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # take avg over cpu dimension, retaining only state label
-          - action: aggregate_labels
-            label_set: [state]
-            aggregation_type: mean
-          # add blank cpu_number label
-          - action: add_label
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
             new_label: cpu_number
-            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state
@@ -410,7 +406,7 @@ processors:
           - otelcol_googlecloudmonitoring_point_count
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/iis:
+  metricstransform/iis:
     transforms:
       - include: \Web Service(_Total)\Current Connections
         action: update
@@ -430,7 +426,7 @@ processors:
         submatch_case: lower
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/mssql:
+  metricstransform/mssql:
     transforms:
       - include: \SQLServer:General Statistics(_Total)\User Connections
         action: update
@@ -443,7 +439,7 @@ processors:
         new_name: mssql/write_transaction_rate
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/agent:
+  metricstransform/agent:
     transforms:
       # otelcol_process_uptime -> agent/uptime
       - metric_name: otelcol_process_uptime
@@ -510,19 +506,19 @@ service:
         - prometheus/agent
       processors:
         - filter/agent
-        - googlemetricstransform/agent
+        - metricstransform/agent
         - resourcedetection
       exporters:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      processors: [agentmetrics/system,filter/system,metricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/iis:
       receivers:  [windowsperfcounters/iis_iis]
-      processors: [googlemetricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
+      processors: [metricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/mssql:
       receivers:  [windowsperfcounters/mssql_mssql]
-      processors: [googlemetricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
+      processors: [metricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/windows/default_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/default_config/golden_otel.conf
@@ -102,7 +102,7 @@ processors:
           # add blank cpu_number label
           - action: add_label
             new_label: cpu_number
-            new_value: ""
+            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_otel.conf
@@ -53,11 +53,8 @@ processors:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring

--- a/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_otel.conf
@@ -57,6 +57,8 @@ processors:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -95,9 +97,13 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_otel.conf
@@ -51,7 +51,7 @@ processors:
   resourcedetection:
     detectors: [gce]
 
-  # perform custom transformations that aren't supported by the googlemetricstransform processor
+  # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
     # 1. converts up down sum types to gauges
     # 2. combines resource process metrics into metrics with processes as labels
@@ -73,7 +73,7 @@ processors:
           - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/system:
+  metricstransform/system:
     transforms:
       # system.cpu.time -> cpu/usage_time
       - metric_name: system.cpu.time
@@ -95,14 +95,10 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # take avg over cpu dimension, retaining only state label
-          - action: aggregate_labels
-            label_set: [state]
-            aggregation_type: mean
-          # add blank cpu_number label
-          - action: add_label
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
             new_label: cpu_number
-            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state
@@ -410,7 +406,7 @@ processors:
           - otelcol_googlecloudmonitoring_point_count
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/iis:
+  metricstransform/iis:
     transforms:
       - include: \Web Service(_Total)\Current Connections
         action: update
@@ -430,7 +426,7 @@ processors:
         submatch_case: lower
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/mssql:
+  metricstransform/mssql:
     transforms:
       - include: \SQLServer:General Statistics(_Total)\User Connections
         action: update
@@ -443,7 +439,7 @@ processors:
         new_name: mssql/write_transaction_rate
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/agent:
+  metricstransform/agent:
     transforms:
       # otelcol_process_uptime -> agent/uptime
       - metric_name: otelcol_process_uptime
@@ -510,19 +506,19 @@ service:
         - prometheus/agent
       processors:
         - filter/agent
-        - googlemetricstransform/agent
+        - metricstransform/agent
         - resourcedetection
       exporters:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      processors: [agentmetrics/system,filter/system,metricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/iis:
       receivers:  [windowsperfcounters/iis_iis]
-      processors: [googlemetricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
+      processors: [metricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/mssql:
       receivers:  [windowsperfcounters/mssql_mssql]
-      processors: [googlemetricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
+      processors: [metricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-multiple_file_sources/golden_otel.conf
@@ -102,7 +102,7 @@ processors:
           # add blank cpu_number label
           - action: add_label
             new_label: cpu_number
-            new_value: ""
+            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/windows/logging-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-no_conf/golden_otel.conf
@@ -53,11 +53,8 @@ processors:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring

--- a/confgenerator/testdata/valid/windows/logging-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-no_conf/golden_otel.conf
@@ -57,6 +57,8 @@ processors:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -95,9 +97,13 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/confgenerator/testdata/valid/windows/logging-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-no_conf/golden_otel.conf
@@ -51,7 +51,7 @@ processors:
   resourcedetection:
     detectors: [gce]
 
-  # perform custom transformations that aren't supported by the googlemetricstransform processor
+  # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
     # 1. converts up down sum types to gauges
     # 2. combines resource process metrics into metrics with processes as labels
@@ -73,7 +73,7 @@ processors:
           - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/system:
+  metricstransform/system:
     transforms:
       # system.cpu.time -> cpu/usage_time
       - metric_name: system.cpu.time
@@ -95,14 +95,10 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # take avg over cpu dimension, retaining only state label
-          - action: aggregate_labels
-            label_set: [state]
-            aggregation_type: mean
-          # add blank cpu_number label
-          - action: add_label
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
             new_label: cpu_number
-            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state
@@ -410,7 +406,7 @@ processors:
           - otelcol_googlecloudmonitoring_point_count
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/iis:
+  metricstransform/iis:
     transforms:
       - include: \Web Service(_Total)\Current Connections
         action: update
@@ -430,7 +426,7 @@ processors:
         submatch_case: lower
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/mssql:
+  metricstransform/mssql:
     transforms:
       - include: \SQLServer:General Statistics(_Total)\User Connections
         action: update
@@ -443,7 +439,7 @@ processors:
         new_name: mssql/write_transaction_rate
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/agent:
+  metricstransform/agent:
     transforms:
       # otelcol_process_uptime -> agent/uptime
       - metric_name: otelcol_process_uptime
@@ -510,19 +506,19 @@ service:
         - prometheus/agent
       processors:
         - filter/agent
-        - googlemetricstransform/agent
+        - metricstransform/agent
         - resourcedetection
       exporters:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      processors: [agentmetrics/system,filter/system,metricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/iis:
       receivers:  [windowsperfcounters/iis_iis]
-      processors: [googlemetricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
+      processors: [metricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/mssql:
       receivers:  [windowsperfcounters/mssql_mssql]
-      processors: [googlemetricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
+      processors: [metricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/windows/logging-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-no_conf/golden_otel.conf
@@ -102,7 +102,7 @@ processors:
           # add blank cpu_number label
           - action: add_label
             new_label: cpu_number
-            new_value: ""
+            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_otel.conf
@@ -53,11 +53,8 @@ processors:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring

--- a/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_otel.conf
@@ -57,6 +57,8 @@ processors:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -95,9 +97,13 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_otel.conf
@@ -51,7 +51,7 @@ processors:
   resourcedetection:
     detectors: [gce]
 
-  # perform custom transformations that aren't supported by the googlemetricstransform processor
+  # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
     # 1. converts up down sum types to gauges
     # 2. combines resource process metrics into metrics with processes as labels
@@ -73,7 +73,7 @@ processors:
           - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/system:
+  metricstransform/system:
     transforms:
       # system.cpu.time -> cpu/usage_time
       - metric_name: system.cpu.time
@@ -95,14 +95,10 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # take avg over cpu dimension, retaining only state label
-          - action: aggregate_labels
-            label_set: [state]
-            aggregation_type: mean
-          # add blank cpu_number label
-          - action: add_label
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
             new_label: cpu_number
-            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state
@@ -410,7 +406,7 @@ processors:
           - otelcol_googlecloudmonitoring_point_count
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/iis:
+  metricstransform/iis:
     transforms:
       - include: \Web Service(_Total)\Current Connections
         action: update
@@ -430,7 +426,7 @@ processors:
         submatch_case: lower
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/mssql:
+  metricstransform/mssql:
     transforms:
       - include: \SQLServer:General Statistics(_Total)\User Connections
         action: update
@@ -443,7 +439,7 @@ processors:
         new_name: mssql/write_transaction_rate
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/agent:
+  metricstransform/agent:
     transforms:
       # otelcol_process_uptime -> agent/uptime
       - metric_name: otelcol_process_uptime
@@ -510,19 +506,19 @@ service:
         - prometheus/agent
       processors:
         - filter/agent
-        - googlemetricstransform/agent
+        - metricstransform/agent
         - resourcedetection
       exporters:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      processors: [agentmetrics/system,filter/system,metricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/iis:
       receivers:  [windowsperfcounters/iis_iis]
-      processors: [googlemetricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
+      processors: [metricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/mssql:
       receivers:  [windowsperfcounters/mssql_mssql]
-      processors: [googlemetricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
+      processors: [metricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-custom_collection_interval/golden_otel.conf
@@ -102,7 +102,7 @@ processors:
           # add blank cpu_number label
           - action: add_label
             new_label: cpu_number
-            new_value: ""
+            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/windows/metrics-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-no_conf/golden_otel.conf
@@ -53,11 +53,8 @@ processors:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring

--- a/confgenerator/testdata/valid/windows/metrics-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-no_conf/golden_otel.conf
@@ -57,6 +57,8 @@ processors:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -95,9 +97,13 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-no_conf/golden_otel.conf
@@ -51,7 +51,7 @@ processors:
   resourcedetection:
     detectors: [gce]
 
-  # perform custom transformations that aren't supported by the googlemetricstransform processor
+  # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
     # 1. converts up down sum types to gauges
     # 2. combines resource process metrics into metrics with processes as labels
@@ -73,7 +73,7 @@ processors:
           - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/system:
+  metricstransform/system:
     transforms:
       # system.cpu.time -> cpu/usage_time
       - metric_name: system.cpu.time
@@ -95,14 +95,10 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # take avg over cpu dimension, retaining only state label
-          - action: aggregate_labels
-            label_set: [state]
-            aggregation_type: mean
-          # add blank cpu_number label
-          - action: add_label
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
             new_label: cpu_number
-            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state
@@ -410,7 +406,7 @@ processors:
           - otelcol_googlecloudmonitoring_point_count
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/iis:
+  metricstransform/iis:
     transforms:
       - include: \Web Service(_Total)\Current Connections
         action: update
@@ -430,7 +426,7 @@ processors:
         submatch_case: lower
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/mssql:
+  metricstransform/mssql:
     transforms:
       - include: \SQLServer:General Statistics(_Total)\User Connections
         action: update
@@ -443,7 +439,7 @@ processors:
         new_name: mssql/write_transaction_rate
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/agent:
+  metricstransform/agent:
     transforms:
       # otelcol_process_uptime -> agent/uptime
       - metric_name: otelcol_process_uptime
@@ -511,19 +507,19 @@ service:
         - prometheus/agent
       processors:
         - filter/agent
-        - googlemetricstransform/agent
+        - metricstransform/agent
         - resourcedetection
       exporters:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      processors: [agentmetrics/system,filter/system,metricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/iis:
       receivers:  [windowsperfcounters/iis_iis]
-      processors: [googlemetricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
+      processors: [metricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/mssql:
       receivers:  [windowsperfcounters/mssql_mssql]
-      processors: [googlemetricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
+      processors: [metricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/windows/metrics-no_conf/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-no_conf/golden_otel.conf
@@ -102,7 +102,7 @@ processors:
           # add blank cpu_number label
           - action: add_label
             new_label: cpu_number
-            new_value: ""
+            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_otel.conf
@@ -53,11 +53,8 @@ processors:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_otel.conf
@@ -57,6 +57,8 @@ processors:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -95,9 +97,13 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_otel.conf
@@ -51,7 +51,7 @@ processors:
   resourcedetection:
     detectors: [gce]
 
-  # perform custom transformations that aren't supported by the googlemetricstransform processor
+  # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
     # 1. converts up down sum types to gauges
     # 2. combines resource process metrics into metrics with processes as labels
@@ -73,7 +73,7 @@ processors:
           - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/system:
+  metricstransform/system:
     transforms:
       # system.cpu.time -> cpu/usage_time
       - metric_name: system.cpu.time
@@ -95,14 +95,10 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # take avg over cpu dimension, retaining only state label
-          - action: aggregate_labels
-            label_set: [state]
-            aggregation_type: mean
-          # add blank cpu_number label
-          - action: add_label
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
             new_label: cpu_number
-            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state
@@ -410,7 +406,7 @@ processors:
           - otelcol_googlecloudmonitoring_point_count
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/iis:
+  metricstransform/iis:
     transforms:
       - include: \Web Service(_Total)\Current Connections
         action: update
@@ -430,7 +426,7 @@ processors:
         submatch_case: lower
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/mssql:
+  metricstransform/mssql:
     transforms:
       - include: \SQLServer:General Statistics(_Total)\User Connections
         action: update
@@ -443,7 +439,7 @@ processors:
         new_name: mssql/write_transaction_rate
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/agent:
+  metricstransform/agent:
     transforms:
       # otelcol_process_uptime -> agent/uptime
       - metric_name: otelcol_process_uptime
@@ -511,19 +507,19 @@ service:
         - prometheus/agent
       processors:
         - filter/agent
-        - googlemetricstransform/agent
+        - metricstransform/agent
         - resourcedetection
       exporters:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      processors: [agentmetrics/system,filter/system,metricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/iis:
       receivers:  [windowsperfcounters/iis_iis]
-      processors: [googlemetricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
+      processors: [metricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/mssql:
       receivers:  [windowsperfcounters/mssql_mssql]
-      processors: [googlemetricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
+      processors: [metricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_iis/golden_otel.conf
@@ -102,7 +102,7 @@ processors:
           # add blank cpu_number label
           - action: add_label
             new_label: cpu_number
-            new_value: ""
+            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_otel.conf
@@ -53,11 +53,8 @@ processors:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_otel.conf
@@ -57,6 +57,8 @@ processors:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -95,9 +97,13 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_otel.conf
@@ -51,7 +51,7 @@ processors:
   resourcedetection:
     detectors: [gce]
 
-  # perform custom transformations that aren't supported by the googlemetricstransform processor
+  # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
     # 1. converts up down sum types to gauges
     # 2. combines resource process metrics into metrics with processes as labels
@@ -73,7 +73,7 @@ processors:
           - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/system:
+  metricstransform/system:
     transforms:
       # system.cpu.time -> cpu/usage_time
       - metric_name: system.cpu.time
@@ -95,14 +95,10 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # take avg over cpu dimension, retaining only state label
-          - action: aggregate_labels
-            label_set: [state]
-            aggregation_type: mean
-          # add blank cpu_number label
-          - action: add_label
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
             new_label: cpu_number
-            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state
@@ -410,7 +406,7 @@ processors:
           - otelcol_googlecloudmonitoring_point_count
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/iis:
+  metricstransform/iis:
     transforms:
       - include: \Web Service(_Total)\Current Connections
         action: update
@@ -430,7 +426,7 @@ processors:
         submatch_case: lower
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/mssql:
+  metricstransform/mssql:
     transforms:
       - include: \SQLServer:General Statistics(_Total)\User Connections
         action: update
@@ -443,7 +439,7 @@ processors:
         new_name: mssql/write_transaction_rate
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/agent:
+  metricstransform/agent:
     transforms:
       # otelcol_process_uptime -> agent/uptime
       - metric_name: otelcol_process_uptime
@@ -511,19 +507,19 @@ service:
         - prometheus/agent
       processors:
         - filter/agent
-        - googlemetricstransform/agent
+        - metricstransform/agent
         - resourcedetection
       exporters:
         - googlecloud/agent
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      processors: [agentmetrics/system,filter/system,metricstransform/system,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/iis:
       receivers:  [windowsperfcounters/iis_iis]
-      processors: [googlemetricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
+      processors: [metricstransform/iis,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]
     metrics/mssql:
       receivers:  [windowsperfcounters/mssql_mssql]
-      processors: [googlemetricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
+      processors: [metricstransform/mssql,resourcedetection,filter/exclude_metrics_filter]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-turn_off_mssql/golden_otel.conf
@@ -102,7 +102,7 @@ processors:
           # add blank cpu_number label
           - action: add_label
             new_label: cpu_number
-            new_value: ""
+            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state

--- a/confgenerator/testdata/valid/windows/valid_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/valid_config/golden_otel.conf
@@ -51,7 +51,7 @@ processors:
   resourcedetection:
     detectors: [gce]
 
-  # perform custom transformations that aren't supported by the googlemetricstransform processor
+  # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
     # 1. converts up down sum types to gauges
     # 2. combines resource process metrics into metrics with processes as labels
@@ -73,7 +73,7 @@ processors:
           - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/system:
+  metricstransform/system:
     transforms:
       # system.cpu.time -> cpu/usage_time
       - metric_name: system.cpu.time
@@ -95,14 +95,10 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # take avg over cpu dimension, retaining only state label
-          - action: aggregate_labels
-            label_set: [state]
-            aggregation_type: mean
-          # add blank cpu_number label
-          - action: add_label
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
             new_label: cpu_number
-            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state
@@ -410,7 +406,7 @@ processors:
           - otelcol_googlecloudmonitoring_point_count
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/iis:
+  metricstransform/iis:
     transforms:
       - include: \Web Service(_Total)\Current Connections
         action: update
@@ -430,7 +426,7 @@ processors:
         submatch_case: lower
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/mssql:
+  metricstransform/mssql:
     transforms:
       - include: \SQLServer:General Statistics(_Total)\User Connections
         action: update
@@ -443,7 +439,7 @@ processors:
         new_name: mssql/write_transaction_rate
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/agent:
+  metricstransform/agent:
     transforms:
       # otelcol_process_uptime -> agent/uptime
       - metric_name: otelcol_process_uptime
@@ -505,19 +501,19 @@ service:
         - prometheus/agent
       processors:
         - filter/agent
-        - googlemetricstransform/agent
+        - metricstransform/agent
         - resourcedetection
       exporters:
         - googlecloud/agent
     metrics/iis:
       receivers:  [windowsperfcounters/iis_iis]
-      processors: [googlemetricstransform/iis,resourcedetection]
+      processors: [metricstransform/iis,resourcedetection]
       exporters: [googlecloud/google]
     metrics/mssql:
       receivers:  [windowsperfcounters/mssql_mssql]
-      processors: [googlemetricstransform/mssql,resourcedetection]
+      processors: [metricstransform/mssql,resourcedetection]
       exporters: [googlecloud/google]
     metrics/system:
       receivers:  [hostmetrics/hostmetrics]
-      processors: [agentmetrics/system,filter/system,googlemetricstransform/system,resourcedetection]
+      processors: [agentmetrics/system,filter/system,metricstransform/system,resourcedetection]
       exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/windows/valid_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/valid_config/golden_otel.conf
@@ -53,11 +53,8 @@ processors:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring

--- a/confgenerator/testdata/valid/windows/valid_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/valid_config/golden_otel.conf
@@ -57,6 +57,8 @@ processors:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -95,9 +97,13 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/confgenerator/testdata/valid/windows/valid_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/valid_config/golden_otel.conf
@@ -102,7 +102,7 @@ processors:
           # add blank cpu_number label
           - action: add_label
             new_label: cpu_number
-            new_value: ""
+            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state

--- a/otel/conf.go
+++ b/otel/conf.go
@@ -156,6 +156,8 @@ windowsperfcounters/mssql_{{.MSSQLID}}:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -194,9 +196,13 @@ windowsperfcounters/mssql_{{.MSSQLID}}:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/otel/conf.go
+++ b/otel/conf.go
@@ -152,11 +152,8 @@ windowsperfcounters/mssql_{{.MSSQLID}}:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring

--- a/otel/conf.go
+++ b/otel/conf.go
@@ -133,7 +133,7 @@ windowsperfcounters/mssql_{{.MSSQLID}}:
         - prometheus/agent
       processors:
         - filter/agent
-        - googlemetricstransform/agent
+        - metricstransform/agent
         - resourcedetection
       exporters:
         - googlecloud/agent
@@ -150,7 +150,7 @@ windowsperfcounters/mssql_{{.MSSQLID}}:
   resourcedetection:
     detectors: [gce]
 
-  # perform custom transformations that aren't supported by the googlemetricstransform processor
+  # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
     # 1. converts up down sum types to gauges
     # 2. combines resource process metrics into metrics with processes as labels
@@ -172,7 +172,7 @@ windowsperfcounters/mssql_{{.MSSQLID}}:
           - system.processes.count
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/system:
+  metricstransform/system:
     transforms:
       # system.cpu.time -> cpu/usage_time
       - metric_name: system.cpu.time
@@ -194,14 +194,10 @@ windowsperfcounters/mssql_{{.MSSQLID}}:
         action: update
         new_name: cpu/utilization
         operations:
-          # take avg over cpu dimension, retaining only state label
-          - action: aggregate_labels
-            label_set: [state]
-            aggregation_type: mean
-          # add blank cpu_number label
-          - action: add_label
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
             new_label: cpu_number
-            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state
@@ -509,7 +505,7 @@ windowsperfcounters/mssql_{{.MSSQLID}}:
           - otelcol_googlecloudmonitoring_point_count
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/iis:
+  metricstransform/iis:
     transforms:
       - include: \Web Service(_Total)\Current Connections
         action: update
@@ -529,7 +525,7 @@ windowsperfcounters/mssql_{{.MSSQLID}}:
         submatch_case: lower
 
   # convert from windows perf counter formats to cloud monitoring formats
-  googlemetricstransform/mssql:
+  metricstransform/mssql:
     transforms:
       - include: \SQLServer:General Statistics(_Total)\User Connections
         action: update
@@ -542,7 +538,7 @@ windowsperfcounters/mssql_{{.MSSQLID}}:
         new_name: mssql/write_transaction_rate
 
   # convert from opentelemetry metric formats to cloud monitoring formats
-  googlemetricstransform/agent:
+  metricstransform/agent:
     transforms:
       # otelcol_process_uptime -> agent/uptime
       - metric_name: otelcol_process_uptime

--- a/otel/conf.go
+++ b/otel/conf.go
@@ -201,7 +201,7 @@ windowsperfcounters/mssql_{{.MSSQLID}}:
           # add blank cpu_number label
           - action: add_label
             new_label: cpu_number
-            new_value: ""
+            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state

--- a/otel/conf_test.go
+++ b/otel/conf_test.go
@@ -276,7 +276,7 @@ processors:
           # add blank cpu_number label
           - action: add_label
             new_label: cpu_number
-            new_value: ""
+            new_value: " "
           # change label state -> cpu_state
           - action: update_label
             label: state

--- a/otel/conf_test.go
+++ b/otel/conf_test.go
@@ -231,6 +231,8 @@ processors:
     # 2. combines resource process metrics into metrics with processes as labels
     # 3. splits "disk.io" metrics into read & write metrics
     # 4. creates utilization metrics from usage metrics
+    blank_metrics:
+    - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring
   filter/system:
@@ -269,9 +271,13 @@ processors:
         action: update
         new_name: cpu/utilization
         operations:
-          # change label cpu -> cpu_number
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
           - action: update_label
-            label: cpu
+            label: blank
             new_label: cpu_number
           # change label state -> cpu_state
           - action: update_label

--- a/otel/conf_test.go
+++ b/otel/conf_test.go
@@ -227,11 +227,8 @@ processors:
 
   # perform custom transformations that aren't supported by the metricstransform processor
   agentmetrics/system:
-    # 1. converts up down sum types to gauges
-    # 2. combines resource process metrics into metrics with processes as labels
-    # 3. splits "disk.io" metrics into read & write metrics
-    # 4. creates utilization metrics from usage metrics
-    blank_metrics:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
     - system.cpu.utilization
 
   # filter out metrics not currently supported by cloud monitoring


### PR DESCRIPTION
This replaces the OT fork with a tiny addition to agentmetricsprocessor to allow adding a blank label to arbitrary metrics.

Do not merge until https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/pull/51 is merged and the submodule is updated.