### PR TITLE
Aggregate away mountpoints using `max`, as there may be duplicates.

### DIFF
--- a/apps/hostmetrics.go
+++ b/apps/hostmetrics.go
@@ -156,13 +156,14 @@ func (r MetricsReceiverHostmetrics) Pipelines() []otel.Pipeline {
 					"disk/bytes_used",
 					// change data type from int64 -> double
 					otel.ToggleScalarDataType,
-					// take sum over mode, mountpoint & type dimensions, retaining only device & state
-					otel.AggregateLabels("sum", "device", "state"),
+					// take max over mode, mountpoint & type dimensions, retaining only device & state
+					// there may be multiple mountpoints for the same device
+					otel.AggregateLabels("max", "device", "state"),
 				),
 				otel.RenameMetric(
 					"system.filesystem.utilization",
 					"disk/percent_used",
-					otel.AggregateLabels("sum", "device", "state"),
+					otel.AggregateLabels("max", "device", "state"),
 				),
 				otel.RenameMetric(
 					"system.memory.usage",

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -154,7 +154,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -163,7 +163,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
@@ -160,7 +160,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -169,7 +169,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -161,7 +161,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -170,7 +170,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -161,7 +161,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -170,7 +170,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
@@ -160,7 +160,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -169,7 +169,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
@@ -175,7 +175,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -184,7 +184,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_otel.conf
@@ -175,7 +175,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -184,7 +184,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
@@ -165,7 +165,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -174,7 +174,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_otel.conf
@@ -165,7 +165,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -174,7 +174,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_otel.conf
@@ -166,7 +166,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -175,7 +175,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_otel.conf
@@ -166,7 +166,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -175,7 +175,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -154,7 +154,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -163,7 +163,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
@@ -169,7 +169,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -178,7 +178,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
@@ -169,7 +169,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -178,7 +178,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
@@ -169,7 +169,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -178,7 +178,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -169,7 +169,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -178,7 +178,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
@@ -172,7 +172,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -181,7 +181,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
@@ -172,7 +172,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -181,7 +181,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
@@ -172,7 +172,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -181,7 +181,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
@@ -191,7 +191,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -200,7 +200,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -175,7 +175,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -184,7 +184,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -175,7 +175,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -184,7 +184,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
@@ -172,7 +172,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -181,7 +181,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
@@ -185,7 +185,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -194,7 +194,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
@@ -185,7 +185,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -194,7 +194,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -169,7 +169,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -178,7 +178,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
@@ -169,7 +169,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -178,7 +178,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
@@ -169,7 +169,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -178,7 +178,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
@@ -169,7 +169,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -178,7 +178,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
@@ -169,7 +169,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -178,7 +178,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state


### PR DESCRIPTION
The standalone monitoring agent discards duplicates: [`df.c:184-203`](https://github.com/Stackdriver/collectd/blob/stackdriver-agent-5.8.1/src/df.c#L184-L203).

b/204269280