### PR TITLE
Install OpenSSL on Windows.

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -68,8 +68,7 @@ RUN $ExpectedHash = \"1e62e6459835f61c418532a1544e295be5400498b3569aadfb6d0b5d7a
       throw \"OpenSSL hash mismatch. Expected: $ExpectedHash, Actual: $ActualHash\"`
     };
 
-RUN Start-Process msiexec.exe -Wait `
-    -ArgumentList '/i C:\local\Win64OpenSSL-1_1_1L.msi /quiet /norestart';
+RUN Start-Process msiexec.exe -Wait -ArgumentList '/i C:\local\Win64OpenSSL-1_1_1L.msi /quiet';
 
 #
 # Install winflexbison

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -61,14 +61,13 @@ RUN Write-Host ('Installing Visual C++ Redistributable Package'); `
 #
 ADD https://slproweb.com/download/Win64OpenSSL-1_1_1L.msi /local/Win64OpenSSL-1_1_1L.msi
 
-# Hash copied from https://github.com/slproweb/opensslhashes
-RUN $ExpectedHash = \"1e62e6459835f61c418532a1544e295be5400498b3569aadfb6d0b5d7a1c1dbc\";`
+# Verify SHA256 hash using expected value from https://github.com/slproweb/opensslhashes
+RUN $ExpectedHash = '1e62e6459835f61c418532a1544e295be5400498b3569aadfb6d0b5d7a1c1dbc';`
     $ActualHash = $(Get-FileHash /local/Win64OpenSSL-1_1_1L.msi).Hash.ToLower();`
     if ($ActualHash -ne $ExpectedHash) {`
       throw \"OpenSSL hash mismatch. Expected: $ExpectedHash, Actual: $ActualHash\"`
-    };
-
-RUN Start-Process msiexec.exe -Wait -ArgumentList '/i C:\local\Win64OpenSSL-1_1_1L.msi /quiet';
+    };`
+    Start-Process msiexec.exe -Wait -ArgumentList '/i C:\local\Win64OpenSSL-1_1_1L.msi /quiet';
 
 #
 # Install winflexbison

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -57,8 +57,16 @@ RUN Write-Host ('Installing Visual C++ Redistributable Package'); `
 
 #
 # Install OpenSSL
+# This must be done after installing Visual Studio
 #
 ADD https://slproweb.com/download/Win64OpenSSL-1_1_1L.msi /local/Win64OpenSSL-1_1_1L.msi
+
+# Hash copied from https://github.com/slproweb/opensslhashes
+RUN $ExpectedHash = \"1e62e6459835f61c418532a1544e295be5400498b3569aadfb6d0b5d7a1c1dbc\";`
+    $ActualHash = $(Get-FileHash /local/Win64OpenSSL-1_1_1L.msi).Hash.ToLower();`
+    if ($ActualHash -ne $ExpectedHash) {`
+      throw \"OpenSSL hash mismatch. Expected: $ExpectedHash, Actual: $ActualHash\"`
+    };
 
 RUN Start-Process msiexec.exe -Wait `
     -ArgumentList '/i C:\local\Win64OpenSSL-1_1_1L.msi /quiet /norestart';

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -60,9 +60,8 @@ RUN Write-Host ('Installing Visual C++ Redistributable Package'); `
 #
 ADD https://slproweb.com/download/Win64OpenSSL-1_1_1L.msi /local/Win64OpenSSL-1_1_1L.msi
 
-RUN Start-Process msiexec.exe `
-    -ArgumentList '/i C:\local\Win64OpenSSL-1_1_1L.msi ', '/quiet ', `
-    '/norestart ' -NoNewWindow -Wait;
+RUN Start-Process msiexec.exe -Wait `
+    -ArgumentList '/i C:\local\Win64OpenSSL-1_1_1L.msi /quiet /norestart';
 
 #
 # Install winflexbison
@@ -183,4 +182,3 @@ COPY --from=gobuilder /work/out /work/out
 COPY --from=javacontrib /work/out /work/out
 
 RUN & .\pkg\goo\build.ps1 -DestDir /work/out;
-

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -56,6 +56,15 @@ RUN Write-Host ('Installing Visual C++ Redistributable Package'); `
     Copy-Item -Path /Windows/System32/vcruntime140.dll -Destination /work/out/bin/;
 
 #
+# Install OpenSSL
+#
+ADD https://slproweb.com/download/Win64OpenSSL-1_1_1L.msi /local/Win64OpenSSL-1_1_1L.msi
+
+RUN Start-Process msiexec.exe `
+    -ArgumentList '/i C:\local\Win64OpenSSL-1_1_1L.msi ', '/quiet ', `
+    '/norestart ' -NoNewWindow -Wait;
+
+#
 # Install winflexbison
 #
 ADD https://github.com/lexxmark/winflexbison/releases/download/v2.5.22/win_flex_bison-2.5.22.zip /local/win_flex_bison.zip


### PR DESCRIPTION
http://b/206154592

Fluent Bit uses either mbedtls or OpenSSL for TLS, and will [default to OpenSSL if it's able to find](https://github.com/fluent/fluent-bit/blob/1d529d9fbc5de5559943ad5fd4e4c070fa319be7/CMakeLists.txt#L468-L473) its headers. There's a bug in mbedtls that's causing connection issues (see https://github.com/fluent/fluent-bit/issues/4300#issuecomment-964752078), so we'll build with OpenSSL instead. Our [Linux builds already install OpenSSL](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/Dockerfile), so this will also make Windows consistent.

Build and test info: http://b/206154592#comment2