### PR TITLE
Switch the internal metrics implementation to prometheus_exporter for Fluent Bit.

### DIFF
--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -128,7 +128,9 @@ func (l *Logging) generateFluentbitComponents(userAgent string, hostInfo *host.I
 	if l.Service.LogLevel == "" {
 		l.Service.LogLevel = "info"
 	}
-	out = append(out, fluentbit.Service{LogLevel: l.Service.LogLevel}.Component())
+	service := fluentbit.Service{LogLevel: l.Service.LogLevel}
+	out = append(out, service.Component())
+	out = append(out, service.MetricsComponent())
 
 	if l != nil && l.Service != nil {
 		// Type for sorting.
@@ -174,6 +176,7 @@ func (l *Logging) generateFluentbitComponents(userAgent string, hostInfo *host.I
 	out = append(out, LoggingReceiverFilesMixin{
 		IncludePaths: []string{"${logs_dir}/logging-module.log"},
 	}.Components("ops-agent-fluent-bit")...)
+
 	out = append(out, stackdriverOutputComponent("ops-agent-fluent-bit", userAgent))
 
 	return out, nil

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -178,6 +178,7 @@ func (l *Logging) generateFluentbitComponents(userAgent string, hostInfo *host.I
 	}.Components("ops-agent-fluent-bit")...)
 
 	out = append(out, stackdriverOutputComponent("ops-agent-fluent-bit", userAgent))
+	out = append(out, prometheusExporterOutputComponent())
 
 	return out, nil
 }

--- a/confgenerator/fluentbit/service.go
+++ b/confgenerator/fluentbit/service.go
@@ -49,3 +49,15 @@ func (s Service) Component() Component {
 		},
 	}
 }
+
+func (s Service) MetricsComponent() Component {
+	return Component{
+		Kind: "INPUT",
+		Config: map[string]string{
+			// https://docs.fluentbit.io/manual/pipeline/inputs/systemd
+			"Name":            "fluentbit_metrics",
+			"Scrape_On_Start": "True",
+			"Scrape_Interval": "30",
+		},
+	}
+}

--- a/confgenerator/fluentbit/service.go
+++ b/confgenerator/fluentbit/service.go
@@ -31,12 +31,6 @@ func (s Service) Component() Component {
 			// Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).
 			"Log_Level": s.LogLevel,
 
-			// https://docs.fluentbit.io/manual/administration/monitoring
-			// Enable a built-in HTTP server that can be used to query internal information and monitor metrics of each running plugin.
-			"HTTP_Server": "On",
-			"HTTP_Listen": "0.0.0.0",
-			"HTTP_PORT":   "2020",
-
 			// Use the legacy DNS resolver mechanism to work around b/206549605 temporarily.
 			"dns.resolver": "legacy",
 			// https://docs.fluentbit.io/manual/administration/buffering-and-storage#service-section-configuration

--- a/confgenerator/fluentbit/service.go
+++ b/confgenerator/fluentbit/service.go
@@ -54,10 +54,9 @@ func (s Service) MetricsComponent() Component {
 	return Component{
 		Kind: "INPUT",
 		Config: map[string]string{
-			// https://docs.fluentbit.io/manual/pipeline/inputs/systemd
 			"Name":            "fluentbit_metrics",
 			"Scrape_On_Start": "True",
-			"Scrape_Interval": "30",
+			"Scrape_Interval": "60",
 		},
 	}
 }

--- a/confgenerator/logging.go
+++ b/confgenerator/logging.go
@@ -72,7 +72,7 @@ func prometheusExporterOutputComponent() fluentbit.Component {
 			"Name":  "prometheus_exporter",
 			"Match": "*",
 			"host":  "0.0.0.0",
-			"port":  "2222",
+			"port":  "20202",
 		},
 	}
 }

--- a/confgenerator/logging.go
+++ b/confgenerator/logging.go
@@ -62,3 +62,17 @@ func stackdriverOutputComponent(match, userAgent string) fluentbit.Component {
 		},
 	}
 }
+
+// prometheusExporterOutputComponent generates a component that outputs to metrics prometheus format.
+func prometheusExporterOutputComponent() fluentbit.Component {
+	return fluentbit.Component{
+		Kind: "OUTPUT",
+		Config: map[string]string{
+			// https://docs.fluentbit.io/manual/pipeline/outputs/prometheus-exporter
+			"Name":  "prometheus_exporter",
+			"Match": "*",
+			"host":  "0.0.0.0",
+			"port":  "2222",
+		},
+	}
+}

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
@@ -71,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -76,4 +76,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/all-built_in_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/all-built_in_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/all-built_in_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/golden_fluent_bit_main.conf
@@ -71,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/all-built_in_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -76,4 +76,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_fluent_bit_main.conf
@@ -71,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -76,4 +76,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 warn
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_fluent_bit_main.conf
@@ -71,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -76,4 +76,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -46,4 +46,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -41,3 +41,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/pipeline1_log_source_id1

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -139,4 +139,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
@@ -134,3 +134,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M
@@ -14,6 +11,11 @@
     storage.max_chunks_up     128
     storage.metrics           on
     storage.sync              normal
