### PR TITLE
Fix the default port of Apache.

### DIFF
--- a/apps/apache.go
+++ b/apps/apache.go
@@ -28,7 +28,7 @@ type MetricsReceiverApache struct {
 	ServerStatusURL string `yaml:"server_status_url" validate:"omitempty,url"`
 }
 
-const defaultServerStatusURL = "http://localhost:8080/server-status?auto"
+const defaultServerStatusURL = "http://localhost:80/server-status?auto"
 
 func (r MetricsReceiverApache) Type() string {
 	return "apache"

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
@@ -394,7 +394,7 @@ processors:
 receivers:
   apache/apache_apache:
     collection_interval: 60s
-    endpoint: http://localhost:8080/server-status?auto
+    endpoint: http://localhost:80/server-status?auto
   hostmetrics/default__pipeline_hostmetrics:
     collection_interval: 60s
     scrapers:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
@@ -441,7 +441,7 @@ processors:
 receivers:
   apache/apache__pipeline_apache__metrics:
     collection_interval: 30s
-    endpoint: http://localhost:8080/server-status?auto
+    endpoint: http://localhost:80/server-status?auto
   hostmetrics/default__pipeline_hostmetrics:
     collection_interval: 60s
     scrapers:

--- a/integration_test/third_party_apps_data/agent/ops-agent/linux/enable_apache
+++ b/integration_test/third_party_apps_data/agent/ops-agent/linux/enable_apache
@@ -21,7 +21,6 @@ metrics:
   receivers:
     apache:
       type: apache
-      server_status_url: http://localhost:80/server-status?auto
   service:
     pipelines:
       apache:


### PR DESCRIPTION
The default port of Apache should be 80 instead of 8080.

Apache users today have to explicitly specify`server_status_url: http://localhost:80/server-status?auto` in their config today to customize the config.

b/207530308