### PR TITLE
Fix bug where the generated Fluent Bit filters were incorrectly ordered.

### DIFF
--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_main.conf
@@ -1,0 +1,285 @@
+[SERVICE]
+    # https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section
+    # Flush logs every 1 second, even if the buffer is not full to minimize log entry arrival delay.
+    Flush      1
+    # We use systemd to manage Fluent Bit instead.
+    Daemon     off
+    # Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).
+    Log_Level  info
+
+    # https://docs.fluentbit.io/manual/administration/monitoring
+    # Enable a built-in HTTP server that can be used to query internal information and monitor metrics of each running plugin.
+    HTTP_Server  On
+    HTTP_Listen  0.0.0.0
+    HTTP_PORT    2020
+
+    # https://docs.fluentbit.io/manual/administration/buffering-and-storage#service-section-configuration
+    # storage.path is set by Fluent Bit systemd unit (e.g. /var/lib/google-cloud-ops-agent/fluent-bit/buffers).
+    storage.sync               normal
+    # Enable the data integrity check when writing and reading data from the filesystem.
+    storage.checksum           on
+    # The maximum amount of data to load into the memory when processing old chunks from the backlog that is from previous Fluent Bit processes (e.g. Fluent Bit may have crashed or restarted).
+    storage.backlog.mem_limit  50M
+    # Enable storage metrics in the built-in HTTP server.
+    storage.metrics            on
+    # This is exclusive to filesystem storage type. It specifies the number of chunks (every chunk is a file) that can be up in memory.
+    # Every chunk is a file, so having it up in memory means having an open file descriptor. In case there are thousands of chunks,
+    # we don't want them to all be loaded into the memory.
+    storage.max_chunks_up      128
+
+[INPUT]
+    # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
+    Name               tail
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/default_pipeline_syslog
+    Path               /var/log/messages,/var/log/syslog
+    Tag                default_pipeline.syslog
+    Read_from_Head     True
+    # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
+    Buffer_Chunk_Size  512k
+    # Set the max size a bit larger to accommodate for long log lines.
+    Buffer_Max_Size    5M
+    # When a message is unstructured (no parser applied), append it under a key named "message".
+    Key                message
+    # Increase this to 30 seconds so log rotations are handled more gracefully.
+    Rotate_Wait        30
+    # Skip long lines instead of skipping the entire file when a long line exceeds buffer size.
+    Skip_Long_Lines    On
+
+    # https://docs.fluentbit.io/manual/administration/buffering-and-storage#input-section-configuration
+    # Buffer in disk to improve reliability.
+    storage.type       filesystem
+
+    # https://docs.fluentbit.io/manual/administration/backpressure#mem_buf_limit
+    # This controls how much data the input plugin can hold in memory once the data is ingested into the core.
+    # This is used to deal with backpressure scenarios (e.g: cannot flush data for some reason).
+    # When the input plugin hits "mem_buf_limit", because we have enabled filesystem storage type, mem_buf_limit acts
+    # as a hint to set "how much data can be up in memory", once the limit is reached it continues writing to disk.
+    Mem_Buf_Limit      10M
+
+[INPUT]
+    # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
+    Name               tail
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-collectd
+    Path               /var/log/google-cloud-ops-agent/subagents/metrics-module.log
+    Tag                ops-agent-collectd
+    Read_from_Head     True
+    # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
+    Buffer_Chunk_Size  512k
+    # Set the max size a bit larger to accommodate for long log lines.
+    Buffer_Max_Size    5M
+    # When a message is unstructured (no parser applied), append it under a key named "message".
+    Key                message
+    # Increase this to 30 seconds so log rotations are handled more gracefully.
+    Rotate_Wait        30
+    # Skip long lines instead of skipping the entire file when a long line exceeds buffer size.
+    Skip_Long_Lines    On
+
+    # https://docs.fluentbit.io/manual/administration/buffering-and-storage#input-section-configuration
+    # Buffer in disk to improve reliability.
+    storage.type       filesystem
+
+    # https://docs.fluentbit.io/manual/administration/backpressure#mem_buf_limit
+    # This controls how much data the input plugin can hold in memory once the data is ingested into the core.
+    # This is used to deal with backpressure scenarios (e.g: cannot flush data for some reason).
+    # When the input plugin hits "mem_buf_limit", because we have enabled filesystem storage type, mem_buf_limit acts
+    # as a hint to set "how much data can be up in memory", once the limit is reached it continues writing to disk.
+    Mem_Buf_Limit      10M
+
+[INPUT]
+    # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
+    Name               tail
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/ops-agent-fluent-bit
+    Path               /var/log/google-cloud-ops-agent/subagents/logging-module.log
+    Tag                ops-agent-fluent-bit
+    Read_from_Head     True
+    # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
+    Buffer_Chunk_Size  512k
+    # Set the max size a bit larger to accommodate for long log lines.
+    Buffer_Max_Size    5M
+    # When a message is unstructured (no parser applied), append it under a key named "message".
+    Key                message
+    # Increase this to 30 seconds so log rotations are handled more gracefully.
+    Rotate_Wait        30
+    # Skip long lines instead of skipping the entire file when a long line exceeds buffer size.
+    Skip_Long_Lines    On
+
+    # https://docs.fluentbit.io/manual/administration/buffering-and-storage#input-section-configuration
+    # Buffer in disk to improve reliability.
+    storage.type       filesystem
+
+    # https://docs.fluentbit.io/manual/administration/backpressure#mem_buf_limit
+    # This controls how much data the input plugin can hold in memory once the data is ingested into the core.
+    # This is used to deal with backpressure scenarios (e.g: cannot flush data for some reason).
+    # When the input plugin hits "mem_buf_limit", because we have enabled filesystem storage type, mem_buf_limit acts
+    # as a hint to set "how much data can be up in memory", once the limit is reached it continues writing to disk.
+    Mem_Buf_Limit      10M
+
+[INPUT]
+    # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
+    Name               tail
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/pipeline1_sample_logs
+    Path               /tmp/*.log
+    Tag                pipeline1.sample_logs
+    Read_from_Head     True
+    # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
+    Buffer_Chunk_Size  512k
+    # Set the max size a bit larger to accommodate for long log lines.
+    Buffer_Max_Size    5M
+    # When a message is unstructured (no parser applied), append it under a key named "message".
+    Key                message
+    # Increase this to 30 seconds so log rotations are handled more gracefully.
+    Rotate_Wait        30
+    # Skip long lines instead of skipping the entire file when a long line exceeds buffer size.
+    Skip_Long_Lines    On
+
+    # https://docs.fluentbit.io/manual/administration/buffering-and-storage#input-section-configuration
+    # Buffer in disk to improve reliability.
+    storage.type       filesystem
+
+    # https://docs.fluentbit.io/manual/administration/backpressure#mem_buf_limit
+    # This controls how much data the input plugin can hold in memory once the data is ingested into the core.
+    # This is used to deal with backpressure scenarios (e.g: cannot flush data for some reason).
+    # When the input plugin hits "mem_buf_limit", because we have enabled filesystem storage type, mem_buf_limit acts
+    # as a hint to set "how much data can be up in memory", once the limit is reached it continues writing to disk.
+    Mem_Buf_Limit      10M
+
+[INPUT]
+    # https://docs.fluentbit.io/manual/pipeline/inputs/tail#config
+    Name               tail
+    DB                 /var/lib/google-cloud-ops-agent/fluent-bit/buffers/pipeline2_sample_logs
+    Path               /tmp/*.log
+    Tag                pipeline2.sample_logs
+    Read_from_Head     True
+    # Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
+    Buffer_Chunk_Size  512k
+    # Set the max size a bit larger to accommodate for long log lines.
+    Buffer_Max_Size    5M
+    # When a message is unstructured (no parser applied), append it under a key named "message".
+    Key                message
+    # Increase this to 30 seconds so log rotations are handled more gracefully.
+    Rotate_Wait        30
+    # Skip long lines instead of skipping the entire file when a long line exceeds buffer size.
+    Skip_Long_Lines    On
+
+    # https://docs.fluentbit.io/manual/administration/buffering-and-storage#input-section-configuration
+    # Buffer in disk to improve reliability.
+    storage.type       filesystem
+
+    # https://docs.fluentbit.io/manual/administration/backpressure#mem_buf_limit
+    # This controls how much data the input plugin can hold in memory once the data is ingested into the core.
+    # This is used to deal with backpressure scenarios (e.g: cannot flush data for some reason).
+    # When the input plugin hits "mem_buf_limit", because we have enabled filesystem storage type, mem_buf_limit acts
+    # as a hint to set "how much data can be up in memory", once the limit is reached it continues writing to disk.
+    Mem_Buf_Limit      10M
+
+[FILTER]
+    Name     parser
+    Match    pipeline1.*
+    Key_Name message
+    Parser   alpha
+
+[FILTER]
+    Name     parser
+    Match    pipeline1.*
+    Key_Name message
+    Parser   beta
+
+[FILTER]
+    Name     parser
+    Match    pipeline2.*
+    Key_Name message
+    Parser   beta
+
+[FILTER]
+    Name     parser
+    Match    pipeline2.*
+    Key_Name message
+    Parser   alpha
+
+[FILTER]
+    Name  modify
+    Match default_pipeline.syslog
+    Add   logName syslog
+
+[FILTER]
+    Name  modify
+    Match pipeline1.sample_logs
+    Add   logName sample_logs
+
+[FILTER]
+    Name  modify
+    Match pipeline2.sample_logs
+    Add   logName sample_logs
+
+[FILTER]
+    Name                  rewrite_tag
+    Match                 default_pipeline.syslog
+    Rule                  $logName .* $logName false
+    Emitter_Storage.type  filesystem
+    Emitter_Mem_Buf_Limit 10M
+
+[FILTER]
+    Name                  rewrite_tag
+    Match                 pipeline1.sample_logs
+    Rule                  $logName .* $logName false
+    Emitter_Storage.type  filesystem
+    Emitter_Mem_Buf_Limit 10M
+
+[FILTER]
+    Name                  rewrite_tag
+    Match                 pipeline2.sample_logs
+    Rule                  $logName .* $logName false
+    Emitter_Storage.type  filesystem
+    Emitter_Mem_Buf_Limit 10M
+
+[FILTER]
+    Name   modify
+    Match  sample_logs
+    Remove logName
+
+[FILTER]
+    Name   modify
+    Match  sample_logs
+    Remove logName
+
+[FILTER]
+    Name   modify
+    Match  syslog
+    Remove logName
+
+[OUTPUT]
+    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
+    Name              stackdriver
+    resource          gce_instance
+    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    workers           8
+    Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
+
+    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
+    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
+    Retry_Limit  3
+
+    # https://docs.fluentbit.io/manual/administration/security
+    # Enable TLS support.
+    tls         On
+    # Do not force certificate validation.
+    tls.verify  Off
+
+[OUTPUT]
+    # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
+    Name              stackdriver
+    resource          gce_instance
+    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    workers           8
+    Match_Regex       ^(syslog|sample_logs|sample_logs)$
+
+    # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
+    # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
+    Retry_Limit  3
+
+    # https://docs.fluentbit.io/manual/administration/security
+    # Enable TLS support.
+    tls         On
+    # Do not force certificate validation.
+    tls.verify  Off
+

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_parser.conf
@@ -1,0 +1,60 @@
+[PARSER]
+    Name        lib:default_message_parser
+    Format      regex
+    Regex       ^(?<message>.*)$
+
+[PARSER]
+    Name        lib:apache
+    Format      regex
+    Regex       ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+    Time_Key    time
+    Time_Format %d/%b/%Y:%H:%M:%S %z
+
+[PARSER]
+    Name        lib:apache2
+    Format      regex
+    Regex       ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>.*)")?$
+    Time_Key    time
+    Time_Format %d/%b/%Y:%H:%M:%S %z
+
+[PARSER]
+    Name   lib:apache_error
+    Format regex
+    Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
+
+[PARSER]
+    Name        lib:mongodb
+    Format      regex
+    Regex       ^(?<time>[^ ]*)\s+(?<severity>\w)\s+(?<component>[^ ]+)\s+\[(?<context>[^\]]+)]\s+(?<message>.*?) *(?<ms>(\d+))?(:?ms)?$
+    Time_Key    time
+    Time_Format %Y-%m-%dT%H:%M:%S.%L
+
+[PARSER]
+    Name        lib:nginx
+    Format      regex
+    Regex       ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")
+    Time_Key    time
+    Time_Format %d/%b/%Y:%H:%M:%S %z
+
+[PARSER]
+    Name        lib:syslog-rfc5424
+    Format      regex
+    Regex       ^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*?)\]|-)) (?<message>.+)$
+    Time_Key    time
+    Time_Format %Y-%m-%dT%H:%M:%S.%L%Z
+
+[PARSER]
+    Name        lib:syslog-rfc3164
+    Format      regex
+    Regex       /^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
+    Time_Key    time
+    Time_Format %b %d %H:%M:%S
+
+[PARSER]
+    Name        alpha
+    Format      json
+
+[PARSER]
+    Name        beta
+    Format      json
+

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
@@ -1,0 +1,490 @@
+receivers:
+  prometheus/agent:
+    config:
+      scrape_configs:
+      - job_name: 'otel-collector'
+        scrape_interval: 1m
+        static_configs:
+        - targets: ['0.0.0.0:8888']
+  hostmetrics/hostmetrics:
+    collection_interval: 60s
+    scrapers:
+      cpu:
+      load:
+      memory:
+      disk:
+      filesystem:
+      network:
+      paging:
+      process:
+      processes:
+processors:
+  resourcedetection:
+    detectors: [gce]
+
+  # perform custom transformations that aren't supported by the metricstransform processor
+  agentmetrics/system:
+    # https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/agentmetricsprocessor/agentmetricsprocessor.go#L58
+    blank_label_metrics:
+    - system.cpu.utilization
+
+  # filter out metrics not currently supported by cloud monitoring
+  filter/system:
+    metrics:
+      exclude:
+        match_type: strict
+        metric_names:
+          # Temporarily exclude system.cpu.time (cpu/usage_time)
+          - system.cpu.time
+          - system.network.dropped
+          - system.filesystem.inodes.usage
+          - system.paging.faults
+          - system.disk.operation_time
+          - system.processes.count
+
+  # convert from opentelemetry metric formats to cloud monitoring formats
+  metricstransform/system:
+    transforms:
+      # system.cpu.time -> cpu/usage_time
+      - metric_name: system.cpu.time
+        action: update
+        new_name: cpu/usage_time
+        operations:
+          # change data type from double -> int64
+          - action: toggle_scalar_data_type
+          # change label cpu -> cpu_number
+          - action: update_label
+            label: cpu
+            new_label: cpu_number
+          # change label state -> cpu_state
+          - action: update_label
+            label: state
+            new_label: cpu_state
+      # system.cpu.utilization -> cpu/utilization
+      - metric_name: system.cpu.utilization
+        action: update
+        new_name: cpu/utilization
+        operations:
+          # take avg over cpu dimension, retaining only state label
+          - action: aggregate_labels
+            label_set: [state, blank]
+            aggregation_type: mean
+          # add blank cpu_number label
+          - action: update_label
+            label: blank
+            new_label: cpu_number
+          # change label state -> cpu_state
+          - action: update_label
+            label: state
+            new_label: cpu_state
+      # system.cpu.load_average.1m -> cpu/load_1m
+      - metric_name: system.cpu.load_average.1m
+        action: update
+        new_name: cpu/load_1m
+      # system.cpu.load_average.5m -> cpu/load_5m
+      - metric_name: system.cpu.load_average.5m
+        action: update
+        new_name: cpu/load_5m
+      # system.cpu.load_average.15m -> cpu/load_15m
+      - metric_name: system.cpu.load_average.15m
+        action: update
+        new_name: cpu/load_15m
+      # system.disk.read_io (as named after custom split logic) -> disk/read_bytes_count
+      - metric_name: system.disk.read_io
+        action: update
+        new_name: disk/read_bytes_count
+      # system.disk.write_io (as named after custom split logic) -> processes/write_bytes_count
+      - metric_name: system.disk.write_io
+        action: update
+        new_name: disk/write_bytes_count
+      # system.disk.operations -> disk/operation_count
+      - metric_name: system.disk.operations
+        action: update
+        new_name: disk/operation_count
+      # system.disk.io_time -> disk/io_time
+      - metric_name: system.disk.io_time
+        action: update
+        new_name: disk/io_time
+        operations:
+          # convert s to ms
+          - action: experimental_scale_value
+            experimental_scale: 1000
+          # change data type from double -> int64
+          - action: toggle_scalar_data_type
+      # system.disk.weighted_io_time -> disk/weighted_io_time
+      - metric_name: system.disk.weighted_io_time
+        action: update
+        new_name: disk/weighted_io_time
+        operations:
+          # convert s to ms
+          - action: experimental_scale_value
+            experimental_scale: 1000
+          # change data type from double -> int64
+          - action: toggle_scalar_data_type
+      # system.disk.average_operation_time -> disk/operation_time
+      - metric_name: system.disk.average_operation_time
+        action: update
+        new_name: disk/operation_time
+        operations:
+          # convert s to ms
+          - action: experimental_scale_value
+            experimental_scale: 1000
+          # change data type from double -> int64
+          - action: toggle_scalar_data_type
+      # system.disk.pending_operations -> disk/pending_operations
+      - metric_name: system.disk.pending_operations
+        action: update
+        new_name: disk/pending_operations
+        operations:
+          # change data type from int64 -> double
+          - action: toggle_scalar_data_type
+      # system.disk.merged -> disk/merged_operations
+      - metric_name: system.disk.merged
+        action: update
+        new_name: disk/merged_operations
+      # system.filesystem.usage -> disk/bytes_used
+      - metric_name: system.filesystem.usage
+        action: update
+        new_name: disk/bytes_used
+        operations:
+          # change data type from int64 -> double
+          - action: toggle_scalar_data_type
+          # take sum over mode, mountpoint & type dimensions, retaining only device & state
+          - action: aggregate_labels
+            label_set: [ device, state ]
+            aggregation_type: sum
+      # system.filesystem.utilization -> disk/percent_used
+      - metric_name: system.filesystem.utilization
+        action: update
+        new_name: disk/percent_used
+        operations:
+          # take sum over mode, mountpoint & type dimensions, retaining only device & state
+          - action: aggregate_labels
+            label_set: [ device, state ]
+            aggregation_type: sum
+      # system.memory.usage -> memory/bytes_used
+      - metric_name: system.memory.usage
+        action: update
+        new_name: memory/bytes_used
+        operations:
+          # change data type from int64 -> double
+          - action: toggle_scalar_data_type
+          # aggregate state label values: slab_reclaimable & slab_unreclaimable -> slab (note this is not currently supported)
+          - action: aggregate_label_values
+            label: state
+            aggregated_values: [slab_reclaimable, slab_unreclaimable]
+            new_value: slab
+            aggregation_type: sum
+      # system.memory.utilization -> memory/percent_used
+      - metric_name: system.memory.utilization
+        action: update
+        new_name: memory/percent_used
+        operations:
+          # sum state label values: slab = slab_reclaimable + slab_unreclaimable
+          - action: aggregate_label_values
+            label: state
+            aggregated_values: [slab_reclaimable, slab_unreclaimable]
+            new_value: slab
+            aggregation_type: sum
+      # system.network.io -> interface/traffic
+      - metric_name: system.network.io
+        action: update
+        new_name: interface/traffic
+        operations:
+          # change label interface -> device
+          - action: update_label
+            label: interface
+            new_label: device
+          # change direction label values receive -> rx
+          - action: update_label
+            label: direction
+            value_actions:
+              # receive -> rx
+              - value: receive
+                new_value: rx
+              # transmit -> tx
+              - value: transmit
+                new_value: tx
+      # system.network.errors -> interface/errors
+      - metric_name: system.network.errors
+        action: update
+        new_name: interface/errors
+        operations:
+          # change label interface -> device
+          - action: update_label
+            label: interface
+            new_label: device
+          # change direction label values receive -> rx
+          - action: update_label
+            label: direction
+            value_actions:
+              # receive -> rx
+              - value: receive
+                new_value: rx
+              # transmit -> tx
+              - value: transmit
+                new_value: tx
+      # system.network.packets -> interface/packets
+      - metric_name: system.network.packets
+        action: update
+        new_name: interface/packets
+        operations:
+          # change label interface -> device
+          - action: update_label
+            label: interface
+            new_label: device
+          # change direction label values receive -> rx
+          - action: update_label
+            label: direction
+            value_actions:
+              # receive -> rx
+              - value: receive
+                new_value: rx
+              # transmit -> tx
+              - value: transmit
+                new_value: tx
+      # system.network.connections -> network/tcp_connections
+      - metric_name: system.network.connections
+        action: update
+        new_name: network/tcp_connections
+        operations:
+          # change data type from int64 -> double
+          - action: toggle_scalar_data_type
+          # remove udp data
+          - action: delete_label_value
+            label: protocol
+            label_value: udp
+          # change label state -> tcp_state
+          - action: update_label
+            label: state
+            new_label: tcp_state
+          # remove protocol label
+          - action: aggregate_labels
+            label_set: [ tcp_state ]
+            aggregation_type: sum
+          - action: add_label
+            new_label: port
+            new_value: all
+      # system.processes.created -> processes/fork_count
+      - metric_name: system.processes.created
+        action: update
+        new_name: processes/fork_count
+      # system.paging.usage -> swap/bytes_used
+      - metric_name: system.paging.usage
+        action: update
+        new_name: swap/bytes_used
+        operations:
+          # change data type from int64 -> double
+          - action: toggle_scalar_data_type
+      # system.paging.utilization -> swap/percent_used
+      - metric_name: system.paging.utilization
+        action: update
+        new_name: swap/percent_used
+      # duplicate swap/percent_used -> pagefile/percent_used
+      - metric_name: swap/percent_used
+        action: insert
+        new_name: pagefile/percent_used
+        operations:
+          # take sum over device dimension, retaining only state
+          - action: aggregate_labels
+            label_set: [ state ]
+            aggregation_type: sum
+      # system.paging.operations -> swap/io
+      - metric_name: system.paging.operations
+        action: update
+        new_name: swap/io
+        operations:
+          # delete single-valued type dimension, retaining only direction
+          - action: aggregate_labels
+            label_set: [ direction ]
+            aggregation_type: sum
+          - action: update_label
+            label: direction
+            # change label value page_in -> in, page_out -> out
+            value_actions:
+              - value: page_in
+                new_value: in
+              - value: page_out
+                new_value: out
+      # process.cpu.time -> processes/cpu_time
+      - metric_name: process.cpu.time
+        action: update
+        new_name: processes/cpu_time
+        operations:
+          # scale from seconds to microseconds
+          - action: experimental_scale_value
+            experimental_scale: 1000000
+          # change data type from double -> int64
+          - action: toggle_scalar_data_type
+          - action: add_label
+            new_label: process
+            new_value: all
+          # retain only user and syst state label values
+          - action: delete_label_value
+            label: state
+            label_value: wait
+          # change label state -> user_or_syst
+          - action: update_label
+            label: state
+            new_label: user_or_syst
+            # change label value system -> syst
+            value_actions:
+              - value: system
+                new_value: syst
+      # process.disk.read_io (as named after custom split logic) -> processes/disk/read_bytes_count
+      - metric_name: process.disk.read_io
+        action: update
+        new_name: processes/disk/read_bytes_count
+        operations:
+          - action: add_label
+            new_label: process
+            new_value: all
+      # process.disk.write_io (as named after custom split logic) -> processes/disk/write_bytes_count
+      - metric_name: process.disk.write_io
+        action: update
+        new_name: processes/disk/write_bytes_count
+        operations:
+          - action: add_label
+            new_label: process
+            new_value: all
+      # process.memory.physical_usage -> processes/rss_usage
+      - metric_name: process.memory.physical_usage
+        action: update
+        new_name: processes/rss_usage
+        operations:
+          # change data type from int64 -> double
+          - action: toggle_scalar_data_type
+          - action: add_label
+            new_label: process
+            new_value: all
+      # process.memory.virtual_usage -> processes/vm_usage
+      - metric_name: process.memory.virtual_usage
+        action: update
+        new_name: processes/vm_usage
+        operations:
+          # change data type from int64 -> double
+          - action: toggle_scalar_data_type
+          - action: add_label
+            new_label: process
+            new_value: all
+
+  # filter to include only agent metrics supported by cloud monitoring
+  filter/agent:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+          - otelcol_process_uptime
+          - otelcol_process_memory_rss
+          - otelcol_grpc_io_client_completed_rpcs
+          - otelcol_googlecloudmonitoring_point_count
+
+  # convert from windows perf counter formats to cloud monitoring formats
+  metricstransform/iis:
+    transforms:
+      - include: \Web Service(_Total)\Current Connections
+        action: update
+        new_name: iis/current_connections
+      - include: ^\\Web Service\(_Total\)\\Total Bytes (?P<direction>.*)$
+        match_type: regexp
+        action: combine
+        new_name: iis/network/transferred_bytes_count
+        submatch_case: lower
+      - include: \Web Service(_Total)\Total Connection Attempts (all instances)
+        action: update
+        new_name: iis/new_connection_count
+      - include: ^\\Web Service\(_Total\)\\Total (?P<http_method>.*) Requests$
+        match_type: regexp
+        action: combine
+        new_name: iis/request_count
+        submatch_case: lower
+
+  # convert from windows perf counter formats to cloud monitoring formats
+  metricstransform/mssql:
+    transforms:
+      - include: \SQLServer:General Statistics(_Total)\User Connections
+        action: update
+        new_name: mssql/connections/user
+      - include: \SQLServer:Databases(_Total)\Transactions/sec
+        action: update
+        new_name: mssql/transaction_rate
+      - include: \SQLServer:Databases(_Total)\Write Transactions/sec
+        action: update
+        new_name: mssql/write_transaction_rate
+
+  # convert from opentelemetry metric formats to cloud monitoring formats
+  metricstransform/agent:
+    transforms:
+      # otelcol_process_uptime -> agent/uptime
+      - metric_name: otelcol_process_uptime
+        action: update
+        new_name: agent/uptime
+        operations:
+          # change data type from double -> int64
+          - action: toggle_scalar_data_type
+          # add version label
+          - action: add_label
+            new_label: version
+            new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      # otelcol_process_memory_rss -> agent/memory_usage
+      - metric_name: otelcol_process_memory_rss
+        action: update
+        new_name: agent/memory_usage
+      # otelcol_grpc_io_client_completed_rpcs -> agent/api_request_count
+      - metric_name: otelcol_grpc_io_client_completed_rpcs
+        action: update
+        new_name: agent/api_request_count
+        operations:
+          # change data type from double -> int64
+          - action: toggle_scalar_data_type
+        # TODO: below is proposed new configuration for the metrics transform processor
+          # ignore any non "google.monitoring" RPCs (note there won't be any other RPCs for now)
+        # - action: select_label_values
+        #   label: grpc_client_method
+        #   value_regexp: ^google\.monitoring
+          # change label grpc_client_status -> state
+          - action: update_label
+            label: grpc_client_status
+            new_label: state
+          # delete grpc_client_method dimension, retaining only state
+          - action: aggregate_labels
+            label_set: [ state ]
+            aggregation_type: sum
+      # otelcol_googlecloudmonitoring_point_count -> agent/monitoring/point_count
+      - metric_name: otelcol_googlecloudmonitoring_point_count
+        action: update
+        new_name: agent/monitoring/point_count
+        operations:
+          # change data type from double -> int64
+          - action: toggle_scalar_data_type
+  filter/exclude_metrics_filter:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names:
+exporters:
+  googlecloud/google:
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    metric:
+      prefix: agent.googleapis.com/
+  googlecloud/agent:
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    metric:
+      prefix: agent.googleapis.com/
+extensions:
+service:
+  pipelines:
+    # reports agent self-observability metrics to cloud monitoring
+    metrics/agent:
+      receivers:
+        - prometheus/agent
+      processors:
+        - filter/agent
+        - metricstransform/agent
+        - resourcedetection
+      exporters:
+        - googlecloud/agent
+    metrics/system:
+      receivers:  [hostmetrics/hostmetrics]
+      processors: [agentmetrics/system,filter/system,metricstransform/system,resourcedetection,filter/exclude_metrics_filter]
+      exporters: [googlecloud/google]

--- a/confgenerator/testdata/valid/linux/logging-processor_order/input.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/input.yaml
@@ -1,0 +1,40 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Create two pipelines that use the same processors but in different
+# orders.  This is to verify that the generated Fluent Bit filters
+# appear in the correct order.
+logging:
+  receivers:
+    sample_logs:
+      type: files
+      include_paths: [/tmp/*.log]
+  processors:
+    alpha:
+      type: parse_json
+    beta:
+      type: parse_json
+  exporters:
+    google:
+      type: google_cloud_logging
+  service:
+    pipelines:
+      pipeline2:
+        receivers: [sample_logs]
+        processors: [beta, alpha]
+        exporters: [google]
+      pipeline1:
+        receivers: [sample_logs]
+        processors: [alpha, beta]
+        exporters: [google]


### PR DESCRIPTION
The new test config is a good example.  It has:

    pipeline2:
      processors: [beta, alpha]
    pipeline1:
      processors: [alpha, beta]

The code previously created a flat list of 4 Fluent Bit filters:

    [pipeline2-beta, pipeline2-alpha, pipeline1-alpha, pipeline1-beta]

which was then sorted, putting the pipeline2 filters out-of-order:

    [pipeline1-alpha, pipeline1-beta, pipeline2-alpha, pipeline2-beta]

This PR keeps the pipelines in groups:

    [[pipeline2-beta, pipeline2-alpha], [pipeline1-alpha, pipeline1-beta]]

and then does not sort within each group:

    [[pipeline1-alpha, pipeline1-beta], [pipeline2-beta, pipeline2-alpha]]

thus maintaining the correct order of filters in the generated Fluent
Bit config.