### PR TITLE
Update docker file to use go 1.17 & Update operations-collector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,11 @@ RUN set -x; apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
     autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
     build-essential cmake bison flex file libsystemd-dev \
-    devscripts cdbs pkg-config golang-go openjdk-11-jdk
+    devscripts cdbs pkg-config openjdk-11-jdk
+
+ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
+RUN set -xe; \
+    tar -xf /tmp/go1.17.linux-amd64.tar.gz -C /usr/local
 
 COPY . /work
 WORKDIR /work
@@ -93,7 +97,11 @@ RUN set -x; apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
     autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
     build-essential cmake bison flex file libsystemd-dev \
-    devscripts cdbs pkg-config golang-go openjdk-11-jdk
+    devscripts cdbs pkg-config openjdk-11-jdk
+
+ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
+RUN set -xe; \
+    tar -xf /tmp/go1.17.linux-amd64.tar.gz -C /usr/local
 
 COPY . /work
 WORKDIR /work

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN set -x; apt-get update && \
     build-essential cmake bison flex file libsystemd-dev \
     devscripts cdbs pkg-config openjdk-11-jdk
 
-ADD https://golang.org/dl/go1.16.3.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
 RUN set -xe; \
     tar -xf /tmp/go1.16.3.linux-amd64.tar.gz -C /usr/local
 
@@ -43,7 +43,7 @@ RUN set -x; apt-get update && \
     build-essential cmake bison flex file libsystemd-dev \
     devscripts cdbs pkg-config openjdk-11-jdk
 
-ADD https://golang.org/dl/go1.16.3.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
 RUN set -xe; \
     tar -xf /tmp/go1.16.3.linux-amd64.tar.gz -C /usr/local
 
@@ -67,9 +67,9 @@ RUN set -xe; \
 
 ENV JAVA_HOME /usr/local/java-11-openjdk/
 
-ADD https://golang.org/dl/go1.16.3.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
 RUN set -xe; \
-    tar -xf /tmp/go1.16.3.linux-amd64.tar.gz -C /usr/local
+    tar -xf /tmp/go1.17.linux-amd64.tar.gz -C /usr/local
 
 COPY . /work
 WORKDIR /work
@@ -107,7 +107,7 @@ RUN set -x; apt-get update && \
     build-essential cmake bison flex file libsystemd-dev \
     devscripts cdbs pkg-config openjdk-11-jdk
 
-ADD https://golang.org/dl/go1.16.3.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
 RUN set -xe; \
     tar -xf /tmp/go1.16.3.linux-amd64.tar.gz -C /usr/local
 
@@ -123,7 +123,7 @@ RUN set -x; apt-get update && \
     build-essential cmake bison flex file libsystemd-dev \
     devscripts cdbs pkg-config openjdk-11-jdk
 
-ADD https://golang.org/dl/go1.16.3.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
 RUN set -xe; \
     tar -xf /tmp/go1.16.3.linux-amd64.tar.gz -C /usr/local
 
@@ -144,7 +144,7 @@ RUN set -x; yum -y update && \
 
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk/
 
-ADD https://golang.org/dl/go1.16.3.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
 RUN set -xe; \
     tar -xf /tmp/go1.16.3.linux-amd64.tar.gz -C /usr/local
 
@@ -162,7 +162,7 @@ RUN set -x; yum -y update && \
     gcc gcc-c++ make cmake bison flex file systemd-devel zlib-devel gtest-devel rpm-build systemd-rpm-macros java-11-openjdk-devel \
     expect rpm-sign
 
-ADD https://golang.org/dl/go1.16.3.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
 RUN set -xe; \
     tar -xf /tmp/go1.16.3.linux-amd64.tar.gz -C /usr/local
 
@@ -194,7 +194,7 @@ RUN set -xe; \
 
 ENV JAVA_HOME /usr/local/java-11-openjdk/
 
-ADD https://golang.org/dl/go1.16.3.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
 RUN set -xe; \
     tar -xf /tmp/go1.16.3.linux-amd64.tar.gz -C /usr/local
 
@@ -213,7 +213,7 @@ RUN set -x; zypper -n install git systemd autoconf automake flex libtool libcurl
     # Allow fluent-bit to find systemd
     ln -fs /usr/lib/systemd /lib/systemd
 
