### PR TITLE
Fix copy paste error in cassandra docs

### DIFF
--- a/docs/cassandra.md
+++ b/docs/cassandra.md
@@ -2,7 +2,6 @@
 
 The `cassandra` metrics receiver can fetch stats from a Cassandra node's Java Virtual Machine (JVM) via [JMX](https://www.oracle.com/java/technologies/javase/javamanagement.html).
 
-
 ## Prerequisites
 
 In order to expose a JMX endpoint, you must set the `com.sun.management.jmxremote.port` system property. It is recommended to also set the `com.sun.management.jmxremote.rmi.port` system property to the same port. To expose JMX endpoint remotely, you must also set the `java.rmi.server.hostname` system property. By default, these properties are set in a Cassandra deployment's cassandra-env.sh file and the default Cassandra installation requires no JMX authentication with JMX exposed locally on 127.0.0.1:7199.
@@ -11,12 +10,14 @@ In order to expose a JMX endpoint, you must set the `com.sun.management.jmxremot
 
 | Field                 | Default            | Description |
 | ---                   | ---                | ---         |
-| `type`                | required           | Must be `jvm`. |
+| `type`                | required           | Must be `cassandra`. |
 | `endpoint`            | `localhost:7199`   | The [JMX Service URL](https://docs.oracle.com/javase/8/docs/api/javax/management/remote/JMXServiceURL.html) or host and port used to construct the Service URL. Must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form will be used to create a Service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`. |
 | `collect_jvm_metrics` | true               | Should the set of support [JVM metrics](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/docs/jvm.md#metrics) also be collected |
 | `username`            | not set by default | The configured username if JMX is configured to require authentication. |
 | `password`            | not set by default | The configured password if JMX is configured to require authentication. |
 | `collection_interval` | `60s`              | A [time.Duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`. |
+
+
 # `cassandra_system`, `cassandra_debug` and `cassandra_gc` Logging Receivers
 
 Example Configuration:


### PR DESCRIPTION
Noticed this in a review, just a quick typo fix from copying cassandra's docs initially from jvm's docs.