### PR TITLE
Solr Metrics Receiver

### DIFF
--- a/apps/solr.go
+++ b/apps/solr.go
@@ -1,0 +1,81 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apps
+
+import (
+	"log"
+
+	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
+	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
+)
+
+type MetricsReceiverSolr struct {
+	confgenerator.ConfigComponent `yaml:",inline"`
+
+	confgenerator.MetricsReceiverShared `yaml:",inline"`
+
+	Endpoint string `yaml:"endpoint" validate:"omitempty,hostname_port"`
+	Username string `yaml:"username" validate:"required_with=Password"`
+	Password string `yaml:"password" validate:"required_with=Username"`
+}
+
+const defaultSolrEndpoint = "localhost:18983"
+
+func (r MetricsReceiverSolr) Type() string {
+	return "solr"
+}
+
+func (r MetricsReceiverSolr) Pipelines() []otel.Pipeline {
+	if r.Endpoint == "" {
+		r.Endpoint = defaultSolrEndpoint
+	}
+
+	jarPath, err := FindJarPath()
+	if err != nil {
+		log.Printf(`Encountered an error discovering the location of the JMX Metrics Exporter, %v`, err)
+	}
+
+	targetSystem := "solr"
+
+	config := map[string]interface{}{
+		"target_system":       targetSystem,
+		"collection_interval": r.CollectionIntervalString(),
+		"endpoint":            r.Endpoint,
+		"jar_path":            jarPath,
+	}
+
+	// Only set the username & password fields if provided
+	if r.Username != "" && r.Password != "" {
+		config["username"] = r.Username
+		config["password"] = r.Password
+	}
+
+	return []otel.Pipeline{{
+		Receiver: otel.Component{
+			Type:   "jmx",
+			Config: config,
+		},
+		Processors: []otel.Component{
+			otel.NormalizeSums(),
+			otel.MetricsTransform(
+				otel.AddPrefix("workload.googleapis.com"),
+			),
+		},
+	}}
+}
+
+func init() {
+	confgenerator.MetricsReceiverTypes.RegisterType(func() confgenerator.Component { return &MetricsReceiverSolr{} })
+}

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_invalid_type_iis/golden_error
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_invalid_type_iis/golden_error
@@ -1,1 +1,1 @@
-metrics receiver with type "iis" is not supported. Supported metrics receiver types: [apache, cassandra, hostmetrics, jvm, memcached, mysql, nginx, postgresql, redis, tomcat].
+metrics receiver with type "iis" is not supported. Supported metrics receiver types: [apache, cassandra, hostmetrics, jvm, memcached, mysql, nginx, postgresql, redis, solr, tomcat].

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_invalid_type_mssql/golden_error
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_invalid_type_mssql/golden_error
@@ -1,1 +1,1 @@
-metrics receiver with type "mssql" is not supported. Supported metrics receiver types: [apache, cassandra, hostmetrics, jvm, memcached, mysql, nginx, postgresql, redis, tomcat].
+metrics receiver with type "mssql" is not supported. Supported metrics receiver types: [apache, cassandra, hostmetrics, jvm, memcached, mysql, nginx, postgresql, redis, solr, tomcat].

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_solr_malformed_url/golden_error
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_solr_malformed_url/golden_error
@@ -1,6 +1,6 @@
-[19:17] Key: 'MetricsReceiverSolr.endpoint' Error:Field validation for 'endpoint' failed on the 'hostname_port' tag
+[19:17] Key: 'MetricsReceiverSharedJVM.endpoint' Error:Field validation for 'endpoint' failed on the 'hostname_port|startswith=service:jmx:' tag
   16 |   receivers:
-  17 |     solr_metrics:
+  17 |     solr:
   18 |       type: solr
 > 19 |       endpoint: localhost
                        ^

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_solr_malformed_url/golden_error
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_solr_malformed_url/golden_error
@@ -1,0 +1,9 @@
+[19:17] Key: 'MetricsReceiverSolr.endpoint' Error:Field validation for 'endpoint' failed on the 'hostname_port' tag
+  16 |   receivers:
+  17 |     solr_metrics:
+  18 |       type: solr
+> 19 |       endpoint: localhost
+                       ^
+  20 |       collection_interval: 30s
+  21 |   service:
+  22 |     pipelines:

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_solr_malformed_url/input.yaml
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_solr_malformed_url/input.yaml
@@ -14,12 +14,12 @@
 
 metrics:
   receivers:
-    solr_metrics:
+    solr:
       type: solr
       endpoint: localhost
       collection_interval: 30s
   service:
     pipelines:
