### PR TITLE
cmd: log built-in-config.yaml and merged-config.yaml

### DIFF
--- a/cmd/google_cloud_ops_agent_engine/main.go
+++ b/cmd/google_cloud_ops_agent_engine/main.go
@@ -51,7 +51,10 @@ func run() error {
 	log.Printf("Built-in config:\n%s", builtInConfig)
 	log.Printf("Merged config:\n%s", mergedConfig)
 
-	hostInfo, _ := host.Info()
+	hostInfo, err := host.Info()
+	if err != nil {
+		return err
+	}
 	uc, err := confgenerator.ParseUnifiedConfigAndValidate(mergedConfig, hostInfo.OS)
 	if err != nil {
 		return err

--- a/cmd/ops_agent_windows/run_windows.go
+++ b/cmd/ops_agent_windows/run_windows.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -112,15 +111,14 @@ func (s *service) checkForStandaloneAgents(unified *confgenerator.UnifiedConfig)
 
 func (s *service) generateConfigs() error {
 	// TODO(lingshi) Move this to a shared place across Linux and Windows.
-	confDebugFolder := filepath.Join(os.Getenv("PROGRAMDATA"), dataDirectory, "run", "conf", "debug")
-	if err := confgenerator.MergeConfFiles(s.userConf, confDebugFolder, "windows", apps.BuiltInConfStructs); err != nil {
-		return err
-	}
-	data, err := ioutil.ReadFile(filepath.Join(confDebugFolder, "merged-config.yaml"))
+	builtInConfig, mergedConfig, err := confgenerator.MergeConfFiles(s.userConf, "windows", apps.BuiltInConfStructs)
 	if err != nil {
 		return err
 	}
-	uc, err := confgenerator.ParseUnifiedConfigAndValidate(data, "windows")
+
+	s.log.Info(1, fmt.Sprintf("Built-in config:\n%s", builtInConfig))
+	s.log.Info(1, fmt.Sprintf("Merged config:\n%s", mergedConfig))
+	uc, err := confgenerator.ParseUnifiedConfigAndValidate(mergedConfig, "windows")
 	if err != nil {
 		return err
 	}

--- a/confgenerator/confgenerator_test.go
+++ b/confgenerator/confgenerator_test.go
@@ -106,36 +106,13 @@ func testGenerateConfsPlatform(t *testing.T, dir string, platform platformConfig
 			// Retrieve the expected golden conf files.
 			expectedFiles := readFileContents(t, testName, platform.OS, dir)
 
-			var got map[string]string
-			var mergedConfBytes, builtInConfBytes []byte
-
 			confDebugFolder := filepath.Join(dirPath, testName)
 			userSpecifiedConfPath := filepath.Join(confDebugFolder, "/input.yaml")
-			if builtInConfBytes, mergedConfBytes, err = confgenerator.MergeConfFiles(userSpecifiedConfPath, platform.OS, apps.BuiltInConfStructs); err != nil {
-				// TODO: Move this inside generateConfigs when we can do MergeConfFiles in-memory
-				if _, ok := expectedFiles["error"]; ok || *updateGolden {
-					// Config generation failed, but that might be expected.
-					got = map[string]string{
-						"error": err.Error(),
-					}
-				} else {
-					t.Fatalf("MergeConfFiles(%q) got: %v", userSpecifiedConfPath, err)
-				}
-			}
 
-			if got == nil {
-				t.Logf("merged config:\n%s", mergedConfBytes)
-
-				// Generate the actual conf files.
-				got, err = generateConfigs(mergedConfBytes, platform)
-
-				if err != nil {
-					t.Logf("config generation returned %v", err)
-				}
-
-				if testName == builtInConfTestName {
-					got["built-in-config.yaml"] = string(builtInConfBytes)
-				}
+			// Generate the actual conf files.
+			got, err := generateConfigs(testName, userSpecifiedConfPath, apps.BuiltInConfStructs, platform)
+			if err != nil {
+				t.Logf("config generation returned %v", err)
 			}
 
 			// Compare the expected and actual and error out in case of diff.
@@ -212,9 +189,15 @@ func updateOrCompareGolden(t *testing.T, testName, goos, dir, name, got, want st
 // 1. Parsing phase of the agent config when the config is not YAML.
 // 2. Config generation phase when the config is invalid.
 // If at any point, an error is generated, immediately return it for validation.
-func generateConfigs(configInput []byte, platform platformConfig) (got map[string]string, err error) {
+func generateConfigs(testName, userSpecifiedConfPath string, builtInConfStructs map[string]*confgenerator.UnifiedConfig, platform platformConfig) (got map[string]string, err error) {
 	got = make(map[string]string)
-	uc, err := confgenerator.ParseUnifiedConfigAndValidate(configInput, platform.OS)
+	builtInConfBytes, mergedConfBytes, err := confgenerator.MergeConfFiles(userSpecifiedConfPath, platform.OS, apps.BuiltInConfStructs)
+	if err != nil {
+		got["error"] = err.Error()
+		return
+	}
+
+	uc, err := confgenerator.ParseUnifiedConfigAndValidate(mergedConfBytes, platform.OS)
 	if err != nil {
 		got["error"] = err.Error()
 		return
@@ -228,12 +211,18 @@ func generateConfigs(configInput []byte, platform platformConfig) (got map[strin
 	for k, v := range fbConfs {
 		got[k] = v
 	}
+
 	otelConf, err := uc.GenerateOtelConfig(platform.InfoStat)
 	if err != nil {
 		got["error"] = err.Error()
 		return
 	} else {
 		got["otel.conf"] = otelConf
+	}
+
+	// Test that the built-in config file is as expected.
+	if testName == builtInConfTestName {
+		got["built-in-config.yaml"] = string(builtInConfBytes)
 	}
 
 	return

--- a/confgenerator/files.go
+++ b/confgenerator/files.go
@@ -23,19 +23,6 @@ import (
 	"github.com/shirou/gopsutil/host"
 )
 
-func GenerateFiles(input, service, logsDir, stateDir, outDir string) error {
-	hostInfo, _ := host.Info()
-	data, err := ioutil.ReadFile(input)
-	if err != nil {
-		return err
-	}
-	uc, err := ParseUnifiedConfigAndValidate(data, hostInfo.OS)
-	if err != nil {
-		return err
-	}
-	return GenerateFilesFromConfig(&uc, service, logsDir, stateDir, outDir)
-}
-
 func ReadUnifiedConfigFromFile(path, platform string) (UnifiedConfig, error) {
 	uc := UnifiedConfig{}
 


### PR DESCRIPTION
This change logs the config files on both windows and linux. It does so
by logging to STDOUT on linux and to the event log on windows.

This is what it looks like in cloud logging:
![image](https://user-images.githubusercontent.com/18472685/151616324-8afc4731-b186-46ba-aaf8-a54b0bd53d1f.png)
