### PR TITLE
Explicitly validate config as part of the main service startup.

### DIFF
--- a/confgenerator/files.go
+++ b/confgenerator/files.go
@@ -53,6 +53,8 @@ func ReadUnifiedConfigFromFile(path string) (UnifiedConfig, error) {
 func GenerateFilesFromConfig(uc *UnifiedConfig, service, logsDir, stateDir, outDir string) error {
 	hostInfo, _ := host.Info()
 	switch service {
+	case "": // Validate-only.
+		return nil
 	case "fluentbit":
 		mainConfig, parserConfig, err := uc.GenerateFluentBitConfigs(logsDir, stateDir, hostInfo)
 		if err != nil {
@@ -72,8 +74,6 @@ func GenerateFilesFromConfig(uc *UnifiedConfig, service, logsDir, stateDir, outD
 		if err = writeConfigFile([]byte(otelConfig), filepath.Join(outDir, "otel.yaml")); err != nil {
 			return err
 		}
-	case "validate-only":
-		return nil
 	default:
 		return fmt.Errorf("unknown service %q", service)
 	}

--- a/confgenerator/files.go
+++ b/confgenerator/files.go
@@ -72,6 +72,8 @@ func GenerateFilesFromConfig(uc *UnifiedConfig, service, logsDir, stateDir, outD
 		if err = writeConfigFile([]byte(otelConfig), filepath.Join(outDir, "otel.yaml")); err != nil {
 			return err
 		}
+	case "validate-only":
+		return nil
 	default:
 		return fmt.Errorf("unknown service %q", service)
 	}

--- a/confgenerator/files.go
+++ b/confgenerator/files.go
@@ -24,7 +24,12 @@ import (
 )
 
 func GenerateFiles(input, service, logsDir, stateDir, outDir string) error {
-	uc, err := ReadUnifiedConfigFromFile(input)
+	hostInfo, _ := host.Info()
+	data, err := ioutil.ReadFile(input)
+	if err != nil {
+		return err
+	}
+	uc, err := ParseUnifiedConfigAndValidate(data, hostInfo.OS)
 	if err != nil {
 		return err
 	}

--- a/systemd/google-cloud-ops-agent.service
+++ b/systemd/google-cloud-ops-agent.service
@@ -18,6 +18,8 @@ Requires=google-cloud-ops-agent-fluent-bit.service google-cloud-ops-agent-opente
 
 [Service]
 Type=oneshot
+# Validate the config.
+ExecStartPre=@PREFIX@/libexec/google_cloud_ops_agent_engine -service=validate-only -in @SYSCONFDIR@/google-cloud-ops-agent/config.yaml
 ExecStart=/bin/true
 
 [Install]

--- a/systemd/google-cloud-ops-agent.service
+++ b/systemd/google-cloud-ops-agent.service
@@ -19,7 +19,7 @@ Requires=google-cloud-ops-agent-fluent-bit.service google-cloud-ops-agent-opente
 [Service]
 Type=oneshot
 # Validate the config.
-ExecStartPre=@PREFIX@/libexec/google_cloud_ops_agent_engine -service=validate-only -in @SYSCONFDIR@/google-cloud-ops-agent/config.yaml
+ExecStartPre=@PREFIX@/libexec/google_cloud_ops_agent_engine -in @SYSCONFDIR@/google-cloud-ops-agent/config.yaml
 ExecStart=/bin/true
 
 [Install]


### PR DESCRIPTION
This also re-enables config validation on Linux, accidentally removed by #111.