### PR TITLE
Add build image for Ubuntu 21.10 (Impish)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,18 @@ COPY . /work
 WORKDIR /work
 RUN ./pkg/deb/build.sh
 
+FROM ubuntu:impish AS impish-build
+
+RUN set -x; apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
+    autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
+    build-essential cmake bison flex file libsystemd-dev \
+    devscripts cdbs pkg-config golang-go openjdk-11-jdk
+
+COPY . /work
+WORKDIR /work
+RUN ./pkg/deb/build.sh
+
 FROM ubuntu:focal AS focal-build
 
 RUN set -x; apt-get update && \
@@ -225,6 +237,10 @@ FROM scratch AS hirsute
 COPY --from=hirsute-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-hirsute.tgz
 COPY --from=hirsute-build /google-cloud-ops-agent*.deb /
 
+FROM scratch AS impish
+COPY --from=impish-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-impish.tgz
+COPY --from=impish-build /google-cloud-ops-agent*.deb /
+
 FROM scratch AS focal
 COPY --from=focal-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-focal.tgz
 COPY --from=focal-build /google-cloud-ops-agent*.deb /
@@ -254,6 +270,7 @@ COPY --from=bullseye /* /
 COPY --from=buster /* /
 COPY --from=stretch /* /
 COPY --from=hirsute /* /
+COPY --from=impish /* /
 COPY --from=focal /* /
 COPY --from=bionic /* /
 COPY --from=centos7 /* /


### PR DESCRIPTION
This change adds the commands for a Ubuntu 21.10 (Impish) image. Used Ubuntu 21.04 (Hirsute) as template. The build and tests PASSED.