### PR TITLE
Set non-harmful connection timeout logs to debug level.

### DIFF
--- a/confgenerator/logging.go
+++ b/confgenerator/logging.go
@@ -56,6 +56,9 @@ func stackdriverOutputComponent(match, userAgent string) fluentbit.Component {
 			"tls.verify": "Off",
 
 			"workers": "8",
+
+			// Mute these errors before https://github.com/fluent/fluent-bit/issues/4473 is fixed.
+			"net.connect_timeout_log_error": "False",
 		},
 	}
 }

--- a/confgenerator/logging.go
+++ b/confgenerator/logging.go
@@ -57,7 +57,7 @@ func stackdriverOutputComponent(match, userAgent string) fluentbit.Component {
 
 			"workers": "8",
 
-			// Mute these errors before https://github.com/fluent/fluent-bit/issues/4473 is fixed.
+			// Mute these errors until https://github.com/fluent/fluent-bit/issues/4473 is fixed.
 			"net.connect_timeout_log_error": "False",
 		},
 	}

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
@@ -49,21 +49,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/all-built_in_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/golden_fluent_bit_main.conf
@@ -49,21 +49,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_fluent_bit_main.conf
@@ -49,21 +49,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_fluent_bit_main.conf
@@ -49,21 +49,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -30,11 +30,12 @@
     storage.type      filesystem
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
@@ -112,21 +112,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.test_syslog_source_id_tcp|pipeline4\.test_syslog_source_id_udp)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.test_syslog_source_id_tcp|pipeline4\.test_syslog_source_id_udp)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_main.conf
@@ -111,21 +111,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog|pipeline1\.sample_logs|pipeline2\.sample_logs)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog|pipeline1\.sample_logs|pipeline2\.sample_logs)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_fluent_bit_main.conf
@@ -124,21 +124,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.test_syslog_source_id_tcp|pipeline4\.test_syslog_source_id_udp)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.test_syslog_source_id_tcp|pipeline4\.test_syslog_source_id_udp)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_fluent_bit_main.conf
@@ -55,21 +55,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_fluent_bit_main.conf
@@ -557,21 +557,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(apache_custom\.apache_custom_access|apache_custom\.apache_custom_error|apache_default\.apache_default_access|apache_default\.apache_default_error|apache_syslog_access\.apache_syslog_access|apache_syslog_error\.apache_syslog_error|default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(apache_custom\.apache_custom_access|apache_custom\.apache_custom_error|apache_default\.apache_default_access|apache_default\.apache_default_error|apache_syslog_access\.apache_syslog_access|apache_syslog_error\.apache_syslog_error|default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_fluent_bit_main.conf
@@ -688,21 +688,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(cassandra_custom\.cassandra_custom_debug|cassandra_custom\.cassandra_custom_gc|cassandra_custom\.cassandra_custom_system|cassandra_default\.cassandra_default_debug|cassandra_default\.cassandra_default_gc|cassandra_default\.cassandra_default_system|cassandra_syslog_system\.cassandra_syslog_debug|cassandra_syslog_system\.cassandra_syslog_gc|cassandra_syslog_system\.cassandra_syslog_system|default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(cassandra_custom\.cassandra_custom_debug|cassandra_custom\.cassandra_custom_gc|cassandra_custom\.cassandra_custom_system|cassandra_default\.cassandra_default_debug|cassandra_default\.cassandra_default_gc|cassandra_default\.cassandra_default_system|cassandra_syslog_system\.cassandra_syslog_debug|cassandra_syslog_system\.cassandra_syslog_gc|cassandra_syslog_system\.cassandra_syslog_system|default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -133,21 +133,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.log_source_id3|pipeline4\.log_source_id4|pipeline5\.log_source_id5)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.log_source_id3|pipeline4\.log_source_id4|pipeline5\.log_source_id5)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_fluent_bit_main.conf
@@ -608,21 +608,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog|mysql_custom\.mysql_custom_error|mysql_custom\.mysql_custom_general|mysql_custom\.mysql_custom_slow|mysql_default\.mysql_default_error|mysql_default\.mysql_default_general|mysql_default\.mysql_default_slow|mysql_syslog_error\.mysql_syslog_error|mysql_syslog_error\.mysql_syslog_general|mysql_syslog_error\.mysql_syslog_slow)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog|mysql_custom\.mysql_custom_error|mysql_custom\.mysql_custom_general|mysql_custom\.mysql_custom_slow|mysql_default\.mysql_default_error|mysql_default\.mysql_default_general|mysql_default\.mysql_default_slow|mysql_syslog_error\.mysql_syslog_error|mysql_syslog_error\.mysql_syslog_general|mysql_syslog_error\.mysql_syslog_slow)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_fluent_bit_main.conf
@@ -413,21 +413,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog|nginx_custom\.nginx_custom_access|nginx_custom\.nginx_custom_error|nginx_default\.nginx_default_access|nginx_default\.nginx_default_error|nginx_syslog_access\.nginx_syslog_access|nginx_syslog_error\.nginx_syslog_error)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog|nginx_custom\.nginx_custom_access|nginx_custom\.nginx_custom_error|nginx_default\.nginx_default_access|nginx_default\.nginx_default_error|nginx_syslog_access\.nginx_syslog_access|nginx_syslog_error\.nginx_syslog_error)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_fluent_bit_main.conf
@@ -264,21 +264,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog|redis_custom\.redis_custom|redis_default\.redis_default|redis_syslog\.redis_syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog|redis_custom\.redis_custom|redis_default\.redis_default|redis_syslog\.redis_syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -72,21 +72,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(pipeline1\.test_syslog_source_id_tcp|pipeline2\.test_syslog_source_id_udp)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(pipeline1\.test_syslog_source_id_tcp|pipeline2\.test_syslog_source_id_udp)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_fluent_bit_main.conf
@@ -59,21 +59,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog|systemd_pipeline\.systemd_logs)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog|systemd_pipeline\.systemd_logs)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_fluent_bit_main.conf
@@ -63,21 +63,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog|tcp_pipeline\.tcp_logs)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog|tcp_pipeline\.tcp_logs)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_fluent_bit_main.conf
@@ -63,21 +63,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog|tcp_pipeline\.tcp_logs)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog|tcp_pipeline\.tcp_logs)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_fluent_bit_main.conf
@@ -49,21 +49,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -49,21 +49,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
@@ -49,21 +49,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
@@ -49,21 +49,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
@@ -49,21 +49,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_fluent_bit_main.conf
@@ -49,21 +49,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_fluent_bit_main.conf
@@ -49,21 +49,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_fluent_bit_main.conf
@@ -49,21 +49,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_fluent_bit_main.conf
@@ -49,21 +49,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
@@ -49,21 +49,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_fluent_bit_main.conf
@@ -49,21 +49,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
@@ -49,21 +49,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_fluent_bit_main.conf
@@ -49,21 +49,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_fluent_bit_main.conf
@@ -49,21 +49,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
@@ -49,21 +49,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_fluent_bit_main.conf
@@ -49,21 +49,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_fluent_bit_main.conf
@@ -49,21 +49,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
@@ -72,21 +72,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.windows_event_log)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_fluent_bit_main.conf
@@ -72,21 +72,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.windows_event_log)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_fluent_bit_main.conf
@@ -72,21 +72,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.windows_event_log)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -30,11 +30,12 @@
     storage.type      filesystem
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -116,21 +116,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log|pipeline1\.log_source_id1|pipeline2\.log_source_id2)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.windows_event_log|pipeline1\.log_source_id1|pipeline2\.log_source_id2)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -72,21 +72,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.windows_event_log)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_fluent_bit_main.conf
@@ -72,21 +72,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.windows_event_log)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_fluent_bit_main.conf
@@ -72,21 +72,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.windows_event_log)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
@@ -72,21 +72,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.windows_event_log)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
@@ -72,21 +72,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.windows_event_log)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
@@ -72,21 +72,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.windows_event_log)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
@@ -72,21 +72,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.windows_event_log)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_fluent_bit_main.conf
@@ -72,21 +72,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.windows_event_log)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_fluent_bit_main.conf
@@ -72,21 +72,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.windows_event_log)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
@@ -72,21 +72,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.windows_event_log)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_fluent_bit_main.conf
@@ -72,21 +72,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.windows_event_log)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
@@ -72,21 +72,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.windows_event_log)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_fluent_bit_main.conf
@@ -72,21 +72,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.windows_event_log)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
@@ -72,21 +72,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.windows_event_log)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8


### PR DESCRIPTION
Workaround for http://b/211011754

Updates Fluent Bit submodule to branch [`1.8.11-upstream-connection-timeout-log`](https://github.com/fluent/fluent-bit/tree/1.8.11-upstream-connection-timeout-log) @ commit `324c827`, which is just Fluent Bit v1.8.11 (the version we were already at) plus a [new `net.connect_timeout_log_error` config option](https://github.com/fluent/fluent-bit/commit/324c8277075b0b86d3a723f8df8d49de14742dd7), which we will set to `false` (meaning `debug` level) in our configs to silence these logs until https://github.com/fluent/fluent-bit/issues/4473 is fixed. This new config option is the only diff in the submodule change.

Integration tests: http://b/211011754#comment2