### PR TITLE
Minor re-arrangement of the Nginx integration tests.

### DIFF
--- a/integration_test/third_party_apps_data/agent/ops-agent/linux/enable_nginx
+++ b/integration_test/third_party_apps_data/agent/ops-agent/linux/enable_nginx
@@ -1,6 +1,6 @@
-set -e
+# Configures Ops Agent to collect telemetry from the app and restart Ops Agent.
 
-curl http://local-stackdriver-agent.stackdriver.com:80/nginx_status
+set -e
 
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 # Copyright 2020 Google LLC
@@ -19,15 +19,15 @@ sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 
 metrics:
   receivers:
-    nginxmetrics:
+    nginx_metrics:
       type: nginx
-      stub_status_url: http://local-stackdriver-agent.stackdriver.com:80/nginx_status
+      stub_status_url: http://127.0.0.1:80/nginx_status
       collection_interval: 30s
   service:
     pipelines:
       nginxpipeline:
         receivers:
-          - nginxmetrics
+          - nginx_metrics
 EOF
 
-sudo systemctl restart google-cloud-ops-agent.service
+sudo service google-cloud-ops-agent restart

--- a/integration_test/third_party_apps_data/applications/nginx/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/nginx/debian_ubuntu/install
@@ -1,8 +1,6 @@
+# Installs the application
+
 set -e
 
 sudo apt update
 sudo apt install -y nginx
-
-# The following lines are from our public instructions.
-(cd /etc/nginx/conf.d/ && sudo curl -O https://raw.githubusercontent.com/Stackdriver/stackdriver-agent-service-configs/master/etc/nginx/conf.d/status.conf)
-sudo systemctl reload nginx

--- a/integration_test/third_party_apps_data/applications/nginx/debian_ubuntu/post
+++ b/integration_test/third_party_apps_data/applications/nginx/debian_ubuntu/post
@@ -1,1 +1,29 @@
-sudo systemctl start nginx
+# Configure the app to expose metrics and reload / restart the app.
+# This might be a no-op for some apps.
+
+set -e
+
+sudo tee /etc/nginx/conf.d/status.conf > /dev/null << EOF
+server {
+    listen 80;
+    server_name 127.0.0.1;
+    location /nginx_status {
+        stub_status on;
+        access_log off;
+        allow 127.0.0.1;
+        deny all;
+    }
+    location / {
+        root /dev/null;
+    }
+}
+EOF
+
+sudo service nginx reload
+
+# Verify the metrics is exposed successfully. Sample output:
+# Active connections: 1
+# server accepts handled requests
+#  9 9 9
+# Reading: 0 Writing: 1 Waiting: 0
+curl http://127.0.0.1:80/nginx_status


### PR DESCRIPTION
The goal is to align the test structure with https://github.com/GoogleCloudPlatform/ops-agent/blob/master/dev-docs/new-receivers.md#test-an-application-manually, so that the doc team can easily verify things when working on the documentation.

For the reference: public Nginx doc is at https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/nginx. 