### PR TITLE
Update otel JMX component

### DIFF
--- a/BUILD_CONFIG
+++ b/BUILD_CONFIG
@@ -1,1 +1,1 @@
-JMX_METRICS_JAR_VERSION="1.6.0" #This is used in build wiring but does not actually specify the version of the submodule
+JMX_METRICS_JAR_VERSION="1.9.0" #This is used in build wiring but does not actually specify the version of the submodule


### PR DESCRIPTION
Based off of research completed by @cpheps https://github.com/GoogleCloudPlatform/ops-agent/issues/288#issuecomment-1011730111 we believe an updated jmx-metrics-jar should resolve issues with JMX metrics appearing as doubles when they should be integers.