### PR TITLE
Cassandra metrics receiver

### DIFF
--- a/apps/cassandra.go
+++ b/apps/cassandra.go
@@ -15,6 +15,7 @@
 package apps
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
@@ -29,6 +30,8 @@ type MetricsReceiverCassandra struct {
 	Endpoint string `yaml:"endpoint" validate:"omitempty,url"`
 	Username string `yaml:"username"`
 	Password string `yaml:"password"`
+
+	CollectJVMMetics *bool `yaml:"collect_jvm_metrics"`
 }
 
 const defaultCassandraEndpoint = "localhost:9999"
@@ -47,8 +50,13 @@ func (r MetricsReceiverCassandra) Pipelines() []otel.Pipeline {
 		log.Printf(`Encountered an error discovering the location of the JMX Metrics Exporter, %v`, err)
 	}
 
+	targetSystem := "cassandra"
+	if r.CollectJVMMetics == nil || *r.CollectJVMMetics {
+		targetSystem = fmt.Sprintf("%s,%s", targetSystem, "jvm")
+	}
+
 	config := map[string]interface{}{
-		"target_system":       "cassandra,jvm",
+		"target_system":       targetSystem,
 		"collection_interval": r.CollectionIntervalString(),
 		"endpoint":            r.Endpoint,
 		"jar_path":            jarPath,

--- a/apps/cassandra.go
+++ b/apps/cassandra.go
@@ -1,0 +1,81 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apps
+
+import (
+	"log"
+
+	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
+	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
+)
+
+type MetricsReceiverCassandra struct {
+	confgenerator.ConfigComponent `yaml:",inline"`
+
+	confgenerator.MetricsReceiverShared `yaml:",inline"`
+
+	Endpoint string `yaml:"endpoint" validate:"omitempty,url"`
+	Username string `yaml:"username"`
+	Password string `yaml:"password"`
+}
+
+const defaultCassandraEndpoint = "localhost:9999"
+
+func (r MetricsReceiverCassandra) Type() string {
+	return "cassandra"
+}
+
+func (r MetricsReceiverCassandra) Pipelines() []otel.Pipeline {
+	if r.Endpoint == "" {
+		r.Endpoint = defaultCassandraEndpoint
+	}
+
+	jarPath, err := FindJarPath()
+	if err != nil {
+		log.Printf(`Encountered an error discovering the location of the JMX Metrics Exporter, %v`, err)
+	}
+
+	config := map[string]interface{}{
+		"target_system":       "cassandra,jvm",
+		"collection_interval": r.CollectionIntervalString(),
+		"endpoint":            r.Endpoint,
+		"jar_path":            jarPath,
+	}
+
+	// Only set the username & password fields if provided
+	if r.Username != "" {
+		config["username"] = r.Username
+	}
+	if r.Password != "" {
+		config["password"] = r.Password
+	}
+
+	return []otel.Pipeline{{
+		Receiver: otel.Component{
+			Type:   "jmx",
+			Config: config,
+		},
+		Processors: []otel.Component{
+			otel.NormalizeSums(),
+			otel.MetricsTransform(
+				otel.AddPrefix("workload.googleapis.com"),
+			),
+		},
+	}}
+}
+
+func init() {
+	confgenerator.MetricsReceiverTypes.RegisterType(func() confgenerator.Component { return &MetricsReceiverCassandra{} })
+}

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_invalid_type_iis/golden_error
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_invalid_type_iis/golden_error
@@ -1,1 +1,1 @@
-metrics receiver with type "iis" is not supported. Supported metrics receiver types: [hostmetrics, jvm, nginx].
+metrics receiver with type "iis" is not supported. Supported metrics receiver types: [cassandra, hostmetrics, jvm, nginx].

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_invalid_type_mssql/golden_error
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_invalid_type_mssql/golden_error
@@ -1,1 +1,1 @@
-metrics receiver with type "mssql" is not supported. Supported metrics receiver types: [hostmetrics, jvm, nginx].
+metrics receiver with type "mssql" is not supported. Supported metrics receiver types: [cassandra, hostmetrics, jvm, nginx].

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_unsupported_type/golden_error
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_unsupported_type/golden_error
@@ -1,1 +1,1 @@
-metrics receiver with type "unsupported_type" is not supported. Supported metrics receiver types: [hostmetrics, jvm, nginx].
+metrics receiver with type "unsupported_type" is not supported. Supported metrics receiver types: [cassandra, hostmetrics, jvm, nginx].

--- a/confgenerator/testdata/invalid/windows/metrics-receiver_unsupported_type/golden_error
+++ b/confgenerator/testdata/invalid/windows/metrics-receiver_unsupported_type/golden_error
@@ -1,1 +1,1 @@
-metrics receiver with type "unsupported_type" is not supported. Supported metrics receiver types: [hostmetrics, iis, jvm, mssql, nginx].
+metrics receiver with type "unsupported_type" is not supported. Supported metrics receiver types: [cassandra, hostmetrics, iis, jvm, mssql, nginx].

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_fluent_bit_main.conf
@@ -1,0 +1,80 @@
+@SET buffers_dir=/var/lib/google-cloud-ops-agent/fluent-bit/buffers
+@SET logs_dir=/var/log/google-cloud-ops-agent/subagents
+
+[SERVICE]
+    Daemon                    off
+    Flush                     1
+    HTTP_Listen               0.0.0.0
+    HTTP_PORT                 2020
+    HTTP_Server               On
+    Log_Level                 info
+    storage.backlog.mem_limit 50M
+    storage.checksum          on
+    storage.max_chunks_up     128
+    storage.metrics           on
+    storage.sync              normal
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   5M
+    DB                ${buffers_dir}/default_pipeline_syslog
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              /var/log/messages,/var/log/syslog
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               default_pipeline.syslog
+    storage.type      filesystem
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   5M
+    DB                ${buffers_dir}/ops-agent-fluent-bit
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/logging-module.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-fluent-bit
+    storage.type      filesystem
+
+[FILTER]
+    Add   logName syslog
+    Match default_pipeline.syslog
+    Name  modify
+
+[FILTER]
+    Emitter_Mem_Buf_Limit 10M
+    Emitter_Storage.type  filesystem
+    Match                 default_pipeline.syslog
+    Name                  rewrite_tag
+    Rule                  $logName .* $logName false
+
+[FILTER]
+    Match  syslog
+    Name   modify
+    Remove logName
+
+[OUTPUT]
+    Match_Regex       ^(syslog)$
+    Name              stackdriver
+    Retry_Limit       3
+    resource          gce_instance
+    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls               On
+    tls.verify        Off
+    workers           8
+
+[OUTPUT]
+    Match_Regex       ^(ops-agent-fluent-bit)$
+    Name              stackdriver
+    Retry_Limit       3
+    resource          gce_instance
+    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls               On
+    tls.verify        Off
+    workers           8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
@@ -1,0 +1,401 @@
+exporters:
+  googlecloud:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+processors:
+  agentmetrics/default__pipeline_hostmetrics_0:
+    blank_label_metrics:
+    - system.cpu.utilization
+  filter/agent_0:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+        - otelcol_process_uptime
+        - otelcol_process_memory_rss
+        - otelcol_grpc_io_client_completed_rpcs
+        - otelcol_googlecloudmonitoring_point_count
+  filter/default__pipeline_hostmetrics_1:
+    metrics:
+      exclude:
+        match_type: strict
+        metric_names:
+        - system.cpu.time
+        - system.network.dropped
+        - system.filesystem.inodes.usage
+        - system.paging.faults
+        - system.disk.operation_time
+        - system.processes.count
+  filter/default__pipeline_hostmetrics_3:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names: []
+  metricstransform/agent_1:
+    transforms:
+    - action: update
+      include: otelcol_process_uptime
+      new_name: agent/uptime
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: version
+        new_value: google-cloud-ops-agent-metrics/latest-build_distro
+    - action: update
+      include: otelcol_process_memory_rss
+      new_name: agent/memory_usage
+    - action: update
+      include: otelcol_grpc_io_client_completed_rpcs
+      new_name: agent/api_request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: grpc_client_status
+        new_label: state
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - state
+    - action: update
+      include: otelcol_googlecloudmonitoring_point_count
+      new_name: agent/monitoring/point_count
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/cassandrapipeline_cassandrametrics_1:
+    transforms:
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: workload.googleapis.com/$${1}
+  metricstransform/default__pipeline_hostmetrics_2:
+    transforms:
+    - action: update
+      include: system.cpu.time
+      new_name: cpu/usage_time
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: cpu
+        new_label: cpu_number
+      - action: update_label
+        label: state
+        new_label: cpu_state
+    - action: update
+      include: system.cpu.utilization
+      new_name: cpu/utilization
+      operations:
+      - action: aggregate_labels
+        aggregation_type: mean
+        label_set:
+        - state
+        - blank
+      - action: update_label
+        label: blank
+        new_label: cpu_number
+      - action: update_label
+        label: state
+        new_label: cpu_state
+    - action: update
+      include: system.cpu.load_average.1m
+      new_name: cpu/load_1m
+    - action: update
+      include: system.cpu.load_average.5m
+      new_name: cpu/load_5m
+    - action: update
+      include: system.cpu.load_average.15m
+      new_name: cpu/load_15m
+    - action: update
+      include: system.disk.read_io
+      new_name: disk/read_bytes_count
+    - action: update
+      include: system.disk.write_io
+      new_name: disk/write_bytes_count
+    - action: update
+      include: system.disk.operations
+      new_name: disk/operation_count
+    - action: update
+      include: system.disk.io_time
+      new_name: disk/io_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.weighted_io_time
+      new_name: disk/weighted_io_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.average_operation_time
+      new_name: disk/operation_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.pending_operations
+      new_name: disk/pending_operations
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.merged
+      new_name: disk/merged_operations
+    - action: update
+      include: system.filesystem.usage
+      new_name: disk/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - device
+        - state
+    - action: update
+      include: system.filesystem.utilization
+      new_name: disk/percent_used
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - device
+        - state
+    - action: update
+      include: system.memory.usage
+      new_name: memory/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_label_values
+        aggregated_values:
+        - slab_reclaimable
+        - slab_unreclaimable
+        aggregation_type: sum
+        label: state
+        new_value: slab
+    - action: update
+      include: system.memory.utilization
+      new_name: memory/percent_used
+      operations:
+      - action: aggregate_label_values
+        aggregated_values:
+        - slab_reclaimable
+        - slab_unreclaimable
+        aggregation_type: sum
+        label: state
+        new_value: slab
+    - action: update
+      include: system.network.io
+      new_name: interface/traffic
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.errors
+      new_name: interface/errors
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.packets
+      new_name: interface/packets
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.connections
+      new_name: network/tcp_connections
+      operations:
+      - action: toggle_scalar_data_type
+      - action: delete_label_value
+        label: protocol
+        label_value: udp
+      - action: update_label
+        label: state
+        new_label: tcp_state
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - tcp_state
+      - action: add_label
+        new_label: port
+        new_value: all
+    - action: update
+      include: system.processes.created
+      new_name: processes/fork_count
+    - action: update
+      include: system.paging.usage
+      new_name: swap/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.paging.utilization
+      new_name: swap/percent_used
+    - action: insert
+      include: swap/percent_used
+      new_name: pagefile/percent_used
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - state
+    - action: update
+      include: system.paging.operations
+      new_name: swap/io
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - direction
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: in
+          value: page_in
+        - new_value: out
+          value: page_out
+    - action: update
+      include: process.cpu.time
+      new_name: processes/cpu_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1e+06
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+      - action: delete_label_value
+        label: state
+        label_value: wait
+      - action: update_label
+        label: state
+        new_label: user_or_syst
+      - action: update_label
+        label: user_or_syst
+        value_actions:
+        - new_value: syst
+          value: system
+    - action: update
+      include: process.disk.read_io
+      new_name: processes/disk/read_bytes_count
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.disk.write_io
+      new_name: processes/disk/write_bytes_count
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.memory.physical_usage
+      new_name: processes/rss_usage
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.memory.virtual_usage
+      new_name: processes/vm_usage
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  normalizesums/cassandrapipeline_cassandrametrics_0: {}
+  resourcedetection/_global_0:
+    detectors:
+    - gce
+receivers:
+  hostmetrics/default__pipeline_hostmetrics:
+    collection_interval: 60s
+    scrapers:
+      cpu: {}
+      disk: {}
+      filesystem: {}
+      load: {}
+      memory: {}
+      network: {}
+      paging: {}
+      process: {}
+      processes: {}
+  jmx/cassandrapipeline_cassandrametrics:
+    collection_interval: 30s
+    endpoint: localhost:7199
+    jar_path: /path/to/executables/opentelemetry-java-contrib-jmx-metrics.jar
+    target_system: cassandra,jvm
+  prometheus/agent:
+    config:
+      scrape_configs:
+      - job_name: otel-collector
+        scrape_interval: 1m
+        static_configs:
+        - targets:
+          - 0.0.0.0:8888
+service:
+  pipelines:
+    metrics/agent:
+      exporters:
+      - googlecloud
+      processors:
+      - filter/agent_0
+      - metricstransform/agent_1
+      - resourcedetection/_global_0
+      receivers:
+      - prometheus/agent
+    metrics/cassandrapipeline_cassandrametrics:
+      exporters:
+      - googlecloud
+      processors:
+      - normalizesums/cassandrapipeline_cassandrametrics_0
+      - metricstransform/cassandrapipeline_cassandrametrics_1
+      - resourcedetection/_global_0
+      receivers:
+      - jmx/cassandrapipeline_cassandrametrics
+    metrics/default__pipeline_hostmetrics:
+      exporters:
+      - googlecloud
+      processors:
+      - agentmetrics/default__pipeline_hostmetrics_0
+      - filter/default__pipeline_hostmetrics_1
+      - metricstransform/default__pipeline_hostmetrics_2
+      - filter/default__pipeline_hostmetrics_3
+      - resourcedetection/_global_0
+      receivers:
+      - hostmetrics/default__pipeline_hostmetrics

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/input.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/input.yaml
@@ -1,0 +1,25 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+metrics:
+  receivers:
+    cassandrametrics:
+      type: cassandra
+      endpoint: localhost:7199
+      collection_interval: 30s
+  service:
+    pipelines:
+      cassandrapipeline:
+        receivers:
+          - cassandrametrics

--- a/docs/cassandra.md
+++ b/docs/cassandra.md
@@ -1,0 +1,58 @@
+# Cassandra Receiver
+
+The `cassandra` receiver can fetch stats from a Cassandra node's Java Virtual Machine (JVM) via [JMX](https://www.oracle.com/java/technologies/javase/javamanagement.html).
+
+
+## Prerequisites
+
+In order to expose a JMX endpoint, you must set the `com.sun.management.jmxremote.port` system property. It is recommended to also set the `com.sun.management.jmxremote.rmi.port` system property to the same port. To expose JMX endpoint remotely, you must also set the `java.rmi.server.hostname` system property. Java system properties can be set via command line args by prepending the property name with `-D` . For example: `-Dcom.sun.management.jmxremote.port`. By default, these are set in a Cassandra deployment's cassandra-env.sh file, and the default has no authentication, exposed locally on 127.0.0.1:7199.
+
+## Configuration
+
+| Field                 | Default            | Description |
+| ---                   | ---                | ---         |
+| `type`                | required           | Must be `jvm`. |
+| `endpoint`            | `localhost:7199`   | The [JMX Service URL](https://docs.oracle.com/javase/8/docs/api/javax/management/remote/JMXServiceURL.html) or host and port used to construct the Service URL. Must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form will be used to create a Service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`. |
+| `collect_jvm_metrics` | true               | Should the set of support [JVM metrics](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/docs/jvm.md#metrics) also be collected |
+| `username`            | not set by default | The configured username if JMX is configured to require authentication. |
+| `password`            | not set by default | The configured password if JMX is configured to require authentication. |
+| `collection_interval` | `60s`              | A [time.Duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`. |
+
+Example Configuration:
+
+```yaml
+metrics:
+  receivers:
+    cassandra_metrics:
+      type: cassandra
+      endpoint: localhost:7199
+      collection_interval: 30s
+  service:
+    pipelines:
+      cassandra_pipeline:
+        receivers:
+          - cassandra_metrics
+```
+
+## Metrics
+In addition to Cassandra specific metrics, by default Cassandra will also report [JVM metrics](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/docs/jvm.md#metrics)
+
+| Metric                                                                   | Data Type | Unit        | Labels | Description |
+| ---                                                                      | ---       | ---         | ---    | ---         | 
+| workload.googleapis.com/cassandra.client.request.read.latency.50p        | gauge     | 1           |        |             |
+| workload.googleapis.com/cassandra.client.request.read.latency.99p        | gauge     | 1           |        |             |
+| workload.googleapis.com/cassandra.client.request.read.latency.count      | sum       | 1           |        |             |
+| workload.googleapis.com/cassandra.client.request.read.latency.max        | gauge     | 1           |        |             |
+| workload.googleapis.com/cassandra.client.request.read.timeout.count      | sum       | 1           |        |             |
+| workload.googleapis.com/cassandra.client.request.read.unavailable.count  | sum       | 1           |        |             |
+| workload.googleapis.com/cassandra.client.request.write.latency.50p       | gauge     | 1           |        |             |
+| workload.googleapis.com/cassandra.client.request.write.latency.99p       | gauge     | 1           |        |             |
+| workload.googleapis.com/cassandra.client.request.write.latency.count     | sum       | 1           |        |             |
+| workload.googleapis.com/cassandra.client.request.write.latency.max       | gauge     | 1           |        |             |
+| workload.googleapis.com/cassandra.client.request.write.timeout.count     | sum       | 1           |        |             |
+| workload.googleapis.com/cassandra.client.request.write.unavailable.count | sum       | 1           |        |             |
+| workload.googleapis.com/cassandra.compaction.tasks.completed             | sum       | 1           |        |             |
+| workload.googleapis.com/cassandra.compaction.tasks.pending               | gauge     | 1           |        |             |
+| workload.googleapis.com/cassandra.storage.load.count                     | sum       | 1           |        |             |
+| workload.googleapis.com/cassandra.storage.total_hints.count              | sum       | 1           |        |             |
+| workload.googleapis.com/cassandra.storage.total_hints.in_progress.count  | sum       | 1           |        |             |

--- a/integration_test/third_party_apps_data/agent/ops-agent/linux/enable_cassandra
+++ b/integration_test/third_party_apps_data/agent/ops-agent/linux/enable_cassandra
@@ -1,0 +1,31 @@
+set -e
+
+sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+metrics:
+  receivers:
+    cassandra_metrics:
+      type: cassandra
+      endpoint: service:jmx:rmi:///jndi/rmi://127.0.0.1:7199/jmxrmi
+      collection_interval: 30s
+  service:
+    pipelines:
+      cassandra_pipeline:
+        receivers:
+          - cassandra_metrics
+EOF
+
+sudo systemctl restart google-cloud-ops-agent.service

--- a/integration_test/third_party_apps_data/agent/ops-agent/linux/supported_applications.txt
+++ b/integration_test/third_party_apps_data/agent/ops-agent/linux/supported_applications.txt
@@ -1,2 +1,3 @@
+cassandra
 nginx
 jvm

--- a/integration_test/third_party_apps_data/applications/cassandra/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/cassandra/centos_rhel/install
@@ -1,0 +1,14 @@
+set -e
+
+cat <<EOF > /etc/yum.repos.d/cassandra.repo
+[cassandra]
+name=Apache Cassandra
+baseurl=https://www.apache.org/dist/cassandra/redhat/40x/
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://www.apache.org/dist/cassandra/KEYS
+EOF
+
+sudo yum update
+
+sudo yum -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel cassandra

--- a/integration_test/third_party_apps_data/applications/cassandra/centos_rhel/post
+++ b/integration_test/third_party_apps_data/applications/cassandra/centos_rhel/post
@@ -1,0 +1,1 @@
+sudo service cassandra start

--- a/integration_test/third_party_apps_data/applications/cassandra/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/cassandra/debian_ubuntu/install
@@ -1,0 +1,11 @@
+set -e
+
+# Required to install cassandra
+echo "deb http://www.apache.org/dist/cassandra/debian 22x main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
+# Required to install java8 (JVM properties of cassandra are incompatible with >9)
+echo "deb http://security.debian.org/debian-security stretch/updates main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
+
+curl https://downloads.apache.org/cassandra/KEYS | sudo apt-key add -
+
+sudo apt update
+sudo apt install -y openjdk-8-jdk cassandra

--- a/integration_test/third_party_apps_data/applications/cassandra/debian_ubuntu/post
+++ b/integration_test/third_party_apps_data/applications/cassandra/debian_ubuntu/post
@@ -1,0 +1,2 @@
+# service is auto-started on install
+# sudo service cassandra start

--- a/integration_test/third_party_apps_data/applications/cassandra/metric_name.txt
+++ b/integration_test/third_party_apps_data/applications/cassandra/metric_name.txt
@@ -1,0 +1,1 @@
+workload.googleapis.com/jvm.memory.heap.used

--- a/integration_test/third_party_apps_data/applications/cassandra/metric_name.txt
+++ b/integration_test/third_party_apps_data/applications/cassandra/metric_name.txt
@@ -1,1 +1,1 @@
-workload.googleapis.com/jvm.memory.heap.used
+workload.googleapis.com/cassandra.compaction.tasks.completed

--- a/integration_test/third_party_apps_data/applications/cassandra/sles/install
+++ b/integration_test/third_party_apps_data/applications/cassandra/sles/install
@@ -14,5 +14,8 @@ sudo zypper -n refresh
 
 sudo zypper -n install java-1_8_0-openjdk java-1_8_0-openjdk-devel
 
+# There is no official or even semi-official zypper package for cassandra
+curl -OL https://dlcdn.apache.org/cassandra/4.0.1/apache-cassandra-4.0.1-bin.tar.gz
+# TODO - compare to curl -L https://downloads.apache.org/cassandra/4.0.1/apache-cassandra-4.0.1-bin.tar.gz.sha256
 
-# ????
+tar xzvf apache-cassandra-4.0.1-bin.tar.gz

--- a/integration_test/third_party_apps_data/applications/cassandra/sles/install
+++ b/integration_test/third_party_apps_data/applications/cassandra/sles/install
@@ -1,0 +1,18 @@
+set -e
+
+source /etc/os-release
+SUSE_VERSION="${VERSION_ID%%.*}"
+
+if [[ "${ID}" == opensuse-leap && "${VERSION_ID}" == 15.[01] ]]; then
+  if [[ "${VERSION_ID}" == 15.0 ]]; then
+    sudo zypper modifyrepo --disable openSUSE-Leap-Cloud-Tools
+  elif [[ "${VERSION_ID}" == 15.1 ]]; then
+    sudo zypper modifyrepo --disable openSUSE-Leap-devel-languages-python-aws
+  fi
+fi
+sudo zypper -n refresh
+
+sudo zypper -n install java-1_8_0-openjdk java-1_8_0-openjdk-devel
+
+
+# ????

--- a/integration_test/third_party_apps_data/applications/cassandra/sles/post
+++ b/integration_test/third_party_apps_data/applications/cassandra/sles/post
@@ -1,2 +1,2 @@
-java -ea -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 HelloWorld > /dev/null 2>&1 &
+cd apache-cassandra-4.0.1/ && bin/cassandra -f &
 ps -f -p $!

--- a/integration_test/third_party_apps_data/applications/cassandra/sles/post
+++ b/integration_test/third_party_apps_data/applications/cassandra/sles/post
@@ -1,0 +1,2 @@
+java -ea -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 HelloWorld > /dev/null 2>&1 &
+ps -f -p $!


### PR DESCRIPTION
Cassandra metrics receiver first draft. As Cassandra is JVM/JMX based, there are no additional open telemetry receivers required for this integration. 

Metrics collected are listed here: https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/jmx-metrics/docs/target-systems/cassandra.md

One possibly contentious aspect of this PR is that the Cassandra receiver can be configured to also collect JVM metrics via a configuration parameter (collect_jvm_metrics). I chose to implement this rather than always requiring a user to create two receivers as the JMX receiver supports collecting multiple "target" scripts in one JVM, and creating two receivers would create two JVMs and have considerable memory overhead. We could abstract this away from the user and combine JMX receivers when the configurations matched, but I didn't try to implement that kind of logic in this PR.

TODO
- Finish documenting metrics
- Validate CI deployments in kokoro
- Implement any feedback from scope document