### PR TITLE
Adjust log name via logging.googleapis.com/logName instead of using a rewrite_tag.

### DIFF
--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -137,7 +137,7 @@ func (l *Logging) generateFluentbitComponents(userAgent string, hostInfo *host.I
 			components []fluentbit.Component
 		}
 		var sources []fbSource
-		var logNames []string
+		var tags []string
 		for pID, p := range l.Service.Pipelines {
 			for _, rID := range p.ReceiverIDs {
 				receiver, ok := l.Receivers[rID]
@@ -157,18 +157,18 @@ func (l *Logging) generateFluentbitComponents(userAgent string, hostInfo *host.I
 					components = append(components, processor.Components(tag, strconv.Itoa(i))...)
 				}
 				components = append(components, setLogNameComponents(tag, rID)...)
-				logNames = append(logNames, regexp.QuoteMeta(tag))
+				tags = append(tags, regexp.QuoteMeta(tag))
 				sources = append(sources, fbSource{tag, components})
 			}
 		}
 		sort.Slice(sources, func(i, j int) bool { return sources[i].tag < sources[j].tag })
-		sort.Strings(logNames)
+		sort.Strings(tags)
 
 		for _, s := range sources {
 			out = append(out, s.components...)
 		}
-		if len(logNames) > 0 {
-			out = append(out, stackdriverOutputComponent(strings.Join(logNames, "|"), userAgent))
+		if len(tags) > 0 {
+			out = append(out, stackdriverOutputComponent(strings.Join(tags, "|"), userAgent))
 		}
 	}
 	out = append(out, LoggingReceiverFilesMixin{

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -157,7 +157,7 @@ func (l *Logging) generateFluentbitComponents(userAgent string, hostInfo *host.I
 					components = append(components, processor.Components(tag, strconv.Itoa(i))...)
 				}
 				components = append(components, setLogNameComponents(tag, rID)...)
-				logNames = append(logNames, regexp.QuoteMeta(rID))
+				logNames = append(logNames, regexp.QuoteMeta(tag))
 				sources = append(sources, fbSource{tag, components})
 			}
 		}

