### PR TITLE
Refactor JVM apps to use shared components

### DIFF
--- a/apps/tomcat.go
+++ b/apps/tomcat.go
@@ -16,7 +16,6 @@ package apps
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
@@ -28,9 +27,7 @@ type MetricsReceiverTomcat struct {
 
 	confgenerator.MetricsReceiverShared `yaml:",inline"`
 
-	Endpoint string `yaml:"endpoint" validate:"omitempty,hostname_port|startswith=service:jmx:"`
-	Username string `yaml:"username" validate:"required_with=Password"`
-	Password string `yaml:"password" validate:"required_with=Username"`
+	confgenerator.MetricsReceiverSharedJVM `yaml:",inline"`
 
 	CollectJVMMetics *bool `yaml:"collect_jvm_metrics"`
 }
@@ -42,45 +39,22 @@ func (r MetricsReceiverTomcat) Type() string {
 }
 
 func (r MetricsReceiverTomcat) Pipelines() []otel.Pipeline {
-	if r.Endpoint == "" {
-		r.Endpoint = defaultTomcatEndpoint
-	}
-
-	jarPath, err := FindJarPath()
-	if err != nil {
-		log.Printf(`Encountered an error discovering the location of the JMX Metrics Exporter, %v`, err)
-	}
-
 	targetSystem := "tomcat"
 	if r.CollectJVMMetics == nil || *r.CollectJVMMetics {
 		targetSystem = fmt.Sprintf("%s,%s", targetSystem, "jvm")
 	}
 
-	config := map[string]interface{}{
-		"target_system":       targetSystem,
-		"collection_interval": r.CollectionIntervalString(),
-		"endpoint":            r.Endpoint,
-		"jar_path":            jarPath,
-	}
-
-	// Only set the username & password fields if provided
-	if r.Username != "" && r.Password != "" {
-		config["username"] = r.Username
-		config["password"] = r.Password
-	}
-
-	return []otel.Pipeline{{
-		Receiver: otel.Component{
-			Type:   "jmx",
-			Config: config,
-		},
-		Processors: []otel.Component{
+	return r.MetricsReceiverSharedJVM.JVMConfig(
+		targetSystem,
+		defaultTomcatEndpoint,
+		r.CollectionIntervalString(),
+		[]otel.Component{
 			otel.NormalizeSums(),
 			otel.MetricsTransform(
 				otel.AddPrefix("workload.googleapis.com"),
 			),
 		},
-	}}
+	)
 }
 
 func init() {

--- a/confgenerator/confgenerator_test.go
+++ b/confgenerator/confgenerator_test.go
@@ -92,7 +92,7 @@ func TestGenerateConfsWithValidInput(t *testing.T) {
 }
 
 func testGenerateConfsWithValidInput(t *testing.T, platform platformConfig) {
-	apps.FindJarPath = func() (string, error) {
+	confgenerator.FindJarPath = func() (string, error) {
 		return "/path/to/executables/opentelemetry-java-contrib-jmx-metrics.jar", nil
 	}
 

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_cassandra_malformed_url/golden_error
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_cassandra_malformed_url/golden_error
@@ -1,4 +1,4 @@
-[19:17] "endpoint" must be a URL
+[19:17] Key: 'MetricsReceiverSharedJVM.endpoint' Error:Field validation for 'endpoint' failed on the 'hostname_port|startswith=service:jmx:' tag
   16 |   receivers:
   17 |     cassandrametrics:
   18 |       type: cassandra

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_jvm_malformed_url/golden_error
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_jvm_malformed_url/golden_error
@@ -1,4 +1,4 @@
-[19:17] "endpoint" must be a URL
+[19:17] Key: 'MetricsReceiverSharedJVM.endpoint' Error:Field validation for 'endpoint' failed on the 'hostname_port|startswith=service:jmx:' tag
   16 |   receivers:
   17 |     jvmmetrics:
   18 |       type: jvm

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_tomcat_malformed_url/golden_error
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_tomcat_malformed_url/golden_error
@@ -1,4 +1,4 @@
-[19:17] Key: 'MetricsReceiverTomcat.endpoint' Error:Field validation for 'endpoint' failed on the 'hostname_port|startswith=service:jmx:' tag
+[19:17] Key: 'MetricsReceiverSharedJVM.endpoint' Error:Field validation for 'endpoint' failed on the 'hostname_port|startswith=service:jmx:' tag
   16 |   receivers:
   17 |     tomcat_metrics:
   18 |       type: tomcat

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_tomcat_not_service_url/golden_error
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_tomcat_not_service_url/golden_error
@@ -1,4 +1,4 @@
-[19:17] Key: 'MetricsReceiverTomcat.endpoint' Error:Field validation for 'endpoint' failed on the 'hostname_port|startswith=service:jmx:' tag
+[19:17] Key: 'MetricsReceiverSharedJVM.endpoint' Error:Field validation for 'endpoint' failed on the 'hostname_port|startswith=service:jmx:' tag
   16 |   receivers:
   17 |     tomcat_metrics:
   18 |       type: tomcat

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_tomcat_username_no_password/golden_error
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_tomcat_username_no_password/golden_error
@@ -1,9 +1,1 @@
-[17:19] "password" is required when "Username" is set
-  15 | metrics:
-  16 |   receivers:
-> 17 |     tomcat_metrics:
-                         ^
-  18 |       type: tomcat
-  19 |       username: usr
-  20 |       collection_interval: 30s
-  21 |   
+"password" is required when "Username" is set

--- a/confgenerator/testdata/invalid/windows/metrics-receiver_jvm_malformed_url/golden_error
+++ b/confgenerator/testdata/invalid/windows/metrics-receiver_jvm_malformed_url/golden_error
@@ -1,4 +1,4 @@
-[19:17] "endpoint" must be a URL
+[19:17] Key: 'MetricsReceiverSharedJVM.endpoint' Error:Field validation for 'endpoint' failed on the 'hostname_port|startswith=service:jmx:' tag
   16 |   receivers:
   17 |     jvmmetrics:
   18 |       type: jvm


### PR DESCRIPTION
Left the processors as a separate parameter because I'll be adding extra ones for kafka to filter out existing unneeded metrics, so I'm just preemptively having that enhancement in the shared component.