+
+[INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 60
+    Scrape_On_Start True
 
 [INPUT]
     Buffer_Chunk_Size 512k
@@ -807,3 +809,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_main.conf
@@ -133,3 +133,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -138,4 +138,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/pipeline1_log_source_id1

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_fluent_bit_main.conf
@@ -146,3 +146,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -151,4 +151,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -82,4 +82,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_fluent_bit_main.conf
@@ -77,3 +77,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/apache_custom_apache_custom_access

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_fluent_bit_main.conf
@@ -579,3 +579,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -584,4 +584,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_refresh_interval/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_refresh_interval/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/apache_custom_apache_custom_access

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_refresh_interval/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -586,4 +586,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_refresh_interval/golden_fluent_bit_main.conf
@@ -581,3 +581,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -715,4 +715,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_fluent_bit_main.conf
@@ -710,3 +710,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/cassandra_custom_cassandra_custom_debug

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_refresh_interval/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_refresh_interval/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -718,4 +718,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_refresh_interval/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/cassandra_custom_cassandra_custom_debug

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_refresh_interval/golden_fluent_bit_main.conf
@@ -713,3 +713,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -96,4 +96,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
@@ -91,3 +91,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/pipeline1_log_source_id1

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -155,3 +155,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -160,4 +160,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -635,4 +635,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_fluent_bit_main.conf
@@ -630,3 +630,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_refresh_interval/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_refresh_interval/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_refresh_interval/golden_fluent_bit_main.conf
@@ -633,3 +633,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_refresh_interval/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -638,4 +638,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_fluent_bit_main.conf
@@ -435,3 +435,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -440,4 +440,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_refresh_interval/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_refresh_interval/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_refresh_interval/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -442,4 +442,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_refresh_interval/golden_fluent_bit_main.conf
@@ -437,3 +437,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_fluent_bit_main.conf
@@ -286,3 +286,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -291,4 +291,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_refresh_interval/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_refresh_interval/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_refresh_interval/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -292,4 +292,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_refresh_interval/golden_fluent_bit_main.conf
@@ -287,3 +287,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -99,4 +99,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Listen        1.1.1.1
     Mem_Buf_Limit 10M
     Mode          tcp

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -94,3 +94,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -86,4 +86,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_fluent_bit_main.conf
@@ -81,3 +81,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -90,4 +90,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_fluent_bit_main.conf
@@ -85,3 +85,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -90,4 +90,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_fluent_bit_main.conf
@@ -85,3 +85,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_fluent_bit_main.conf
@@ -71,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -76,4 +76,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -71,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -76,4 +76,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
@@ -71,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -76,4 +76,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
@@ -71,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -76,4 +76,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
@@ -71,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -76,4 +76,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M
@@ -14,6 +11,11 @@
     storage.max_chunks_up     128
     storage.metrics           on
     storage.sync              normal
+
+[INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 60
+    Scrape_On_Start True
 
 [INPUT]
     Buffer_Chunk_Size 512k
@@ -69,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  20202

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_fluent_bit_main.conf
@@ -71,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -76,4 +76,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_fluent_bit_main.conf
@@ -71,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -76,4 +76,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_fluent_bit_main.conf
@@ -71,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -76,4 +76,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_fluent_bit_main.conf
@@ -71,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -76,4 +76,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
@@ -71,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -76,4 +76,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_fluent_bit_main.conf
@@ -71,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -76,4 +76,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
@@ -71,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -76,4 +76,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_fluent_bit_main.conf
@@ -71,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -76,4 +76,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_fluent_bit_main.conf
@@ -71,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -76,4 +76,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_fluent_bit_main.conf
@@ -71,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -76,4 +76,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_fluent_bit_main.conf
@@ -71,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -76,4 +76,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
@@ -71,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -76,4 +76,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_fluent_bit_main.conf
@@ -71,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -76,4 +76,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_fluent_bit_main.conf
@@ -71,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -76,4 +76,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M
@@ -14,6 +11,11 @@
     storage.max_chunks_up     128
     storage.metrics           on
     storage.sync              normal
+
+[INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 60
+    Scrape_On_Start True
 
 [INPUT]
     Buffer_Chunk_Size 512k
@@ -69,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  20202

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_no_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_no_jvm/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M
@@ -14,6 +11,11 @@
     storage.max_chunks_up     128
     storage.metrics           on
     storage.sync              normal
+
+[INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 60
+    Scrape_On_Start True
 
 [INPUT]
     Buffer_Chunk_Size 512k
@@ -69,3 +71,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  20202

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -99,4 +99,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Channels     System,Application,Security
     DB           ${buffers_dir}/default_pipeline_windows_event_log
     Interval_Sec 1

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
@@ -94,3 +94,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -99,4 +99,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Channels     System,Application,Security
     DB           ${buffers_dir}/default_pipeline_windows_event_log
     Interval_Sec 1

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_fluent_bit_main.conf
@@ -94,3 +94,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -99,4 +99,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Channels     System,Application,Security
     DB           ${buffers_dir}/default_pipeline_windows_event_log
     Interval_Sec 1

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_fluent_bit_main.conf
@@ -94,3 +94,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -46,4 +46,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -41,3 +41,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Channels     System,Application,Security
     DB           ${buffers_dir}/default_pipeline_windows_event_log
     Interval_Sec 1

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
@@ -114,3 +114,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -119,4 +119,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -138,3 +138,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Channels     System,Application,Security
     DB           ${buffers_dir}/default_pipeline_windows_event_log
     Interval_Sec 1

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -143,4 +143,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -99,4 +99,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Channels     System,Application,Security
     DB           ${buffers_dir}/default_pipeline_windows_event_log
     Interval_Sec 1

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -94,3 +94,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -99,4 +99,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Channels     System,Application,Security
     DB           ${buffers_dir}/default_pipeline_windows_event_log
     Interval_Sec 1

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_fluent_bit_main.conf
@@ -94,3 +94,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -99,4 +99,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Channels     System,Application,Security
     DB           ${buffers_dir}/default_pipeline_windows_event_log
     Interval_Sec 1

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_fluent_bit_main.conf
@@ -94,3 +94,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -99,4 +99,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Channels     System,Application,Security
     DB           ${buffers_dir}/default_pipeline_windows_event_log
     Interval_Sec 1

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
@@ -94,3 +94,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -99,4 +99,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Channels     System,Application,Security
     DB           ${buffers_dir}/default_pipeline_windows_event_log
     Interval_Sec 1

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
@@ -94,3 +94,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -99,4 +99,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Channels     System,Application,Security
     DB           ${buffers_dir}/default_pipeline_windows_event_log
     Interval_Sec 1

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
@@ -94,3 +94,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -99,4 +99,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Channels     System,Application,Security
     DB           ${buffers_dir}/default_pipeline_windows_event_log
     Interval_Sec 1

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
@@ -94,3 +94,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -99,4 +99,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Channels     System,Application,Security
     DB           ${buffers_dir}/default_pipeline_windows_event_log
     Interval_Sec 1

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_fluent_bit_main.conf
@@ -94,3 +94,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -99,4 +99,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Channels     System,Application,Security
     DB           ${buffers_dir}/default_pipeline_windows_event_log
     Interval_Sec 1

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_fluent_bit_main.conf
@@ -94,3 +94,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -99,4 +99,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Channels     System,Application,Security
     DB           ${buffers_dir}/default_pipeline_windows_event_log
     Interval_Sec 1

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
@@ -94,3 +94,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -99,4 +99,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Channels     System,Application,Security
     DB           ${buffers_dir}/default_pipeline_windows_event_log
     Interval_Sec 1

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_fluent_bit_main.conf
@@ -94,3 +94,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -99,4 +99,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Channels     System,Application,Security
     DB           ${buffers_dir}/default_pipeline_windows_event_log
     Interval_Sec 1

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
@@ -94,3 +94,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -99,4 +99,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Channels     System,Application,Security
     DB           ${buffers_dir}/default_pipeline_windows_event_log
     Interval_Sec 1

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_fluent_bit_main.conf
@@ -94,3 +94,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -99,4 +99,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Channels     System,Application,Security
     DB           ${buffers_dir}/default_pipeline_windows_event_log
     Interval_Sec 1

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_fluent_bit_main.conf
@@ -94,3 +94,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -99,4 +99,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Channels     System,Application,Security
     DB           ${buffers_dir}/default_pipeline_windows_event_log
     Interval_Sec 1

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_fluent_bit_main.conf
@@ -94,3 +94,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
@@ -14,7 +14,7 @@
 
 [INPUT]
     Name            fluentbit_metrics
-    Scrape_Interval 30
+    Scrape_Interval 60
     Scrape_On_Start True
 
 [INPUT]
@@ -99,4 +99,4 @@
     Match *
     Name  prometheus_exporter
     host  0.0.0.0
-    port  2222
+    port  20202

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
@@ -13,6 +13,11 @@
     storage.sync              normal
 
 [INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 30
+    Scrape_On_Start True
+
+[INPUT]
     Channels     System,Application,Security
     DB           ${buffers_dir}/default_pipeline_windows_event_log
     Interval_Sec 1

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
@@ -94,3 +94,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  2222


### PR DESCRIPTION
Merged PRs #318 #319 and #328 into one. It changes the port that metrics are exported from 2020 to 20202 (or whatever we think it's more appropriate).