-ADD https://golang.org/dl/go1.16.3.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
 RUN set -xe; \
     tar -xf /tmp/go1.16.3.linux-amd64.tar.gz -C /usr/local
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,9 @@ RUN set -x; apt-get update && \
     build-essential cmake bison flex file libsystemd-dev \
     devscripts cdbs pkg-config openjdk-11-jdk
 
-ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
 RUN set -xe; \
-    tar -xf /tmp/go1.16.3.linux-amd64.tar.gz -C /usr/local
+    tar -xf /tmp/go1.17.linux-amd64.tar.gz -C /usr/local
 
 COPY . /work
 WORKDIR /work
@@ -43,9 +43,9 @@ RUN set -x; apt-get update && \
     build-essential cmake bison flex file libsystemd-dev \
     devscripts cdbs pkg-config openjdk-11-jdk
 
-ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
 RUN set -xe; \
-    tar -xf /tmp/go1.16.3.linux-amd64.tar.gz -C /usr/local
+    tar -xf /tmp/go1.17.linux-amd64.tar.gz -C /usr/local
 
 COPY . /work
 WORKDIR /work
@@ -107,9 +107,9 @@ RUN set -x; apt-get update && \
     build-essential cmake bison flex file libsystemd-dev \
     devscripts cdbs pkg-config openjdk-11-jdk
 
-ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
 RUN set -xe; \
-    tar -xf /tmp/go1.16.3.linux-amd64.tar.gz -C /usr/local
+    tar -xf /tmp/go1.17.linux-amd64.tar.gz -C /usr/local
 
 COPY . /work
 WORKDIR /work
@@ -123,9 +123,9 @@ RUN set -x; apt-get update && \
     build-essential cmake bison flex file libsystemd-dev \
     devscripts cdbs pkg-config openjdk-11-jdk
 
-ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
 RUN set -xe; \
-    tar -xf /tmp/go1.16.3.linux-amd64.tar.gz -C /usr/local
+    tar -xf /tmp/go1.17.linux-amd64.tar.gz -C /usr/local
 
 COPY . /work
 WORKDIR /work
@@ -144,9 +144,9 @@ RUN set -x; yum -y update && \
 
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk/
 
-ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
 RUN set -xe; \
-    tar -xf /tmp/go1.16.3.linux-amd64.tar.gz -C /usr/local
+    tar -xf /tmp/go1.17.linux-amd64.tar.gz -C /usr/local
 
 COPY . /work
 WORKDIR /work
@@ -162,9 +162,9 @@ RUN set -x; yum -y update && \
     gcc gcc-c++ make cmake bison flex file systemd-devel zlib-devel gtest-devel rpm-build systemd-rpm-macros java-11-openjdk-devel \
     expect rpm-sign
 
-ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
 RUN set -xe; \
-    tar -xf /tmp/go1.16.3.linux-amd64.tar.gz -C /usr/local
+    tar -xf /tmp/go1.17.linux-amd64.tar.gz -C /usr/local
 
 COPY . /work
 WORKDIR /work
@@ -194,9 +194,9 @@ RUN set -xe; \
 
 ENV JAVA_HOME /usr/local/java-11-openjdk/
 
-ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
 RUN set -xe; \
-    tar -xf /tmp/go1.16.3.linux-amd64.tar.gz -C /usr/local
+    tar -xf /tmp/go1.17.linux-amd64.tar.gz -C /usr/local
 
 COPY . /work
 WORKDIR /work
@@ -213,9 +213,9 @@ RUN set -x; zypper -n install git systemd autoconf automake flex libtool libcurl
     # Allow fluent-bit to find systemd
     ln -fs /usr/lib/systemd /lib/systemd
 
-ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.16.3.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
 RUN set -xe; \
-    tar -xf /tmp/go1.16.3.linux-amd64.tar.gz -C /usr/local
+    tar -xf /tmp/go1.17.linux-amd64.tar.gz -C /usr/local
 
 COPY . /work
 WORKDIR /work