--- a/confgenerator/logging.go
+++ b/confgenerator/logging.go
@@ -22,32 +22,13 @@ import (
 
 // setLogNameComponents generates a series of components that rewrites the tag on log entries tagged `tag` to be `logName`.
 func setLogNameComponents(tag, logName string) []fluentbit.Component {
-	// TODO: Can we just set log_name_key in the output plugin and avoid this mess?
 	return []fluentbit.Component{
 		{
 			Kind: "FILTER",
 			Config: map[string]string{
 				"Match": tag,
-				"Add":   fmt.Sprintf("logName %s", logName),
+				"Add":   fmt.Sprintf("logging.googleapis.com/logName %s", logName),
 				"Name":  "modify",
-			},
-		},
-		{
-			Kind: "FILTER",
-			Config: map[string]string{
-				"Emitter_Mem_Buf_Limit": "10M",
-				"Emitter_Storage.type":  "filesystem",
-				"Match":                 tag,
-				"Name":                  "rewrite_tag",
-				"Rule":                  "$logName .* $logName false",
-			},
-		},
-		{
-			Kind: "FILTER",
-			Config: map[string]string{
-				"Match":  logName,
-				"Name":   "modify",
-				"Remove": "logName",
 			},
 		},
 	}

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
@@ -43,24 +43,12 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog)$
+    Match_Regex       ^(default_pipeline\.syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/all-built_in_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/golden_fluent_bit_main.conf
@@ -43,24 +43,12 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog)$
+    Match_Regex       ^(default_pipeline\.syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_fluent_bit_main.conf
@@ -43,24 +43,12 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog)$
+    Match_Regex       ^(default_pipeline\.syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_fluent_bit_main.conf
@@ -43,24 +43,12 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog)$
+    Match_Regex       ^(default_pipeline\.syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
@@ -79,38 +79,14 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName log_source_id1
+    Add   logging.googleapis.com/logName log_source_id1
     Match pipeline1.log_source_id1
     Name  modify
 
 [FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 pipeline1.log_source_id1
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  log_source_id1
-    Name   modify
-    Remove logName
-
-[FILTER]
-    Add   logName log_source_id2
+    Add   logging.googleapis.com/logName log_source_id2
     Match pipeline2.log_source_id2
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 pipeline2.log_source_id2
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  log_source_id2
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -119,21 +95,9 @@
     Parser   pipeline3.test_syslog_source_id_tcp.0
 
 [FILTER]
-    Add   logName test_syslog_source_id_tcp
+    Add   logging.googleapis.com/logName test_syslog_source_id_tcp
     Match pipeline3.test_syslog_source_id_tcp
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 pipeline3.test_syslog_source_id_tcp
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  test_syslog_source_id_tcp
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -142,24 +106,12 @@
     Parser   pipeline4.test_syslog_source_id_udp.0
 
 [FILTER]
-    Add   logName test_syslog_source_id_udp
+    Add   logging.googleapis.com/logName test_syslog_source_id_udp
     Match pipeline4.test_syslog_source_id_udp
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 pipeline4.test_syslog_source_id_udp
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  test_syslog_source_id_udp
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(log_source_id1|log_source_id2|test_syslog_source_id_tcp|test_syslog_source_id_udp)$
+    Match_Regex       ^(pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.test_syslog_source_id_tcp|pipeline4\.test_syslog_source_id_udp)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_main.conf
@@ -71,21 +71,9 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -100,21 +88,9 @@
     Parser   pipeline1.sample_logs.1
 
 [FILTER]
-    Add   logName sample_logs
+    Add   logging.googleapis.com/logName sample_logs
     Match pipeline1.sample_logs
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 pipeline1.sample_logs
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  sample_logs
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -129,24 +105,12 @@
     Parser   pipeline2.sample_logs.1
 
 [FILTER]
-    Add   logName sample_logs
+    Add   logging.googleapis.com/logName sample_logs
     Match pipeline2.sample_logs
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 pipeline2.sample_logs
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  sample_logs
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(sample_logs|sample_logs|syslog)$
+    Match_Regex       ^(default_pipeline\.syslog|pipeline1\.sample_logs|pipeline2\.sample_logs)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_fluent_bit_main.conf
@@ -85,21 +85,9 @@
     Parser   pipeline1.log_source_id1.0
 
 [FILTER]
-    Add   logName log_source_id1
+    Add   logging.googleapis.com/logName log_source_id1
     Match pipeline1.log_source_id1
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 pipeline1.log_source_id1
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  log_source_id1
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name key_1
@@ -108,21 +96,9 @@
     Parser   pipeline2.log_source_id2.0
 
 [FILTER]
-    Add   logName log_source_id2
+    Add   logging.googleapis.com/logName log_source_id2
     Match pipeline2.log_source_id2
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 pipeline2.log_source_id2
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  log_source_id2
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -131,21 +107,9 @@
     Parser   pipeline3.test_syslog_source_id_tcp.0
 
 [FILTER]
-    Add   logName test_syslog_source_id_tcp
+    Add   logging.googleapis.com/logName test_syslog_source_id_tcp
     Match pipeline3.test_syslog_source_id_tcp
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 pipeline3.test_syslog_source_id_tcp
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  test_syslog_source_id_tcp
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -154,24 +118,12 @@
     Parser   pipeline4.test_syslog_source_id_udp.0
 
 [FILTER]
-    Add   logName test_syslog_source_id_udp
+    Add   logging.googleapis.com/logName test_syslog_source_id_udp
     Match pipeline4.test_syslog_source_id_udp
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 pipeline4.test_syslog_source_id_udp
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  test_syslog_source_id_udp
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(log_source_id1|log_source_id2|test_syslog_source_id_tcp|test_syslog_source_id_udp)$
+    Match_Regex       ^(pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.test_syslog_source_id_tcp|pipeline4\.test_syslog_source_id_udp)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_fluent_bit_main.conf
@@ -49,24 +49,12 @@
     Parser   default_pipeline.syslog.0
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog)$
+    Match_Regex       ^(default_pipeline\.syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_fluent_bit_main.conf
@@ -151,21 +151,9 @@
     Wildcard      http_request_*
 
 [FILTER]
-    Add   logName apache_custom_access
+    Add   logging.googleapis.com/logName apache_custom_access
     Match apache_custom.apache_custom_access
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 apache_custom.apache_custom_access
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  apache_custom_access
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -270,21 +258,9 @@
     Name      modify
 
 [FILTER]
-    Add   logName apache_custom_error
+    Add   logging.googleapis.com/logName apache_custom_error
     Match apache_custom.apache_custom_error
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 apache_custom.apache_custom_error
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  apache_custom_error
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -319,21 +295,9 @@
     Wildcard      http_request_*
 
 [FILTER]
-    Add   logName apache_default_access
+    Add   logging.googleapis.com/logName apache_default_access
     Match apache_default.apache_default_access
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 apache_default.apache_default_access
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  apache_default_access
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -438,21 +402,9 @@
     Name      modify
 
 [FILTER]
-    Add   logName apache_default_error
+    Add   logging.googleapis.com/logName apache_default_error
     Match apache_default.apache_default_error
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 apache_default.apache_default_error
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  apache_default_error
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -487,21 +439,9 @@
     Wildcard      http_request_*
 
 [FILTER]
-    Add   logName apache_syslog_access
+    Add   logging.googleapis.com/logName apache_syslog_access
     Match apache_syslog_access.apache_syslog_access
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 apache_syslog_access.apache_syslog_access
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  apache_syslog_access
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -606,41 +546,17 @@
     Name      modify
 
 [FILTER]
-    Add   logName apache_syslog_error
+    Add   logging.googleapis.com/logName apache_syslog_error
     Match apache_syslog_error.apache_syslog_error
     Name  modify
 
 [FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 apache_syslog_error.apache_syslog_error
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  apache_syslog_error
-    Name   modify
-    Remove logName
-
-[FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(apache_custom_access|apache_custom_error|apache_default_access|apache_default_error|apache_syslog_access|apache_syslog_error|syslog)$
+    Match_Regex       ^(apache_custom\.apache_custom_access|apache_custom\.apache_custom_error|apache_default\.apache_default_access|apache_default\.apache_default_error|apache_syslog_access\.apache_syslog_access|apache_syslog_error\.apache_syslog_error|default_pipeline\.syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_fluent_bit_main.conf
@@ -199,21 +199,9 @@
     Name      modify
 
 [FILTER]
-    Add   logName cassandra_custom_debug
+    Add   logging.googleapis.com/logName cassandra_custom_debug
     Match cassandra_custom.cassandra_custom_debug
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 cassandra_custom.cassandra_custom_debug
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  cassandra_custom_debug
-    Name   modify
-    Remove logName
 
 [FILTER]
     Match                 cassandra_custom.cassandra_custom_gc
@@ -228,21 +216,9 @@
     Parser   cassandra_custom.cassandra_custom_gc.cassandra_gc.0
 
 [FILTER]
-    Add   logName cassandra_custom_gc
+    Add   logging.googleapis.com/logName cassandra_custom_gc
     Match cassandra_custom.cassandra_custom_gc
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 cassandra_custom.cassandra_custom_gc
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  cassandra_custom_gc
-    Name   modify
-    Remove logName
 
 [FILTER]
     Match                 cassandra_custom.cassandra_custom_system
@@ -287,21 +263,9 @@
     Name      modify
 
 [FILTER]
-    Add   logName cassandra_custom_system
+    Add   logging.googleapis.com/logName cassandra_custom_system
     Match cassandra_custom.cassandra_custom_system
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 cassandra_custom.cassandra_custom_system
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  cassandra_custom_system
-    Name   modify
-    Remove logName
 
 [FILTER]
     Match                 cassandra_default.cassandra_default_debug
@@ -346,21 +310,9 @@
     Name      modify
 
 [FILTER]
-    Add   logName cassandra_default_debug
+    Add   logging.googleapis.com/logName cassandra_default_debug
     Match cassandra_default.cassandra_default_debug
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 cassandra_default.cassandra_default_debug
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  cassandra_default_debug
-    Name   modify
-    Remove logName
 
 [FILTER]
     Match                 cassandra_default.cassandra_default_gc
@@ -375,21 +327,9 @@
     Parser   cassandra_default.cassandra_default_gc.cassandra_gc.0
 
 [FILTER]
-    Add   logName cassandra_default_gc
+    Add   logging.googleapis.com/logName cassandra_default_gc
     Match cassandra_default.cassandra_default_gc
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 cassandra_default.cassandra_default_gc
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  cassandra_default_gc
-    Name   modify
-    Remove logName
 
 [FILTER]
     Match                 cassandra_default.cassandra_default_system
@@ -434,21 +374,9 @@
     Name      modify
 
 [FILTER]
-    Add   logName cassandra_default_system
+    Add   logging.googleapis.com/logName cassandra_default_system
     Match cassandra_default.cassandra_default_system
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 cassandra_default.cassandra_default_system
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  cassandra_default_system
-    Name   modify
-    Remove logName
 
 [FILTER]
     Match                 cassandra_syslog_system.cassandra_syslog_debug
@@ -547,21 +475,9 @@
     Parser   cassandra_syslog_system.cassandra_syslog_debug.2.0
 
 [FILTER]
-    Add   logName cassandra_syslog_debug
+    Add   logging.googleapis.com/logName cassandra_syslog_debug
     Match cassandra_syslog_system.cassandra_syslog_debug
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 cassandra_syslog_system.cassandra_syslog_debug
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  cassandra_syslog_debug
-    Name   modify
-    Remove logName
 
 [FILTER]
     Match                 cassandra_syslog_system.cassandra_syslog_gc
@@ -660,21 +576,9 @@
     Parser   cassandra_syslog_system.cassandra_syslog_gc.2.0
 
 [FILTER]
-    Add   logName cassandra_syslog_gc
+    Add   logging.googleapis.com/logName cassandra_syslog_gc
     Match cassandra_syslog_system.cassandra_syslog_gc
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 cassandra_syslog_system.cassandra_syslog_gc
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  cassandra_syslog_gc
-    Name   modify
-    Remove logName
 
 [FILTER]
     Match                 cassandra_syslog_system.cassandra_syslog_system
@@ -773,41 +677,17 @@
     Parser   cassandra_syslog_system.cassandra_syslog_system.2.0
 
 [FILTER]
-    Add   logName cassandra_syslog_system
+    Add   logging.googleapis.com/logName cassandra_syslog_system
     Match cassandra_syslog_system.cassandra_syslog_system
     Name  modify
 
 [FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 cassandra_syslog_system.cassandra_syslog_system
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  cassandra_syslog_system
-    Name   modify
-    Remove logName
-
-[FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(cassandra_custom_debug|cassandra_custom_gc|cassandra_custom_system|cassandra_default_debug|cassandra_default_gc|cassandra_default_system|cassandra_syslog_debug|cassandra_syslog_gc|cassandra_syslog_system|syslog)$
+    Match_Regex       ^(cassandra_custom\.cassandra_custom_debug|cassandra_custom\.cassandra_custom_gc|cassandra_custom\.cassandra_custom_system|cassandra_default\.cassandra_default_debug|cassandra_default\.cassandra_default_gc|cassandra_default\.cassandra_default_system|cassandra_syslog_system\.cassandra_syslog_debug|cassandra_syslog_system\.cassandra_syslog_gc|cassandra_syslog_system\.cassandra_syslog_system|default_pipeline\.syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -101,72 +101,24 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName log_source_id1
+    Add   logging.googleapis.com/logName log_source_id1
     Match pipeline1.log_source_id1
     Name  modify
 
 [FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 pipeline1.log_source_id1
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  log_source_id1
-    Name   modify
-    Remove logName
-
-[FILTER]
-    Add   logName log_source_id2
+    Add   logging.googleapis.com/logName log_source_id2
     Match pipeline2.log_source_id2
     Name  modify
 
 [FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 pipeline2.log_source_id2
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  log_source_id2
-    Name   modify
-    Remove logName
-
-[FILTER]
-    Add   logName log_source_id3
+    Add   logging.googleapis.com/logName log_source_id3
     Match pipeline3.log_source_id3
     Name  modify
 
 [FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 pipeline3.log_source_id3
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  log_source_id3
-    Name   modify
-    Remove logName
-
-[FILTER]
-    Add   logName log_source_id4
+    Add   logging.googleapis.com/logName log_source_id4
     Match pipeline4.log_source_id4
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 pipeline4.log_source_id4
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  log_source_id4
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name key_5
@@ -175,24 +127,12 @@
     Parser   pipeline5.log_source_id5.0
 
 [FILTER]
-    Add   logName log_source_id5
+    Add   logging.googleapis.com/logName log_source_id5
     Match pipeline5.log_source_id5
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 pipeline5.log_source_id5
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  log_source_id5
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(log_source_id1|log_source_id2|log_source_id3|log_source_id4|log_source_id5)$
+    Match_Regex       ^(pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.log_source_id3|pipeline4\.log_source_id4|pipeline5\.log_source_id5)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_fluent_bit_main.conf
@@ -157,21 +157,9 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -230,21 +218,9 @@
     Name      modify
 
 [FILTER]
-    Add   logName mysql_custom_error
+    Add   logging.googleapis.com/logName mysql_custom_error
     Match mysql_custom.mysql_custom_error
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 mysql_custom.mysql_custom_error
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  mysql_custom_error
-    Name   modify
-    Remove logName
 
 [FILTER]
     Match                 mysql_custom.mysql_custom_general
@@ -259,21 +235,9 @@
     Parser   mysql_custom.mysql_custom_general.mysql_general.0
 
 [FILTER]
-    Add   logName mysql_custom_general
+    Add   logging.googleapis.com/logName mysql_custom_general
     Match mysql_custom.mysql_custom_general
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 mysql_custom.mysql_custom_general
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  mysql_custom_general
-    Name   modify
-    Remove logName
 
 [FILTER]
     Match                 mysql_custom.mysql_custom_slow
@@ -288,21 +252,9 @@
     Parser   mysql_custom.mysql_custom_slow.mysql_slow.0
 
 [FILTER]
-    Add   logName mysql_custom_slow
+    Add   logging.googleapis.com/logName mysql_custom_slow
     Match mysql_custom.mysql_custom_slow
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 mysql_custom.mysql_custom_slow
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  mysql_custom_slow
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -361,21 +313,9 @@
     Name      modify
 
 [FILTER]
-    Add   logName mysql_default_error
+    Add   logging.googleapis.com/logName mysql_default_error
     Match mysql_default.mysql_default_error
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 mysql_default.mysql_default_error
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  mysql_default_error
-    Name   modify
-    Remove logName
 
 [FILTER]
     Match                 mysql_default.mysql_default_general
@@ -390,21 +330,9 @@
     Parser   mysql_default.mysql_default_general.mysql_general.0
 
 [FILTER]
-    Add   logName mysql_default_general
+    Add   logging.googleapis.com/logName mysql_default_general
     Match mysql_default.mysql_default_general
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 mysql_default.mysql_default_general
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  mysql_default_general
-    Name   modify
-    Remove logName
 
 [FILTER]
     Match                 mysql_default.mysql_default_slow
@@ -419,21 +347,9 @@
     Parser   mysql_default.mysql_default_slow.mysql_slow.0
 
 [FILTER]
-    Add   logName mysql_default_slow
+    Add   logging.googleapis.com/logName mysql_default_slow
     Match mysql_default.mysql_default_slow
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 mysql_default.mysql_default_slow
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  mysql_default_slow
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -516,21 +432,9 @@
     Parser   mysql_syslog_error.mysql_syslog_error.2.0
 
 [FILTER]
-    Add   logName mysql_syslog_error
+    Add   logging.googleapis.com/logName mysql_syslog_error
     Match mysql_syslog_error.mysql_syslog_error
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 mysql_syslog_error.mysql_syslog_error
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  mysql_syslog_error
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -613,21 +517,9 @@
     Parser   mysql_syslog_error.mysql_syslog_general.2.0
 
 [FILTER]
-    Add   logName mysql_syslog_general
+    Add   logging.googleapis.com/logName mysql_syslog_general
     Match mysql_syslog_error.mysql_syslog_general
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 mysql_syslog_error.mysql_syslog_general
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  mysql_syslog_general
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -710,24 +602,12 @@
     Parser   mysql_syslog_error.mysql_syslog_slow.2.0
 
 [FILTER]
-    Add   logName mysql_syslog_slow
+    Add   logging.googleapis.com/logName mysql_syslog_slow
     Match mysql_syslog_error.mysql_syslog_slow
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 mysql_syslog_error.mysql_syslog_slow
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  mysql_syslog_slow
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(mysql_custom_error|mysql_custom_general|mysql_custom_slow|mysql_default_error|mysql_default_general|mysql_default_slow|mysql_syslog_error|mysql_syslog_general|mysql_syslog_slow|syslog)$
+    Match_Regex       ^(default_pipeline\.syslog|mysql_custom\.mysql_custom_error|mysql_custom\.mysql_custom_general|mysql_custom\.mysql_custom_slow|mysql_default\.mysql_default_error|mysql_default\.mysql_default_general|mysql_default\.mysql_default_slow|mysql_syslog_error\.mysql_syslog_error|mysql_syslog_error\.mysql_syslog_general|mysql_syslog_error\.mysql_syslog_slow)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_fluent_bit_main.conf
@@ -119,21 +119,9 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -168,21 +156,9 @@
     Wildcard      http_request_*
 
 [FILTER]
-    Add   logName nginx_custom_access
+    Add   logging.googleapis.com/logName nginx_custom_access
     Match nginx_custom.nginx_custom_access
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 nginx_custom.nginx_custom_access
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  nginx_custom_access
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -239,21 +215,9 @@
     Name      modify
 
 [FILTER]
-    Add   logName nginx_custom_error
+    Add   logging.googleapis.com/logName nginx_custom_error
     Match nginx_custom.nginx_custom_error
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 nginx_custom.nginx_custom_error
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  nginx_custom_error
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -288,21 +252,9 @@
     Wildcard      http_request_*
 
 [FILTER]
-    Add   logName nginx_default_access
+    Add   logging.googleapis.com/logName nginx_default_access
     Match nginx_default.nginx_default_access
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 nginx_default.nginx_default_access
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  nginx_default_access
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -359,21 +311,9 @@
     Name      modify
 
 [FILTER]
-    Add   logName nginx_default_error
+    Add   logging.googleapis.com/logName nginx_default_error
     Match nginx_default.nginx_default_error
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 nginx_default.nginx_default_error
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  nginx_default_error
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -408,21 +348,9 @@
     Wildcard      http_request_*
 
 [FILTER]
-    Add   logName nginx_syslog_access
+    Add   logging.googleapis.com/logName nginx_syslog_access
     Match nginx_syslog_access.nginx_syslog_access
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 nginx_syslog_access.nginx_syslog_access
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  nginx_syslog_access
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -479,24 +407,12 @@
     Name      modify
 
 [FILTER]
-    Add   logName nginx_syslog_error
+    Add   logging.googleapis.com/logName nginx_syslog_error
     Match nginx_syslog_error.nginx_syslog_error
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 nginx_syslog_error.nginx_syslog_error
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  nginx_syslog_error
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(nginx_custom_access|nginx_custom_error|nginx_default_access|nginx_default_error|nginx_syslog_access|nginx_syslog_error|syslog)$
+    Match_Regex       ^(default_pipeline\.syslog|nginx_custom\.nginx_custom_access|nginx_custom\.nginx_custom_error|nginx_default\.nginx_default_access|nginx_default\.nginx_default_error|nginx_syslog_access\.nginx_syslog_access|nginx_syslog_error\.nginx_syslog_error)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_fluent_bit_main.conf
@@ -81,21 +81,9 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -152,21 +140,9 @@
     Name      modify
 
 [FILTER]
-    Add   logName redis_custom
+    Add   logging.googleapis.com/logName redis_custom
     Match redis_custom.redis_custom
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 redis_custom.redis_custom
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  redis_custom
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -223,21 +199,9 @@
     Name      modify
 
 [FILTER]
-    Add   logName redis_default
+    Add   logging.googleapis.com/logName redis_default
     Match redis_default.redis_default
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 redis_default.redis_default
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  redis_default
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -294,24 +258,12 @@
     Name      modify
 
 [FILTER]
-    Add   logName redis_syslog
+    Add   logging.googleapis.com/logName redis_syslog
     Match redis_syslog.redis_syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 redis_syslog.redis_syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  redis_syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(redis_custom|redis_default|redis_syslog|syslog)$
+    Match_Regex       ^(default_pipeline\.syslog|redis_custom\.redis_custom|redis_default\.redis_default|redis_syslog\.redis_syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -55,21 +55,9 @@
     Parser   pipeline1.test_syslog_source_id_tcp.0
 
 [FILTER]
-    Add   logName test_syslog_source_id_tcp
+    Add   logging.googleapis.com/logName test_syslog_source_id_tcp
     Match pipeline1.test_syslog_source_id_tcp
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 pipeline1.test_syslog_source_id_tcp
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  test_syslog_source_id_tcp
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name message
@@ -78,24 +66,12 @@
     Parser   pipeline2.test_syslog_source_id_udp.0
 
 [FILTER]
-    Add   logName test_syslog_source_id_udp
+    Add   logging.googleapis.com/logName test_syslog_source_id_udp
     Match pipeline2.test_syslog_source_id_udp
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 pipeline2.test_syslog_source_id_udp
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  test_syslog_source_id_udp
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(test_syslog_source_id_tcp|test_syslog_source_id_udp)$
+    Match_Regex       ^(pipeline1\.test_syslog_source_id_tcp|pipeline2\.test_syslog_source_id_udp)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_fluent_bit_main.conf
@@ -48,41 +48,17 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
 [FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
-[FILTER]
-    Add   logName systemd_logs
+    Add   logging.googleapis.com/logName systemd_logs
     Match systemd_pipeline.systemd_logs
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 systemd_pipeline.systemd_logs
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  systemd_logs
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog|systemd_logs)$
+    Match_Regex       ^(default_pipeline\.syslog|systemd_pipeline\.systemd_logs)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_fluent_bit_main.conf
@@ -52,41 +52,17 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
 [FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
-[FILTER]
-    Add   logName tcp_logs
+    Add   logging.googleapis.com/logName tcp_logs
     Match tcp_pipeline.tcp_logs
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 tcp_pipeline.tcp_logs
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  tcp_logs
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog|tcp_logs)$
+    Match_Regex       ^(default_pipeline\.syslog|tcp_pipeline\.tcp_logs)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_fluent_bit_main.conf
@@ -52,41 +52,17 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
 [FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
-[FILTER]
-    Add   logName tcp_logs
+    Add   logging.googleapis.com/logName tcp_logs
     Match tcp_pipeline.tcp_logs
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 tcp_pipeline.tcp_logs
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  tcp_logs
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog|tcp_logs)$
+    Match_Regex       ^(default_pipeline\.syslog|tcp_pipeline\.tcp_logs)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_fluent_bit_main.conf
@@ -43,24 +43,12 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog)$
+    Match_Regex       ^(default_pipeline\.syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -43,24 +43,12 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog)$
+    Match_Regex       ^(default_pipeline\.syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
@@ -43,24 +43,12 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog)$
+    Match_Regex       ^(default_pipeline\.syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
@@ -43,24 +43,12 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog)$
+    Match_Regex       ^(default_pipeline\.syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_fluent_bit_main.conf
@@ -43,24 +43,12 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog)$
+    Match_Regex       ^(default_pipeline\.syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_fluent_bit_main.conf
@@ -43,24 +43,12 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog)$
+    Match_Regex       ^(default_pipeline\.syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_fluent_bit_main.conf
@@ -43,24 +43,12 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog)$
+    Match_Regex       ^(default_pipeline\.syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_fluent_bit_main.conf
@@ -43,24 +43,12 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog)$
+    Match_Regex       ^(default_pipeline\.syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
@@ -43,24 +43,12 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog)$
+    Match_Regex       ^(default_pipeline\.syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_fluent_bit_main.conf
@@ -43,24 +43,12 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog)$
+    Match_Regex       ^(default_pipeline\.syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
@@ -43,24 +43,12 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog)$
+    Match_Regex       ^(default_pipeline\.syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_fluent_bit_main.conf
@@ -43,24 +43,12 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog)$
+    Match_Regex       ^(default_pipeline\.syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_fluent_bit_main.conf
@@ -43,24 +43,12 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog)$
+    Match_Regex       ^(default_pipeline\.syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
@@ -43,24 +43,12 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog)$
+    Match_Regex       ^(default_pipeline\.syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_fluent_bit_main.conf
@@ -43,24 +43,12 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog)$
+    Match_Regex       ^(default_pipeline\.syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_fluent_bit_main.conf
@@ -43,24 +43,12 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logName syslog
+    Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.syslog
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  syslog
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(syslog)$
+    Match_Regex       ^(default_pipeline\.syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
@@ -66,24 +66,12 @@
     Name      modify
 
 [FILTER]
-    Add   logName windows_event_log
+    Add   logging.googleapis.com/logName windows_event_log
     Match default_pipeline.windows_event_log
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.windows_event_log
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  windows_event_log
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(windows_event_log)$
+    Match_Regex       ^(default_pipeline\.windows_event_log)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_fluent_bit_main.conf
@@ -66,24 +66,12 @@
     Name      modify
 
 [FILTER]
-    Add   logName windows_event_log
+    Add   logging.googleapis.com/logName windows_event_log
     Match default_pipeline.windows_event_log
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.windows_event_log
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  windows_event_log
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(windows_event_log)$
+    Match_Regex       ^(default_pipeline\.windows_event_log)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_fluent_bit_main.conf
@@ -66,24 +66,12 @@
     Name      modify
 
 [FILTER]
-    Add   logName windows_event_log
+    Add   logging.googleapis.com/logName windows_event_log
     Match default_pipeline.windows_event_log
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.windows_event_log
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  windows_event_log
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(windows_event_log)$
+    Match_Regex       ^(default_pipeline\.windows_event_log)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -94,38 +94,14 @@
     Name      modify
 
 [FILTER]
-    Add   logName windows_event_log
+    Add   logging.googleapis.com/logName windows_event_log
     Match default_pipeline.windows_event_log
     Name  modify
 
 [FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.windows_event_log
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  windows_event_log
-    Name   modify
-    Remove logName
-
-[FILTER]
-    Add   logName log_source_id1
+    Add   logging.googleapis.com/logName log_source_id1
     Match pipeline1.log_source_id1
     Name  modify
-
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 pipeline1.log_source_id1
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  log_source_id1
-    Name   modify
-    Remove logName
 
 [FILTER]
     Key_Name key_5
@@ -134,24 +110,12 @@
     Parser   pipeline2.log_source_id2.0
 
 [FILTER]
-    Add   logName log_source_id2
+    Add   logging.googleapis.com/logName log_source_id2
     Match pipeline2.log_source_id2
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 pipeline2.log_source_id2
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  log_source_id2
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(log_source_id1|log_source_id2|windows_event_log)$
+    Match_Regex       ^(default_pipeline\.windows_event_log|pipeline1\.log_source_id1|pipeline2\.log_source_id2)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -66,24 +66,12 @@
     Name      modify
 
 [FILTER]
-    Add   logName windows_event_log
+    Add   logging.googleapis.com/logName windows_event_log
     Match default_pipeline.windows_event_log
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.windows_event_log
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  windows_event_log
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(windows_event_log)$
+    Match_Regex       ^(default_pipeline\.windows_event_log)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_fluent_bit_main.conf
@@ -66,24 +66,12 @@
     Name      modify
 
 [FILTER]
-    Add   logName windows_event_log
+    Add   logging.googleapis.com/logName windows_event_log
     Match default_pipeline.windows_event_log
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.windows_event_log
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  windows_event_log
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(windows_event_log)$
+    Match_Regex       ^(default_pipeline\.windows_event_log)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_fluent_bit_main.conf
@@ -66,24 +66,12 @@
     Name      modify
 
 [FILTER]
-    Add   logName windows_event_log
+    Add   logging.googleapis.com/logName windows_event_log
     Match default_pipeline.windows_event_log
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.windows_event_log
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  windows_event_log
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(windows_event_log)$
+    Match_Regex       ^(default_pipeline\.windows_event_log)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
@@ -66,24 +66,12 @@
     Name      modify
 
 [FILTER]
-    Add   logName windows_event_log
+    Add   logging.googleapis.com/logName windows_event_log
     Match default_pipeline.windows_event_log
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.windows_event_log
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  windows_event_log
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(windows_event_log)$
+    Match_Regex       ^(default_pipeline\.windows_event_log)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
@@ -66,24 +66,12 @@
     Name      modify
 
 [FILTER]
-    Add   logName windows_event_log
+    Add   logging.googleapis.com/logName windows_event_log
     Match default_pipeline.windows_event_log
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.windows_event_log
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  windows_event_log
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(windows_event_log)$
+    Match_Regex       ^(default_pipeline\.windows_event_log)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
@@ -66,24 +66,12 @@
     Name      modify
 
 [FILTER]
-    Add   logName windows_event_log
+    Add   logging.googleapis.com/logName windows_event_log
     Match default_pipeline.windows_event_log
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.windows_event_log
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  windows_event_log
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(windows_event_log)$
+    Match_Regex       ^(default_pipeline\.windows_event_log)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_fluent_bit_main.conf
@@ -66,24 +66,12 @@
     Name      modify
 
 [FILTER]
-    Add   logName windows_event_log
+    Add   logging.googleapis.com/logName windows_event_log
     Match default_pipeline.windows_event_log
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.windows_event_log
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  windows_event_log
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(windows_event_log)$
+    Match_Regex       ^(default_pipeline\.windows_event_log)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_fluent_bit_main.conf
@@ -66,24 +66,12 @@
     Name      modify
 
 [FILTER]
-    Add   logName windows_event_log
+    Add   logging.googleapis.com/logName windows_event_log
     Match default_pipeline.windows_event_log
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.windows_event_log
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  windows_event_log
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(windows_event_log)$
+    Match_Regex       ^(default_pipeline\.windows_event_log)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
@@ -66,24 +66,12 @@
     Name      modify
 
 [FILTER]
-    Add   logName windows_event_log
+    Add   logging.googleapis.com/logName windows_event_log
     Match default_pipeline.windows_event_log
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.windows_event_log
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  windows_event_log
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(windows_event_log)$
+    Match_Regex       ^(default_pipeline\.windows_event_log)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_fluent_bit_main.conf
@@ -66,24 +66,12 @@
     Name      modify
 
 [FILTER]
-    Add   logName windows_event_log
+    Add   logging.googleapis.com/logName windows_event_log
     Match default_pipeline.windows_event_log
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.windows_event_log
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  windows_event_log
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(windows_event_log)$
+    Match_Regex       ^(default_pipeline\.windows_event_log)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
@@ -66,24 +66,12 @@
     Name      modify
 
 [FILTER]
-    Add   logName windows_event_log
+    Add   logging.googleapis.com/logName windows_event_log
     Match default_pipeline.windows_event_log
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.windows_event_log
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  windows_event_log
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(windows_event_log)$
+    Match_Regex       ^(default_pipeline\.windows_event_log)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_fluent_bit_main.conf
@@ -66,24 +66,12 @@
     Name      modify
 
 [FILTER]
-    Add   logName windows_event_log
+    Add   logging.googleapis.com/logName windows_event_log
     Match default_pipeline.windows_event_log
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.windows_event_log
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  windows_event_log
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(windows_event_log)$
+    Match_Regex       ^(default_pipeline\.windows_event_log)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
@@ -66,24 +66,12 @@
     Name      modify
 
 [FILTER]
-    Add   logName windows_event_log
+    Add   logging.googleapis.com/logName windows_event_log
     Match default_pipeline.windows_event_log
     Name  modify
 
-[FILTER]
-    Emitter_Mem_Buf_Limit 10M
-    Emitter_Storage.type  filesystem
-    Match                 default_pipeline.windows_event_log
-    Name                  rewrite_tag
-    Rule                  $logName .* $logName false
-
-[FILTER]
-    Match  windows_event_log
-    Name   modify
-    Remove logName
-
 [OUTPUT]
-    Match_Regex       ^(windows_event_log)$
+    Match_Regex       ^(default_pipeline\.windows_event_log)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance


### PR DESCRIPTION
The current implementation has a section that changes log tag from `{PIPELINE_ID}`.`{RECEIVER_ID}` to `{RECEIVER_ID}`, because the output plugin decides the LogEntry.LogName based on the log tag, and we do not want to expose `{PIPELINE_ID}` in log name. This involves a `rewrite_tag` filter that is very heavy performance wise (It throws all log entries back to the pool to be re-processed.

This change refactor the config to make use of the `logging.googleapis.com/logName` field instead, which is a field that the output plugin recognizes already.

## Old Config

```
[FILTER]
    Add   logName syslog
    Match default_pipeline.syslog
    Name  modify

[FILTER]
    Emitter_Mem_Buf_Limit 10M
    Emitter_Storage.type  filesystem
    Match                 default_pipeline.syslog
    Name                  rewrite_tag
    Rule                  $logName .* $logName false

[FILTER]
    Match  syslog
    Name   modify
    Remove logName

[OUTPUT]
    Match_Regex       ^(syslog)$
    Name              stackdriver
    Retry_Limit       3
    resource          gce_instance
```

# New config

```
[FILTER]
    Add   logging.googleapis.com/logName syslog
    Match default_pipeline.syslog
    Name  modify

[OUTPUT]
    Match_Regex       ^(default_pipeline\.syslog)$
    Name              stackdriver
    Retry_Limit       3
    resource          gce_instance
```

Manually tested: b/206012639#comment2