### PR TITLE
Update Fluent Bit to v1.8.4 and enable multithreading on Windows.

### DIFF
--- a/confgenerator/fluentbit/conf.go
+++ b/confgenerator/fluentbit/conf.go
@@ -258,9 +258,7 @@ const (
     Match_Regex       ^({{.Match}})$
     resource          gce_instance
     stackdriver_agent {{.UserAgent}}
-    {{- if .Workers}}
-    workers           {{.Workers}}
-    {{- end}}
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -743,7 +741,6 @@ func (w WindowsEventlog) renderConfig() (string, error) {
 type Stackdriver struct {
 	Match     string
 	UserAgent string
-	Workers   int
 }
 
 var stackdriverTemplate = template.Must(template.New("stackdriver").Parse(stackdriverConf))

--- a/confgenerator/fluentbit/conf_test.go
+++ b/confgenerator/fluentbit/conf_test.go
@@ -601,7 +601,6 @@ func TestStackdriver(t *testing.T) {
 	s := Stackdriver{
 		Match:     "test_match",
 		UserAgent: "user_agent",
-		Workers:   8,
 	}
 	want := `[OUTPUT]
     # https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
@@ -87,6 +87,7 @@
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -104,6 +105,7 @@
     Match_Regex       ^(windows_event_log)$
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_fluent_bit_main.conf
@@ -87,6 +87,7 @@
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -104,6 +105,7 @@
     Match_Regex       ^(windows_event_log)$
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_fluent_bit_main.conf
@@ -87,6 +87,7 @@
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -104,6 +105,7 @@
     Match_Regex       ^(windows_event_log)$
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -62,6 +62,7 @@
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -185,6 +185,7 @@
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -202,6 +203,7 @@
     Match_Regex       ^(windows_event_log|log_source_id1|log_source_id2)$
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -87,6 +87,7 @@
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -104,6 +105,7 @@
     Match_Regex       ^(windows_event_log)$
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_fluent_bit_main.conf
@@ -87,6 +87,7 @@
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -104,6 +105,7 @@
     Match_Regex       ^(windows_event_log)$
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_fluent_bit_main.conf
@@ -87,6 +87,7 @@
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -104,6 +105,7 @@
     Match_Regex       ^(windows_event_log)$
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
@@ -87,6 +87,7 @@
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -104,6 +105,7 @@
     Match_Regex       ^(windows_event_log)$
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
@@ -87,6 +87,7 @@
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -104,6 +105,7 @@
     Match_Regex       ^(windows_event_log)$
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
@@ -87,6 +87,7 @@
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -104,6 +105,7 @@
     Match_Regex       ^(windows_event_log)$
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
@@ -87,6 +87,7 @@
     Match_Regex       ^(ops-agent-fluent-bit|ops-agent-collectd)$
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
@@ -104,6 +105,7 @@
     Match_Regex       ^(windows_event_log)$
     resource          gce_instance
     stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    workers           8
 
     # https://docs.fluentbit.io/manual/administration/scheduling-and-retries
     # After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.


### PR DESCRIPTION
This PR replaces https://github.com/GoogleCloudPlatform/ops-agent/pull/126 &mdash; see previous conversation there.

- Updates Fluent Bit `v1.7.8` &rarr; `v1.8.4`.
- Enables multithreading on Windows by changing default number of workers from 0 &rarr; 8 (to match Linux). 
- Removes configurability of number of workers now that they're consistent.

Related:
- `v1.7.9` issue: https://github.com/fluent/fluent-bit/issues/3646#issuecomment-883663469
  - Fix released in `v1.8.3`: https://github.com/fluent/fluent-bit/pull/3836
- `v1.8.3` issue: https://github.com/ARMmbed/mbedtls/issues/4233, https://github.com/fluent/fluent-bit/issues/3816
  - Fix released in `v1.8.4`: https://github.com/fluent/fluent-bit/pull/3949

http://b/191158630