### PR TITLE
Fix typos in JVM documentation

### DIFF
--- a/docs/jvm.md
+++ b/docs/jvm.md
@@ -39,10 +39,10 @@ metrics:
 
 | Metric                                             | Data Type | Unit        | Labels | Description |
 | ---                                                | ---       | ---         | ---    | ---         | 
-| workload.googleapis.com/jvm.classes.loade          | gauge     | 1           |        | Current number of loaded classes |
+| workload.googleapis.com/jvm.classes.loaded         | gauge     | 1           |        | Current number of loaded classes |
 | workload.googleapis.com/jvm.gc.collections.count   | cumulative       | 1           | name   | Total number of garbage collections |
 | workload.googleapis.com/jvm.gc.collections.elapsed | cumulative       | ms          | name   | Time spent garbage collecting |
 | workload.googleapis.com/jvm.memory.heap            | gauge     | by          |        | Current heap usage |
 | workload.googleapis.com/jvm.memory.nonheap         | gauge     | by          |        | Current non-heap usage |
-| workload.googleapis.com/jvm.memory.jvm.memory.pool | gauge     | by          | name   | Current memory pool usage |
+| workload.googleapis.com/jvm.memory.pool            | gauge     | by          | name   | Current memory pool usage |
 | workload.googleapis.com/jvm.threads.count          | gauge     | 1           |        | Current number of threads |


### PR DESCRIPTION
Issues were noted on the previous PR 
https://github.com/GoogleCloudPlatform/ops-agent/pull/174#discussion_r752820577
https://github.com/GoogleCloudPlatform/ops-agent/pull/174#discussion_r752817970