### PR TITLE
Use libexec instead of opt as base path

### DIFF
--- a/pkg/rpm/google-cloud-ops-agent.spec
+++ b/pkg/rpm/google-cloud-ops-agent.spec
@@ -26,9 +26,8 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 %description
 The Google Cloud Ops Agent collects metrics and logs from the system.
 
-%define _prefix /opt/%{name}
+%define _installdir /usr/libexec/%{name}
 %define _confdir /etc/%{name}
-%define _subagentdir %{_prefix}/subagents
 
 %prep
 
@@ -39,11 +38,9 @@ CODE_VERSION=%{version} BUILD_DISTRO=${build_distro#.} DESTDIR="%{buildroot}" ./
 
 %files
 %config %{_confdir}/config.yaml
-%{_subagentdir}/fluent-bit/*
-%{_subagentdir}/opentelemetry-collector/*
-# We aren't using %{_libexecdir} here because that would be lib on some
-# platforms, but the build.sh script hard-codes libexec.
-%{_prefix}/libexec/google_cloud_ops_agent_engine
+%{_installdir}/fluent-bit
+%{_installdir}/otelopscol
+%{_installdir}/google_cloud_ops_agent_engine
 %{_unitdir}/%{name}*
 %{_unitdir}-preset/*-%{name}*
 

--- a/systemd/google-cloud-ops-agent-fluent-bit.service
+++ b/systemd/google-cloud-ops-agent-fluent-bit.service
@@ -23,8 +23,8 @@ RuntimeDirectory=google-cloud-ops-agent-fluent-bit
 StateDirectory=google-cloud-ops-agent/fluent-bit
 LogsDirectory=google-cloud-ops-agent/subagents
 Type=simple
-ExecStartPre=@PREFIX@/libexec/google_cloud_ops_agent_engine -service=fluentbit -in @SYSCONFDIR@/google-cloud-ops-agent/config.yaml -logs ${LOGS_DIRECTORY} -state ${STATE_DIRECTORY}
-ExecStart=@PREFIX@/subagents/fluent-bit/bin/fluent-bit --config ${RUNTIME_DIRECTORY}/fluent_bit_main.conf --parser ${RUNTIME_DIRECTORY}/fluent_bit_parser.conf --log_file ${LOGS_DIRECTORY}/logging-module.log --storage_path ${STATE_DIRECTORY}/buffers
+ExecStartPre=@PREFIX@/google_cloud_ops_agent_engine -service=fluentbit -in @SYSCONFDIR@/google-cloud-ops-agent/config.yaml -logs ${LOGS_DIRECTORY} -state ${STATE_DIRECTORY}
+ExecStart=@PREFIX@/fluent-bit --config ${RUNTIME_DIRECTORY}/fluent_bit_main.conf --parser ${RUNTIME_DIRECTORY}/fluent_bit_parser.conf --log_file ${LOGS_DIRECTORY}/logging-module.log --storage_path ${STATE_DIRECTORY}/buffers
 Restart=always
 # For debugging:
 RuntimeDirectoryPreserve=yes

--- a/systemd/google-cloud-ops-agent-opentelemetry-collector.service
+++ b/systemd/google-cloud-ops-agent-opentelemetry-collector.service
@@ -23,8 +23,8 @@ RuntimeDirectory=google-cloud-ops-agent-opentelemetry-collector
 StateDirectory=google-cloud-ops-agent/opentelemetry-collector
 LogsDirectory=google-cloud-ops-agent/subagents
 Type=simple
-ExecStartPre=@PREFIX@/libexec/google_cloud_ops_agent_engine -service=otel -in @SYSCONFDIR@/google-cloud-ops-agent/config.yaml -logs ${LOGS_DIRECTORY}
-ExecStart=@PREFIX@/subagents/opentelemetry-collector/otelopscol --add-instance-id=false --config=${RUNTIME_DIRECTORY}/otel.yaml
+ExecStartPre=@PREFIX@/google_cloud_ops_agent_engine -service=otel -in @SYSCONFDIR@/google-cloud-ops-agent/config.yaml -logs ${LOGS_DIRECTORY}
+ExecStart=@PREFIX@/otelopscol --add-instance-id=false --config=${RUNTIME_DIRECTORY}/otel.yaml
 Restart=always
 # For debugging:
 RuntimeDirectoryPreserve=yes

--- a/systemd/google-cloud-ops-agent.service
+++ b/systemd/google-cloud-ops-agent.service
@@ -19,7 +19,7 @@ Wants=google-cloud-ops-agent-fluent-bit.service google-cloud-ops-agent-opentelem
 [Service]
 Type=oneshot
 # Validate the config.
-ExecStartPre=@PREFIX@/libexec/google_cloud_ops_agent_engine -in @SYSCONFDIR@/google-cloud-ops-agent/config.yaml
+ExecStartPre=@PREFIX@/google_cloud_ops_agent_engine -in @SYSCONFDIR@/google-cloud-ops-agent/config.yaml
 ExecStart=/bin/true
 RemainAfterExit=yes
 


### PR DESCRIPTION
This PR updates file locations of binary components from /opt/ to /usr/libexec/
This is in keeping with FHS and distribution file path requirements. Tested working with EL SElinux rules.