--- a/apps/apache.go
+++ b/apps/apache.go
@@ -42,7 +42,7 @@ func (r MetricsReceiverApache) Pipelines() []otel.Pipeline {
 	}
 	return []otel.Pipeline{{
 		Receiver: otel.Component{
-			Type: "httpd",
+			Type: "apache",
 			Config: map[string]interface{}{
 				"collection_interval": r.CollectionIntervalString(),
 				"endpoint":            r.ServerStatusURL,
@@ -52,11 +52,10 @@ func (r MetricsReceiverApache) Pipelines() []otel.Pipeline {
 			otel.MetricsFilter(
 				"exclude",
 				"strict",
-				"httpd.uptime",
+				"apache.uptime",
 			),
 			otel.NormalizeSums(),
 			otel.MetricsTransform(
-				otel.ChangePrefix("httpd", "apache"),
 				otel.AddPrefix("workload.googleapis.com"),
 			),
 		},

--- a/cmd/ops_agent_windows/main_windows.go
+++ b/cmd/ops_agent_windows/main_windows.go
@@ -107,7 +107,6 @@ func initServices() error {
 			fmt.Sprintf("%s - Metrics Agent", serviceDisplayName),
 			filepath.Join(base, "google-cloud-metrics-agent_windows_amd64.exe"),
 			[]string{
-				"--add-instance-id=false",
 				"--config=" + filepath.Join(configOutDir, `otel\otel.yaml`),
 			},
 		},

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
@@ -21,7 +21,7 @@ processors:
       exclude:
         match_type: strict
         metric_names:
-        - httpd.uptime
+        - apache.uptime
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -86,10 +86,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/apache__pipeline_apache__metrics_2:
     transforms:
-    - action: update
-      include: ^httpd(.*)$$
-      match_type: regexp
-      new_name: apache$${1}
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -365,6 +361,9 @@ processors:
     detectors:
     - gce
 receivers:
+  apache/apache__pipeline_apache__metrics:
+    collection_interval: 30s
+    endpoint: http://localhost/server-status?auto
   hostmetrics/default__pipeline_hostmetrics:
     collection_interval: 60s
     scrapers:
@@ -377,9 +376,6 @@ receivers:
       paging: {}
       process: {}
       processes: {}
-  httpd/apache__pipeline_apache__metrics:
-    collection_interval: 30s
-    endpoint: http://localhost/server-status?auto
   prometheus/agent:
     config:
       scrape_configs:
@@ -408,7 +404,7 @@ service:
       - metricstransform/apache__pipeline_apache__metrics_2
       - resourcedetection/_global_0
       receivers:
-      - httpd/apache__pipeline_apache__metrics
+      - apache/apache__pipeline_apache__metrics
     metrics/default__pipeline_hostmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_otel.conf
@@ -21,7 +21,7 @@ processors:
       exclude:
         match_type: strict
         metric_names:
-        - httpd.uptime
+        - apache.uptime
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -86,10 +86,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/apache__pipeline_apache__metrics_2:
     transforms:
-    - action: update
-      include: ^httpd(.*)$$
-      match_type: regexp
-      new_name: apache$${1}
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -365,6 +361,9 @@ processors:
     detectors:
     - gce
 receivers:
+  apache/apache__pipeline_apache__metrics:
+    collection_interval: 30s
+    endpoint: http://localhost:8080/server-status?auto
   hostmetrics/default__pipeline_hostmetrics:
     collection_interval: 60s
     scrapers:
@@ -377,9 +376,6 @@ receivers:
       paging: {}
       process: {}
       processes: {}
-  httpd/apache__pipeline_apache__metrics:
-    collection_interval: 30s
-    endpoint: http://localhost:8080/server-status?auto
   prometheus/agent:
     config:
       scrape_configs:
@@ -408,7 +404,7 @@ service:
       - metricstransform/apache__pipeline_apache__metrics_2
       - resourcedetection/_global_0
       receivers:
-      - httpd/apache__pipeline_apache__metrics
+      - apache/apache__pipeline_apache__metrics
     metrics/default__pipeline_hostmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
@@ -21,7 +21,7 @@ processors:
       exclude:
         match_type: strict
         metric_names:
-        - httpd.uptime
+        - apache.uptime
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -96,10 +96,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/apache__pipeline_apache__metrics_2:
     transforms:
-    - action: update
-      include: ^httpd(.*)$$
-      match_type: regexp
-      new_name: apache$${1}
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -412,6 +408,9 @@ processors:
     detectors:
     - gce
 receivers:
+  apache/apache__pipeline_apache__metrics:
+    collection_interval: 30s
+    endpoint: http://localhost/server-status?auto
   hostmetrics/default__pipeline_hostmetrics:
     collection_interval: 60s
     scrapers:
@@ -424,9 +423,6 @@ receivers:
       paging: {}
       process: {}
       processes: {}
-  httpd/apache__pipeline_apache__metrics:
-    collection_interval: 30s
-    endpoint: http://localhost/server-status?auto
   prometheus/agent:
     config:
       scrape_configs:
@@ -487,7 +483,7 @@ service:
       - metricstransform/apache__pipeline_apache__metrics_2
       - resourcedetection/_global_0
       receivers:
-      - httpd/apache__pipeline_apache__metrics
+      - apache/apache__pipeline_apache__metrics
     metrics/default__pipeline_hostmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
@@ -21,7 +21,7 @@ processors:
       exclude:
         match_type: strict
         metric_names:
-        - httpd.uptime
+        - apache.uptime
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -96,10 +96,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/apache__pipeline_apache__metrics_2:
     transforms:
-    - action: update
-      include: ^httpd(.*)$$
-      match_type: regexp
-      new_name: apache$${1}
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -412,6 +408,9 @@ processors:
     detectors:
     - gce
 receivers:
+  apache/apache__pipeline_apache__metrics:
+    collection_interval: 30s
+    endpoint: http://localhost:8080/server-status?auto
   hostmetrics/default__pipeline_hostmetrics:
     collection_interval: 60s
     scrapers:
@@ -424,9 +423,6 @@ receivers:
       paging: {}
       process: {}
       processes: {}
-  httpd/apache__pipeline_apache__metrics:
-    collection_interval: 30s
-    endpoint: http://localhost:8080/server-status?auto
   prometheus/agent:
     config:
       scrape_configs:
@@ -487,7 +483,7 @@ service:
       - metricstransform/apache__pipeline_apache__metrics_2
       - resourcedetection/_global_0
       receivers:
-      - httpd/apache__pipeline_apache__metrics
+      - apache/apache__pipeline_apache__metrics
     metrics/default__pipeline_hostmetrics:
       exporters:
       - googlecloud

--- a/dev-docs/dev.md
+++ b/dev-docs/dev.md
@@ -645,7 +645,7 @@ See [Create a GCE Windows test VM](create-gce-windows-test-vm.md).
 -   Run Open Telemetry Metrics Agent individually:
 
     ```
-    C:\Users\{{USERNAME}}\tmp\out\bin\google-cloud-metrics-agent_windows_amd64.exe --add-instance-id=false "--config=C:\ProgramData\Google\Cloud Operations\Ops Agent\generated_configs\otel\otel.yaml"
+    C:\Users\{{USERNAME}}\tmp\out\bin\google-cloud-metrics-agent_windows_amd64.exe "--config=C:\ProgramData\Google\Cloud Operations\Ops Agent\generated_configs\otel\otel.yaml"
     ```
 
 #### Uninstall the agent
@@ -1059,7 +1059,7 @@ show it.
 ### Run Open Telemetry Metrics Agent individually on Windows
 
 ```
-'C:\Program Files\Google\Cloud Operations\Ops Agent\bin\google-cloud-metrics-agent_windows_amd64.exe' --add-instance-id=false "--config=C:\ProgramData\Google\Cloud Operations\Ops Agent\generated_configs\otel\otel.yaml"
+'C:\Program Files\Google\Cloud Operations\Ops Agent\bin\google-cloud-metrics-agent_windows_amd64.exe' "--config=C:\ProgramData\Google\Cloud Operations\Ops Agent\generated_configs\otel\otel.yaml"
 ```
 
 ### Known issues

--- a/systemd/google-cloud-ops-agent-opentelemetry-collector.service
+++ b/systemd/google-cloud-ops-agent-opentelemetry-collector.service
@@ -24,7 +24,7 @@ StateDirectory=google-cloud-ops-agent/opentelemetry-collector
 LogsDirectory=google-cloud-ops-agent/subagents
 Type=simple
 ExecStartPre=@PREFIX@/libexec/google_cloud_ops_agent_engine -service=otel -in @SYSCONFDIR@/google-cloud-ops-agent/config.yaml -logs ${LOGS_DIRECTORY}
-ExecStart=@PREFIX@/subagents/opentelemetry-collector/otelopscol --add-instance-id=false --config=${RUNTIME_DIRECTORY}/otel.yaml
+ExecStart=@PREFIX@/subagents/opentelemetry-collector/otelopscol --config=${RUNTIME_DIRECTORY}/otel.yaml
 Restart=always
 # For debugging:
 RuntimeDirectoryPreserve=yes


### PR DESCRIPTION
Update docker file to use 1.17 to fix kokoro issues on https://github.com/GoogleCloudPlatform/ops-agent/pull/218 and https://github.com/GoogleCloudPlatform/ops-agent/pull/278 having to do with `github.com/clarketm/json` where it is using newer go 1.17 features.