### PR TITLE
Escape `$` characters in generated Otel collector configs for IIS.

### DIFF
--- a/apps/iis.go
+++ b/apps/iis.go
@@ -62,8 +62,10 @@ func (r MetricsReceiverIis) Pipelines() []otel.Pipeline {
 					`\Web Service(_Total)\Current Connections`,
 					"iis/current_connections",
 				),
+				// $ needs to be escaped because reasons.
+				// https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor#rename-multiple-metrics-using-substitution
 				otel.CombineMetrics(
-					`^\\Web Service\(_Total\)\\Total Bytes (?P<direction>.*)$`,
+					`^\\Web Service\(_Total\)\\Total Bytes (?P<direction>.*)$$`,
 					"iis/network/transferred_bytes_count",
 				),
 				otel.RenameMetric(
@@ -71,7 +73,7 @@ func (r MetricsReceiverIis) Pipelines() []otel.Pipeline {
 					"iis/new_connection_count",
 				),
 				otel.CombineMetrics(
-					`^\\Web Service\(_Total\)\\Total (?P<http_method>.*) Requests$`,
+					`^\\Web Service\(_Total\)\\Total (?P<http_method>.*) Requests$$`,
 					"iis/request_count",
 				),
 				otel.AddPrefix("agent.googleapis.com"),

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -345,7 +345,7 @@ processors:
       include: "\\Web Service(_Total)\\Current Connections"
       new_name: iis/current_connections
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
       submatch_case: lower
@@ -353,7 +353,7 @@ processors:
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
       submatch_case: lower

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
@@ -360,7 +360,7 @@ processors:
       include: "\\Web Service(_Total)\\Current Connections"
       new_name: iis/current_connections
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
       submatch_case: lower
@@ -368,7 +368,7 @@ processors:
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
       submatch_case: lower

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
@@ -360,7 +360,7 @@ processors:
       include: "\\Web Service(_Total)\\Current Connections"
       new_name: iis/current_connections
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
       submatch_case: lower
@@ -368,7 +368,7 @@ processors:
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
       submatch_case: lower

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
@@ -360,7 +360,7 @@ processors:
       include: "\\Web Service(_Total)\\Current Connections"
       new_name: iis/current_connections
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
       submatch_case: lower
@@ -368,7 +368,7 @@ processors:
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
       submatch_case: lower

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -360,7 +360,7 @@ processors:
       include: "\\Web Service(_Total)\\Current Connections"
       new_name: iis/current_connections
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
       submatch_case: lower
@@ -368,7 +368,7 @@ processors:
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
       submatch_case: lower

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
@@ -363,7 +363,7 @@ processors:
       include: "\\Web Service(_Total)\\Current Connections"
       new_name: iis/current_connections
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
       submatch_case: lower
@@ -371,7 +371,7 @@ processors:
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
       submatch_case: lower

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
@@ -363,7 +363,7 @@ processors:
       include: "\\Web Service(_Total)\\Current Connections"
       new_name: iis/current_connections
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
       submatch_case: lower
@@ -371,7 +371,7 @@ processors:
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
       submatch_case: lower

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
@@ -363,7 +363,7 @@ processors:
       include: "\\Web Service(_Total)\\Current Connections"
       new_name: iis/current_connections
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
       submatch_case: lower
@@ -371,7 +371,7 @@ processors:
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
       submatch_case: lower

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
@@ -79,7 +79,7 @@ processors:
       include: "\\Web Service(_Total)\\Current Connections"
       new_name: iis/current_connections
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
       submatch_case: lower
@@ -87,7 +87,7 @@ processors:
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
       submatch_case: lower

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -366,7 +366,7 @@ processors:
       include: "\\Web Service(_Total)\\Current Connections"
       new_name: iis/current_connections
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
       submatch_case: lower
@@ -374,7 +374,7 @@ processors:
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
       submatch_case: lower

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -366,7 +366,7 @@ processors:
       include: "\\Web Service(_Total)\\Current Connections"
       new_name: iis/current_connections
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
       submatch_case: lower
@@ -374,7 +374,7 @@ processors:
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
       submatch_case: lower

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
@@ -376,7 +376,7 @@ processors:
       include: "\\Web Service(_Total)\\Current Connections"
       new_name: iis/current_connections
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
       submatch_case: lower
@@ -384,7 +384,7 @@ processors:
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
       submatch_case: lower

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
@@ -376,7 +376,7 @@ processors:
       include: "\\Web Service(_Total)\\Current Connections"
       new_name: iis/current_connections
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
       submatch_case: lower
@@ -384,7 +384,7 @@ processors:
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
       submatch_case: lower

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -360,7 +360,7 @@ processors:
       include: "\\Web Service(_Total)\\Current Connections"
       new_name: iis/current_connections
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
       submatch_case: lower
@@ -368,7 +368,7 @@ processors:
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
       submatch_case: lower

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
@@ -360,7 +360,7 @@ processors:
       include: "\\Web Service(_Total)\\Current Connections"
       new_name: iis/current_connections
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
       submatch_case: lower
@@ -368,7 +368,7 @@ processors:
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
       submatch_case: lower

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
@@ -360,7 +360,7 @@ processors:
       include: "\\Web Service(_Total)\\Current Connections"
       new_name: iis/current_connections
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
       submatch_case: lower
@@ -368,7 +368,7 @@ processors:
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
       submatch_case: lower

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
@@ -360,7 +360,7 @@ processors:
       include: "\\Web Service(_Total)\\Current Connections"
       new_name: iis/current_connections
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
       submatch_case: lower
@@ -368,7 +368,7 @@ processors:
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
       submatch_case: lower

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
@@ -360,7 +360,7 @@ processors:
       include: "\\Web Service(_Total)\\Current Connections"
       new_name: iis/current_connections
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
       submatch_case: lower
@@ -368,7 +368,7 @@ processors:
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
     - action: combine
-      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$"
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
       submatch_case: lower


### PR DESCRIPTION
b/202318079.