### PR TITLE
Added validation for logging processor for requirement of time_format when time_key is present.

### DIFF
--- a/confgenerator/logging_processors.go
+++ b/confgenerator/logging_processors.go
@@ -25,8 +25,8 @@ import (
 
 // ParserShared holds common parameters that are used by all processors that are implemented with fluentbit's "parser" filter.
 type ParserShared struct {
-	TimeKey    string `yaml:"time_key,omitempty"`    // by default does not parse timestamp
-	TimeFormat string `yaml:"time_format,omitempty"` // must be provided if time_key is present
+	TimeKey    string `yaml:"time_key,omitempty" validate:"required_with=TimeFormat"` // by default does not parse timestamp
+	TimeFormat string `yaml:"time_format,omitempty" validate:"required_with=TimeKey"` // must be provided if time_key is present
 	// Types allows parsing the extracted fields.
 	// Not exposed to users for now, but can be used by app receivers.
 	// Documented at https://docs.fluentbit.io/manual/v/1.3/parser

--- a/confgenerator/testdata/invalid/linux/logging-processor_parse_json_type_missing_time_format_required_with_time_key/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-processor_parse_json_type_missing_time_format_required_with_time_key/golden_error
@@ -1,0 +1,1 @@
+Key: 'ParserShared.time_format' Error:Field validation for 'time_format' failed on the 'required_with' tag

--- a/confgenerator/testdata/invalid/linux/logging-processor_parse_json_type_missing_time_format_required_with_time_key/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-processor_parse_json_type_missing_time_format_required_with_time_key/golden_error
@@ -1,1 +1,1 @@
-Key: 'ParserShared.time_format' Error:Field validation for 'time_format' failed on the 'required_with' tag
+"time_format" is required when "TimeKey" is set

--- a/confgenerator/testdata/invalid/linux/logging-processor_parse_json_type_missing_time_format_required_with_time_key/input.yaml
+++ b/confgenerator/testdata/invalid/linux/logging-processor_parse_json_type_missing_time_format_required_with_time_key/input.yaml
@@ -1,0 +1,16 @@
+logging:
+  receivers:
+    syslog:
+      type: files
+      include_paths:
+      - /var/log/messages
+      - /var/log/syslog
+  processors:
+    json_processor:
+      type: parse_json
+      field: field_1
+      time_key: time_key_1
+  service:
+    pipelines:
+      default_pipeline:
+        receivers: [syslog]

--- a/confgenerator/testdata/invalid/linux/logging-processor_parse_regex_type_missing_time_format_required_with_time_key/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-processor_parse_regex_type_missing_time_format_required_with_time_key/golden_error
@@ -1,0 +1,1 @@
+Key: 'ParserShared.time_format' Error:Field validation for 'time_format' failed on the 'required_with' tag

--- a/confgenerator/testdata/invalid/linux/logging-processor_parse_regex_type_missing_time_format_required_with_time_key/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-processor_parse_regex_type_missing_time_format_required_with_time_key/golden_error
@@ -1,1 +1,1 @@
-Key: 'ParserShared.time_format' Error:Field validation for 'time_format' failed on the 'required_with' tag
+"time_format" is required when "TimeKey" is set

--- a/confgenerator/testdata/invalid/linux/logging-processor_parse_regex_type_missing_time_format_required_with_time_key/input.yaml
+++ b/confgenerator/testdata/invalid/linux/logging-processor_parse_regex_type_missing_time_format_required_with_time_key/input.yaml
@@ -1,0 +1,17 @@
+logging:
+  receivers:
+    syslog:
+      type: files
+      include_paths:
+      - /var/log/messages
+      - /var/log/syslog
+  processors:
+    regex_processor:
+      type: parse_regex
+      field: field_1
+      regex: regex_pattern_1
+      time_key: time_key_1
+  service:
+    pipelines:
+      default_pipeline:
+        receivers: [syslog]

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/input.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/input.yaml
@@ -46,26 +46,12 @@ logging:
       field: key_1
       time_key: time_key_1
       time_format: time_format_1
-    parse_json_2:
-      type: parse_json
-      time_key: time_key_2
-    parse_json_3:
-      type: parse_json
-      time_format: time_format_3
     parse_regex_1:
       type: parse_regex
       field: key_1
       regex: regex_pattern_1
       time_key: time_key_1
       time_format: time_format_1
-    parse_regex_2:
-      type: parse_regex
-      regex: regex_pattern_2
-      time_key: time_key_2
-    parse_regex_3:
-      type: parse_regex
-      regex: regex_pattern_3
-      time_format: time_format_3
   service:
     pipelines:
       default_pipeline:


### PR DESCRIPTION
- Updated logging_processors.go so time_format is required when time_key is present and the other way around.
- Added input.yaml and generated golden_error files in the /testdata/invalid/ folder.
- Updated /valid/logging-processor_parse_json_and_parse_regex_types/input.yaml to remove the cases where time_format or time_key are missing.