### PR TITLE
Update SLES12 build image (openSUSE Leap 42.3) to new name.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -159,7 +159,7 @@ WORKDIR /work
 RUN ./pkg/rpm/build.sh
 
 # Use OpenSUSE Leap 42.3 to emulate SLES 12: https://en.opensuse.org/openSUSE:Build_Service_cross_distribution_howto#Detect_a_distribution_flavor_for_special_code
-FROM opensuse/leap:42.3 AS sles12-build
+FROM opensuse/archive:42.3 AS sles12-build
 
 RUN set -x; zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros && \
     # Remove expired root certificate.


### PR DESCRIPTION
http://b/210893428

`opensuse/leap:42.3` -->  `opensuse/archive:42.3`

From https://hub.docker.com/_/opensuse:
![image](https://user-images.githubusercontent.com/35477443/146272825-6cf4305d-0557-4345-9110-606dbd4e363a.png)

Before this change, building SLES12 errored out:
  - ```
    #97 149.2 Download (curl) error for 'http://download.opensuse.org/distribution/leap/42.3/repo/non-oss/suse/media.1/media':
    #97 149.2 Error code: Curl error 52
    #97 149.2 Error message: Empty reply from server
    ```
   -  ![image](https://user-images.githubusercontent.com/35477443/146273134-aa2be0f9-4e90-4ed6-90ee-18b5953cfd7b.png)


With this change, it builds correctly:
  - ![image](https://user-images.githubusercontent.com/35477443/146273021-a4aa175b-9f43-4181-8ce4-56b738f3d1dc.png)
  - confirmed that the full build succeeded: 
![image](https://user-images.githubusercontent.com/35477443/146274229-455aa9a3-cec7-4d13-98e0-1f64b470d0c1.png)


