### PR TITLE
Fix tomcat download URL

### DIFF
--- a/integration_test/third_party_apps_data/applications/tomcat/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/tomcat/centos_rhel/install
@@ -2,7 +2,7 @@ set -e
 
 sudo yum install -y curl java
 sudo mkdir -p /opt/tomcat/stage
-sudo curl "https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.56/bin/apache-tomcat-9.0.56.tar.gz" -o /opt/tomcat/stage/tomcat.tgz
+sudo curl "https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.58/bin/apache-tomcat-9.0.58.tar.gz" -o /opt/tomcat/stage/tomcat.tgz
 sudo tar -xvzf /opt/tomcat/stage/tomcat.tgz -C /opt/tomcat --strip 1
 
 cat << EOF > tomcat.service

--- a/integration_test/third_party_apps_data/applications/tomcat/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/tomcat/debian_ubuntu/install
@@ -2,7 +2,7 @@ set -e
 
 sudo apt-get install -y curl default-jre
 sudo mkdir -p /opt/tomcat/stage
-sudo curl "https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.56/bin/apache-tomcat-9.0.56.tar.gz" -o /opt/tomcat/stage/tomcat.tgz
+sudo curl "https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.58/bin/apache-tomcat-9.0.58.tar.gz" -o /opt/tomcat/stage/tomcat.tgz
 sudo tar -xvzf /opt/tomcat/stage/tomcat.tgz -C /opt/tomcat --strip 1
 
 cat << EOF > tomcat.service

--- a/integration_test/third_party_apps_data/applications/tomcat/sles/install
+++ b/integration_test/third_party_apps_data/applications/tomcat/sles/install
@@ -2,7 +2,7 @@ set -e
 
 sudo zypper install -y curl java-11-openjdk
 sudo mkdir -p /opt/tomcat/stage
-sudo curl "https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.56/bin/apache-tomcat-9.0.56.tar.gz" -o /opt/tomcat/stage/tomcat.tgz
+sudo curl "https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.58/bin/apache-tomcat-9.0.58.tar.gz" -o /opt/tomcat/stage/tomcat.tgz
 sudo tar -xvzf /opt/tomcat/stage/tomcat.tgz -C /opt/tomcat --strip 1
 
 cat << EOF > tomcat.service


### PR DESCRIPTION
This is a temporary fix to get integration tests passing for tomcat.

It appears the CDN we're using to download tomcat for integration tests only offers one version and there wasn't an obvious mirror with older versions remaining available. Longer term fix will be to download from an appropriate package repo or find a better CDN.