### PR TITLE
-update_golden creating empty files

### DIFF
--- a/confgenerator/confgenerator_test.go
+++ b/confgenerator/confgenerator_test.go
@@ -191,6 +191,17 @@ func updateOrCompareGolden(t *testing.T, testName string, goos string, expectedB
 		} else {
 			t.Errorf("test %q: golden file at %s mismatch (-want +got):\n%s", testName, goldenPath, diff)
 		}
+	} else {
+		if *updateGolden {
+			// If the diff is empty and we need to update goldens, we check whether the diff is
+			// empty because the file doesn't exist yet.
+			if _, err := os.Stat(goldenPath); err != nil {
+				t.Logf("Detected -update_golden flag. Creating %q golden file.", goldenPath)
+				if err := ioutil.WriteFile(goldenPath, []byte(""), 0644); err != nil {
+					t.Fatalf("error creating golden file at %q : %s", goldenPath, err)
+				}
+			}
+		}
 	}
 }
 

--- a/confgenerator/confgenerator_test.go
+++ b/confgenerator/confgenerator_test.go
@@ -184,6 +184,8 @@ func updateOrCompareGolden(t *testing.T, testName string, goos string, expectedB
 	goldenPath := fmt.Sprintf(path, goos, testName)
 	diff := cmp.Diff(expected, actual)
 	if *updateGolden {
+		// If there is a diff, or if the actual is empty (it may be due to the file
+		// not existing), write the golden file with the expected content.
 		if diff != "" || actual == "" {
 			// Update the expected to match the actual.
 			t.Logf("Detected -update_golden flag. Rewriting the %q golden file to apply the following diff\n%s.", goldenPath, cmp.Diff(actual, expected))

--- a/confgenerator/confgenerator_test.go
+++ b/confgenerator/confgenerator_test.go
@@ -193,7 +193,7 @@ func updateOrCompareGolden(t *testing.T, testName string, goos string, expectedB
 		}
 	} else {
 		if *updateGolden {
-			// If the diff is empty and we need to update goldens, we check whether the diff is
+			// If the diff is empty and we need to update goldens, check whether the diff is
 			// empty because the file doesn't exist yet.
 			if _, err := os.Stat(goldenPath); err != nil {
 				t.Logf("Detected -update_golden flag. Creating %q golden file.", goldenPath)

--- a/confgenerator/confgenerator_test.go
+++ b/confgenerator/confgenerator_test.go
@@ -184,7 +184,7 @@ func updateOrCompareGolden(t *testing.T, testName string, goos string, expectedB
 	goldenPath := fmt.Sprintf(path, goos, testName)
 	diff := cmp.Diff(expected, actual)
 	if *updateGolden {
-		if diff != "" || !fileExists(t, testName, goldenPath) {
+		if diff != "" || actual == "" {
 			// Update the expected to match the actual.
 			t.Logf("Detected -update_golden flag. Rewriting the %q golden file to apply the following diff\n%s.", goldenPath, cmp.Diff(actual, expected))
 			if err := ioutil.WriteFile(goldenPath, []byte(actual), 0644); err != nil {
@@ -194,17 +194,6 @@ func updateOrCompareGolden(t *testing.T, testName string, goos string, expectedB
 	} else if diff != "" {
 		t.Errorf("test %q: golden file at %s mismatch (-want +got):\n%s", testName, goldenPath, diff)
 	}
-}
-
-func fileExists(t *testing.T, testName, path string) bool {
-	if _, err := os.Stat(path); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return false
-		} else {
-			t.Fatalf("test %q: error reading the file from %s : %s", testName, path, err)
-		}
-	}
-	return true
 }
 
 func TestGenerateConfigsWithInvalidInput(t *testing.T) {


### PR DESCRIPTION
`updateOrCompareGolden` did not detect the case where a diff is empty
because the file doesn't exist yet. Added a check for the edge case that
creates the empty golden file if it doesn't exist yet.