### PR TITLE
Point to the official Cloud documentation site for the launched apps.

### DIFF
--- a/docs/apache.md
+++ b/docs/apache.md
@@ -1,52 +1,11 @@
-# `apache httpd` Metrics Receiver
+# Apache Web Server (httpd)
 
-The Apache httpd receiver can retrieve stats from your Apache web server using the `/server-status?auto` endpoint.
-
-
-## Prerequisites
-
-The receiver requires that you enable the [mod_status module](https://httpd.apache.org/docs/2.4/mod/mod_status.html) on your Apache web server.
-
- This requires adding the following lines to the server’s `httpd.conf` file:
-
-```
-<Location "/server-status">
-    SetHandler server-status
-    Require host localhost
-</Location>
-```
-
-## Configuration
-
-Following the guide for [Configuring the Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/configuration#file-location), add the required elements for your Apache web server configuration.
-
-To configure a receiver for your Apache web server metrics, specify the following fields:
-
-| Field                 | Default                   | Description |
-| ---                   | ---                       | ---         |
-| `type`                | required                  | Must be `apache`. |
-| `server_status_url`     | `http://localhost:8080/server-status?auto` | The url exposed by the `mod_status` module. |
-| `collection_interval` | `60s`                     | A [time.Duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`. |
-
-Example Configuration:
-
-```yaml
-metrics:
-  receivers:
-    apache_metrics:
-      type: apache
-      server_status_url: http://localhost:8080/server-status?auto
-      collection_interval: 30s
-  service:
-    pipelines:
-      apache_pipeline:
-        receivers:
-          - apache_metrics
-```
+Follow https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/apache
+for instructions to collect logs and metrics from this application using Ops Agent.
 
 ## Metrics
 
-The Ops Agent collects the following metrics from your Apache web servers.
+The following table provides the list of metrics that the Ops Agent collects from this application.
 
 | Metric                                            | Data Type | Unit        | Labels              | Description |
 | ---                                               | ---       | ---         | ---                 | ---         | 
@@ -55,43 +14,6 @@ The Ops Agent collects the following metrics from your Apache web servers.
 | workload.googleapis.com/apache.workers             | gauge     | connections | server_name, workers_state     | The number of workers currently attached to the HTTP server |
 | workload.googleapis.com/apache.scoreboard          | gauge     | scoreboard  | server_name, scoreboard_state  | Apache HTTP server scoreboard values. |
 | workload.googleapis.com/apache.traffic             | sum       | byte |     server_name     | Total HTTP server traffic. |
-
-# `apache_access` and `apache_error` Logging Receivers
-
-## Configuration
-
-To configure a receiver for your apache access logs, specify the following fields:
-
-| Field                 | Default                       | Description |
-| ---                   | ---                           | ---         |
-| `type`                | required                      | Must be `apache_access`. |
-| `include_paths`       | `[/var/log/apache2/access.log]` | A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `/var/log/apache*/*.log`.
-| `exclude_paths`       | `[]`                          | A list of filesystem path patterns to exclude from the set matched by `include_paths`.
-
-To configure a receiver for your apache error logs, specify the following fields:
-
-| Field                 | Default                      | Description |
-| ---                   | ---                          | ---         |
-| `type`                | required                     | Must be `apache_error`. |
-| `include_paths`       | `[/var/log/apache2/error.log]` | The log files to read. |
-| `exclude_paths`       | `[]`                         | Log files to exclude (if `include_paths` contains a glob or directory). |
-
-Example Configuration:
-
-```yaml
-logging:
-  receivers:
-    apache_default_access:
-      type: apache_access
-    apache_default_error:
-      type: apache_error
-  service:
-    pipelines:
-      apache:
-        receivers:
-          - apache_default_access
-          - apache_default_error
-```
 
 ## Logs
 

--- a/docs/apache.md
+++ b/docs/apache.md
@@ -1,6 +1,6 @@
 # Apache Web Server (httpd)
 
-Follow https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/apache
+Follow [installation guide](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/apache)
 for instructions to collect logs and metrics from this application using Ops Agent.
 
 ## Metrics

--- a/docs/cassandra.md
+++ b/docs/cassandra.md
@@ -1,6 +1,6 @@
 # Cassandra
 
-Follow https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/cassandra
+Follow [installation guide](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/cassandra)
 for instructions to collect logs and metrics from this application using Ops Agent.
 
 ## Metrics

--- a/docs/cassandra.md
+++ b/docs/cassandra.md
@@ -1,41 +1,13 @@
-# `cassandra` Metrics Receiver
+# Cassandra
 
-The `cassandra` metrics receiver can fetch stats from a Cassandra node's Java Virtual Machine (JVM) via [JMX](https://www.oracle.com/java/technologies/javase/javamanagement.html).
-
-## Prerequisites
-
-In order to expose a JMX endpoint, you must set the `com.sun.management.jmxremote.port` system property. It is recommended to also set the `com.sun.management.jmxremote.rmi.port` system property to the same port. To expose JMX endpoint remotely, you must also set the `java.rmi.server.hostname` system property. By default, these properties are set in a Cassandra deployment's cassandra-env.sh file and the default Cassandra installation requires no JMX authentication with JMX exposed locally on 127.0.0.1:7199.
-
-## Configuration
-
-| Field                 | Default            | Description |
-| ---                   | ---                | ---         |
-| `type`                | required           | Must be `cassandra`. |
-| `endpoint`            | `localhost:7199`   | The [JMX Service URL](https://docs.oracle.com/javase/8/docs/api/javax/management/remote/JMXServiceURL.html) or host and port used to construct the Service URL. Must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form will be used to create a Service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`. |
-| `collect_jvm_metrics` | true               | Should the set of support [JVM metrics](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/docs/jvm.md#metrics) also be collected |
-| `username`            | not set by default | The configured username if JMX is configured to require authentication. |
-| `password`            | not set by default | The configured password if JMX is configured to require authentication. |
-| `collection_interval` | `60s`              | A [time.Duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`. |
-
-
-Example Configuration:
-
-```yaml
-metrics:
-  receivers:
-    cassandra_metrics:
-      type: cassandra
-      endpoint: localhost:7199
-      collection_interval: 30s
-  service:
-    pipelines:
-      cassandra_pipeline:
-        receivers:
-          - cassandra_metrics
-```
+Follow https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/cassandra
+for instructions to collect logs and metrics from this application using Ops Agent.
 
 ## Metrics
-In addition to Cassandra specific metrics, by default Cassandra will also report [JVM metrics](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/docs/jvm.md#metrics)
+
+The following table provides the list of metrics that the Ops Agent collects from this application.
+
+In addition to these Cassandra specific metrics, by default Cassandra will also report [JVM metrics](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/docs/jvm.md#metrics)
 
 | Metric                                                                          | Data Type | Unit        | Labels | Description |
 | ---                                                                             | ---       | ---         | ---    | ---         | 
@@ -55,55 +27,6 @@ In addition to Cassandra specific metrics, by default Cassandra will also report
 | workload.googleapis.com/cassandra.storage.load.count                            | gauge       | bytes       |        | Size of the on disk data size this node manages |
 | workload.googleapis.com/cassandra.storage.total_hints.count                     | cumulative       | 1           |        | Number of hint messages written to this node since start |
 | workload.googleapis.com/cassandra.storage.total_hints.in_progress.count         | gauge       | 1           |        | Number of hints attempting to be sent currently |
-
-
-# `cassandra_system`, `cassandra_debug` and `cassandra_gc` Logging Receivers
-
-## Configuration
-
-To configure a receiver for your cassandra system logs, specify the following fields:
-
-| Field                 | Default                       | Description |
-| ---                   | ---                           | ---         |
-| `type`                | required                      | Must be `cassandra_system`. |
-| `include_paths`       | `[/var/log/cassandra/system*.log]` | A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `/var/log/apache*/*.log`.
-| `exclude_paths`       | `[]`                          | A list of filesystem path patterns to exclude from the set matched by `include_paths`.
-
-To configure a receiver for your cassandra debug logs, specify the following fields:
-
-| Field                 | Default                      | Description |
-| ---                   | ---                          | ---         |
-| `type`                | required                     | Must be `cassandra_debug`. |
-| `include_paths`       | `[/var/log/cassandra/debug*.log]` | The log files to read. |
-| `exclude_paths`       | `[]`                         | Log files to exclude (if `include_paths` contains a glob or directory). |
-
-To configure a receiver for your cassandra gc logs, specify the following fields:
-
-| Field                 | Default                      | Description |
-| ---                   | ---                          | ---         |
-| `type`                | required                     | Must be `cassandra_gc`. |
-| `include_paths`       | `[/var/log/cassandra/gc.log.*.current]` | The log files to read. |
-| `exclude_paths`       | `[]`                         | Log files to exclude (if `include_paths` contains a glob or directory). |
-
-Example Configuration:
-
-```yaml
-logging:
-  receivers:
-    cassandra_default_system:
-      type: cassandra_system
-    cassandra_default_debug:
-      type: cassandra_debug
-    cassandra_default_gc:
-      type: cassandra_gc
-  service:
-    pipelines:
-      cassandra:
-        receivers:
-          - cassandra_default_system
-          - cassandra_default_debug
-          - cassandra_default_gc
-```
 
 ## Logs
 

--- a/docs/elasticsearch.md
+++ b/docs/elasticsearch.md
@@ -1,41 +1,7 @@
-# `elasticsearch_json` and `elasticsearch_gc` Logging Receivers
+# Elasticsearch
 
-## Configuration
-
-To configure a receiver for your Elasticsearch JSON logs, specify the following fields:
-
-| Field                 | Default                       | Description |
-| ---                   | ---                           | ---         |
-| `type`                | required                      | Must be `elasticsearch_json`. |
-| `include_paths`       | `[/var/log/elasticsearch/*_server.json, /var/log/elasticsearch/*_deprecation.json, /var/log/elasticsearch/*_index_search_slowlog.json, /var/log/elasticsearch/*_index_indexing_slowlog.json, /var/log/elasticsearch/*_audit.json]` | The log files to read. |
-| `exclude_paths`       | `[]`                          | Log files to exclude (if `include_paths` contains a glob or directory). |
-| `wildcard_refresh_interval` | `60s` | The interval at which wildcard file paths in include_paths are refreshed. Specified as a time interval parsable by [time.ParseDuration](https://pkg.go.dev/time#ParseDuration). Must be a multiple of 1s.|
-
-To configure a receiver for Elasticsearch GC logs, specify the following fields:
-
-| Field                 | Default                      | Description |
-| ---                   | ---                          | ---         |
-| `type`                | required                     | Must be `elasticsearch_gc`. |
-| `include_paths`       | `[/var/log/elasticsearch/gc.log]` | The log files to read. |
-| `exclude_paths`       | `[]`                         | Log files to exclude (if `include_paths` contains a glob or directory). |
-| `wildcard_refresh_interval` | `60s` | The interval at which wildcard file paths in include_paths are refreshed. Specified as a time interval parsable by [time.ParseDuration](https://pkg.go.dev/time#ParseDuration). Must be a multiple of 1s.|
-
-Example Configuration:
-
-```yaml
-logging:
-  receivers:
-    elasticsearch_json:
-      type: elasticsearch_json
-    elasticsearch_gc:
-      type: elasticsearch_gc
-  service:
-    pipelines:
-      elasticsearch:
-        receivers:
-          - elasticsearch_json
-          - elasticsearch_gc
-```
+Follow [installation guide](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/elasticsearch)
+for instructions to collect logs and metrics from this application using Ops Agent.
 
 ## Logs
 

--- a/docs/jvm.md
+++ b/docs/jvm.md
@@ -1,6 +1,6 @@
 # JVM
 
-Follow https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/jvm
+Follow [installation guide](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/jvm)
 for instructions to collect metrics from this application using Ops Agent.
 
 ## Metrics

--- a/docs/jvm.md
+++ b/docs/jvm.md
@@ -1,41 +1,11 @@
-# JVM Receiver
+# JVM
 
-The `jvm` receiver can fetch stats from a Jave Virtual Machine via [JMX](https://www.oracle.com/java/technologies/javase/javamanagement.html).
-
-
-## Prerequisites
-
-In order to expose a JMX endpoint, you must set the `com.sun.management.jmxremote.port` system property. It is recommended to also set the `com.sun.management.jmxremote.rmi.port` system property to the same port. To expose JMX endpoint remotely, you must also set the `java.rmi.server.hostname` system property. Java system properties can be set via command line args by prepending the property name with `-D` . For example: `-Dcom.sun.management.jmxremote.port`
-
-## Configuration
-
-| Field                 | Default            | Description |
-| ---                   | ---                | ---         |
-| `type`                | required           | Must be `jvm`. |
-| `endpoint`            | `localhost:9999`   | The [JMX Service URL](https://docs.oracle.com/javase/8/docs/api/javax/management/remote/JMXServiceURL.html) or host and port used to construct the Service URL. Must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form will be used to create a Service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`. |
-| `username`            | not set by default | The configured username if JMX is configured to require authentication. |
-| `password`            | not set by default | The configured password if JMX is configured to require authentication. |
-| `collection_interval` | `60s`              | A [time.Duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`. |
-
-Example Configuration:
-
-```yaml
-metrics:
-  receivers:
-    jvm_metrics:
-      type: jvm
-      endpoint: localhost:9999
-      password: otelp
-      username: otelu
-      collection_interval: 30s
-  service:
-    pipelines:
-      jvm:
-        receivers:
-          - jvm_metrics
-```
+Follow https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/jvm
+for instructions to collect metrics from this application using Ops Agent.
 
 ## Metrics
+
+The following table provides the list of metrics that the Ops Agent collects from this application.
 
 | Metric                                             | Data Type | Unit        | Labels | Description |
 | ---                                                | ---       | ---         | ---    | ---         | 

--- a/docs/memcached.md
+++ b/docs/memcached.md
@@ -1,39 +1,11 @@
-# `memcached` Metrics Receiver
+# Memcache
 
-The memcached receiver can retrieve stats from your memcached server through the . 
-
-
-## Configuration
-
-Following the guide for [Configuring the Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/configuration#file-location), add the required elements for your memcached configuration.
-
-To configure a receiver for your memcached metrics, specify the following fields:
-
-| Field                 | Default                   | Description |
-| ---                   | ---                       | ---         |
-| `type`                | required                  | Must be `memcached`. |
-| `endpoint`            | `localhost:3306`          | The url, or unix socket file path, for your memcached server. |
-| `collection_interval` | `60s`                     | A [time.Duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`. |
-
-Example Configuration:
-
-```yaml
-metrics:
-  receivers:
-    memcached_metrics:
-      type: memcached
-      collection_interval: 60s
-  service:
-    pipelines:
-      memcached_pipeline:
-        receivers:
-          - memcached_metrics
-```
-
+Follow https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/memcached
+for instructions to collect logs and metrics from this application using Ops Agent.
 
 ## Metrics
 
-These are the metrics available for this scraper.
+The following table provides the list of metrics that the Ops Agent collects from this application.
 
 | Name | Description | Unit | Type | Attributes |
 | ---- | ----------- | ---- | ---- | ---------- |
@@ -48,7 +20,7 @@ These are the metrics available for this scraper.
 | memcached.operations | Operation counts. | 1 | Sum | <ul> <li>type</li> <li>operation</li> </ul> |
 | memcached.threads | Number of threads used by the memcached instance. | 1 | Gauge | <ul> </ul> |
 
-## Attributes
+### Metrics labels
 
 | Name | Description | Values |
 | ---- | ----------- | ------ |
@@ -57,7 +29,3 @@ These are the metrics available for this scraper.
 | operation | The type of operation. | <ul> <li>increment</li> <li>decrement</li> <li>get</li> </ul> |
 | state | The type of CPU usage. | <ul> <li>system</li> <li>user</li> </ul> |
 | type | Result of cache request. | <ul> <li>hit</li> <li>miss</li> </ul> |
-
-# `memcached` Logging Receiver
-
-Memcached logs are collected by the default syslog receiver.

--- a/docs/memcached.md
+++ b/docs/memcached.md
@@ -1,6 +1,6 @@
-# Memcache
+# Memcached
 
-Follow https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/memcached
+Follow [installation guide](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/memcached)
 for instructions to collect logs and metrics from this application using Ops Agent.
 
 ## Metrics
@@ -9,23 +9,23 @@ The following table provides the list of metrics that the Ops Agent collects fro
 
 | Name | Description | Unit | Type | Attributes |
 | ---- | ----------- | ---- | ---- | ---------- |
-| memcached.bytes | Current number of bytes used by this server to store items. | By | Gauge | <ul> </ul> |
-| memcached.commands | Commands executed. | 1 | Sum | <ul> <li>command</li> </ul> |
-| memcached.connections.current | The current number of open connections. | connections | Gauge | <ul> </ul> |
-| memcached.connections.total | Total number of connections opened since the server started running. | connections | Sum | <ul> </ul> |
-| memcached.cpu.usage | Accumulated user and system time. | 1 | Sum | <ul> <li>state</li> </ul> |
-| memcached.current_items | Number of items currently stored in the cache. | 1 | Gauge | <ul> </ul> |
-| memcached.evictions | Cache item evictions. | 1 | Sum | <ul> </ul> |
-| memcached.network | Bytes transferred over the network. | by | Sum | <ul> <li>direction</li> </ul> |
-| memcached.operations | Operation counts. | 1 | Sum | <ul> <li>type</li> <li>operation</li> </ul> |
-| memcached.threads | Number of threads used by the memcached instance. | 1 | Gauge | <ul> </ul> |
+| memcached.bytes | Current number of bytes used by this server to store items. | By | Gauge | |
+| memcached.commands | Commands executed. | 1 | Sum | command |
+| memcached.connections.current | The current number of open connections. | connections | Gauge | |
+| memcached.connections.total | Total number of connections opened since the server started running. | connections | Sum | |
+| memcached.cpu.usage | Accumulated user and system time. | 1 | Sum | state |
+| memcached.current_items | Number of items currently stored in the cache. | 1 | Gauge | |
+| memcached.evictions | Cache item evictions. | 1 | Sum | |
+| memcached.network | Bytes transferred over the network. | by | Sum | direction |
+| memcached.operations | Operation counts. | 1 | Sum | type, operation |
+| memcached.threads | Number of threads used by the memcached instance. | 1 | Gauge | |
 
 ### Metrics labels
 
 | Name | Description | Values |
 | ---- | ----------- | ------ |
-| command | The type of command. | <ul> <li>get</li> <li>set</li> <li>flush</li> <li>touch</li> </ul>
-| direction | Direction of data flow. | <ul> <li>sent</li> <li>received</li> </ul>
-| operation | The type of operation. | <ul> <li>increment</li> <li>decrement</li> <li>get</li> </ul> |
-| state | The type of CPU usage. | <ul> <li>system</li> <li>user</li> </ul> |
-| type | Result of cache request. | <ul> <li>hit</li> <li>miss</li> </ul> |
+| command | The type of command. | get, set, flush, touch |
+| direction | Direction of data flow. | sent, received |
+| operation | The type of operation. | increment, decrement, get |
+| state | The type of CPU usage. | system, user |
+| type | Result of cache request. | hit, miss |

--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -1,6 +1,6 @@
 # MySQL
 
-Follow https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/mysql
+Follow [installation guide](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/mysql)
 for instructions to collect logs and metrics from this application using Ops Agent.
 
 ## Metrics

--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -1,60 +1,11 @@
-# `mysql` Metrics Receiver
+# MySQL
 
-The mysql receiver can retrieve stats from your mysql instance by connecting as a monitoring user.
-
-## Prerequisites
-
-The `mysql` receiver defaults to connecting to a local MySQL server using a Unix socket and Unix authentication as the `root` user.
-
-## Configuration
-
-Following the guide for [Configuring the Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/configuration#file-location), add the required elements for your mysql configuration.
-
-To configure a receiver for your mysql metrics, specify the following fields:
-
-| Field                 | Default                         | Description |
-| ---                   | ---                             | ---         |
-| `type`                | required                        | Must be `mysql`. |
-| `endpoint`            | `/var/run/mysqld/mysqld.sock`   | The hostname:port or socket path used by mysql |
-| `collection_interval` | `60s`                           | A [time.Duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`. |
-| `username`            | `root`                          | The username used to connect to the server. |
-| `password`            |                                 | The password used to connect to the server. |
-
-Example Configuration:
-
-```yaml
-metrics:
-  receivers:
-    mysql_metrics:
-      type: mysql
-  service:
-    pipelines:
-      mysql_pipeline:
-        receivers:
-          - mysql_metrics
-```
-
-TCP connection with a username and password:
-
-```yaml
-metrics:
-  receivers:
-    mysql_metrics:
-      type: mysql 
-      endpoint: localhost:3306
-      collection_interval: 30s
-      password: pwd
-      username: usr
-  service:
-    pipelines:
-      mysql_pipeline:
-        receivers:
-          - mysql_metrics
-```
+Follow https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/mysql
+for instructions to collect logs and metrics from this application using Ops Agent.
 
 ## Metrics
 
-The Ops Agent collects the following metrics from your mysql instances.
+The following table provides the list of metrics that the Ops Agent collects from this application.
 
 | Metric                                               | Data Type | Unit        | Labels                  | Description    |
 | ---                                                  | ---       | ---         | ---                     | ---            | 
@@ -72,56 +23,6 @@ The Ops Agent collects the following metrics from your mysql instances.
 | workload.googleapis.com/mysql.locks                  | sum       | 1           | locks                   | MySQL lock count. |
 | workload.googleapis.com/mysql.sorts                  | sum       | 1           | sorts                   | MySQL sort count. |
 | workload.googleapis.com/mysql.threads                | gauge     | 1           | threads                 | Thread count. |
-
-
-
-# `mysql_error`, `mysql_general` and `mysql_slow` Logging Receivers
-
-## Configuration
-
-To configure a receiver for your mysql error logs, specify the following fields:
-
-| Field                 | Default                       | Description |
-| ---                   | ---                           | ---         |
-| `type`                | required                      | Must be `mysql_error`. |
-| `include_paths`       | `[/var/log/mysqld.log, /var/log/mysql/mysqld.log, /var/log/mysql/error.log]` | A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `/var/log/apache*/*.log`.
-| `exclude_paths`       | `[]`                          | A list of filesystem path patterns to exclude from the set matched by `include_paths`.
-
-To configure a receiver for your mysql general query logs, specify the following fields:
-
-| Field                 | Default                      | Description |
-| ---                   | ---                          | ---         |
-| `type`                | required                     | Must be `mysql_general`. |
-| `include_paths`       | `[/var/lib/mysql/${HOSTNAME}.log]` | The log files to read. |
-| `exclude_paths`       | `[]`                         | Log files to exclude (if `include_paths` contains a glob or directory). |
-
-To configure a receiver for your mysql slow query logs, specify the following fields:
-
-| Field                 | Default                      | Description |
-| ---                   | ---                          | ---         |
-| `type`                | required                     | Must be `mysql_slow`. |
-| `include_paths`       | `[/var/lib/mysql/${HOSTNAME}-slow.log` | The log files to read. |
-| `exclude_paths`       | `[]`                         | Log files to exclude (if `include_paths` contains a glob or directory). |
-
-Example Configuration:
-
-```yaml
-logging:
-  receivers:
-    mysql_error:
-      type: mysql_error
-    mysql_general:
-      type: mysql_general
-    mysql_slow:
-      type: mysql_slow
-  service:
-    pipelines:
-      mysql:
-        receivers:
-          - mysql_error
-          - mysql_general
-          - mysql_slow
-```
 
 ## Logs
 

--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -1,73 +1,7 @@
-# `nginx` Metrics Receiver
+# Nginx
 
-The nginx receiver can retrieve stats from your nginx instance using the `mod_status` endpoint.
-
-
-## Prerequisites
-
-The receiver requires that you enable the [status module](http://nginx.org/en/docs/http/ngx_http_stub_status_module.html) on your nginx instance.
-
-To enable the status module, complete the following steps:
-
-1. Edit the `status.conf` file. You can find this file in the nginx configuration directory, typically found at `/etc/nginx/conf.d`.
-2. Add the following lines to your configuration file:
-
-   ```
-   location /status {
-       stub_status on;
-   }
-   ```
-
-    1. Alternately, you can append these lines to your `nginx.conf` file, which is typically located in one of the following directories: `/etc/nginx`, `/usr/local/nginx/conf`, or `/usr/local/etc/nginx`.
-
-   Your configuration file might look like the following example:
-   ```
-   server {
-       listen 80;
-       server_name mynginx.domain.com; 
-       location /status {
-           stub_status on;
-       }
-       location / {
-           root /dev/null;  
-       }
-   }
-   ```
-
-3. Reload the nginx configuration:
-
-   ```
-   sudo service nginx reload
-   ```
-
-
-## Configuration
-
-Following the guide for [Configuring the Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/configuration#file-location), add the required elements for your nginx configuration.
-
-To configure a receiver for your nginx metrics, specify the following fields:
-
-| Field                 | Default                   | Description |
-| ---                   | ---                       | ---         |
-| `type`                | required                  | Must be `nginx`. |
-| `stub_status_url`     | `http://localhost/status` | The url exposed by the nginx stats module. |
-| `collection_interval` | `60s`                     | A [time.Duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`. |
-
-Example Configuration:
-
-```yaml
-metrics:
-  receivers:
-    nginx_metrics:
-      type: nginx
-      stub_status_url: http://localhost:80/status
-      collection_interval: 30s
-  service:
-    pipelines:
-      nginx:
-        receivers:
-          - nginx_metrics
-```
+Follow https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/nginx
+for instructions to collect logs and metrics from this application using Ops Agent.
 
 ## Metrics
 
@@ -79,43 +13,6 @@ The Ops Agent collects the following metrics from your nginx instances.
 | workload.googleapis.com/nginx.connections_accepted | cumulative       | connections |        | Total number of accepted client connections. |
 | workload.googleapis.com/nginx.connections_handled  | cumulative       | connections |        | Total number of handled connections. |
 | workload.googleapis.com/nginx.connections_current  | gauge     | connections | state  | Current number of connections. |
-
-# `nginx_access` and `nginx_error` Logging Receivers
-
-## Configuration
-
-To configure a receiver for your nginx access logs, specify the following fields:
-
-| Field                 | Default                       | Description |
-| ---                   | ---                           | ---         |
-| `type`                | required                      | Must be `nginx_access`. |
-| `include_paths`       | `[/var/log/nginx/access.log]` | The log files to read. |
-| `exclude_paths`       | `[]`                          | Log files to exclude (if `include_paths` contains a glob or directory). |
-
-To configure a receiver for your nginx error logs, specify the following fields:
-
-| Field                 | Default                      | Description |
-| ---                   | ---                          | ---         |
-| `type`                | required                     | Must be `nginx_error`. |
-| `include_paths`       | `[/var/log/nginx/error.log]` | The log files to read. |
-| `exclude_paths`       | `[]`                         | Log files to exclude (if `include_paths` contains a glob or directory). |
-
-Example Configuration:
-
-```yaml
-logging:
-  receivers:
-    nginx_default_access:
-      type: nginx_access
-    nginx_default_error:
-      type: nginx_error
-  service:
-    pipelines:
-      nginx:
-        receivers:
-          - nginx_default_access
-          - nginx_default_error
-```
 
 ## Logs
 

--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -1,6 +1,6 @@
 # Nginx
 
-Follow https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/nginx
+Follow [installation guide](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/nginx)
 for instructions to collect logs and metrics from this application using Ops Agent.
 
 ## Metrics

--- a/docs/postgresql.md
+++ b/docs/postgresql.md
@@ -1,86 +1,7 @@
-# `postgresql` Metrics Receiver
+# PostgreSQL
 
-The postgresql receiver can retrieve stats from your postgresql instance by connecting as a monitoring user.
-
-## Prerequisites
-
-The `postgresql` receiver defaults to connecting to a local postgresql server using a Unix socket and Unix authentication as the `root` user.
-
-## Configuration
-
-Following the guide for [Configuring the Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/configuration#file-location), add the required elements for your postgresql configuration.
-
-To configure a receiver for your postgresql metrics, specify the following fields:
-
-| Field                   | Required | Default                         | Description |
-| ---                     | ---      | ---                             | ---         |
-| `type`                  | required |                      | Must be `postgresql`. |
-| `endpoint`              | optional | `/var/run/postgresql/.s.PGSQL.5432`   | The hostname:port or socket path starting with `/` used to connect to postgresql |
-| `collection_interval`   | required |                                 | A [time.Duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`. |
-| `username`              | optional |                                 | The username used to connect to the server. |
-| `password`              | optional |                                 | The password used to connect to the server. |
-| `insecure`              | optional | true                            | Signals whether to use a secure TLS connection or not. If insecure is true TLS will not be enabled. |
-| `insecure_skip_verify`  | optional | false                           | Whether to skip verifying the certificate or not. A false value of insecure_skip_verify will not be used if insecure is true as the connection will not use TLS at all. |
-| `cert_file`             | optional |                             | Path to the TLS cert to use for TLS required connections. |
-| `key_file`              | optional |                             | Path to the TLS key to use for TLS required connections. |
-| `ca_file`               | optional |                             | Path to the CA cert. As a client this verifies the server certificate. If empty, uses system root CA. |
-
-Example Configuration:
-
-```yaml
-metrics:
-  receivers:
-    postgresql_metrics:
-      type: postgresql
-      collection_interval: 60s
-      username: usr
-      password: pwd
-  service:
-    pipelines:
-      postgresql_pipeline:
-        receivers:
-          - postgresql_metrics
-```
-
-TCP connection with a username and password:
-
-```yaml
-metrics:
-  receivers:
-    postgresql_metrics:
-      type: postgresql 
-      endpoint: localhost:3306
-      collection_interval: 60s
-      password: pwd
-      username: usr
-  service:
-    pipelines:
-      postgresql_pipeline:
-        receivers:
-          - postgresql_metrics
-```
-
-TCP connection with a username and password and TLS:
-
-```yaml
-metrics:
-  receivers:
-    postgresql_metrics:
-      type: postgresql 
-      endpoint: localhost:3306
-      collection_interval: 60s
-      password: pwd
-      username: usr
-      insecure: false
-      insecure_skip_verify: false
-      cert_file: /path/to/cert
-      ca_file: /path/to/ca
-  service:
-    pipelines:
-      postgresql_pipeline:
-        receivers:
-          - postgresql_metrics
-```
+Follow [installation guide](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/postgresql)
+for instructions to collect logs and metrics from this application using Ops Agent.
 
 ## Metrics
 
@@ -95,34 +16,6 @@ The Ops Agent collects the following metrics from your postgresql instances.
 | workload.googleapis.com/postgresql.operations          | sum       | 1           | database, table, operation      | The number of db row operations. |
 | workload.googleapis.com/postgresql.rollbacks           | sum       | 1           | database                        | The number of rollbacks. |
 | workload.googleapis.com/postgresql.rows                | sum       | 1           | database, table, state          | The number of rows in the database. |
-
-
-
-# `postgresql_general` Logging Receiver
-
-## Configuration
-
-To configure a receiver for your postgresql general logs, specify the following fields:
-
-| Field                 | Default                      | Description |
-| ---                   | ---                          | ---         |
-| `type`                | required                     | Must be `postgresql_general`. |
-| `include_paths`       | `[/var/log/postgresql/postgresql*.log, /var/lib/pgsql/data/log/postgresql*.log, /var/lib/pgsql/*/data/log/postgresql*.log]` | The log files to read. |
-| `exclude_paths`       | `[]`                         | Log files to exclude (if `include_paths` contains a glob or directory). |
-
-Example Configuration:
-
-```yaml
-logging:
-  receivers:
-    postgresql_general:
-      type: postgresql_general
-  service:
-    pipelines:
-      postgresql:
-        receivers:
-          - postgresql_general
-```
 
 ## Logs
 

--- a/docs/redis.md
+++ b/docs/redis.md
@@ -1,6 +1,6 @@
 # Redis
 
-Follow https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/redis
+Follow [installation guide](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/redis)
 for instructions to collect logs and metrics from this application using Ops Agent.
 
 ## Metrics

--- a/docs/redis.md
+++ b/docs/redis.md
@@ -1,96 +1,39 @@
-# `redis` Metrics Receiver
+# Redis
 
-The redis receiver can retrieve stats from your redis server through the [INFO](https://redis.io/commands/info) command. 
-
-
-## Configuration
-
-Following the guide for [Configuring the Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/configuration#file-location), add the required elements for your redis configuration.
-
-To configure a receiver for your redis metrics, specify the following fields:
-
-| Field                 | Default                   | Description |
-| ---                   | ---                       | ---         |
-| `type`                | required                  | Must be `redis`. |
-| `address`             | `localhost:6379`          | The url exposed by redis |
-| `collection_interval` | `60s`                     | A [time.Duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`. |
-| `password`            |                           | The password used to connect to the server. |
-
-Example Configuration:
-
-```yaml
-metrics:
-  receivers:
-    redis_metrics:
-      type: redis
-      address: localhost:6379
-      collection_interval: 30s
-      password: pwd
-  service:
-    pipelines:
-      redis_pipeline:
-        receivers:
-          - redis_metrics
-```
+Follow https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/redis
+for instructions to collect logs and metrics from this application using Ops Agent.
 
 ## Metrics
 
 The Ops Agent collects the following metrics from your redis servers.
 
-| Metric                                                              | Data Type | Unit    | Labels  | Description    |
-| ---                                                                 | ---    | ---     | ---     | ---            | 
-| workload.googleapis.com/redis.cpu.time	                            | sum	   | s	     | state:  | System CPU consumed by the Redis server in seconds since server start |
-| workload.googleapis.com/redis.clients.connected	                    | gauge  | 1		   |         | Number of client connections (excluding connections from replicas) |
-| workload.googleapis.com/redis.clients.max_input_buffer	            | gauge	 | 1		   |         | Biggest input buffer among current client connections |
-| workload.googleapis.com/redis.clients.max_output_buffer	            | gauge	 | 1		   |         | Longest output list among current client connections |
-| workload.googleapis.com/redis.clients.blocked	                      | gauge  | 1		   |         | Number of clients pending on a blocking call |
-| workload.googleapis.com/redis.keys.expired	                        | sum	   | 1		   |         | Total number of key expiration events |
-| workload.googleapis.com/redis.keys.evicted	                        | sum	   | 1		   |         | Number of evicted keys due to maxmemory limit |
-| workload.googleapis.com/redis.connections.received	                | sum	   | 1		   |         | Total number of connections accepted by the server |
-| workload.googleapis.com/redis.connections.rejected	                | sum	   | 1		   |         | Number of connections rejected because of maxclients limit |
-| workload.googleapis.com/redis.memory.used	                          | gauge	 | by	     |         | Total number of bytes allocated by Redis using its allocator |
-| workload.googleapis.com/redis.memory.peak	                          | gauge	 | by	     |         | Peak memory consumed by Redis (in bytes) |
-| workload.googleapis.com/redis.memory.rss	                          | gauge	 | by	     |         | Number of bytes that Redis allocated as seen by the operating system |
-| workload.googleapis.com/redis.memory.lua	                          | gauge	 | by	     |         | Number of bytes used by the Lua engine |
-| workload.googleapis.com/redis.memory.fragmentation_ratio	          | gauge	 | 1		   |         | Ratio between used_memory_rss and used_memory |
-| workload.googleapis.com/redis.rdb.changes_since_last_save	          | gauge  | 1		   |         | Number of changes since the last dump |
-| workload.googleapis.com/redis.commands	                            | gauge	 | {ops}/s |         | Number of commands processed per second |
-| workload.googleapis.com/redis.commands.processed	                  | sum	   | 1		   |         | Total number of commands processed by the server |
-| workload.googleapis.com/redis.net.input	                            | sum	   | by	     |         | The total number of bytes read from the network |
-| workload.googleapis.com/redis.net.output	                          | sum	   | by	     |         | The total number of bytes written to the network |
-| workload.googleapis.com/redis.keyspace.hits	                        | sum	   | 1		   |         | Number of successful lookup of keys in the main dictionary |
-| workload.googleapis.com/redis.keyspace.misses	                      | sum	   | 1	     |         | Number of failed lookup of keys in the main dictionary |
-| workload.googleapis.com/redis.latest_fork	                          | guage	 | us	     |         | Duration of the latest fork operation in microseconds |
-| workload.googleapis.com/redis.slaves.connected	                    | gauge  | 1		   |         | Number of connected replicas |
-| workload.googleapis.com/redis.replication.backlog_first_byte_offset	| gauge	 | 1		   |         | The master offset of the replication backlog buffer |
-| workload.googleapis.com/redis.replication.offset	                  | gauge	 | 1		   |         | The server's current replication o
-        
-# `redis` Logging Receiver
-
-## Configuration
-
-To configure a receiver for your redis logs, specify the following fields:
-
-| Field                 | Default                       | Description |
-| ---                   | ---                           | ---         |
-| `type`                | required                      | Must be `redis`. |
-| `include_paths`       | `[/var/log/redis/redis-server.log, /var/log/redis_6379.log, /var/log/redis/redis.log, /var/log/redis/default.log, /var/log/redis/redis_6379.log]` | A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `/var/log/redis/*.log`.
-| `exclude_paths`       | `[]`                          | A list of filesystem path patterns to exclude from the set matched by `include_paths`.
-
-
-Example Configuration:
-
-```yaml
-logging:
-  receivers:
-    redis_default:
-      type: redis
-  service:
-    pipelines:
-      redis:
-        receivers:
-        - redis_default
-```
+| Metric                                                              | Data Type | Unit    | Labels | Description |
+| ---                                                                 | ---       | ---     | ---    | ---         |
+| workload.googleapis.com/redis.cpu.time                              | sum       | s       | state  | System CPU consumed by the Redis server in seconds since server start |
+| workload.googleapis.com/redis.clients.connected                     | gauge     | 1       |        | Number of client connections (excluding connections from replicas) |
+| workload.googleapis.com/redis.clients.max_input_buffer              | gauge     | 1       |        | Biggest input buffer among current client connections |
+| workload.googleapis.com/redis.clients.max_output_buffer             | gauge     | 1       |        | Longest output list among current client connections |
+| workload.googleapis.com/redis.clients.blocked                       | gauge     | 1       |        | Number of clients pending on a blocking call |
+| workload.googleapis.com/redis.keys.expired                          | sum       | 1       |        | Total number of key expiration events |
+| workload.googleapis.com/redis.keys.evicted                          | sum       | 1       |        | Number of evicted keys due to maxmemory limit |
+| workload.googleapis.com/redis.connections.received                  | sum       | 1       |        | Total number of connections accepted by the server |
+| workload.googleapis.com/redis.connections.rejected                  | sum       | 1       |        | Number of connections rejected because of maxclients limit |
+| workload.googleapis.com/redis.memory.used                           | gauge     | by      |        | Total number of bytes allocated by Redis using its allocator |
+| workload.googleapis.com/redis.memory.peak                           | gauge     | by      |        | Peak memory consumed by Redis (in bytes) |
+| workload.googleapis.com/redis.memory.rss                            | gauge     | by      |        | Number of bytes that Redis allocated as seen by the operating system |
+| workload.googleapis.com/redis.memory.lua                            | gauge     | by      |        | Number of bytes used by the Lua engine |
+| workload.googleapis.com/redis.memory.fragmentation_ratio            | gauge     | 1       |        | Ratio between used_memory_rss and used_memory |
+| workload.googleapis.com/redis.rdb.changes_since_last_save           | gauge     | 1       |        | Number of changes since the last dump |
+| workload.googleapis.com/redis.commands                              | gauge     | {ops}/s |        | Number of commands processed per second |
+| workload.googleapis.com/redis.commands.processed                    | sum       | 1       |        | Total number of commands processed by the server |
+| workload.googleapis.com/redis.net.input                             | sum       | by      |        | The total number of bytes read from the network |
+| workload.googleapis.com/redis.net.output                            | sum       | by      |        | The total number of bytes written to the network |
+| workload.googleapis.com/redis.keyspace.hits                         | sum       | 1       |        | Number of successful lookup of keys in the main dictionary |
+| workload.googleapis.com/redis.keyspace.misses                       | sum       | 1       |        | Number of failed lookup of keys in the main dictionary |
+| workload.googleapis.com/redis.latest_fork                           | guage     | us      |        | Duration of the latest fork operation in microseconds |
+| workload.googleapis.com/redis.slaves.connected                      | gauge     | 1       |        | Number of connected replicas |
+| workload.googleapis.com/redis.replication.backlog_first_byte_offset | gauge     | 1       |        | The master offset of the replication backlog buffer |
+| workload.googleapis.com/redis.replication.offset                    | gauge     | 1       |        | The server's current replication o
 
 ## Logs
 

--- a/docs/tomcat.md
+++ b/docs/tomcat.md
@@ -1,37 +1,7 @@
-# `tomcat` Metrics Receiver
+# Apache Tomcat
 
-The `tomcat` metrics receiver can fetch stats from a Tomcat server's Java Virtual Machine (JVM) via [JMX](https://www.oracle.com/java/technologies/javase/javamanagement.html).
-
-## Prerequisites
-
-In order to expose a JMX endpoint, you must set the `com.sun.management.jmxremote.port` system property. It is recommended to also set the `com.sun.management.jmxremote.rmi.port` system property to the same port. To expose JMX endpoint remotely, you must also set the `java.rmi.server.hostname` system property. By default, these properties are set in a Tomcat deployment's tomcat-env.sh file and the default Tomcat installation requires no JMX authentication with JMX exposed locally on 127.0.0.1:8050.
-
-## Configuration
-
-| Field                 | Default            | Description |
-| ---                   | ---                | ---         |
-| `type`                | required           | Must be `tomcat`. |
-| `endpoint`            | `localhost:8050`   | The [JMX Service URL](https://docs.oracle.com/javase/8/docs/api/javax/management/remote/JMXServiceURL.html) or host and port used to construct the Service URL. Must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form will be used to create a Service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`. |
-| `collect_jvm_metrics` | true               | Should the set of support [JVM metrics](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/docs/jvm.md#metrics) also be collected |
-| `username`            | not set by default | The configured username if JMX is configured to require authentication. |
-| `password`            | not set by default | The configured password if JMX is configured to require authentication. |
-| `collection_interval` | `60s`              | A [time.Duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`. |
-
-
-Example Configuration:
-
-```yaml
-metrics:
-  receivers:
-    tomcat_metrics:
-      type: tomcat
-      collection_interval: 60s
-  service:
-    pipelines:
-      tomcat_pipeline:
-        receivers:
-          - tomcat_metrics
-```
+Follow [installation guide](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/tomcat)
+for instructions to collect logs and metrics from this application using Ops Agent.
 
 ## Metrics
 In addition to Tomcat specific metrics, by default Tomcat will also report [JVM metrics](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/docs/jvm.md#metrics)
@@ -45,45 +15,6 @@ In addition to Tomcat specific metrics, by default Tomcat will also report [JVM 
 | workload.googleapis.com/tomcat.threads               | Gauge          | threads     | proto_handler, state           | The number of threads. |
 | workload.googleapis.com/tomcat.max_time              | Gauge          | ms          | proto_handler                  | Maximum time to process a request. |
 | workload.googleapis.com/tomcat.request_count         | Cumulative     | requests    | proto_handler                  | The total requests. |
-
-
-
-# `tomcat_system` and `tomcat_access` Logging Receivers
-
-## Configuration
-
-To configure a receiver for your tomcat system logs, specify the following fields:
-
-| Field                 | Default                           | Description |
-| ---                   | ---                               | ---         |
-| `type`                | required                          | Must be `tomcat_system`. |
-| `include_paths`       | `[/opt/tomcat/logs/catalina.out]` | A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `/var/log/apache*/*.log`.
-| `exclude_paths`       | `[]`                              | A list of filesystem path patterns to exclude from the set matched by `include_paths`.
-
-To configure a receiver for your tomcat access logs, specify the following fields:
-
-| Field                 | Default                                         | Description |
-| ---                   | ---                                             | ---         |
-| `type`                | required                                        | Must be `tomcat_access`. |
-| `include_paths`       | `[/opt/tomcat/logs/localhost_access_log.*.txt]` | The log files to read. |
-| `exclude_paths`       | `[]`                                            | Log files to exclude (if `include_paths` contains a glob or directory). |
-
-Example Configuration:
-
-```yaml
-logging:
-  receivers:
-    tomcat_system:
-      type: tomcat_system
-    tomcat_access:
-      type: tomcat_access
-  service:
-    pipelines:
-      tomcat:
-        receivers:
-          - tomcat_system
-          - tomcat_access
-```
 
 ## Logs
 


### PR DESCRIPTION
This way we can avoid maintaining multiple copies.