### PR TITLE
Add a '#Requires' directive to ensure minimum PowerShell version.

### DIFF
--- a/pkg/goo/maint.ps1
+++ b/pkg/goo/maint.ps1
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#Requires -Version 3.0
+
 Param(
     [Parameter(Mandatory=$true)][string]$InstallDir,
     [Parameter(Mandatory=$true)][ValidateSet('install','uninstall')][string]$Action


### PR DESCRIPTION
Prevents cryptic errors like "A parameter cannot be found that matches parameter name 'Property'" on unsupported Windows versions.