-      solr_pipeline:
+      solr:
         receivers:
-          - solr_metrics
+          - solr

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_solr_malformed_url/input.yaml
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_solr_malformed_url/input.yaml
@@ -1,0 +1,25 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+metrics:
+  receivers:
+    solr_metrics:
+      type: solr
+      endpoint: localhost
+      collection_interval: 30s
+  service:
+    pipelines:
+      solr_pipeline:
+        receivers:
+          - solr_metrics

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_solr_not_service_url/golden_error
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_solr_not_service_url/golden_error
@@ -1,0 +1,9 @@
+[19:17] Key: 'MetricsReceiverSolr.endpoint' Error:Field validation for 'endpoint' failed on the 'hostname_port' tag
+  16 |   receivers:
+  17 |     solr_metrics:
+  18 |       type: solr
+> 19 |       endpoint: http://localhost:80/forbidden.html
+                       ^
+  20 |       collection_interval: 30s
+  21 |   service:
+  22 |     pipelines:

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_solr_not_service_url/golden_error
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_solr_not_service_url/golden_error
@@ -1,6 +1,6 @@
-[19:17] Key: 'MetricsReceiverSolr.endpoint' Error:Field validation for 'endpoint' failed on the 'hostname_port' tag
+[19:17] Key: 'MetricsReceiverSharedJVM.endpoint' Error:Field validation for 'endpoint' failed on the 'hostname_port|startswith=service:jmx:' tag
   16 |   receivers:
-  17 |     solr_metrics:
+  17 |     solr:
   18 |       type: solr
 > 19 |       endpoint: http://localhost:80/forbidden.html
                        ^

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_solr_not_service_url/input.yaml
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_solr_not_service_url/input.yaml
@@ -1,0 +1,25 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+metrics:
+  receivers:
+    solr_metrics:
+      type: solr
+      endpoint: http://localhost:80/forbidden.html
+      collection_interval: 30s
+  service:
+    pipelines:
+      solr_pipeline:
+        receivers:
+          - solr_metrics

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_solr_not_service_url/input.yaml
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_solr_not_service_url/input.yaml
@@ -14,12 +14,12 @@
 
 metrics:
   receivers:
-    solr_metrics:
+    solr:
       type: solr
       endpoint: http://localhost:80/forbidden.html
       collection_interval: 30s
   service:
     pipelines:
-      solr_pipeline:
+      solr:
         receivers:
-          - solr_metrics
+          - solr

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_solr_username_no_password/golden_error
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_solr_username_no_password/golden_error
@@ -1,0 +1,9 @@
+[17:17] "password" is required when "Username" is set
+  15 | metrics:
+  16 |   receivers:
+> 17 |     solr_metrics:
+                       ^
+  18 |       type: solr
+  19 |       username: usr
+  20 |       collection_interval: 30s
+  21 |   

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_solr_username_no_password/golden_error
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_solr_username_no_password/golden_error
@@ -1,9 +1,1 @@
-[17:17] "password" is required when "Username" is set
-  15 | metrics:
-  16 |   receivers:
-> 17 |     solr_metrics:
-                       ^
-  18 |       type: solr
-  19 |       username: usr
-  20 |       collection_interval: 30s
-  21 |   
+"password" is required when "Username" is set

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_solr_username_no_password/input.yaml
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_solr_username_no_password/input.yaml
@@ -14,12 +14,12 @@
 
 metrics:
   receivers:
-    solr_metrics:
+    solr:
       type: solr
       username: usr
       collection_interval: 30s
   service:
     pipelines:
-      solr_pipeline:
+      solr:
         receivers:
-          - solr_metrics
+          - solr

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_solr_username_no_password/input.yaml
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_solr_username_no_password/input.yaml
@@ -1,0 +1,25 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+metrics:
+  receivers:
+    solr_metrics:
+      type: solr
+      username: usr
+      collection_interval: 30s
+  service:
+    pipelines:
+      solr_pipeline:
+        receivers:
+          - solr_metrics

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_unsupported_type/golden_error
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_unsupported_type/golden_error
@@ -1,1 +1,1 @@
-metrics receiver with type "unsupported_type" is not supported. Supported metrics receiver types: [apache, cassandra, hostmetrics, jvm, memcached, mysql, nginx, postgresql, redis, tomcat].
+metrics receiver with type "unsupported_type" is not supported. Supported metrics receiver types: [apache, cassandra, hostmetrics, jvm, memcached, mysql, nginx, postgresql, redis, solr, tomcat].

