### PR TITLE
Generate multiline parsers for fluent bit

### DIFF
--- a/confgenerator/testdata/multiline_fluent_bit.conf
+++ b/confgenerator/testdata/multiline_fluent_bit.conf
@@ -1,0 +1,25 @@
+
+[FILTER]
+    Match                 pipe.receiver
+    Multiline.Key_Content message
+    Multiline.Parser      pipe.receiver.123.multiline
+    Name                  multiline
+
+[FILTER]
+    Key_Name message
+    Match    pipe.receiver
+    Name     parser
+    Parser   pipe.receiver.123
+
+[PARSER]
+    Format      regex
+    Name        pipe.receiver.123
+    Regex       testRegex.*
+    Time_Format %Y/%m/%d %H:%M:%S
+    Time_Key    time
+
+[MULTILINE_PARSER]
+    Name pipe.receiver.123.multiline
+    Type regex
+    rule    "start_state"    "\d{4}"    "cont"
+    rule    "cont"    "\s*at.*"    "cont"

--- a/confgenerator/testdata/multiline_fluent_bit.conf
+++ b/confgenerator/testdata/multiline_fluent_bit.conf
@@ -1,25 +1,26 @@
 
 [FILTER]
-    Match                 pipe.receiver
+    Match                 cassandra.cassandra_system
     Multiline.Key_Content message
-    Multiline.Parser      pipe.receiver.123.multiline
+    Multiline.Parser      cassandra.cassandra_system.123.multiline
     Name                  multiline
 
 [FILTER]
     Key_Name message
-    Match    pipe.receiver
+    Match    cassandra.cassandra_system
     Name     parser
-    Parser   pipe.receiver.123
+    Parser   cassandra.cassandra_system.123
 
 [PARSER]
     Format      regex
-    Name        pipe.receiver.123
-    Regex       testRegex.*
-    Time_Format %Y/%m/%d %H:%M:%S
+    Name        cassandra.cassandra_system.123
+    Regex       (?<level>[A-Z]+)\s+\[(?<type>[^\]]+)\]\s+(?<time>\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+)\s+(?<extendedMessage>(?<message>(?:(?<javaClass>[\w\.]+):(?<lineNumber>\d+))?.+)[\S\s]+)
+    Time_Format %Y-%m-%d %H:%M:%S,%L
     Time_Key    time
+    Types       lineNumber:integer
 
 [MULTILINE_PARSER]
-    Name pipe.receiver.123.multiline
+    Name cassandra.cassandra_system.123.multiline
     Type regex
-    rule    "start_state"    "\d{4}"    "cont"
-    rule    "cont"    "\s*at.*"    "cont"
+    rule    "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule    "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"


### PR DESCRIPTION
This config used in test is copied from cassandra development, it works properly for cassandra system logs parsing.