### PR TITLE
Update Win64OpenSSL MSI path to match the upstream change.

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -59,15 +59,16 @@ RUN Write-Host ('Installing Visual C++ Redistributable Package'); `
 # Install OpenSSL
 # This must be done after installing Visual Studio
 #
-ADD https://slproweb.com/download/Win64OpenSSL-1_1_1L.msi /local/Win64OpenSSL-1_1_1L.msi
+# TODO: Put "Win64OpenSSL_Light-1_1_1m.msi" into an ARG.
+ADD https://slproweb.com/download/Win64OpenSSL_Light-1_1_1m.msi /local/Win64OpenSSL_Light-1_1_1m.msi
 
 # Verify SHA256 hash using expected value from https://github.com/slproweb/opensslhashes
 RUN $ExpectedHash = '1e62e6459835f61c418532a1544e295be5400498b3569aadfb6d0b5d7a1c1dbc';`
-    $ActualHash = $(Get-FileHash /local/Win64OpenSSL-1_1_1L.msi).Hash.ToLower();`
+    $ActualHash = $(Get-FileHash /local/Win64OpenSSL_Light-1_1_1m.msi).Hash.ToLower();`
     if ($ActualHash -ne $ExpectedHash) {`
       throw \"OpenSSL hash mismatch. Expected: $ExpectedHash, Actual: $ActualHash\"`
     };`
-    Start-Process msiexec.exe -Wait -ArgumentList '/i C:\local\Win64OpenSSL-1_1_1L.msi /quiet';
+    Start-Process msiexec.exe -Wait -ArgumentList '/i C:\local\Win64OpenSSL_Light-1_1_1m.msi /quiet';
 
 #
 # Install winflexbison


### PR DESCRIPTION
Fixes http://b/210907996.

* Old URL: https://slproweb.com/download/Win64OpenSSL-1_1_1L.msi
* New URL: https://slproweb.com/download/Win64OpenSSL_Light-1_1_1m.msi

Sample error

```
2021/12/15 19:09:07 GCEMetadataScripts: windows-startup-script-ps1: Step 16/52 : ADD https://slproweb.com/download/Win64OpenSSL-1_1_1L.msi /local/Win64OpenSSL-1_1_1L.msi
2021/12/15 19:09:10 GCEMetadataScripts: windows-startup-script-ps1: ADD failed: failed to GET https://slproweb.com/download/Win64OpenSSL-1_1_1L.msi with status 404 Not Found: <html>
2021/12/15 19:09:10 GCEMetadataScripts: windows-startup-script-ps1: <head><title>404 Not Found</title></head>
2021/12/15 19:09:10 GCEMetadataScripts: windows-startup-script-ps1: <body>
2021/12/15 19:09:10 GCEMetadataScripts: windows-startup-script-ps1: <center><h1>404 Not Found</h1></center>
2021/12/15 19:09:10 GCEMetadataScripts: windows-startup-script-ps1: <hr><center>nginx/1.18.0</center>
2021/12/15 19:09:10 GCEMetadataScripts: windows-startup-script-ps1: </body>
2021/12/15 19:09:10 GCEMetadataScripts: windows-startup-script-ps1: </html>
```