### PR TITLE
Add agentmetrics processor to agentmetrics pipeline

### DIFF
--- a/confgenerator/agentmetrics.go
+++ b/confgenerator/agentmetrics.go
@@ -41,6 +41,10 @@ func (r MetricsReceiverAgent) Pipeline() otel.Pipeline {
 			},
 		},
 		Processors: []otel.Component{
+			{
+				// perform custom transformations that aren't supported by the metricstransform processor
+				Type: "agentmetrics",
+			},
 			otel.MetricsFilter(
 				"include",
 				"strict",

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -27,7 +28,7 @@ processors:
         - system.paging.faults
         - system.disk.operation_time
         - system.processes.count
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -357,8 +358,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -28,7 +27,7 @@ processors:
         - system.paging.faults
         - system.disk.operation_time
         - system.processes.count
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -38,9 +37,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -58,6 +65,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -358,9 +369,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -362,8 +363,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -363,9 +374,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -362,8 +363,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -363,9 +374,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -362,8 +363,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -363,9 +374,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -362,8 +363,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -363,9 +374,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -362,8 +363,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -363,9 +374,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -362,8 +363,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -363,9 +374,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -362,8 +363,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -363,9 +374,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -362,8 +363,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -363,9 +374,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -362,8 +363,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -363,9 +374,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -362,8 +363,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -363,9 +374,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -362,8 +363,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -363,9 +374,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -362,8 +363,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -363,9 +374,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -362,8 +363,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -363,9 +374,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -362,8 +363,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -363,9 +374,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -362,8 +363,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -363,9 +374,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -362,8 +363,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -363,9 +374,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -362,8 +363,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -363,9 +374,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -362,8 +363,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -363,9 +374,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -362,8 +363,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -363,9 +374,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -33,7 +34,7 @@ processors:
         match_type: regexp
         metric_names:
         - ^.*$
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -363,8 +364,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -34,7 +33,7 @@ processors:
         match_type: regexp
         metric_names:
         - ^.*$
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -44,9 +43,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -64,6 +71,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -364,9 +375,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -35,7 +34,7 @@ processors:
         metric_names:
         - ^processes/.*$
         - ^cpu/.*$
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -45,9 +44,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -65,6 +72,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -365,9 +376,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -34,7 +35,7 @@ processors:
         metric_names:
         - ^processes/.*$
         - ^cpu/.*$
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -364,8 +365,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -35,7 +34,7 @@ processors:
         metric_names:
         - ^proce.*ses/.*$
         - ^c.*u/.*$
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -45,9 +44,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -65,6 +72,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -365,9 +376,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -34,7 +35,7 @@ processors:
         metric_names:
         - ^proce.*ses/.*$
         - ^c.*u/.*$
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -364,8 +365,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -376,8 +377,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -377,9 +388,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -376,8 +377,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -377,9 +388,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -362,8 +363,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -363,9 +374,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -375,9 +386,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -374,8 +375,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -375,9 +386,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -374,8 +375,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -376,8 +377,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -377,9 +388,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -373,9 +384,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -372,8 +373,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -33,7 +32,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -43,9 +42,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -63,6 +70,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -373,9 +384,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -32,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -372,8 +373,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -28,7 +27,7 @@ processors:
         - system.paging.faults
         - system.disk.operation_time
         - system.processes.count
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -38,9 +37,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -58,6 +65,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -427,9 +438,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -27,7 +28,7 @@ processors:
         - system.paging.faults
         - system.disk.operation_time
         - system.processes.count
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -426,8 +427,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -42,7 +43,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -441,8 +442,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -43,7 +42,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -53,9 +52,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -73,6 +80,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -442,9 +453,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -42,7 +43,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -441,8 +442,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -43,7 +42,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -53,9 +52,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -73,6 +80,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -442,9 +453,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -42,7 +43,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -441,8 +442,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -43,7 +42,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -53,9 +52,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -73,6 +80,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -442,9 +453,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -42,7 +43,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -441,8 +442,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -43,7 +42,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -53,9 +52,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -73,6 +80,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -442,9 +453,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -46,7 +45,7 @@ processors:
         match_type: regexp
         metric_names:
         - ^.*$
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -56,9 +55,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -76,6 +83,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -445,9 +456,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -45,7 +46,7 @@ processors:
         match_type: regexp
         metric_names:
         - ^.*$
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -444,8 +445,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -46,7 +45,7 @@ processors:
         match_type: regexp
         metric_names:
         - ^iis/.*$
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -56,9 +55,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -76,6 +83,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -445,9 +456,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -45,7 +46,7 @@ processors:
         match_type: regexp
         metric_names:
         - ^iis/.*$
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -444,8 +445,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -45,7 +46,7 @@ processors:
         match_type: regexp
         metric_names:
         - ^mssql/.*$
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -444,8 +445,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -46,7 +45,7 @@ processors:
         match_type: regexp
         metric_names:
         - ^mssql/.*$
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -56,9 +55,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -76,6 +83,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -445,9 +456,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -28,7 +27,7 @@ processors:
         - system.paging.faults
         - system.disk.operation_time
         - system.processes.count
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -38,9 +37,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -58,6 +65,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -427,9 +438,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -27,7 +28,7 @@ processors:
         - system.paging.faults
         - system.disk.operation_time
         - system.processes.count
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -426,8 +427,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -48,7 +49,7 @@ processors:
         metric_names:
         - ^processes/.*$
         - ^cpu/.*$
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -447,8 +448,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -49,7 +48,7 @@ processors:
         metric_names:
         - ^processes/.*$
         - ^cpu/.*$
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -59,9 +58,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -79,6 +86,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -448,9 +459,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -48,7 +49,7 @@ processors:
         metric_names:
         - ^proce.*ses/.*$
         - ^c.*u/.*$
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -447,8 +448,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -49,7 +48,7 @@ processors:
         metric_names:
         - ^proce.*ses/.*$
         - ^c.*u/.*$
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -59,9 +58,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -79,6 +86,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -448,9 +459,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -42,7 +43,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -441,8 +442,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -43,7 +42,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -53,9 +52,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -73,6 +80,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -442,9 +453,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -43,7 +42,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -53,9 +52,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -73,6 +80,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -454,9 +465,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -42,7 +43,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -453,8 +454,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -43,7 +42,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -53,9 +52,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -73,6 +80,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -454,9 +465,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -42,7 +43,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -453,8 +454,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -42,7 +43,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -451,8 +452,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -43,7 +42,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -53,9 +52,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -73,6 +80,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -452,9 +463,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
@@ -4,10 +4,11 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
+  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_0:
+  filter/agent_1:
     metrics:
       include:
         match_type: strict
@@ -42,7 +43,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_1:
+  metricstransform/agent_2:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -451,8 +452,9 @@ service:
       exporters:
       - googlecloud
       processors:
-      - filter/agent_0
-      - metricstransform/agent_1
+      - agentmetrics/agent_0
+      - filter/agent_1
+      - metricstransform/agent_2
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
@@ -4,11 +4,10 @@ exporters:
       prefix: ""
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
-  agentmetrics/agent_0: null
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  filter/agent_1:
+  filter/agent_0:
     metrics:
       include:
         match_type: strict
@@ -43,7 +42,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  metricstransform/agent_2:
+  metricstransform/agent_1:
     transforms:
     - action: update
       include: otelcol_process_uptime
@@ -53,9 +52,17 @@ processors:
       - action: add_label
         new_label: version
         new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
     - action: update
       include: otelcol_process_memory_rss
       new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: otelcol_grpc_io_client_completed_rpcs
       new_name: agent/api_request_count
@@ -73,6 +80,10 @@ processors:
       new_name: agent/monitoring/point_count
       operations:
       - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -452,9 +463,8 @@ service:
       exporters:
       - googlecloud
       processors:
-      - agentmetrics/agent_0
-      - filter/agent_1
-      - metricstransform/agent_2
+      - filter/agent_0
+      - metricstransform/agent_1
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent


### PR DESCRIPTION
This resolves issues with the new service_version label not being removed on prometheus metrics.