### PR TITLE
Convert IIS total metrics to int64 cumulatives.

### DIFF
--- a/apps/iis.go
+++ b/apps/iis.go
@@ -67,14 +67,20 @@ func (r MetricsReceiverIis) Pipelines() []otel.Pipeline {
 				otel.CombineMetrics(
 					`^\\Web Service\(_Total\)\\Total Bytes (?P<direction>.*)$$`,
 					"iis/network/transferred_bytes_count",
+					// change data type from double -> int64
+					otel.ToggleScalarDataType,
 				),
 				otel.RenameMetric(
 					`\Web Service(_Total)\Total Connection Attempts (all instances)`,
 					"iis/new_connection_count",
+					// change data type from double -> int64
+					otel.ToggleScalarDataType,
 				),
 				otel.CombineMetrics(
 					`^\\Web Service\(_Total\)\\Total (?P<http_method>.*) Requests$$`,
 					"iis/request_count",
+					// change data type from double -> int64
+					otel.ToggleScalarDataType,
 				),
 				otel.AddPrefix("agent.googleapis.com"),
 			),

--- a/apps/iis.go
+++ b/apps/iis.go
@@ -78,6 +78,12 @@ func (r MetricsReceiverIis) Pipelines() []otel.Pipeline {
 				),
 				otel.AddPrefix("agent.googleapis.com"),
 			),
+			otel.CastToSum(
+				"agent.googleapis.com/iis/network/transferred_bytes_count",
+				"agent.googleapis.com/iis/new_connection_count",
+				"agent.googleapis.com/iis/request_count",
+			),
+			otel.NormalizeSums(),
 		},
 	}}
 }

--- a/confgenerator/otel/processors.go
+++ b/confgenerator/otel/processors.go
@@ -57,6 +57,16 @@ func NormalizeSums() Component {
 	}
 }
 
