### PR TITLE
Add agent.googleapis.com/processes/count_by_state

### DIFF
--- a/apps/hostmetrics.go
+++ b/apps/hostmetrics.go
@@ -68,7 +68,6 @@ func (r MetricsReceiverHostmetrics) Pipelines() []otel.Pipeline {
 				"system.filesystem.inodes.usage",
 				"system.paging.faults",
 				"system.disk.operation_time",
-				"system.processes.count",
 			),
 			otel.MetricsTransform(
 				otel.RenameMetric(
@@ -221,6 +220,13 @@ func (r MetricsReceiverHostmetrics) Pipelines() []otel.Pipeline {
 				otel.RenameMetric(
 					"system.processes.created",
 					"processes/fork_count",
+				),
+				otel.RenameMetric(
+					"system.processes.count",
+					"processes/count_by_state",
+					// change data type from int64 -> double
+					otel.ToggleScalarDataType,
+					otel.RenameLabel("status", "state"),
 				),
 				otel.RenameMetric(
 					"system.paging.usage",

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   metricstransform/agent_1:
     transforms:
     - action: update
@@ -253,6 +252,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_refresh_interval/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_refresh_interval/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_refresh_interval/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_refresh_interval/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_refresh_interval/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -259,6 +258,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -260,6 +259,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -260,6 +259,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -259,6 +258,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
@@ -32,7 +32,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -270,6 +269,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_otel.conf
@@ -32,7 +32,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -270,6 +269,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -264,6 +263,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -264,6 +263,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -264,6 +263,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -258,6 +257,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -265,6 +264,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -265,6 +264,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   metricstransform/agent_1:
     transforms:
     - action: update
@@ -253,6 +252,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -268,6 +267,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -268,6 +267,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -268,6 +267,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -268,6 +267,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -268,6 +267,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -271,6 +270,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -271,6 +270,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -271,6 +270,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   metricstransform/agent_1:
     transforms:
     - action: update
@@ -290,6 +289,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -274,6 +273,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -274,6 +273,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -271,6 +270,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
@@ -32,7 +32,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -280,6 +279,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
@@ -32,7 +32,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -280,6 +279,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -268,6 +267,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -268,6 +267,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -268,6 +267,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -268,6 +267,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -268,6 +267,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -268,6 +267,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
@@ -26,7 +26,6 @@ processors:
         - system.filesystem.inodes.usage
         - system.paging.faults
         - system.disk.operation_time
-        - system.processes.count
   filter/default__pipeline_hostmetrics_3:
     metrics:
       exclude:
@@ -268,6 +267,14 @@ processors:
     - action: update
       include: system.processes.created
       new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
     - action: update
       include: system.paging.usage
       new_name: swap/bytes_used


### PR DESCRIPTION
`agent.googleapis.com/processes/count_by_state` was not supported until an upstream fix.
Here are the two upstream PRs which have been released and the version has been picked up by submodules.
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/4856
https://github.com/shirou/gopsutil/pull/1123

Test:
b/191804990#comment22