### PR TITLE
Initial configuration for multi-distro testing.

### DIFF
--- a/integration_test/third_party_apps_data/test_config.yaml
+++ b/integration_test/third_party_apps_data/test_config.yaml
@@ -10,8 +10,8 @@ platforms_override:
   - sles-12
   - sles-15
   - ubuntu-1604-lts
-  - ubuntu-minimal-1604-lts
   - ubuntu-2004-lts
+  - ubuntu-minimal-1604-lts
   - ubuntu-minimal-2004-lts
 per_application_overrides:
   apache:
@@ -28,8 +28,8 @@ per_application_overrides:
       - sles-12
       - sles-15
       - ubuntu-1604-lts
-      - ubuntu-minimal-1604-lts
       - ubuntu-2004-lts
+      - ubuntu-minimal-1604-lts
       - ubuntu-minimal-2004-lts
   cassandra:
     platforms_to_skip: *common_skips


### PR DESCRIPTION
The idea is to turn on lots of distros by default (i.e. for new applications), but for the existing applications, to disable everything but debian-10. This allows us to support multi-distro testing going forward without breaking the existing tests. We know there are many issues to sort out before we can really enable the existing tests.

This PR is based off of changelist number 404360028.