### PR TITLE
Removed duplicated stackdriver output from fluentbit

### DIFF
--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -162,6 +162,7 @@ func (l *Logging) generateFluentbitComponents(userAgent string, hostInfo *host.I
 			}
 		}
 		sort.Slice(sources, func(i, j int) bool { return sources[i].tag < sources[j].tag })
+		tags = append(tags, "ops-agent-fluent-bit")
 		sort.Strings(tags)
 
 		for _, s := range sources {
@@ -174,7 +175,6 @@ func (l *Logging) generateFluentbitComponents(userAgent string, hostInfo *host.I
 	out = append(out, LoggingReceiverFilesMixin{
 		IncludePaths: []string{"${logs_dir}/logging-module.log"},
 	}.Components("ops-agent-fluent-bit")...)
-	out = append(out, stackdriverOutputComponent("ops-agent-fluent-bit", userAgent))
 
 	return out, nil
 }

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
@@ -48,17 +48,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/all-built_in_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/golden_fluent_bit_main.conf
@@ -48,17 +48,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_fluent_bit_main.conf
@@ -48,17 +48,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_fluent_bit_main.conf
@@ -48,17 +48,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
@@ -111,17 +111,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.test_syslog_source_id_tcp|pipeline4\.test_syslog_source_id_udp)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(ops-agent-fluent-bit|pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.test_syslog_source_id_tcp|pipeline4\.test_syslog_source_id_udp)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_main.conf
@@ -110,17 +110,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog|pipeline1\.sample_logs|pipeline2\.sample_logs)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit|pipeline1\.sample_logs|pipeline2\.sample_logs)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_fluent_bit_main.conf
@@ -123,17 +123,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.test_syslog_source_id_tcp|pipeline4\.test_syslog_source_id_udp)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(ops-agent-fluent-bit|pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.test_syslog_source_id_tcp|pipeline4\.test_syslog_source_id_udp)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_fluent_bit_main.conf
@@ -54,17 +54,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_fluent_bit_main.conf
@@ -556,17 +556,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(apache_custom\.apache_custom_access|apache_custom\.apache_custom_error|apache_default\.apache_default_access|apache_default\.apache_default_error|apache_syslog_access\.apache_syslog_access|apache_syslog_error\.apache_syslog_error|default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(apache_custom\.apache_custom_access|apache_custom\.apache_custom_error|apache_default\.apache_default_access|apache_default\.apache_default_error|apache_syslog_access\.apache_syslog_access|apache_syslog_error\.apache_syslog_error|default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_fluent_bit_main.conf
@@ -687,17 +687,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(cassandra_custom\.cassandra_custom_debug|cassandra_custom\.cassandra_custom_gc|cassandra_custom\.cassandra_custom_system|cassandra_default\.cassandra_default_debug|cassandra_default\.cassandra_default_gc|cassandra_default\.cassandra_default_system|cassandra_syslog_system\.cassandra_syslog_debug|cassandra_syslog_system\.cassandra_syslog_gc|cassandra_syslog_system\.cassandra_syslog_system|default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(cassandra_custom\.cassandra_custom_debug|cassandra_custom\.cassandra_custom_gc|cassandra_custom\.cassandra_custom_system|cassandra_default\.cassandra_default_debug|cassandra_default\.cassandra_default_gc|cassandra_default\.cassandra_default_system|cassandra_syslog_system\.cassandra_syslog_debug|cassandra_syslog_system\.cassandra_syslog_gc|cassandra_syslog_system\.cassandra_syslog_system|default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -132,17 +132,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.log_source_id3|pipeline4\.log_source_id4|pipeline5\.log_source_id5)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(ops-agent-fluent-bit|pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.log_source_id3|pipeline4\.log_source_id4|pipeline5\.log_source_id5)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_fluent_bit_main.conf
@@ -607,17 +607,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog|mysql_custom\.mysql_custom_error|mysql_custom\.mysql_custom_general|mysql_custom\.mysql_custom_slow|mysql_default\.mysql_default_error|mysql_default\.mysql_default_general|mysql_default\.mysql_default_slow|mysql_syslog_error\.mysql_syslog_error|mysql_syslog_error\.mysql_syslog_general|mysql_syslog_error\.mysql_syslog_slow)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|mysql_custom\.mysql_custom_error|mysql_custom\.mysql_custom_general|mysql_custom\.mysql_custom_slow|mysql_default\.mysql_default_error|mysql_default\.mysql_default_general|mysql_default\.mysql_default_slow|mysql_syslog_error\.mysql_syslog_error|mysql_syslog_error\.mysql_syslog_general|mysql_syslog_error\.mysql_syslog_slow|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_fluent_bit_main.conf
@@ -412,17 +412,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog|nginx_custom\.nginx_custom_access|nginx_custom\.nginx_custom_error|nginx_default\.nginx_default_access|nginx_default\.nginx_default_error|nginx_syslog_access\.nginx_syslog_access|nginx_syslog_error\.nginx_syslog_error)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|nginx_custom\.nginx_custom_access|nginx_custom\.nginx_custom_error|nginx_default\.nginx_default_access|nginx_default\.nginx_default_error|nginx_syslog_access\.nginx_syslog_access|nginx_syslog_error\.nginx_syslog_error|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_fluent_bit_main.conf
@@ -263,17 +263,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog|redis_custom\.redis_custom|redis_default\.redis_default|redis_syslog\.redis_syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit|redis_custom\.redis_custom|redis_default\.redis_default|redis_syslog\.redis_syslog)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -71,17 +71,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(pipeline1\.test_syslog_source_id_tcp|pipeline2\.test_syslog_source_id_udp)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(ops-agent-fluent-bit|pipeline1\.test_syslog_source_id_tcp|pipeline2\.test_syslog_source_id_udp)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_fluent_bit_main.conf
@@ -58,17 +58,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog|systemd_pipeline\.systemd_logs)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit|systemd_pipeline\.systemd_logs)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_fluent_bit_main.conf
@@ -62,17 +62,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog|tcp_pipeline\.tcp_logs)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit|tcp_pipeline\.tcp_logs)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_fluent_bit_main.conf
@@ -62,17 +62,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog|tcp_pipeline\.tcp_logs)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit|tcp_pipeline\.tcp_logs)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_fluent_bit_main.conf
@@ -48,17 +48,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -48,17 +48,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
@@ -48,17 +48,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
@@ -48,17 +48,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
@@ -48,17 +48,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_fluent_bit_main.conf
@@ -48,17 +48,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_fluent_bit_main.conf
@@ -48,17 +48,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_fluent_bit_main.conf
@@ -48,17 +48,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_fluent_bit_main.conf
@@ -48,17 +48,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
@@ -48,17 +48,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_fluent_bit_main.conf
@@ -48,17 +48,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
@@ -48,17 +48,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_fluent_bit_main.conf
@@ -48,17 +48,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_fluent_bit_main.conf
@@ -48,17 +48,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
@@ -48,17 +48,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_fluent_bit_main.conf
@@ -48,17 +48,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_fluent_bit_main.conf
@@ -48,17 +48,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.syslog|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
@@ -71,17 +71,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.windows_event_log|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_fluent_bit_main.conf
@@ -71,17 +71,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.windows_event_log|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_fluent_bit_main.conf
@@ -71,17 +71,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.windows_event_log|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -115,17 +115,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log|pipeline1\.log_source_id1|pipeline2\.log_source_id2)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.windows_event_log|ops-agent-fluent-bit|pipeline1\.log_source_id1|pipeline2\.log_source_id2)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -71,17 +71,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.windows_event_log|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_fluent_bit_main.conf
@@ -71,17 +71,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.windows_event_log|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_fluent_bit_main.conf
@@ -71,17 +71,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.windows_event_log|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
@@ -71,17 +71,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.windows_event_log|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
@@ -71,17 +71,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.windows_event_log|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
@@ -71,17 +71,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.windows_event_log|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
@@ -71,17 +71,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.windows_event_log|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_fluent_bit_main.conf
@@ -71,17 +71,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.windows_event_log|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_fluent_bit_main.conf
@@ -71,17 +71,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.windows_event_log|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
@@ -71,17 +71,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.windows_event_log|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_fluent_bit_main.conf
@@ -71,17 +71,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.windows_event_log|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
@@ -71,17 +71,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.windows_event_log|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_fluent_bit_main.conf
@@ -71,17 +71,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.windows_event_log|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
@@ -71,17 +71,7 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
-
-[OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
+    Match_Regex       ^(default_pipeline\.windows_event_log|ops-agent-fluent-bit)$
     Name              stackdriver
     Retry_Limit       3
     resource          gce_instance


### PR DESCRIPTION
Now aggregating the match regex on a single output driver instead
of two identical ones.

This will also reduce the number of workers allocated in fluentbit. Currently we have 8 works that Match_Regex ^(ops-agent-fluent-bit)$, and 8 workers that match the other regex we are interested in.