### PR TITLE
Simplify special-casing of the default config in tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+git:
+  symlinks: true
+
 os:
 - linux
 - windows

--- a/confgenerator/testdata/valid/linux/all-built_in_config/golden_built_in.yaml
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/golden_built_in.yaml
@@ -1,0 +1,1 @@
+../../../../built-in-config-linux.yaml

--- a/confgenerator/testdata/valid/linux/all-built_in_config/input.yaml
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/input.yaml
@@ -1,0 +1,1 @@
+../../../../default-config.yaml

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_built_in.yaml
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_built_in.yaml
@@ -1,0 +1,1 @@
+../../../../built-in-config-windows.yaml

--- a/confgenerator/testdata/valid/windows/all-built_in_config/input.yaml
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/input.yaml
@@ -1,0 +1,1 @@
+../../../../default-config.yaml


### PR DESCRIPTION
Create golden symlinks to built-in-config-*.yaml, so they can be handled by -update_golden.
Add symlinks to the default config in the all-built_in_config testdata directories, to remove the special input handling.