### PR TITLE
apps: `hostmetrics` use mute_process_name_error

### DIFF
--- a/apps/hostmetrics.go
+++ b/apps/hostmetrics.go
@@ -44,7 +44,9 @@ func (r MetricsReceiverHostmetrics) Pipelines() []otel.Pipeline {
 					"network":    struct{}{},
 					"paging":     struct{}{},
 					"process":    struct{}{},
-					"processes":  struct{}{},
+					"processes": map[string]bool{
+						"mute_process_name_error": true,
+					},
 				},
 			},
 		},

--- a/apps/hostmetrics.go
+++ b/apps/hostmetrics.go
@@ -43,10 +43,10 @@ func (r MetricsReceiverHostmetrics) Pipelines() []otel.Pipeline {
 					"filesystem": struct{}{},
 					"network":    struct{}{},
 					"paging":     struct{}{},
-					"process":    struct{}{},
-					"processes": map[string]bool{
+					"process": map[string]bool{
 						"mute_process_name_error": true,
 					},
+					"processes": struct{}{},
 				},
 			},
 		},

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -385,7 +385,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -384,9 +384,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_refresh_interval/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_refresh_interval/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_refresh_interval/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_refresh_interval/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_refresh_interval/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_refresh_interval/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_refresh_interval/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_refresh_interval/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_refresh_interval/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_refresh_interval/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_refresh_interval/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_refresh_interval/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_complex/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_complex/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_complex/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_complex/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
@@ -390,9 +390,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
@@ -391,7 +391,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -391,9 +391,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -392,7 +392,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -391,9 +391,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -392,7 +392,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
@@ -390,9 +390,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
@@ -391,7 +391,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_otel.conf
@@ -385,7 +385,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_otel.conf
@@ -384,9 +384,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
@@ -406,7 +406,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
@@ -405,9 +405,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_otel.conf
@@ -406,7 +406,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_missing_status_url/golden_otel.conf
@@ -405,9 +405,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
@@ -396,9 +396,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   jmx/cassandrapipeline_cassandrametrics:
     collection_interval: 30s
     endpoint: localhost:7199

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
@@ -397,7 +397,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   jmx/cassandrapipeline_cassandrametrics:
     collection_interval: 30s
     endpoint: localhost:7199

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_otel.conf
@@ -396,9 +396,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   jmx/cassandrapipeline_cassandrametrics:
     collection_interval: 30s
     endpoint: localhost:7199

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_no_jvm/golden_otel.conf
@@ -397,7 +397,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   jmx/cassandrapipeline_cassandrametrics:
     collection_interval: 30s
     endpoint: localhost:7199

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -389,9 +389,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -390,7 +390,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
@@ -396,9 +396,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   jmx/jvmpipeline_jvmmetrics:
     collection_interval: 30s
     endpoint: localhost:9999

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
@@ -397,7 +397,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   jmx/jvmpipeline_jvmmetrics:
     collection_interval: 30s
     endpoint: localhost:9999

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
@@ -396,9 +396,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   jmx/jvmpipeline_jvmmetrics:
     collection_interval: 30s
     endpoint: localhost:9999

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
@@ -397,7 +397,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   jmx/jvmpipeline_jvmmetrics:
     collection_interval: 30s
     endpoint: localhost:9999

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
@@ -396,9 +396,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   jmx/jvmpipeline_jvmmetrics:
     collection_interval: 30s
     endpoint: localhost:9999

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
@@ -397,7 +397,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   jmx/jvmpipeline_jvmmetrics:
     collection_interval: 30s
     endpoint: localhost:9999

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_otel.conf
@@ -402,9 +402,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   memcached/memcachedpipeline_memcachedmetrics:
     collection_interval: 30s
     endpoint: localhost:11211

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_otel.conf
@@ -403,7 +403,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   memcached/memcachedpipeline_memcachedmetrics:
     collection_interval: 30s
     endpoint: localhost:11211

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_otel.conf
@@ -397,7 +397,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   mysql/mysqlpipeline_mysqlmetrics:
     collection_interval: 30s
     endpoint: localhost:3306

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_otel.conf
@@ -396,9 +396,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   mysql/mysqlpipeline_mysqlmetrics:
     collection_interval: 30s
     endpoint: localhost:3306

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
@@ -396,9 +396,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   nginx/nginxpipeline_nginxmetrics:
     collection_interval: 30s
     endpoint: http://localhost/status

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
@@ -397,7 +397,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   nginx/nginxpipeline_nginxmetrics:
     collection_interval: 30s
     endpoint: http://localhost/status

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_otel.conf
@@ -396,9 +396,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   nginx/nginxpipeline_nginxmetrics:
     collection_interval: 30s
     endpoint: http://localhost/status

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_missing_status_url/golden_otel.conf
@@ -397,7 +397,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   nginx/nginxpipeline_nginxmetrics:
     collection_interval: 30s
     endpoint: http://localhost/status

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_no_tls/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_no_tls/golden_otel.conf
@@ -397,7 +397,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   postgresql/postgresqlpipeline_postgresqlmetrics:
     collection_interval: 30s
     endpoint: var/run/postgresql/:5432

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_no_tls/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_no_tls/golden_otel.conf
@@ -396,9 +396,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   postgresql/postgresqlpipeline_postgresqlmetrics:
     collection_interval: 30s
     endpoint: var/run/postgresql/:5432

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden_otel.conf
@@ -397,7 +397,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   postgresql/postgresqlpipeline_postgresqlmetrics:
     collection_interval: 30s
     endpoint: localhost:3306

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden_otel.conf
@@ -396,9 +396,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   postgresql/postgresqlpipeline_postgresqlmetrics:
     collection_interval: 30s
     endpoint: localhost:3306

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden_otel.conf
@@ -397,7 +397,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   postgresql/postgresqlpipeline_postgresqlmetrics:
     collection_interval: 30s
     endpoint: localhost:3306

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden_otel.conf
@@ -396,9 +396,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   postgresql/postgresqlpipeline_postgresqlmetrics:
     collection_interval: 30s
     endpoint: localhost:3306

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden_otel.conf
@@ -397,7 +397,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   postgresql/postgresqlpipeline_postgresqlmetrics:
     collection_interval: 30s
     endpoint: localhost:3306

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden_otel.conf
@@ -396,9 +396,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   postgresql/postgresqlpipeline_postgresqlmetrics:
     collection_interval: 30s
     endpoint: localhost:3306

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_otel.conf
@@ -403,9 +403,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_otel.conf
@@ -404,7 +404,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_otel.conf
@@ -403,9 +403,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_missing_address/golden_otel.conf
@@ -404,7 +404,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden_otel.conf
@@ -397,7 +397,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   jmx/tomcat__pipeline_tomcat__metrics:
     collection_interval: 30s
     endpoint: localhost:8050

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden_otel.conf
@@ -396,9 +396,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   jmx/tomcat__pipeline_tomcat__metrics:
     collection_interval: 30s
     endpoint: localhost:8050

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_no_jvm/golden_otel.conf
@@ -397,7 +397,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   jmx/tomcat__pipeline_tomcat__metrics:
     collection_interval: 30s
     endpoint: localhost:7199

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_no_jvm/golden_otel.conf
@@ -396,9 +396,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   jmx/tomcat__pipeline_tomcat__metrics:
     collection_interval: 30s
     endpoint: localhost:7199

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -421,9 +421,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -422,7 +422,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
@@ -436,9 +436,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
@@ -437,7 +437,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
@@ -436,9 +436,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
@@ -437,7 +437,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
@@ -436,9 +436,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
@@ -437,7 +437,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
@@ -436,9 +436,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
@@ -437,7 +437,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -436,9 +436,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -437,7 +437,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
@@ -440,7 +440,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
@@ -439,9 +439,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
@@ -440,7 +440,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
@@ -439,9 +439,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
@@ -440,7 +440,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
@@ -439,9 +439,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
@@ -421,9 +421,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
@@ -422,7 +422,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -443,7 +443,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -442,9 +442,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -443,7 +443,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -442,9 +442,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
@@ -440,7 +440,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
@@ -439,9 +439,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
@@ -453,7 +453,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
@@ -452,9 +452,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
@@ -453,7 +453,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
@@ -452,9 +452,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -436,9 +436,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -437,7 +437,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
@@ -443,9 +443,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   jmx/jvmpipeline_jvmmetrics:
     collection_interval: 30s
     endpoint: localhost:9999

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
@@ -444,7 +444,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   jmx/jvmpipeline_jvmmetrics:
     collection_interval: 30s
     endpoint: localhost:9999

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
@@ -443,9 +443,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   jmx/jvmpipeline_jvmmetrics:
     collection_interval: 30s
     endpoint: localhost:9999

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
@@ -444,7 +444,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   jmx/jvmpipeline_jvmmetrics:
     collection_interval: 30s
     endpoint: localhost:9999

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_otel.conf
@@ -443,9 +443,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   mysql/mysqlpipeline_mysqlmetrics:
     collection_interval: 30s
     endpoint: localhost:3306

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_otel.conf
@@ -444,7 +444,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   mysql/mysqlpipeline_mysqlmetrics:
     collection_interval: 30s
     endpoint: localhost:3306

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_otel.conf
@@ -443,9 +443,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   mysql/mysqlpipeline_mysqlmetrics:
     collection_interval: 30s
     endpoint: /var/run/mysqld/mysqld.sock

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_otel.conf
@@ -444,7 +444,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   mysql/mysqlpipeline_mysqlmetrics:
     collection_interval: 30s
     endpoint: /var/run/mysqld/mysqld.sock

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
@@ -443,9 +443,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   nginx/nginxpipeline_nginxmetrics:
     collection_interval: 30s
     endpoint: http://localhost/status

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
@@ -444,7 +444,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   nginx/nginxpipeline_nginxmetrics:
     collection_interval: 30s
     endpoint: http://localhost/status

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
@@ -443,9 +443,9 @@ receivers:
       memory: {}
       network: {}
       paging: {}
-      process: {}
-      processes:
+      process:
         mute_process_name_error: true
+      processes: {}
   nginx/nginxpipeline_nginxmetrics:
     collection_interval: 30s
     endpoint: http://localhost/status

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
@@ -444,7 +444,8 @@ receivers:
       network: {}
       paging: {}
       process: {}
-      processes: {}
+      processes:
+        mute_process_name_error: true
   nginx/nginxpipeline_nginxmetrics:
     collection_interval: 30s
     endpoint: http://localhost/status


### PR DESCRIPTION
Use the new `mute_process_name_error` config to mitigate process
readlink log spam.