--- a/confgenerator/testdata/invalid/windows/metrics-receiver_unsupported_type/golden_error
+++ b/confgenerator/testdata/invalid/windows/metrics-receiver_unsupported_type/golden_error
@@ -1,1 +1,1 @@
-metrics receiver with type "unsupported_type" is not supported. Supported metrics receiver types: [apache, cassandra, hostmetrics, iis, jvm, memcached, mssql, mysql, nginx, postgresql, redis, tomcat].
+metrics receiver with type "unsupported_type" is not supported. Supported metrics receiver types: [apache, cassandra, hostmetrics, iis, jvm, memcached, mssql, mysql, nginx, postgresql, redis, solr, tomcat].

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden_fluent_bit_main.conf
@@ -1,0 +1,79 @@
+@SET buffers_dir=/var/lib/google-cloud-ops-agent/fluent-bit/buffers
+@SET logs_dir=/var/log/google-cloud-ops-agent/subagents
+
+[SERVICE]
+    Daemon                    off
+    Flush                     1
+    Log_Level                 info
+    dns.resolver              legacy
+    storage.backlog.mem_limit 50M
+    storage.checksum          on
+    storage.max_chunks_up     128
+    storage.metrics           on
+    storage.sync              normal
+
+[INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 60
+    Scrape_On_Start True
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   5M
+    DB                ${buffers_dir}/default_pipeline_syslog
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              /var/log/messages,/var/log/syslog
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               default_pipeline.syslog
+    storage.type      filesystem
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   5M
+    DB                ${buffers_dir}/ops-agent-fluent-bit
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/logging-module.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-fluent-bit
+    storage.type      filesystem
+
+[FILTER]
+    Add   logging.googleapis.com/logName syslog
+    Match default_pipeline.syslog
+    Name  modify
+
+[OUTPUT]
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  20202

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden_otel.conf
@@ -1,0 +1,464 @@
+exporters:
+  googlecloud:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+processors:
+  agentmetrics/default__pipeline_hostmetrics_0:
+    blank_label_metrics:
+    - system.cpu.utilization
+  filter/default__pipeline_hostmetrics_1:
+    metrics:
+      exclude:
+        match_type: strict
+        metric_names:
+        - system.cpu.time
+        - system.network.dropped
+        - system.filesystem.inodes.usage
+        - system.paging.faults
+        - system.disk.operation_time
+  filter/default__pipeline_hostmetrics_3:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names: []
+  filter/fluentbit_0:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+        - fluentbit_uptime
+  filter/otel_0:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+        - otelcol_process_uptime
+        - otelcol_process_memory_rss
+        - otelcol_grpc_io_client_completed_rpcs
+        - otelcol_googlecloudmonitoring_point_count
+  metricstransform/default__pipeline_hostmetrics_2:
+    transforms:
+    - action: update
+      include: system.cpu.time
+      new_name: cpu/usage_time
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: cpu
+        new_label: cpu_number
+      - action: update_label
+        label: state
+        new_label: cpu_state
+    - action: update
+      include: system.cpu.utilization
+      new_name: cpu/utilization
+      operations:
+      - action: aggregate_labels
+        aggregation_type: mean
+        label_set:
+        - state
+        - blank
+      - action: update_label
+        label: blank
+        new_label: cpu_number
+      - action: update_label
+        label: state
+        new_label: cpu_state
+    - action: update
+      include: system.cpu.load_average.1m
+      new_name: cpu/load_1m
+    - action: update
+      include: system.cpu.load_average.5m
+      new_name: cpu/load_5m
+    - action: update
+      include: system.cpu.load_average.15m
+      new_name: cpu/load_15m
+    - action: update
+      include: system.disk.read_io
+      new_name: disk/read_bytes_count
+    - action: update
+      include: system.disk.write_io
+      new_name: disk/write_bytes_count
+    - action: update
+      include: system.disk.operations
+      new_name: disk/operation_count
+    - action: update
+      include: system.disk.io_time
+      new_name: disk/io_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.weighted_io_time
+      new_name: disk/weighted_io_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.average_operation_time
+      new_name: disk/operation_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.pending_operations
+      new_name: disk/pending_operations
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.merged
+      new_name: disk/merged_operations
+    - action: update
+      include: system.filesystem.usage
+      new_name: disk/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: max
+        label_set:
+        - device
+        - state
+    - action: update
+      include: system.filesystem.utilization
+      new_name: disk/percent_used
+      operations:
+      - action: aggregate_labels
+        aggregation_type: max
+        label_set:
+        - device
+        - state
+    - action: update
+      include: system.memory.usage
+      new_name: memory/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_label_values
+        aggregated_values:
+        - slab_reclaimable
+        - slab_unreclaimable
+        aggregation_type: sum
+        label: state
+        new_value: slab
+    - action: update
+      include: system.memory.utilization
+      new_name: memory/percent_used
+      operations:
+      - action: aggregate_label_values
+        aggregated_values:
+        - slab_reclaimable
+        - slab_unreclaimable
+        aggregation_type: sum
+        label: state
+        new_value: slab
+    - action: update
+      include: system.network.io
+      new_name: interface/traffic
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.errors
+      new_name: interface/errors
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.packets
+      new_name: interface/packets
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.connections
+      new_name: network/tcp_connections
+      operations:
+      - action: toggle_scalar_data_type
+      - action: delete_label_value
+        label: protocol
+        label_value: udp
+      - action: update_label
+        label: state
+        new_label: tcp_state
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - tcp_state
+      - action: add_label
+        new_label: port
+        new_value: all
+    - action: update
+      include: system.processes.created
+      new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
+    - action: update
+      include: system.paging.usage
+      new_name: swap/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.paging.utilization
+      new_name: swap/percent_used
+    - action: insert
+      include: swap/percent_used
+      new_name: pagefile/percent_used
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - state
+    - action: update
+      include: system.paging.operations
+      new_name: swap/io
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - direction
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: in
+          value: page_in
+        - new_value: out
+          value: page_out
+    - action: update
+      include: process.cpu.time
+      new_name: processes/cpu_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1e+06
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+      - action: delete_label_value
+        label: state
+        label_value: wait
+      - action: update_label
+        label: state
+        new_label: user_or_syst
+      - action: update_label
+        label: user_or_syst
+        value_actions:
+        - new_value: syst
+          value: system
+    - action: update
+      include: process.disk.read_io
+      new_name: processes/disk/read_bytes_count
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.disk.write_io
+      new_name: processes/disk/write_bytes_count
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.memory.physical_usage
+      new_name: processes/rss_usage
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.memory.virtual_usage
+      new_name: processes/vm_usage
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/fluentbit_1:
+    transforms:
+    - action: update
+      include: fluentbit_uptime
+      new_name: agent/uptime
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: version
+        new_value: google-cloud-ops-agent-logging/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/otel_1:
+    transforms:
+    - action: update
+      include: otelcol_process_uptime
+      new_name: agent/uptime
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: version
+        new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
+    - action: update
+      include: otelcol_process_memory_rss
+      new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
+    - action: update
+      include: otelcol_grpc_io_client_completed_rpcs
+      new_name: agent/api_request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: grpc_client_status
+        new_label: state
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - state
+    - action: update
+      include: otelcol_googlecloudmonitoring_point_count
+      new_name: agent/monitoring/point_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/solr__pipeline_solr__metrics_1:
+    transforms:
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: workload.googleapis.com/$${1}
+  normalizesums/solr__pipeline_solr__metrics_0: {}
+  resourcedetection/_global_0:
+    detectors:
+    - gce
+receivers:
+  hostmetrics/default__pipeline_hostmetrics:
+    collection_interval: 60s
+    scrapers:
+      cpu: {}
+      disk: {}
+      filesystem: {}
+      load: {}
+      memory: {}
+      network: {}
+      paging: {}
+      process: {}
+      processes: {}
+  jmx/solr__pipeline_solr__metrics:
+    collection_interval: 30s
+    endpoint: localhost:18983
+    jar_path: /path/to/executables/opentelemetry-java-contrib-jmx-metrics.jar
+    password: otelp
+    target_system: solr
+    username: otelu
+  prometheus/fluentbit:
+    config:
+      scrape_configs:
+      - job_name: logging-collector
+        metrics_path: /metrics
+        scrape_interval: 1m
+        static_configs:
+        - targets:
+          - 0.0.0.0:20202
+  prometheus/otel:
+    config:
+      scrape_configs:
+      - job_name: otel-collector
+        scrape_interval: 1m
+        static_configs:
+        - targets:
+          - 0.0.0.0:8888
+service:
+  pipelines:
+    metrics/default__pipeline_hostmetrics:
+      exporters:
+      - googlecloud
+      processors:
+      - agentmetrics/default__pipeline_hostmetrics_0
+      - filter/default__pipeline_hostmetrics_1
+      - metricstransform/default__pipeline_hostmetrics_2
+      - filter/default__pipeline_hostmetrics_3
+      - resourcedetection/_global_0
+      receivers:
+      - hostmetrics/default__pipeline_hostmetrics
+    metrics/fluentbit:
+      exporters:
+      - googlecloud
+      processors:
+      - filter/fluentbit_0
+      - metricstransform/fluentbit_1
+      - resourcedetection/_global_0
+      receivers:
+      - prometheus/fluentbit
+    metrics/otel:
+      exporters:
+      - googlecloud
+      processors:
+      - filter/otel_0
+      - metricstransform/otel_1
+      - resourcedetection/_global_0
+      receivers:
+      - prometheus/otel
+    metrics/solr__pipeline_solr__metrics:
+      exporters:
+      - googlecloud
+      processors:
+      - normalizesums/solr__pipeline_solr__metrics_0
+      - metricstransform/solr__pipeline_solr__metrics_1
+      - resourcedetection/_global_0
+      receivers:
+      - jmx/solr__pipeline_solr__metrics

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden_otel.conf
@@ -375,13 +375,13 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  metricstransform/solr__pipeline_solr__metrics_1:
+  metricstransform/solr_solr_1:
     transforms:
     - action: update
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  normalizesums/solr__pipeline_solr__metrics_0: {}
+  normalizesums/solr_solr_0: {}
   resourcedetection/_global_0:
     detectors:
     - gce
@@ -396,10 +396,11 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
+      process:
+        mute_process_name_error: true
       processes: {}
-  jmx/solr__pipeline_solr__metrics:
-    collection_interval: 30s
+  jmx/solr_solr:
+    collection_interval: 60s
     endpoint: localhost:18983
     jar_path: /path/to/executables/opentelemetry-java-contrib-jmx-metrics.jar
     password: otelp
@@ -453,12 +454,12 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
-    metrics/solr__pipeline_solr__metrics:
+    metrics/solr_solr:
       exporters:
       - googlecloud
       processors:
-      - normalizesums/solr__pipeline_solr__metrics_0
-      - metricstransform/solr__pipeline_solr__metrics_1
+      - normalizesums/solr_solr_0
+      - metricstransform/solr_solr_1
       - resourcedetection/_global_0
       receivers:
-      - jmx/solr__pipeline_solr__metrics
+      - jmx/solr_solr

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/input.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/input.yaml
@@ -14,14 +14,13 @@
 
 metrics:
   receivers:
-    solr_metrics:
+    solr:
       type: solr
       # exercising default endpoint
       username: otelu
       password: otelp
-      collection_interval: 30s
   service:
     pipelines:
-      solr_pipeline:
+      solr:
         receivers:
-          - solr_metrics
+          - solr

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/input.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/input.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+metrics:
+  receivers:
+    solr_metrics:
+      type: solr
+      # exercising default endpoint
+      username: otelu
+      password: otelp
+      collection_interval: 30s
+  service:
+    pipelines:
+      solr_pipeline:
+        receivers:
+          - solr_metrics

--- a/docs/solr.md
+++ b/docs/solr.md
@@ -1,0 +1,50 @@
+# `solr` Metrics Receiver
+
+The `solr` metrics receiver can fetch stats from a Solr server's Java Virtual Machine (JVM) via [JMX](https://www.oracle.com/java/technologies/javase/javamanagement.html).
+
+## Prerequisites
+
+In order to expose a JMX endpoint, you must set the `com.sun.management.jmxremote.port` system property. It is recommended to also set the `com.sun.management.jmxremote.rmi.port` system property to the same port. To expose JMX endpoint remotely, you must also set the `java.rmi.server.hostname` system property. By default, these properties are set in a Solr deployment's solr-env.sh file and the default Solr installation requires no JMX authentication with JMX exposed locally on 127.0.0.1:18983.
+
+## Configuration
+
+| Field                 | Default            | Description |
+| ---                   | ---                | ---         |
+| `type`                | required           | Must be `solr`. |
+| `endpoint`            | `localhost:18983`  | The [JMX Service URL](https://docs.oracle.com/javase/8/docs/api/javax/management/remote/JMXServiceURL.html) or host and port used to construct the Service URL. Must be in the form of `host:port`. Values in `host:port` form will be used to create a Service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`. |
+| `username`            | not set by default | The configured username if JMX is configured to require authentication. |
+| `password`            | not set by default | The configured password if JMX is configured to require authentication. |
+| `collection_interval` | `60s`              | A [time.Duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`. |
+
+
+Example Configuration:
+
+```yaml
+metrics:
+  receivers:
+    solr_metrics:
+      type: solr
+      collection_interval: 60s
+  service:
+    pipelines:
+      solr_pipeline:
+        receivers:
+          - solr_metrics
+```
+
+## Metrics
+The Ops Agent collects the following metrics from Solr.
+
+| Metric                                               | Data Type      | Unit        | Labels                         | Description |
+| ---                                                  | ---            | ---         | ---                            | ---         | 
+| workload.googleapis.com/solr.document.count          | Gauge          | documents   | core                           | The total number of indexed documents. |
+| workload.googleapis.com/solr.index.size              | Gauge          | by          | core                           | The total index size. |
+| workload.googleapis.com/solr.request.count           | Cumulative     | queries     | core, type, handler            | The number of queries made. |
+| workload.googleapis.com/solr.request.time.average    | Gauge          | ms          | core, type, handler            | The average time of a query, based on Solr's histogram configuration. |
+| workload.googleapis.com/solr.request.error.count     | Cumulative     | queries     | core, type, handler            | The number of queries resulting in an error. |
+| workload.googleapis.com/solr.request.timeout.count   | Cumulative     | queries     | core, type, handler            | The number of queries resulting in a timeout. |
+| workload.googleapis.com/solr.cache.eviction.count    | Cumulative     | evictions   | core, cache                    | The number of evictions from a cache. |
+| workload.googleapis.com/solr.cache.hit.count         | Cumulative     | hits        | core, cache                    | The number of hits from a cache. |
+| workload.googleapis.com/solr.cache.insert.count      | Cumulative     | inserts     | core, cache                    | The number of inserts from a cache. |
+| workload.googleapis.com/solr.cache.lookup.count      | Cumulative     | lookups     | core, cache                    | The number of lookups from a cache. |
+| workload.googleapis.com/solr.cache.size              | Gauge          | by          | core, cache                    | The size of the cache occupied in memory. |

--- a/docs/solr.md
+++ b/docs/solr.md
@@ -22,18 +22,20 @@ Example Configuration:
 ```yaml
 metrics:
   receivers:
-    solr_metrics:
+    solr:
       type: solr
       collection_interval: 60s
   service:
     pipelines:
-      solr_pipeline:
+      solr:
         receivers:
-          - solr_metrics
+          - solr
 ```
 
 ## Metrics
 The Ops Agent collects the following metrics from Solr.
+
+Note: Limited metrics will be reported if no cores have been created.
 
 | Metric                                               | Data Type      | Unit        | Labels                         | Description |
 | ---                                                  | ---            | ---         | ---                            | ---         | 

--- a/integration_test/third_party_apps_data/agent/ops-agent/linux/enable_solr
+++ b/integration_test/third_party_apps_data/agent/ops-agent/linux/enable_solr
@@ -19,15 +19,14 @@ sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 
 metrics:
   receivers:
-    solr_metrics:
+    solr:
       type: solr
       endpoint: localhost:18983
-      collection_interval: 60s
   service:
     pipelines:
-      solr_pipeline:
+      solr:
         receivers:
-          - solr_metrics
+          - solr
 EOF
 
 sudo service google-cloud-ops-agent restart

--- a/integration_test/third_party_apps_data/agent/ops-agent/linux/enable_solr
+++ b/integration_test/third_party_apps_data/agent/ops-agent/linux/enable_solr
@@ -1,0 +1,33 @@
+# Configures Ops Agent to collect telemetry from the app and restart Ops Agent.
+
+set -e
+
+sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+metrics:
+  receivers:
+    solr_metrics:
+      type: solr
+      endpoint: localhost:18983
+      collection_interval: 60s
+  service:
+    pipelines:
+      solr_pipeline:
+        receivers:
+          - solr_metrics
+EOF
+
+sudo service google-cloud-ops-agent restart

--- a/integration_test/third_party_apps_data/agent/ops-agent/linux/supported_applications.txt
+++ b/integration_test/third_party_apps_data/agent/ops-agent/linux/supported_applications.txt
@@ -1,5 +1,6 @@
 apache
 cassandra
+elasticsearch
 jvm
 memcached
 mongodb
@@ -7,5 +8,5 @@ mysql
 nginx
 postgresql
 redis
+solr
 tomcat
-elasticsearch

--- a/integration_test/third_party_apps_data/applications/solr/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/solr/centos_rhel/install
@@ -1,0 +1,40 @@
+set -e
+
+sudo setenforce 0
+
+cat <<EOF | sudo tee /etc/selinux/config
+SELINUX=disabled
+SELINUXTYPE=targeted
+EOF
+
+sudo yum install -y \
+    java-1.8.0-openjdk java-1.8.0-openjdk-devel curl lsof
+
+curl -L -o \
+    solr-8.11.1.tgz \
+    https://downloads.apache.org/lucene/solr/8.11.1/solr-8.11.1.tgz
+
+tar -xzf \
+    solr-8.11.1.tgz \
+    solr-8.11.1/bin/install_solr_service.sh \
+    --strip-components=2
+
+sudo bash ./install_solr_service.sh solr-8.11.1.tgz -n
+
+sudo chown -R solr:solr /opt/solr*
+
+cat <<EOF | sudo tee /etc/default/solr.in.sh
+# default
+SOLR_PID_DIR="/var/solr"
+SOLR_HOME="/var/solr/data"
+LOG4J_PROPS="/var/solr/log4j2.xml"
+SOLR_LOGS_DIR="/var/solr/logs"
+SOLR_PORT="8983"
+
+# enable jmx
+ENABLE_REMOTE_JMX_OPTS="true"  
+RMI_PORT=18983
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable solr

--- a/integration_test/third_party_apps_data/applications/solr/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/solr/centos_rhel/install
@@ -23,18 +23,8 @@ sudo bash ./install_solr_service.sh solr-8.11.1.tgz -n
 
 sudo chown -R solr:solr /opt/solr*
 
-cat <<EOF | sudo tee /etc/default/solr.in.sh
-# default
-SOLR_PID_DIR="/var/solr"
-SOLR_HOME="/var/solr/data"
-LOG4J_PROPS="/var/solr/log4j2.xml"
-SOLR_LOGS_DIR="/var/solr/logs"
-SOLR_PORT="8983"
-
-# enable jmx
-ENABLE_REMOTE_JMX_OPTS="true"  
-RMI_PORT=18983
-EOF
+sudo sed -i '/ENABLE_REMOTE_JMX_OPTS/s/false/true/' /etc/default/solr.in.sh
+sudo sed -i '/ENABLE_REMOTE_JMX_OPTS/s/^# *//' /etc/default/solr.in.sh
 
 sudo systemctl daemon-reload
 sudo systemctl enable solr

--- a/integration_test/third_party_apps_data/applications/solr/centos_rhel/post
+++ b/integration_test/third_party_apps_data/applications/solr/centos_rhel/post
@@ -1,0 +1,5 @@
+set -e
+
+sudo systemctl restart solr
+
+sudo su - solr -c "/opt/solr/bin/solr create -c otel"

--- a/integration_test/third_party_apps_data/applications/solr/centos_rhel/post
+++ b/integration_test/third_party_apps_data/applications/solr/centos_rhel/post
@@ -2,4 +2,5 @@ set -e
 
 sudo systemctl restart solr
 
+# Adding a core called otel so that there are some metrics to scrape
 sudo su - solr -c "/opt/solr/bin/solr create -c otel"

--- a/integration_test/third_party_apps_data/applications/solr/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/solr/debian_ubuntu/install
@@ -1,0 +1,34 @@
+set -e
+
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install \
+    -y default-jdk default-jdk-headless curl lsof
+
+curl -L -o \
+    solr-8.11.1.tgz \
+    https://downloads.apache.org/lucene/solr/8.11.1/solr-8.11.1.tgz
+
+tar -xzf \
+    solr-8.11.1.tgz \
+    solr-8.11.1/bin/install_solr_service.sh \
+    --strip-components=2
+
+sudo bash ./install_solr_service.sh solr-8.11.1.tgz -n
+
+sudo chown -R solr:solr /opt/solr*
+
+cat <<EOF | sudo tee /etc/default/solr.in.sh
+# default
+SOLR_PID_DIR="/var/solr"
+SOLR_HOME="/var/solr/data"
+LOG4J_PROPS="/var/solr/log4j2.xml"
+SOLR_LOGS_DIR="/var/solr/logs"
+SOLR_PORT="8983"
+
+# enable jmx
+ENABLE_REMOTE_JMX_OPTS="true"  
+RMI_PORT=18983
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable solr

--- a/integration_test/third_party_apps_data/applications/solr/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/solr/debian_ubuntu/install
@@ -17,18 +17,8 @@ sudo bash ./install_solr_service.sh solr-8.11.1.tgz -n
 
 sudo chown -R solr:solr /opt/solr*
 
-cat <<EOF | sudo tee /etc/default/solr.in.sh
-# default
-SOLR_PID_DIR="/var/solr"
-SOLR_HOME="/var/solr/data"
-LOG4J_PROPS="/var/solr/log4j2.xml"
-SOLR_LOGS_DIR="/var/solr/logs"
-SOLR_PORT="8983"
-
-# enable jmx
-ENABLE_REMOTE_JMX_OPTS="true"  
-RMI_PORT=18983
-EOF
+sudo sed -i '/ENABLE_REMOTE_JMX_OPTS/s/false/true/' /etc/default/solr.in.sh
+sudo sed -i '/ENABLE_REMOTE_JMX_OPTS/s/^# *//' /etc/default/solr.in.sh
 
 sudo systemctl daemon-reload
 sudo systemctl enable solr

--- a/integration_test/third_party_apps_data/applications/solr/debian_ubuntu/post
+++ b/integration_test/third_party_apps_data/applications/solr/debian_ubuntu/post
@@ -1,0 +1,5 @@
+set -e
+
+sudo systemctl restart solr
+
+sudo su - solr -c "/opt/solr/bin/solr create -c otel"

--- a/integration_test/third_party_apps_data/applications/solr/debian_ubuntu/post
+++ b/integration_test/third_party_apps_data/applications/solr/debian_ubuntu/post
@@ -2,4 +2,5 @@ set -e
 
 sudo systemctl restart solr
 
+# Adding a core called otel so that there are some metrics to scrape
 sudo su - solr -c "/opt/solr/bin/solr create -c otel"

--- a/integration_test/third_party_apps_data/applications/solr/metric_name.txt
+++ b/integration_test/third_party_apps_data/applications/solr/metric_name.txt
@@ -1,0 +1,1 @@
+workload.googleapis.com/solr.cache.size

--- a/integration_test/third_party_apps_data/applications/solr/sles/install
+++ b/integration_test/third_party_apps_data/applications/solr/sles/install
@@ -16,18 +16,8 @@ sudo bash ./install_solr_service.sh solr-8.11.1.tgz -n
 
 sudo chown -R solr:solr /opt/solr*
 
-cat <<EOF | sudo tee /etc/default/solr.in.sh
-# default
-SOLR_PID_DIR="/var/solr"
-SOLR_HOME="/var/solr/data"
-LOG4J_PROPS="/var/solr/log4j2.xml"
-SOLR_LOGS_DIR="/var/solr/logs"
-SOLR_PORT="8983"
-
-# enable jmx
-ENABLE_REMOTE_JMX_OPTS="true"  
-RMI_PORT=18983
-EOF
+sudo sed -i '/ENABLE_REMOTE_JMX_OPTS/s/false/true/' /etc/default/solr.in.sh
+sudo sed -i '/ENABLE_REMOTE_JMX_OPTS/s/^# *//' /etc/default/solr.in.sh
 
 sudo systemctl daemon-reload
 sudo systemctl enable solr

--- a/integration_test/third_party_apps_data/applications/solr/sles/install
+++ b/integration_test/third_party_apps_data/applications/solr/sles/install
@@ -1,0 +1,33 @@
+set -e
+
+sudo zypper install -y \
+    java-11-openjdk java-11-openjdk-devel curl lsof insserv-compat
+
+curl -L -o \
+    solr-8.11.1.tgz \
+    https://downloads.apache.org/lucene/solr/8.11.1/solr-8.11.1.tgz
+
+tar -xzf \
+    solr-8.11.1.tgz \
+    solr-8.11.1/bin/install_solr_service.sh \
+    --strip-components=2
+
+sudo bash ./install_solr_service.sh solr-8.11.1.tgz -n
+
+sudo chown -R solr:solr /opt/solr*
+
+cat <<EOF | sudo tee /etc/default/solr.in.sh
+# default
+SOLR_PID_DIR="/var/solr"
+SOLR_HOME="/var/solr/data"
+LOG4J_PROPS="/var/solr/log4j2.xml"
+SOLR_LOGS_DIR="/var/solr/logs"
+SOLR_PORT="8983"
+
+# enable jmx
+ENABLE_REMOTE_JMX_OPTS="true"  
+RMI_PORT=18983
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable solr

--- a/integration_test/third_party_apps_data/applications/solr/sles/post
+++ b/integration_test/third_party_apps_data/applications/solr/sles/post
@@ -1,0 +1,5 @@
+set -e
+
+sudo systemctl restart solr
+
+sudo su - solr -c "/opt/solr/bin/solr create -c otel"

--- a/integration_test/third_party_apps_data/applications/solr/sles/post
+++ b/integration_test/third_party_apps_data/applications/solr/sles/post
@@ -2,4 +2,5 @@ set -e
 
 sudo systemctl restart solr
 
+# Adding a core called otel so that there are some metrics to scrape
 sudo su - solr -c "/opt/solr/bin/solr create -c otel"


### PR DESCRIPTION
Adds ability to collect Solr metrics to ops-agent.

[Scope doc](https://docs.google.com/document/d/1GiSjVfshBnTr4-838bLF2EmCY_SUkz9oakk9bbJP9V0/edit#)