### PR TITLE
Check out submodules when running GitHub actions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
     - run: |
         git config --global core.symlinks true
     - uses: actions/checkout@v2
+      with:
+        submodules: true
     - if: ${{ runner.os == 'Linux' }}
       run: if [ $(goimports -l .) ]; then goimports -d .; echo 'Failed the goimports format check. Please format the code using "goimports -w ."'; exit 1; fi
     - run: go test -mod=mod -coverprofile=covprofile ./...


### PR DESCRIPTION
Travis used to do that by default. This fixes a migration regression from #189.