### PR TITLE
Update fluent-bit submodule to v1.8.11 and switch dns resolver to legacy.

### DIFF
--- a/confgenerator/fluentbit/service.go
+++ b/confgenerator/fluentbit/service.go
@@ -37,6 +37,8 @@ func (s Service) Component() Component {
 			"HTTP_Listen": "0.0.0.0",
 			"HTTP_PORT":   "2020",
 
+			// Use the legacy DNS resolver mechanism to work around b/206549605 temporarily.
+			"dns.resolver": "legacy",
 			// https://docs.fluentbit.io/manual/administration/buffering-and-storage#service-section-configuration
 			// storage.path is set by Fluent Bit systemd unit (e.g. /var/lib/google-cloud-ops-agent/fluent-bit/buffers).
 			"storage.sync": "normal",

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/all-built_in_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 warn
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128


### PR DESCRIPTION
When we upgrade to Fluent Bit `1.8.11`, we ran into an issue https://github.com/fluent/fluent-bit/issues/4300. Keeping the DNS resolver in legacy mode instead of the new async mode (introduced in `1.8.5`) to bypass it: http://b/203725238#comment40

Test results look reasonable: http://b/203725238#comment41.

Also
![image](https://user-images.githubusercontent.com/5287526/146310300-237f7add-4b1b-43f7-b69d-62a2ef7d1f81.png)
