### PR TITLE
confgenerator: update goldens from master

### DIFF
--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_refresh_interval/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128
@@ -558,21 +559,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(apache_custom\.apache_custom_access|apache_custom\.apache_custom_error|apache_default\.apache_default_access|apache_default\.apache_default_error|apache_syslog_access\.apache_syslog_access|apache_syslog_error\.apache_syslog_error|default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(apache_custom\.apache_custom_access|apache_custom\.apache_custom_error|apache_default\.apache_default_access|apache_default\.apache_default_error|apache_syslog_access\.apache_syslog_access|apache_syslog_error\.apache_syslog_error|default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_refresh_interval/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_refresh_interval/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128
@@ -690,21 +691,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(cassandra_custom\.cassandra_custom_debug|cassandra_custom\.cassandra_custom_gc|cassandra_custom\.cassandra_custom_system|cassandra_default\.cassandra_default_debug|cassandra_default\.cassandra_default_gc|cassandra_default\.cassandra_default_system|cassandra_syslog_system\.cassandra_syslog_debug|cassandra_syslog_system\.cassandra_syslog_gc|cassandra_syslog_system\.cassandra_syslog_system|default_pipeline\.syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(cassandra_custom\.cassandra_custom_debug|cassandra_custom\.cassandra_custom_gc|cassandra_custom\.cassandra_custom_system|cassandra_default\.cassandra_default_debug|cassandra_default\.cassandra_default_gc|cassandra_default\.cassandra_default_system|cassandra_syslog_system\.cassandra_syslog_debug|cassandra_syslog_system\.cassandra_syslog_gc|cassandra_syslog_system\.cassandra_syslog_system|default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_refresh_interval/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128
@@ -68,21 +69,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog|pipeline1\.log_source_id1)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog|pipeline1\.log_source_id1)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_refresh_interval/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128
@@ -610,21 +611,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog|mysql_custom\.mysql_custom_error|mysql_custom\.mysql_custom_general|mysql_custom\.mysql_custom_slow|mysql_default\.mysql_default_error|mysql_default\.mysql_default_general|mysql_default\.mysql_default_slow|mysql_syslog_error\.mysql_syslog_error|mysql_syslog_error\.mysql_syslog_general|mysql_syslog_error\.mysql_syslog_slow)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog|mysql_custom\.mysql_custom_error|mysql_custom\.mysql_custom_general|mysql_custom\.mysql_custom_slow|mysql_default\.mysql_default_error|mysql_default\.mysql_default_general|mysql_default\.mysql_default_slow|mysql_syslog_error\.mysql_syslog_error|mysql_syslog_error\.mysql_syslog_general|mysql_syslog_error\.mysql_syslog_slow)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_refresh_interval/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_refresh_interval/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128
@@ -414,21 +415,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog|nginx_custom\.nginx_custom_access|nginx_custom\.nginx_custom_error|nginx_default\.nginx_default_access|nginx_default\.nginx_default_error|nginx_syslog_access\.nginx_syslog_access|nginx_syslog_error\.nginx_syslog_error)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog|nginx_custom\.nginx_custom_access|nginx_custom\.nginx_custom_error|nginx_default\.nginx_default_access|nginx_default\.nginx_default_error|nginx_syslog_access\.nginx_syslog_access|nginx_syslog_error\.nginx_syslog_error)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_refresh_interval/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_refresh_interval/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128
@@ -264,21 +265,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.syslog|redis_custom\.redis_custom|redis_default\.redis_default|redis_syslog\.redis_syslog)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.syslog|redis_custom\.redis_custom|redis_default\.redis_default|redis_syslog\.redis_syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_refresh_interval/golden_otel.conf
@@ -159,7 +159,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -168,7 +168,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
@@ -8,6 +8,7 @@
     HTTP_PORT                 2020
     HTTP_Server               On
     Log_Level                 info
+    dns.resolver              legacy
     storage.backlog.mem_limit 50M
     storage.checksum          on
     storage.max_chunks_up     128
@@ -91,21 +92,23 @@
     Name  modify
 
 [OUTPUT]
-    Match_Regex       ^(default_pipeline\.windows_event_log|pipeline1\.log_source_id1)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(default_pipeline\.windows_event_log|pipeline1\.log_source_id1)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
 
 [OUTPUT]
-    Match_Regex       ^(ops-agent-fluent-bit)$
-    Name              stackdriver
-    Retry_Limit       3
-    resource          gce_instance
-    stackdriver_agent Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls               On
-    tls.verify        Off
-    workers           8
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
@@ -169,7 +169,7 @@ processors:
       operations:
       - action: toggle_scalar_data_type
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state
@@ -178,7 +178,7 @@ processors:
       new_name: disk/percent_used
       operations:
       - action: aggregate_labels
-        aggregation_type: sum
+        aggregation_type: max
         label_set:
         - device
         - state


### PR DESCRIPTION
Some new functionality was introduced since the goldens for my PR were
generated. This PR updates the goldens to combine the new functionality
from master with the refresh interval functionality.

Follow up to #283 and #276 which both failed after merging to master, since they had to sit unmerged for long enough that new functionality emerged.