### PR TITLE
confgenerator: make collection_interval optional

### DIFF
--- a/confgenerator/config.go
+++ b/confgenerator/config.go
@@ -143,6 +143,11 @@ func newValidator() *validator.Validate {
 	})
 	// duration validates that the value is a valid duration and >= the parameter
 	v.RegisterValidation("duration", func(fl validator.FieldLevel) bool {
+		fieldStr := fl.Field().String()
+		if fieldStr == "" {
+			// Ignore the case where this field is not actually specified or is left empty.
+			return true
+		}
 		t, err := time.ParseDuration(fl.Field().String())
 		if err != nil {
 			return false
@@ -372,7 +377,7 @@ type MetricsReceiver interface {
 }
 
 type MetricsReceiverShared struct {
-	CollectionInterval string `yaml:"collection_interval" validate:"required,duration=10s"` // time.Duration format
+	CollectionInterval string `yaml:"collection_interval" validate:"duration=10s"` // time.Duration format
 }
 
 func (m MetricsReceiverShared) CollectionIntervalString() string {

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_fluent_bit_main.conf
@@ -1,0 +1,71 @@
+@SET buffers_dir=/var/lib/google-cloud-ops-agent/fluent-bit/buffers
+@SET logs_dir=/var/log/google-cloud-ops-agent/subagents
+
+[SERVICE]
+    Daemon                    off
+    Flush                     1
+    HTTP_Listen               0.0.0.0
+    HTTP_PORT                 2020
+    HTTP_Server               On
+    Log_Level                 info
+    dns.resolver              legacy
+    storage.backlog.mem_limit 50M
+    storage.checksum          on
+    storage.max_chunks_up     128
+    storage.metrics           on
+    storage.sync              normal
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   5M
+    DB                ${buffers_dir}/default_pipeline_syslog
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              /var/log/messages,/var/log/syslog
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               default_pipeline.syslog
+    storage.type      filesystem
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   5M
+    DB                ${buffers_dir}/ops-agent-fluent-bit
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/logging-module.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-fluent-bit
+    storage.type      filesystem
+
+[FILTER]
+    Add   logging.googleapis.com/logName syslog
+    Match default_pipeline.syslog
+    Name  modify
+
+[OUTPUT]
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_otel.conf
@@ -1,0 +1,393 @@
+exporters:
+  googlecloud:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+processors:
+  agentmetrics/default__pipeline_hostmetrics_0:
+    blank_label_metrics:
+    - system.cpu.utilization
+  filter/agent_0:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+        - otelcol_process_uptime
+        - otelcol_process_memory_rss
+        - otelcol_grpc_io_client_completed_rpcs
+        - otelcol_googlecloudmonitoring_point_count
+  filter/default__pipeline_hostmetrics_1:
+    metrics:
+      exclude:
+        match_type: strict
+        metric_names:
+        - system.cpu.time
+        - system.network.dropped
+        - system.filesystem.inodes.usage
+        - system.paging.faults
+        - system.disk.operation_time
+  metricstransform/agent_1:
+    transforms:
+    - action: update
+      include: otelcol_process_uptime
+      new_name: agent/uptime
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: version
+        new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
+    - action: update
+      include: otelcol_process_memory_rss
+      new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
+    - action: update
+      include: otelcol_grpc_io_client_completed_rpcs
+      new_name: agent/api_request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: grpc_client_status
+        new_label: state
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - state
+    - action: update
+      include: otelcol_googlecloudmonitoring_point_count
+      new_name: agent/monitoring/point_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/default__pipeline_hostmetrics_2:
+    transforms:
+    - action: update
+      include: system.cpu.time
+      new_name: cpu/usage_time
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: cpu
+        new_label: cpu_number
+      - action: update_label
+        label: state
+        new_label: cpu_state
+    - action: update
+      include: system.cpu.utilization
+      new_name: cpu/utilization
+      operations:
+      - action: aggregate_labels
+        aggregation_type: mean
+        label_set:
+        - state
+        - blank
+      - action: update_label
+        label: blank
+        new_label: cpu_number
+      - action: update_label
+        label: state
+        new_label: cpu_state
+    - action: update
+      include: system.cpu.load_average.1m
+      new_name: cpu/load_1m
+    - action: update
+      include: system.cpu.load_average.5m
+      new_name: cpu/load_5m
+    - action: update
+      include: system.cpu.load_average.15m
+      new_name: cpu/load_15m
+    - action: update
+      include: system.disk.read_io
+      new_name: disk/read_bytes_count
+    - action: update
+      include: system.disk.write_io
+      new_name: disk/write_bytes_count
+    - action: update
+      include: system.disk.operations
+      new_name: disk/operation_count
+    - action: update
+      include: system.disk.io_time
+      new_name: disk/io_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.weighted_io_time
+      new_name: disk/weighted_io_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.average_operation_time
+      new_name: disk/operation_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.pending_operations
+      new_name: disk/pending_operations
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.merged
+      new_name: disk/merged_operations
+    - action: update
+      include: system.filesystem.usage
+      new_name: disk/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: max
+        label_set:
+        - device
+        - state
+    - action: update
+      include: system.filesystem.utilization
+      new_name: disk/percent_used
+      operations:
+      - action: aggregate_labels
+        aggregation_type: max
+        label_set:
+        - device
+        - state
+    - action: update
+      include: system.memory.usage
+      new_name: memory/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_label_values
+        aggregated_values:
+        - slab_reclaimable
+        - slab_unreclaimable
+        aggregation_type: sum
+        label: state
+        new_value: slab
+    - action: update
+      include: system.memory.utilization
+      new_name: memory/percent_used
+      operations:
+      - action: aggregate_label_values
+        aggregated_values:
+        - slab_reclaimable
+        - slab_unreclaimable
+        aggregation_type: sum
+        label: state
+        new_value: slab
+    - action: update
+      include: system.network.io
+      new_name: interface/traffic
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.errors
+      new_name: interface/errors
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.packets
+      new_name: interface/packets
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.connections
+      new_name: network/tcp_connections
+      operations:
+      - action: toggle_scalar_data_type
+      - action: delete_label_value
+        label: protocol
+        label_value: udp
+      - action: update_label
+        label: state
+        new_label: tcp_state
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - tcp_state
+      - action: add_label
+        new_label: port
+        new_value: all
+    - action: update
+      include: system.processes.created
+      new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
+    - action: update
+      include: system.paging.usage
+      new_name: swap/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.paging.utilization
+      new_name: swap/percent_used
+    - action: insert
+      include: swap/percent_used
+      new_name: pagefile/percent_used
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - state
+    - action: update
+      include: system.paging.operations
+      new_name: swap/io
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - direction
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: in
+          value: page_in
+        - new_value: out
+          value: page_out
+    - action: update
+      include: process.cpu.time
+      new_name: processes/cpu_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1e+06
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+      - action: delete_label_value
+        label: state
+        label_value: wait
+      - action: update_label
+        label: state
+        new_label: user_or_syst
+      - action: update_label
+        label: user_or_syst
+        value_actions:
+        - new_value: syst
+          value: system
+    - action: update
+      include: process.disk.read_io
+      new_name: processes/disk/read_bytes_count
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.disk.write_io
+      new_name: processes/disk/write_bytes_count
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.memory.physical_usage
+      new_name: processes/rss_usage
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.memory.virtual_usage
+      new_name: processes/vm_usage
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  resourcedetection/_global_0:
+    detectors:
+    - gce
+receivers:
+  hostmetrics/default__pipeline_hostmetrics:
+    collection_interval: 60s
+    scrapers:
+      cpu: {}
+      disk: {}
+      filesystem: {}
+      load: {}
+      memory: {}
+      network: {}
+      paging: {}
+      process: {}
+      processes: {}
+  prometheus/agent:
+    config:
+      scrape_configs:
+      - job_name: otel-collector
+        scrape_interval: 1m
+        static_configs:
+        - targets:
+          - 0.0.0.0:8888
+service:
+  pipelines:
+    metrics/agent:
+      exporters:
+      - googlecloud
+      processors:
+      - filter/agent_0
+      - metricstransform/agent_1
+      - resourcedetection/_global_0
+      receivers:
+      - prometheus/agent
+    metrics/default__pipeline_hostmetrics:
+      exporters:
+      - googlecloud
+      processors:
+      - agentmetrics/default__pipeline_hostmetrics_0
+      - filter/default__pipeline_hostmetrics_1
+      - metricstransform/default__pipeline_hostmetrics_2
+      - resourcedetection/_global_0
+      receivers:
+      - hostmetrics/default__pipeline_hostmetrics

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/input.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/input.yaml
@@ -1,0 +1,22 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+metrics:
+  receivers:
+    hostmetrics:
+      type: hostmetrics
+  service:
+    pipelines:
+      default_pipeline:
+        receivers: [hostmetrics]


### PR DESCRIPTION
The collection_interval is supposed to be an optional field. Mark it as
optional, and update the duration validator to ignore the scenario where
the field is not specified.