### PR TITLE
Updating golden_error files due to confgenerator error mismatch.

### DIFF
--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M
@@ -14,6 +11,11 @@
     storage.max_chunks_up     128
     storage.metrics           on
     storage.sync              normal
+
+[INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 60
+    Scrape_On_Start True
 
 [INPUT]
     Buffer_Chunk_Size 512k
@@ -192,3 +194,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_complex/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_complex/golden_fluent_bit_main.conf
@@ -4,9 +4,6 @@
 [SERVICE]
     Daemon                    off
     Flush                     1
-    HTTP_Listen               0.0.0.0
-    HTTP_PORT                 2020
-    HTTP_Server               On
     Log_Level                 info
     dns.resolver              legacy
     storage.backlog.mem_limit 50M
@@ -14,6 +11,11 @@
     storage.max_chunks_up     128
     storage.metrics           on
     storage.sync              normal
+
+[INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 60
+    Scrape_On_Start True
 
 [INPUT]
     Buffer_Chunk_Size 512k
@@ -515,3 +517,9 @@
     tls                           On
     tls.verify                    Off
     workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  20202


### PR DESCRIPTION
- Updating golden_error files due to mismatch in logging-receiver_tomcat and logging-receiver_tomcat_complex.
- Commit obtained after running: 
go test -mod=mod github.com/GoogleCloudPlatform/ops-agent/confgenerator -update_golden