### PR TITLE
Keep config.yaml file if existing

### DIFF
--- a/pkg/goo/google-cloud-ops-agent.goospec
+++ b/pkg/goo/google-cloud-ops-agent.goospec
@@ -19,7 +19,7 @@
     "out\\bin\\fluent-bit.dll": "{{$INSTALL_DIR}}/bin/fluent-bit.dll",
     "out\\bin\\google-cloud-metrics-agent_{{$GOOS}}_{{$GOARCH}}.exe": "{{$INSTALL_DIR}}/bin/google-cloud-metrics-agent_{{$GOOS}}_{{$GOARCH}}.exe",
     "out\\bin\\google-cloud-ops-agent.exe": "{{$INSTALL_DIR}}/bin/google-cloud-ops-agent.exe",
-    "confgenerator\\default-config.yaml": "{{$INSTALL_DIR}}/config/config.yaml"
+    "confgenerator\\default-config.yaml": "{{$INSTALL_DIR}}/config/default-config.yaml"
   },
   "install": {
     "path": "pkg/goo/maint.ps1",

--- a/pkg/goo/google-cloud-ops-agent.goospec
+++ b/pkg/goo/google-cloud-ops-agent.goospec
@@ -19,7 +19,6 @@
     "out\\bin\\fluent-bit.dll": "{{$INSTALL_DIR}}/bin/fluent-bit.dll",
     "out\\bin\\google-cloud-metrics-agent_{{$GOOS}}_{{$GOARCH}}.exe": "{{$INSTALL_DIR}}/bin/google-cloud-metrics-agent_{{$GOOS}}_{{$GOARCH}}.exe",
     "out\\bin\\google-cloud-ops-agent.exe": "{{$INSTALL_DIR}}/bin/google-cloud-ops-agent.exe",
-    "confgenerator\\default-config.yaml": "{{$INSTALL_DIR}}/config/default-config.yaml"
   },
   "install": {
     "path": "pkg/goo/maint.ps1",

--- a/pkg/goo/google-cloud-ops-agent.goospec
+++ b/pkg/goo/google-cloud-ops-agent.goospec
@@ -18,7 +18,7 @@
     "out\\bin\\fluent-bit.exe": "{{$INSTALL_DIR}}/bin/fluent-bit.exe",
     "out\\bin\\fluent-bit.dll": "{{$INSTALL_DIR}}/bin/fluent-bit.dll",
     "out\\bin\\google-cloud-metrics-agent_{{$GOOS}}_{{$GOARCH}}.exe": "{{$INSTALL_DIR}}/bin/google-cloud-metrics-agent_{{$GOOS}}_{{$GOARCH}}.exe",
-    "out\\bin\\google-cloud-ops-agent.exe": "{{$INSTALL_DIR}}/bin/google-cloud-ops-agent.exe",
+    "out\\bin\\google-cloud-ops-agent.exe": "{{$INSTALL_DIR}}/bin/google-cloud-ops-agent.exe"
   },
   "install": {
     "path": "pkg/goo/maint.ps1",

--- a/pkg/goo/maint.ps1
+++ b/pkg/goo/maint.ps1
@@ -31,8 +31,7 @@ $configFilePath = "$InstallDir\config\config.yaml"
 if ($Action -eq "install") {
     if (-not(Test-Path -Path $configFilePath -PathType Leaf)) {
          try {
-             Get-Location
-             Copy-Item -Path "$PSScriptRoot\confgenerator\default-config.yaml" -Destination $configFilePath
+             Copy-Item -Path "$($PSScriptRoot.TrimEnd("\pkg\goo"))\confgenerator\default-config.yaml" -Destination $configFilePath
              Write-Host "The file [$configFilePath] has been created."
          }
          catch {

--- a/pkg/goo/maint.ps1
+++ b/pkg/goo/maint.ps1
@@ -31,7 +31,8 @@ $configFilePath = "$InstallDir\config\config.yaml"
 if ($Action -eq "install") {
     if (-not(Test-Path -Path $configFilePath -PathType Leaf)) {
          try {
-             Copy-Item -Path "$InstallDir\config\default-config.yaml" -Destination $configFilePath
+             Get-Location
+             Copy-Item -Path "confgenerator\default-config.yaml" -Destination $configFilePath
              Write-Host "The file [$configFilePath] has been created."
          }
          catch {

--- a/pkg/goo/maint.ps1
+++ b/pkg/goo/maint.ps1
@@ -32,7 +32,7 @@ if ($Action -eq "install") {
     if (-not(Test-Path -Path $configFilePath -PathType Leaf)) {
          try {
              Get-Location
-             Copy-Item -Path "confgenerator\default-config.yaml" -Destination $configFilePath
+             Copy-Item -Path "$PSScriptRoot\confgenerator\default-config.yaml" -Destination $configFilePath
              Write-Host "The file [$configFilePath] has been created."
          }
          catch {

--- a/pkg/goo/maint.ps1
+++ b/pkg/goo/maint.ps1
@@ -27,17 +27,20 @@ $envFromMatch = {
 $InstallDir = [regex]::Replace($InstallDir,'^<([^>]+)>',$envFromMatch)
 
 $configFilePath = "$InstallDir\config\config.yaml"
-if (-not(Test-Path -Path $configFilePath -PathType Leaf)) {
-     try {
-         Copy-Item -Path "$InstallDir\config\default-config.yaml" -Destination $configFilePath
-         Write-Host "The file [$configFilePath] has been created."
+
+if ($Action -eq "install") {
+    if (-not(Test-Path -Path $configFilePath -PathType Leaf)) {
+         try {
+             Copy-Item -Path "$InstallDir\config\default-config.yaml" -Destination $configFilePath
+             Write-Host "The file [$configFilePath] has been created."
+         }
+         catch {
+             throw $_.Exception.Message
+         }
      }
-     catch {
-         throw $_.Exception.Message
+     else {
+         Write-Host "Keep [$configFilePath] as-is because a file with that name already exists."
      }
- }
- else {
-     Write-Host "Keep [$configFilePath] as-is because a file with that name already exists."
- }
+}
 
 & "$InstallDir\bin\google-cloud-ops-agent.exe" "--$Action"

--- a/pkg/goo/maint.ps1
+++ b/pkg/goo/maint.ps1
@@ -26,4 +26,18 @@ $envFromMatch = {
 }
 $InstallDir = [regex]::Replace($InstallDir,'^<([^>]+)>',$envFromMatch)
 
+$configFilePath = "$InstallDir\config\config.yaml"
+if (-not(Test-Path -Path $configFilePath -PathType Leaf)) {
+     try {
+         Copy-Item -Path "$InstallDir\config\default-config.yaml" -Destination $configFilePath
+         Write-Host "The file [$configFilePath] has been created."
+     }
+     catch {
+         throw $_.Exception.Message
+     }
+ }
+ else {
+     Write-Host "Keep [$configFilePath] as-is because a file with that name already exists."
+ }
+
 & "$InstallDir\bin\google-cloud-ops-agent.exe" "--$Action"


### PR DESCRIPTION
## Test when there is no config file

![Screen Shot 2021-08-03 at 4 43 48 PM](https://user-images.githubusercontent.com/8354694/128083584-73dfe8e7-6456-4388-8a4c-47ef8576ad7b.png)

## Test when there is config file

![Screen Shot 2021-08-03 at 4 45 01 PM](https://user-images.githubusercontent.com/8354694/128083709-d7d0a9c1-f7c9-4e29-bc40-a0dbacba753f.png)

## ToDOO

- work with jimmy on documenting the caveat for previous versions as a known issue SGTM. e.g. a note in https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/installation#upgrade and https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/transition#migrate_preview

- later after we have at least two versions of ops-agent that contains this change, we can add a testcase in ops-agent-test.go for checking if existing config file  is kept untouched.