+// CastToSum returns a Component that performs a cast of each metric to a sum.
+func CastToSum(metrics ...string) Component {
+	return Component{
+		Type: "casttosum",
+		Config: map[string]interface{}{
+			"metrics": metrics,
+		},
+	}
+}
+
 // AddPrefix returns a config snippet that adds a prefix to all metrics.
 func AddPrefix(prefix string) map[string]interface{} {
 	// $ needs to be escaped because reasons.

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -7,6 +7,11 @@ processors:
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
+  casttosum/default__pipeline_iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -407,6 +412,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  normalizesums/default__pipeline_iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gce
@@ -490,6 +496,8 @@ service:
       - googlecloud
       processors:
       - metricstransform/default__pipeline_iis_0
+      - casttosum/default__pipeline_iis_1
+      - normalizesums/default__pipeline_iis_2
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/default__pipeline_iis

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -320,14 +320,20 @@ processors:
       include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
     - action: combine
       include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: ^(.*)$$

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
@@ -335,14 +335,20 @@ processors:
       include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
     - action: combine
       include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: ^(.*)$$

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
@@ -7,6 +7,11 @@ processors:
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
+  casttosum/default__pipeline_iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -22,7 +27,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/default__pipeline_iis_1:
+  filter/default__pipeline_iis_3:
     metrics:
       exclude:
         match_type: regexp
@@ -422,6 +427,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  normalizesums/default__pipeline_iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gce
@@ -506,7 +512,9 @@ service:
       - googlecloud
       processors:
       - metricstransform/default__pipeline_iis_0
-      - filter/default__pipeline_iis_1
+      - casttosum/default__pipeline_iis_1
+      - normalizesums/default__pipeline_iis_2
+      - filter/default__pipeline_iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/default__pipeline_iis

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
@@ -335,14 +335,20 @@ processors:
       include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
     - action: combine
       include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: ^(.*)$$

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
@@ -7,6 +7,11 @@ processors:
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
+  casttosum/default__pipeline_iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -22,7 +27,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/default__pipeline_iis_1:
+  filter/default__pipeline_iis_3:
     metrics:
       exclude:
         match_type: regexp
@@ -422,6 +427,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  normalizesums/default__pipeline_iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gce
@@ -506,7 +512,9 @@ service:
       - googlecloud
       processors:
       - metricstransform/default__pipeline_iis_0
-      - filter/default__pipeline_iis_1
+      - casttosum/default__pipeline_iis_1
+      - normalizesums/default__pipeline_iis_2
+      - filter/default__pipeline_iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/default__pipeline_iis

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
@@ -335,14 +335,20 @@ processors:
       include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
     - action: combine
       include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: ^(.*)$$

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
@@ -7,6 +7,11 @@ processors:
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
+  casttosum/default__pipeline_iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -22,7 +27,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/default__pipeline_iis_1:
+  filter/default__pipeline_iis_3:
     metrics:
       exclude:
         match_type: regexp
@@ -422,6 +427,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  normalizesums/default__pipeline_iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gce
@@ -506,7 +512,9 @@ service:
       - googlecloud
       processors:
       - metricstransform/default__pipeline_iis_0
-      - filter/default__pipeline_iis_1
+      - casttosum/default__pipeline_iis_1
+      - normalizesums/default__pipeline_iis_2
+      - filter/default__pipeline_iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/default__pipeline_iis

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
@@ -335,14 +335,20 @@ processors:
       include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
     - action: combine
       include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: ^(.*)$$

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
@@ -7,6 +7,11 @@ processors:
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
+  casttosum/default__pipeline_iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -22,7 +27,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/default__pipeline_iis_1:
+  filter/default__pipeline_iis_3:
     metrics:
       exclude:
         match_type: regexp
@@ -422,6 +427,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  normalizesums/default__pipeline_iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gce
@@ -506,7 +512,9 @@ service:
       - googlecloud
       processors:
       - metricstransform/default__pipeline_iis_0
-      - filter/default__pipeline_iis_1
+      - casttosum/default__pipeline_iis_1
+      - normalizesums/default__pipeline_iis_2
+      - filter/default__pipeline_iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/default__pipeline_iis

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -335,14 +335,20 @@ processors:
       include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
     - action: combine
       include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: ^(.*)$$

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -7,6 +7,11 @@ processors:
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
+  casttosum/default__pipeline_iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -22,7 +27,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/default__pipeline_iis_1:
+  filter/default__pipeline_iis_3:
     metrics:
       exclude:
         match_type: regexp
@@ -422,6 +427,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  normalizesums/default__pipeline_iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gce
@@ -506,7 +512,9 @@ service:
       - googlecloud
       processors:
       - metricstransform/default__pipeline_iis_0
-      - filter/default__pipeline_iis_1
+      - casttosum/default__pipeline_iis_1
+      - normalizesums/default__pipeline_iis_2
+      - filter/default__pipeline_iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/default__pipeline_iis

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
@@ -7,6 +7,11 @@ processors:
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
+  casttosum/default__pipeline_iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -23,7 +28,7 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/.*$$"
-  filter/default__pipeline_iis_1:
+  filter/default__pipeline_iis_3:
     metrics:
       exclude:
         match_type: regexp
@@ -425,6 +430,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  normalizesums/default__pipeline_iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gce
@@ -509,7 +515,9 @@ service:
       - googlecloud
       processors:
       - metricstransform/default__pipeline_iis_0
-      - filter/default__pipeline_iis_1
+      - casttosum/default__pipeline_iis_1
+      - normalizesums/default__pipeline_iis_2
+      - filter/default__pipeline_iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/default__pipeline_iis

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
@@ -338,14 +338,20 @@ processors:
       include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
     - action: combine
       include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: ^(.*)$$

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
@@ -7,6 +7,11 @@ processors:
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
+  casttosum/default__pipeline_iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -23,7 +28,7 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/iis/.*$$"
-  filter/default__pipeline_iis_1:
+  filter/default__pipeline_iis_3:
     metrics:
       exclude:
         match_type: regexp
@@ -425,6 +430,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  normalizesums/default__pipeline_iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gce
@@ -509,7 +515,9 @@ service:
       - googlecloud
       processors:
       - metricstransform/default__pipeline_iis_0
-      - filter/default__pipeline_iis_1
+      - casttosum/default__pipeline_iis_1
+      - normalizesums/default__pipeline_iis_2
+      - filter/default__pipeline_iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/default__pipeline_iis

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
@@ -338,14 +338,20 @@ processors:
       include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
     - action: combine
       include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: ^(.*)$$

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
@@ -7,6 +7,11 @@ processors:
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
+  casttosum/default__pipeline_iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -23,7 +28,7 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/mssql/.*$$"
-  filter/default__pipeline_iis_1:
+  filter/default__pipeline_iis_3:
     metrics:
       exclude:
         match_type: regexp
@@ -425,6 +430,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  normalizesums/default__pipeline_iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gce
@@ -509,7 +515,9 @@ service:
       - googlecloud
       processors:
       - metricstransform/default__pipeline_iis_0
-      - filter/default__pipeline_iis_1
+      - casttosum/default__pipeline_iis_1
+      - normalizesums/default__pipeline_iis_2
+      - filter/default__pipeline_iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/default__pipeline_iis

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
@@ -338,14 +338,20 @@ processors:
       include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
     - action: combine
       include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: ^(.*)$$

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
@@ -7,6 +7,11 @@ processors:
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
+  casttosum/another__another__pipeline_iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -407,6 +412,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  normalizesums/another__another__pipeline_iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gce
@@ -480,6 +486,8 @@ service:
       - googlecloud
       processors:
       - metricstransform/another__another__pipeline_iis_0
+      - casttosum/another__another__pipeline_iis_1
+      - normalizesums/another__another__pipeline_iis_2
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/another__another__pipeline_iis

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
@@ -46,14 +46,20 @@ processors:
       include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
     - action: combine
       include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: ^(.*)$$

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -341,14 +341,20 @@ processors:
       include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
     - action: combine
       include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: ^(.*)$$

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -7,6 +7,11 @@ processors:
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
+  casttosum/default__pipeline_iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -24,7 +29,7 @@ processors:
         metric_names:
         - "^agent\\.googleapis\\.com/processes/.*$$"
         - "^agent\\.googleapis\\.com/cpu/.*$$"
-  filter/default__pipeline_iis_1:
+  filter/default__pipeline_iis_3:
     metrics:
       exclude:
         match_type: regexp
@@ -428,6 +433,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  normalizesums/default__pipeline_iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gce
@@ -512,7 +518,9 @@ service:
       - googlecloud
       processors:
       - metricstransform/default__pipeline_iis_0
-      - filter/default__pipeline_iis_1
+      - casttosum/default__pipeline_iis_1
+      - normalizesums/default__pipeline_iis_2
+      - filter/default__pipeline_iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/default__pipeline_iis

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -341,14 +341,20 @@ processors:
       include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
     - action: combine
       include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: ^(.*)$$

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -7,6 +7,11 @@ processors:
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
+  casttosum/default__pipeline_iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -24,7 +29,7 @@ processors:
         metric_names:
         - "^agent\\.googleapis\\.com/proce.*ses/.*$$"
         - "^agent\\.googleapis\\.com/c.*u/.*$$"
-  filter/default__pipeline_iis_1:
+  filter/default__pipeline_iis_3:
     metrics:
       exclude:
         match_type: regexp
@@ -428,6 +433,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  normalizesums/default__pipeline_iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gce
@@ -512,7 +518,9 @@ service:
       - googlecloud
       processors:
       - metricstransform/default__pipeline_iis_0
-      - filter/default__pipeline_iis_1
+      - casttosum/default__pipeline_iis_1
+      - normalizesums/default__pipeline_iis_2
+      - filter/default__pipeline_iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/default__pipeline_iis

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
@@ -7,6 +7,11 @@ processors:
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
+  casttosum/default__pipeline_iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -23,7 +28,7 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/x\\$$y\\(%28\\)z\\\\,a':w-\\+!/.*$$"
-  filter/default__pipeline_iis_1:
+  filter/default__pipeline_iis_3:
     metrics:
       exclude:
         match_type: regexp
@@ -425,6 +430,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  normalizesums/default__pipeline_iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gce
@@ -509,7 +515,9 @@ service:
       - googlecloud
       processors:
       - metricstransform/default__pipeline_iis_0
-      - filter/default__pipeline_iis_1
+      - casttosum/default__pipeline_iis_1
+      - normalizesums/default__pipeline_iis_2
+      - filter/default__pipeline_iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/default__pipeline_iis

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
@@ -338,14 +338,20 @@ processors:
       include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
     - action: combine
       include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: ^(.*)$$

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
@@ -347,14 +347,20 @@ processors:
       include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
     - action: combine
       include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: ^(.*)$$

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
@@ -7,6 +7,11 @@ processors:
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
+  casttosum/default__pipeline_iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
   filter/apache__pipeline_apache__metrics_0:
     metrics:
       exclude:
@@ -28,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/default__pipeline_iis_1:
+  filter/default__pipeline_iis_3:
     metrics:
       exclude:
         match_type: regexp
@@ -435,6 +440,7 @@ processors:
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
   normalizesums/apache__pipeline_apache__metrics_1: {}
+  normalizesums/default__pipeline_iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gce
@@ -532,7 +538,9 @@ service:
       - googlecloud
       processors:
       - metricstransform/default__pipeline_iis_0
-      - filter/default__pipeline_iis_1
+      - casttosum/default__pipeline_iis_1
+      - normalizesums/default__pipeline_iis_2
+      - filter/default__pipeline_iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/default__pipeline_iis

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
@@ -347,14 +347,20 @@ processors:
       include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
     - action: combine
       include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: ^(.*)$$

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
@@ -7,6 +7,11 @@ processors:
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
+  casttosum/default__pipeline_iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
   filter/apache__pipeline_apache__metrics_0:
     metrics:
       exclude:
@@ -28,7 +33,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/default__pipeline_iis_1:
+  filter/default__pipeline_iis_3:
     metrics:
       exclude:
         match_type: regexp
@@ -435,6 +440,7 @@ processors:
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
   normalizesums/apache__pipeline_apache__metrics_1: {}
+  normalizesums/default__pipeline_iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gce
@@ -532,7 +538,9 @@ service:
       - googlecloud
       processors:
       - metricstransform/default__pipeline_iis_0
-      - filter/default__pipeline_iis_1
+      - casttosum/default__pipeline_iis_1
+      - normalizesums/default__pipeline_iis_2
+      - filter/default__pipeline_iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/default__pipeline_iis

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -335,14 +335,20 @@ processors:
       include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
     - action: combine
       include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: ^(.*)$$

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -7,6 +7,11 @@ processors:
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
+  casttosum/default__pipeline_iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -22,7 +27,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/default__pipeline_iis_1:
+  filter/default__pipeline_iis_3:
     metrics:
       exclude:
         match_type: regexp
@@ -422,6 +427,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  normalizesums/default__pipeline_iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gce
@@ -506,7 +512,9 @@ service:
       - googlecloud
       processors:
       - metricstransform/default__pipeline_iis_0
-      - filter/default__pipeline_iis_1
+      - casttosum/default__pipeline_iis_1
+      - normalizesums/default__pipeline_iis_2
+      - filter/default__pipeline_iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/default__pipeline_iis

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
@@ -335,14 +335,20 @@ processors:
       include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
     - action: combine
       include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: ^(.*)$$

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
@@ -7,6 +7,11 @@ processors:
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
+  casttosum/default__pipeline_iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -22,7 +27,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/default__pipeline_iis_1:
+  filter/default__pipeline_iis_3:
     metrics:
       exclude:
         match_type: regexp
@@ -428,6 +433,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  normalizesums/default__pipeline_iis_2: {}
   normalizesums/jvmpipeline_jvmmetrics_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -518,7 +524,9 @@ service:
       - googlecloud
       processors:
       - metricstransform/default__pipeline_iis_0
-      - filter/default__pipeline_iis_1
+      - casttosum/default__pipeline_iis_1
+      - normalizesums/default__pipeline_iis_2
+      - filter/default__pipeline_iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/default__pipeline_iis

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
@@ -335,14 +335,20 @@ processors:
       include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
     - action: combine
       include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: ^(.*)$$

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
@@ -7,6 +7,11 @@ processors:
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
+  casttosum/default__pipeline_iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -22,7 +27,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/default__pipeline_iis_1:
+  filter/default__pipeline_iis_3:
     metrics:
       exclude:
         match_type: regexp
@@ -428,6 +433,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  normalizesums/default__pipeline_iis_2: {}
   normalizesums/jvmpipeline_jvmmetrics_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -518,7 +524,9 @@ service:
       - googlecloud
       processors:
       - metricstransform/default__pipeline_iis_0
-      - filter/default__pipeline_iis_1
+      - casttosum/default__pipeline_iis_1
+      - normalizesums/default__pipeline_iis_2
+      - filter/default__pipeline_iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/default__pipeline_iis

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_otel.conf
@@ -335,14 +335,20 @@ processors:
       include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
     - action: combine
       include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: ^(.*)$$

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_otel.conf
@@ -7,6 +7,11 @@ processors:
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
+  casttosum/default__pipeline_iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -22,7 +27,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/default__pipeline_iis_1:
+  filter/default__pipeline_iis_3:
     metrics:
       exclude:
         match_type: regexp
@@ -428,6 +433,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  normalizesums/default__pipeline_iis_2: {}
   normalizesums/mysqlpipeline_mysqlmetrics_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -519,7 +525,9 @@ service:
       - googlecloud
       processors:
       - metricstransform/default__pipeline_iis_0
-      - filter/default__pipeline_iis_1
+      - casttosum/default__pipeline_iis_1
+      - normalizesums/default__pipeline_iis_2
+      - filter/default__pipeline_iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/default__pipeline_iis

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_otel.conf
@@ -335,14 +335,20 @@ processors:
       include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
     - action: combine
       include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: ^(.*)$$

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_otel.conf
@@ -7,6 +7,11 @@ processors:
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
+  casttosum/default__pipeline_iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -22,7 +27,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/default__pipeline_iis_1:
+  filter/default__pipeline_iis_3:
     metrics:
       exclude:
         match_type: regexp
@@ -428,6 +433,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  normalizesums/default__pipeline_iis_2: {}
   normalizesums/mysqlpipeline_mysqlmetrics_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -519,7 +525,9 @@ service:
       - googlecloud
       processors:
       - metricstransform/default__pipeline_iis_0
-      - filter/default__pipeline_iis_1
+      - casttosum/default__pipeline_iis_1
+      - normalizesums/default__pipeline_iis_2
+      - filter/default__pipeline_iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/default__pipeline_iis

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
@@ -335,14 +335,20 @@ processors:
       include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
     - action: combine
       include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: ^(.*)$$

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
@@ -7,6 +7,11 @@ processors:
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
+  casttosum/default__pipeline_iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -22,7 +27,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/default__pipeline_iis_1:
+  filter/default__pipeline_iis_3:
     metrics:
       exclude:
         match_type: regexp
@@ -428,6 +433,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  normalizesums/default__pipeline_iis_2: {}
   normalizesums/nginxpipeline_nginxmetrics_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -516,7 +522,9 @@ service:
       - googlecloud
       processors:
       - metricstransform/default__pipeline_iis_0
-      - filter/default__pipeline_iis_1
+      - casttosum/default__pipeline_iis_1
+      - normalizesums/default__pipeline_iis_2
+      - filter/default__pipeline_iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/default__pipeline_iis

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
@@ -335,14 +335,20 @@ processors:
       include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
       match_type: regexp
       new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
       new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
     - action: combine
       include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
       match_type: regexp
       new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
       submatch_case: lower
     - action: update
       include: ^(.*)$$

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
@@ -7,6 +7,11 @@ processors:
   agentmetrics/default__pipeline_hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
+  casttosum/default__pipeline_iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
   filter/default__pipeline_hostmetrics_1:
     metrics:
       exclude:
@@ -22,7 +27,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/default__pipeline_iis_1:
+  filter/default__pipeline_iis_3:
     metrics:
       exclude:
         match_type: regexp
@@ -428,6 +433,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  normalizesums/default__pipeline_iis_2: {}
   normalizesums/nginxpipeline_nginxmetrics_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -516,7 +522,9 @@ service:
       - googlecloud
       processors:
       - metricstransform/default__pipeline_iis_0
-      - filter/default__pipeline_iis_1
+      - casttosum/default__pipeline_iis_1
+      - normalizesums/default__pipeline_iis_2
+      - filter/default__pipeline_iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/default__pipeline_iis

--- a/integration_test/third_party_apps_data/applications/iis/metric_name.txt
+++ b/integration_test/third_party_apps_data/applications/iis/metric_name.txt
@@ -1,1 +1,1 @@
-agent.googleapis.com/iis/current_connections
+agent.googleapis.com/iis/request_count


### PR DESCRIPTION
This works around the limitation of [`windowsperfcountersreceiver`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper.go#L120) that it can only create gauge metrics. Certain values gathered from the performance counters are cumulative (e.g., [those that start with "Total"](https://docs.microsoft.com/en-us/previous-versions//aa394298(v=vs.85))), so they are converted to int64 sums and normalized.

Requires GoogleCloudPlatform/opentelemetry-operations-collector#80.

b/202318079