### PR TITLE
Fix "inactive (dead)" main service

### DIFF
--- a/systemd/google-cloud-ops-agent.service
+++ b/systemd/google-cloud-ops-agent.service
@@ -14,7 +14,7 @@
 
 [Unit]
 Description=Google Cloud Ops Agent
-Requires=google-cloud-ops-agent-fluent-bit.service google-cloud-ops-agent-opentelemetry-collector.service
+Wants=google-cloud-ops-agent-fluent-bit.service google-cloud-ops-agent-opentelemetry-collector.service
 
 [Service]
 Type=oneshot

--- a/systemd/google-cloud-ops-agent.service
+++ b/systemd/google-cloud-ops-agent.service
@@ -21,6 +21,7 @@ Type=oneshot
 # Validate the config.
 ExecStartPre=@PREFIX@/libexec/google_cloud_ops_agent_engine -in @SYSCONFDIR@/google-cloud-ops-agent/config.yaml
 ExecStart=/bin/true
+RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Setting `RemainAfterExit` will cause systemd to show "active (exited)" as the state of the parent service, instead of "inactive (dead)".

NOTE that this appears to also cause systemd to propagate failure/restart of one subagent onto the parent agent and then onto the other subagent. This isn't necessarily a bad thing but it's a change. AFAICT it's completely undocumented that failure of a dependency will propagate to the parent - the docs say

> Besides, with or without specifying After=, this unit will be stopped if one of the other units is explicitly stopped.

but it seems to apply whether the subagent is explicitly stopped or it crashes. 

[See [comment](https://github.com/GoogleCloudPlatform/ops-agent/pull/132#issuecomment-873155707), it doesn't seem to consistently pass down error message to the parent]

We could switch to a `Wants` dependency, but then the parent service would also not fail to initially start if one of the children fails to start. I guess we could combine that with config validation in the parent service to get the best of both worlds.

/cc @sophieyfang 