### PR TITLE
Updates for logging processor requirement of time_format when time_key is present.

### DIFF
--- a/confgenerator/logging_processors.go
+++ b/confgenerator/logging_processors.go
@@ -25,8 +25,8 @@ import (
 
 // ParserShared holds common parameters that are used by all processors that are implemented with fluentbit's "parser" filter.
 type ParserShared struct {
-	TimeKey    string `yaml:"time_key,omitempty"`    // by default does not parse timestamp
-	TimeFormat string `yaml:"time_format,omitempty"` // must be provided if time_key is present
+	TimeKey    string `yaml:"time_key,omitempty" validate:"required_with=TimeFormat"` // by default does not parse timestamp
+	TimeFormat string `yaml:"time_format,omitempty" validate:"required_with=TimeKey"` // must be provided if time_key is present
 	// Types allows parsing the extracted fields.
 	// Not exposed to users for now, but can be used by app receivers.
 	// Documented at https://docs.fluentbit.io/manual/v/1.3/parser

--- a/confgenerator/testdata/invalid/linux/logging-processor_parse_json_type_missing_time_format_required_with_time_key/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-processor_parse_json_type_missing_time_format_required_with_time_key/golden_error
@@ -1,9 +1,1 @@
-[9:16] "regex" is a required field
-   6 |       - /var/log/messages
-   7 |       - /var/log/syslog
-   8 |   processors:
->  9 |     processor_1:
-                      ^
-  10 |       type: parse_regex
-  11 |       field: field_1
-  12 |   service:
+"time_format" is required when "TimeKey" is set

--- a/confgenerator/testdata/invalid/linux/logging-processor_parse_json_type_missing_time_format_required_with_time_key/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-processor_parse_json_type_missing_time_format_required_with_time_key/golden_error
@@ -1,0 +1,9 @@
+[9:16] "regex" is a required field
+   6 |       - /var/log/messages
+   7 |       - /var/log/syslog
+   8 |   processors:
+>  9 |     processor_1:
+                      ^
+  10 |       type: parse_regex
+  11 |       field: field_1
+  12 |   service:

--- a/confgenerator/testdata/invalid/linux/logging-processor_parse_json_type_missing_time_format_required_with_time_key/input.yaml
+++ b/confgenerator/testdata/invalid/linux/logging-processor_parse_json_type_missing_time_format_required_with_time_key/input.yaml
@@ -1,0 +1,16 @@
+logging:
+  receivers:
+    syslog:
+      type: files
+      include_paths:
+      - /var/log/messages
+      - /var/log/syslog
+  processors:
+    json_processor:
+      type: parse_json
+      field: field_1
+      time_key: time_key_1
+  service:
+    pipelines:
+      default_pipeline:
+        receivers: [syslog]

--- a/confgenerator/testdata/invalid/linux/logging-processor_parse_regex_type_missing_time_format_required_with_time_key/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-processor_parse_regex_type_missing_time_format_required_with_time_key/golden_error
@@ -1,9 +1,1 @@
-[9:16] "regex" is a required field
-   6 |       - /var/log/messages
-   7 |       - /var/log/syslog
-   8 |   processors:
->  9 |     processor_1:
-                      ^
-  10 |       type: parse_regex
-  11 |       field: field_1
-  12 |   service:
+"time_format" is required when "TimeKey" is set

--- a/confgenerator/testdata/invalid/linux/logging-processor_parse_regex_type_missing_time_format_required_with_time_key/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-processor_parse_regex_type_missing_time_format_required_with_time_key/golden_error
@@ -1,0 +1,9 @@
+[9:16] "regex" is a required field
+   6 |       - /var/log/messages
+   7 |       - /var/log/syslog
+   8 |   processors:
+>  9 |     processor_1:
+                      ^
+  10 |       type: parse_regex
+  11 |       field: field_1
+  12 |   service:

--- a/confgenerator/testdata/invalid/linux/logging-processor_parse_regex_type_missing_time_format_required_with_time_key/input.yaml
+++ b/confgenerator/testdata/invalid/linux/logging-processor_parse_regex_type_missing_time_format_required_with_time_key/input.yaml
@@ -1,0 +1,17 @@
+logging:
+  receivers:
+    syslog:
+      type: files
+      include_paths:
+      - /var/log/messages
+      - /var/log/syslog
+  processors:
+    regex_processor:
+      type: parse_regex
+      field: field_1
+      regex: regex_pattern_1
+      time_key: time_key_1
+  service:
+    pipelines:
+      default_pipeline:
+        receivers: [syslog]

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/input.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/input.yaml
@@ -46,26 +46,12 @@ logging:
       field: key_1
       time_key: time_key_1
       time_format: time_format_1
-    parse_json_2:
-      type: parse_json
-      time_key: time_key_2
-    parse_json_3:
-      type: parse_json
-      time_format: time_format_3
     parse_regex_1:
       type: parse_regex
       field: key_1
       regex: regex_pattern_1
       time_key: time_key_1
       time_format: time_format_1
-    parse_regex_2:
-      type: parse_regex
-      regex: regex_pattern_2
-      time_key: time_key_2
-    parse_regex_3:
-      type: parse_regex
-      regex: regex_pattern_3
-      time_format: time_format_3
   service:
     pipelines:
       default_pipeline:

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -357,7 +357,7 @@ func TestProcessorOrder(t *testing.T) {
         receivers: [mylog_source]
         processors: [json1, json2]
         exporters: [google]
-`, logPath, "%Y-%m-%dT%H:%M:%S.%L%Z")
+`, logPath, "%Y-%m-%dT%H:%M:%S.%L%z")
 
 		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
 			t.Fatal(err)

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -347,6 +347,7 @@ func TestProcessorOrder(t *testing.T) {
       type: parse_json
       field: message
       time_key: time
+      time_format: "%s"
     json2:
       type: parse_json
       field: log
@@ -356,7 +357,7 @@ func TestProcessorOrder(t *testing.T) {
         receivers: [mylog_source]
         processors: [json1, json2]
         exporters: [google]
-`, logPath)
+`, logPath, "%Y-%m-%dT%H:%M:%S.%L%Z")
 
 		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
 			t.Fatal(err)

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -363,7 +363,7 @@ func TestProcessorOrder(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		line := fmt.Sprintf(`{"log":"{\"level\":\"info\",\"message\":\"start\"}\n","time":"%s"}`, time.Now().Format(time.RFC3339Nano)) + "\n"
+		line := fmt.Sprintf(`{"log":"{\"level\":\"info\",\"message\":\"start\"}\n","time":"%s"}`, time.Now().UTC().Format(time.RFC3339Nano)) + "\n"
 		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(line), logPath); err != nil {
 			t.Fatalf("error writing dummy log line: %v", err)
 		}

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -363,6 +363,7 @@ func TestProcessorOrder(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		// When not using UTC timestamps, the parsing with "%Y-%m-%dT%H:%M:%S.%L%z" doesn't work correctly in windows (b/218888265).
 		line := fmt.Sprintf(`{"log":"{\"level\":\"info\",\"message\":\"start\"}\n","time":"%s"}`, time.Now().UTC().Format(time.RFC3339Nano)) + "\n"
 		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(line), logPath); err != nil {
 			t.Fatalf("error writing dummy log line: %v", err)

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -367,7 +367,7 @@ func TestProcessorOrder(t *testing.T) {
 		// correctly in windows (b/218888265). The similar test TestCustomLogFormat uses the time
 		// format "%Y-%m-%dT%H:%M:%S.%L%Z" which is invalid to parse time.RFC3339Nano format.
 		// TestCustomLogFormat passes since it fallbacks to use a "now" timestamp when parsing fails.
-		ine := fmt.Sprintf(`{"log":"{\"level\":\"info\",\"message\":\"start\"}\n","time":"%s"}`, time.Now().UTC().Format(time.RFC3339Nano)) + "\n"
+		line := fmt.Sprintf(`{"log":"{\"level\":\"info\",\"message\":\"start\"}\n","time":"%s"}`, time.Now().UTC().Format(time.RFC3339Nano)) + "\n"
 		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(line), logPath); err != nil {
 			t.Fatalf("error writing dummy log line: %v", err)
 		}

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -363,8 +363,11 @@ func TestProcessorOrder(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// When not using UTC timestamps, the parsing with "%Y-%m-%dT%H:%M:%S.%L%z" doesn't work correctly in windows (b/218888265).
-		line := fmt.Sprintf(`{"log":"{\"level\":\"info\",\"message\":\"start\"}\n","time":"%s"}`, time.Now().UTC().Format(time.RFC3339Nano)) + "\n"
+		// When not using UTC timestamps, the parsing with "%Y-%m-%dT%H:%M:%S.%L%z" doesn't work
+		// correctly in windows (b/218888265). The similar test TestCustomLogFormat uses the time
+		// format "%Y-%m-%dT%H:%M:%S.%L%Z" which is invalid to parse time.RFC3339Nano format.
+		// TestCustomLogFormat passes since it fallbacks to use a "now" timestamp when parsing fails.
+		ine := fmt.Sprintf(`{"log":"{\"level\":\"info\",\"message\":\"start\"}\n","time":"%s"}`, time.Now().UTC().Format(time.RFC3339Nano)) + "\n"
 		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(line), logPath); err != nil {
 			t.Fatalf("error writing dummy log line: %v", err)
 		}

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -255,6 +255,7 @@ func TestCustomLogFormat(t *testing.T) {
 		ctx, logger, vm := agents.CommonSetup(t, platform)
 
 		logPath := logPathForPlatform(vm.Platform)
+		// TODO(b/219518200) : Update time_format to use correct format.
 		config := fmt.Sprintf(`logging:
   receivers:
     mylog_source:


### PR DESCRIPTION
- Updated TestProcessorOrder in integration_test/ops_agent_test.go, since the config used is missing time_format.
- Updated logging_processors.go so time_format is required when time_key is present and the other way around.
- Added input.yaml and generated golden_error files in the /testdata/invalid/ folder.
- Updated /valid/logging-processor_parse_json_and_parse_regex_types/input.yaml to remove the cases where time_format or time_key are missing.

b/212428534 - This PR has the same updates as #333 (which was reverted) and adding required updates to the integration tests.