### PR TITLE
Disable stream processor when building Fluent Bit.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -68,7 +68,7 @@ function build_fluentbit() {
   # Additionally, -DFLB_SHARED_LIB=OFF skips building libfluent-bit.so
   cmake .. -DCMAKE_INSTALL_PREFIX=$subagentdir/fluent-bit \
     -DFLB_HTTP_SERVER=ON -DFLB_DEBUG=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-    -DWITHOUT_HEADERS=ON -DFLB_SHARED_LIB=OFF
+    -DWITHOUT_HEADERS=ON -DFLB_SHARED_LIB=OFF -DFLB_STREAM_PROCESSOR=OFF
   make -j8
   make DESTDIR="$DESTDIR" install
   # We don't want fluent-bit's service or configuration, but there are no cmake


### PR DESCRIPTION
Stream processor is a feature to run SQL queries in the config. We are not using it in our case.