### PR TITLE
Solr System Log fixes

### DIFF
--- a/apps/solr.go
+++ b/apps/solr.go
@@ -68,7 +68,7 @@ func (p LoggingProcessorSolrSystem) Components(tag string, uid string) []fluentb
 			Parsers: []confgenerator.RegexParser{
 				{
 					// Sample line: 2022-01-06 04:16:08.794 INFO  (qtp1489933928-64) [   x:gettingstarted] o.a.s.c.S.Request [gettingstarted]  webapp=/solr path=/get params={q=*:*&_=1641440398872} status=0 QTime=2
-					Regex: `^(?<timestamp>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3,6})\s(?<level>[A-z]+)\s{2}\((?<thread>[^\)]+)\)\s\[c?:?(?<collection>[^\s]*)\ss?:?(?<shard>[^\s]*)\sr?:?(?<replica>[^\s]*)\sx?:?(?<core>[^\]]*)\]\s(?<source>[^\s]+)\s(?<message>(?:(?!\s\=\>)[\s\S])+)\s?=?>?(?<exception>[\s\S]*)`,
+					Regex: `^(?<timestamp>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3,6})\s(?<level>[A-z]+)\s{1,5}\((?<thread>[^\)]+)\)\s\[c?:?(?<collection>[^\s]*)\ss?:?(?<shard>[^\s]*)\sr?:?(?<replica>[^\s]*)\sx?:?(?<core>[^\]]*)\]\s(?<source>[^\s]+)\s(?<message>(?:(?!\s\=\>)[\s\S])+)\s?=?>?(?<exception>[\s\S]*)`,
 					Parser: confgenerator.ParserShared{
 						TimeKey:    "timestamp",
 						TimeFormat: "%Y-%m-%d %H:%M:%S.%L",
@@ -80,12 +80,12 @@ func (p LoggingProcessorSolrSystem) Components(tag string, uid string) []fluentb
 			{
 				StateName: "start_state",
 				NextState: "cont",
-				Regex:     `\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s[A-z]+\s{2}`,
+				Regex:     `\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s[A-z]+\s{1,5}`,
 			},
 			{
 				StateName: "cont",
 				NextState: "cont",
-				Regex:     `^(?!\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s[A-z]+\s{2})`,
+				Regex:     `^(?!\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s[A-z]+\s{1,5})`,
 			},
 		},
 	}.Components(tag, uid)
@@ -94,12 +94,12 @@ func (p LoggingProcessorSolrSystem) Components(tag string, uid string) []fluentb
 	c = append(c,
 		fluentbit.TranslationComponents(tag, "level", "logging.googleapis.com/severity", true,
 			[]struct{ SrcVal, DestVal string }{
-				{"FINEST", "DEBUG"},
-				{"FINE", "DEBUG"},
-				{"CONFIG", "ERROR"},
+				{"TRACE", "DEBUG"},
+				{"DEBUG", "DEBUG"},
 				{"INFO", "INFO"},
 				{"WARN", "WARNING"},
-				{"SEVERE", "CRITICAL"},
+				{"ERROR", "ERROR"},
+				{"FATAL", "CRITICAL"},
 			},
 		)...,
 	)

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden_fluent_bit_main.conf
@@ -78,21 +78,14 @@
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals level FINEST
+    Condition Key_Value_Equals level TRACE
     Match     solr.solr_system
     Name      modify
     Remove    level
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals level FINE
-    Match     solr.solr_system
-    Name      modify
-    Remove    level
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals level CONFIG
+    Condition Key_Value_Equals level DEBUG
     Match     solr.solr_system
     Name      modify
     Remove    level
@@ -112,8 +105,15 @@
     Remove    level
 
 [FILTER]
+    Add       logging.googleapis.com/severity ERROR
+    Condition Key_Value_Equals level ERROR
+    Match     solr.solr_system
+    Name      modify
+    Remove    level
+
+[FILTER]
     Add       logging.googleapis.com/severity CRITICAL
-    Condition Key_Value_Equals level SEVERE
+    Condition Key_Value_Equals level FATAL
     Match     solr.solr_system
     Name      modify
     Remove    level

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden_fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden_fluent_bit_parser.conf
@@ -1,12 +1,12 @@
 [PARSER]
     Format      regex
     Name        solr.solr_system.solr_system.0
-    Regex       ^(?<timestamp>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3,6})\s(?<level>[A-z]+)\s{2}\((?<thread>[^\)]+)\)\s\[c?:?(?<collection>[^\s]*)\ss?:?(?<shard>[^\s]*)\sr?:?(?<replica>[^\s]*)\sx?:?(?<core>[^\]]*)\]\s(?<source>[^\s]+)\s(?<message>(?:(?!\s\=\>)[\s\S])+)\s?=?>?(?<exception>[\s\S]*)
+    Regex       ^(?<timestamp>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3,6})\s(?<level>[A-z]+)\s{1,5}\((?<thread>[^\)]+)\)\s\[c?:?(?<collection>[^\s]*)\ss?:?(?<shard>[^\s]*)\sr?:?(?<replica>[^\s]*)\sx?:?(?<core>[^\]]*)\]\s(?<source>[^\s]+)\s(?<message>(?:(?!\s\=\>)[\s\S])+)\s?=?>?(?<exception>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L
     Time_Key    timestamp
 
 [MULTILINE_PARSER]
     Name solr.solr_system.solr_system.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s[A-z]+\s{2}"    "cont"
-    rule "cont"    "^(?!\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s[A-z]+\s{2})"    "cont"
+    rule "start_state"    "\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s[A-z]+\s{1,5}"    "cont"
+    rule "cont"    "^(?!\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s[A-z]+\s{1,5})"    "cont"


### PR DESCRIPTION
Modifies Solr System Log regex to fix Severity not always being properly parsed (which also fixes multi line issues too)

Also translates severity properly (Solr documentation was incorrect on the various log severity levels)