### PR TITLE
confgenerator: move modify filter before the processors

### DIFF
--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -234,6 +234,14 @@ func (l *Logging) generateFluentbitComponents(userAgent string, hostInfo *host.I
 				tags = append(tags, regexp.QuoteMeta(tag)+regexSuffix)
 				tag = tag + globSuffix
 
+				components = append(components, setLogNameComponents(tag, rID)...)
+
+				// Logs ingested using the fluent_forward receiver must add the existing_tag
+				// on the record to the LogName. This is done with a Lua filter.
+				if receiver.Type() == "fluent_forward" {
+					components = append(components, addLuaFilter(tag, "add_log_name.lua", "add_log_name")...)
+				}
+
 				for i, pID := range p.ProcessorIDs {
 					processor, ok := l.Processors[pID]
 					if !ok {
@@ -247,13 +255,6 @@ func (l *Logging) generateFluentbitComponents(userAgent string, hostInfo *host.I
 						return nil, err
 					}
 					components = append(components, processorComponents...)
-				}
-				components = append(components, setLogNameComponents(tag, rID)...)
-
-				// Logs ingested using the fluent_forward receiver must add the existing_tag
-				// on the record to the LogName. This is done with a Lua filter.
-				if receiver.Type() == "fluent_forward" {
-					components = append(components, addLuaFilter(tag, "add_log_name.lua", "add_log_name")...)
 				}
 				sources = append(sources, fbSource{tag, components})
 			}

--- a/confgenerator/fluentbit/processors.go
+++ b/confgenerator/fluentbit/processors.go
@@ -107,6 +107,10 @@ func ParserFilterComponent(tag string, field string, parserNames []string) Compo
 			"Match":    tag,
 			"Name":     "parser",
 			"Key_Name": "message", // Required
+
+			// We need to preserve existing fields (like LogName) that are present
+			// before parsing.
+			"Reserve_Data": "True",
 		},
 		OrderedConfig: parsers,
 	}

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_fluent_bit_main.conf
@@ -65,6 +65,11 @@
     Name  modify
 
 [FILTER]
+    Add   logging.googleapis.com/logName sample_logs
+    Match p1.sample_logs
+    Name  modify
+
+[FILTER]
     Match      p1.sample_logs
     Name       nest
     Nest_under record
@@ -782,11 +787,6 @@
     Name         nest
     Nested_under record
     Operation    lift
-
-[FILTER]
-    Add   logging.googleapis.com/logName sample_logs
-    Match p1.sample_logs
-    Name  modify
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|p1\.sample_logs)$

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_main.conf
@@ -79,38 +79,42 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    pipeline1.sample_logs
-    Name     parser
-    Parser   pipeline1.sample_logs.0
-
-[FILTER]
-    Key_Name message
-    Match    pipeline1.sample_logs
-    Name     parser
-    Parser   pipeline1.sample_logs.1
-
-[FILTER]
     Add   logging.googleapis.com/logName sample_logs
     Match pipeline1.sample_logs
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    pipeline2.sample_logs
-    Name     parser
-    Parser   pipeline2.sample_logs.0
+    Key_Name     message
+    Match        pipeline1.sample_logs
+    Name         parser
+    Reserve_Data True
+    Parser       pipeline1.sample_logs.0
 
 [FILTER]
-    Key_Name message
-    Match    pipeline2.sample_logs
-    Name     parser
-    Parser   pipeline2.sample_logs.1
+    Key_Name     message
+    Match        pipeline1.sample_logs
+    Name         parser
+    Reserve_Data True
+    Parser       pipeline1.sample_logs.1
 
 [FILTER]
     Add   logging.googleapis.com/logName sample_logs
     Match pipeline2.sample_logs
     Name  modify
+
+[FILTER]
+    Key_Name     message
+    Match        pipeline2.sample_logs
+    Name         parser
+    Reserve_Data True
+    Parser       pipeline2.sample_logs.0
+
+[FILTER]
+    Key_Name     message
+    Match        pipeline2.sample_logs
+    Name         parser
+    Reserve_Data True
+    Parser       pipeline2.sample_logs.1
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|pipeline1\.sample_logs|pipeline2\.sample_logs)$

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_fluent_bit_main.conf
@@ -82,21 +82,16 @@
     storage.type      filesystem
 
 [FILTER]
-    Key_Name key_1
-    Match    pipeline1.log_source_id1
-    Name     parser
-    Parser   pipeline1.log_source_id1.0
-
-[FILTER]
     Add   logging.googleapis.com/logName log_source_id1
     Match pipeline1.log_source_id1
     Name  modify
 
 [FILTER]
-    Key_Name key_1
-    Match    pipeline2.log_source_id2
-    Name     parser
-    Parser   pipeline2.log_source_id2.0
+    Key_Name     key_1
+    Match        pipeline1.log_source_id1
+    Name         parser
+    Reserve_Data True
+    Parser       pipeline1.log_source_id1.0
 
 [FILTER]
     Add   logging.googleapis.com/logName log_source_id2
@@ -104,10 +99,11 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    pipeline3.test_syslog_source_id_tcp
-    Name     parser
-    Parser   pipeline3.test_syslog_source_id_tcp.0
+    Key_Name     key_1
+    Match        pipeline2.log_source_id2
+    Name         parser
+    Reserve_Data True
+    Parser       pipeline2.log_source_id2.0
 
 [FILTER]
     Add   logging.googleapis.com/logName test_syslog_source_id_tcp
@@ -115,15 +111,23 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    pipeline4.test_syslog_source_id_udp
-    Name     parser
-    Parser   pipeline4.test_syslog_source_id_udp.0
+    Key_Name     message
+    Match        pipeline3.test_syslog_source_id_tcp
+    Name         parser
+    Reserve_Data True
+    Parser       pipeline3.test_syslog_source_id_tcp.0
 
 [FILTER]
     Add   logging.googleapis.com/logName test_syslog_source_id_udp
     Match pipeline4.test_syslog_source_id_udp
     Name  modify
+
+[FILTER]
+    Key_Name     message
+    Match        pipeline4.test_syslog_source_id_udp
+    Name         parser
+    Reserve_Data True
+    Parser       pipeline4.test_syslog_source_id_udp.0
 
 [OUTPUT]
     Match_Regex                   ^(pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.test_syslog_source_id_tcp|pipeline4\.test_syslog_source_id_udp)$

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden_fluent_bit_main.conf
@@ -67,14 +67,14 @@
     Name  modify
 
 [FILTER]
-    Match  p1.files_1
-    Name   modify
-    Rename log message
-
-[FILTER]
     Add   logging.googleapis.com/logName files_1
     Match p1.files_1
     Name  modify
+
+[FILTER]
+    Match  p1.files_1
+    Name   modify
+    Rename log message
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|p1\.files_1)$

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_fluent_bit_main.conf
@@ -46,15 +46,16 @@
     storage.type      filesystem
 
 [FILTER]
-    Key_Name key_1
-    Match    default_pipeline.syslog
-    Name     parser
-    Parser   default_pipeline.syslog.0
-
-[FILTER]
     Add   logging.googleapis.com/logName syslog
     Match default_pipeline.syslog
     Name  modify
+
+[FILTER]
+    Key_Name     key_1
+    Match        default_pipeline.syslog
+    Name         parser
+    Reserve_Data True
+    Parser       default_pipeline.syslog.0
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$

--- a/confgenerator/testdata/valid/linux/logging-processor_preserve_existing_fields/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_preserve_existing_fields/golden_fluent_bit_main.conf
@@ -20,52 +20,30 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
-    DB                ${buffers_dir}/pipeline1_log_source_id1
-    Exclude_Path      /path/to/log/1/a/exclude_a,/path/to/log/1/b/exclude_b
+    DB                ${buffers_dir}/default_pipeline_syslog
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              /path/to/log/1/a/*,/path/to/log/1/b/*
+    Path              /var/log/messages,/var/log/syslog
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               pipeline1.log_source_id1
+    Tag               default_pipeline.syslog
     storage.type      filesystem
 
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
-    DB                ${buffers_dir}/pipeline2_log_source_id2
-    Exclude_Path      /path/to/log/2/a/exclude_a,/path/to/log/2/b/exclude_b
+    DB                ${buffers_dir}/pipeline1_sample_logs
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              /path/to/log/2/a/*,/path/to/log/2/b/*
+    Path              /tmp/*.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               pipeline2.log_source_id2
+    Tag               pipeline1.sample_logs
     storage.type      filesystem
-
-[INPUT]
-    Listen        1.1.1.1
-    Mem_Buf_Limit 10M
-    Mode          tcp
-    Name          syslog
-    Parser        pipeline3.test_syslog_source_id_tcp
-    Port          1111
-    Tag           pipeline3.test_syslog_source_id_tcp
-    storage.type  filesystem
-
-[INPUT]
-    Listen        2.2.2.2
-    Mem_Buf_Limit 10M
-    Mode          udp
-    Name          syslog
-    Parser        pipeline4.test_syslog_source_id_udp
-    Port          2222
-    Tag           pipeline4.test_syslog_source_id_udp
-    storage.type  filesystem
 
 [INPUT]
     Buffer_Chunk_Size 512k
@@ -82,41 +60,24 @@
     storage.type      filesystem
 
 [FILTER]
-    Add   logging.googleapis.com/logName log_source_id1
-    Match pipeline1.log_source_id1
+    Add   logging.googleapis.com/logName syslog
+    Match default_pipeline.syslog
     Name  modify
 
 [FILTER]
-    Add   logging.googleapis.com/logName log_source_id2
-    Match pipeline2.log_source_id2
-    Name  modify
-
-[FILTER]
-    Add   logging.googleapis.com/logName test_syslog_source_id_tcp
-    Match pipeline3.test_syslog_source_id_tcp
+    Add   logging.googleapis.com/logName sample_logs
+    Match pipeline1.sample_logs
     Name  modify
 
 [FILTER]
     Key_Name     message
-    Match        pipeline3.test_syslog_source_id_tcp
+    Match        pipeline1.sample_logs
     Name         parser
     Reserve_Data True
-    Parser       pipeline3.test_syslog_source_id_tcp.0
-
-[FILTER]
-    Add   logging.googleapis.com/logName test_syslog_source_id_udp
-    Match pipeline4.test_syslog_source_id_udp
-    Name  modify
-
-[FILTER]
-    Key_Name     message
-    Match        pipeline4.test_syslog_source_id_udp
-    Name         parser
-    Reserve_Data True
-    Parser       pipeline4.test_syslog_source_id_udp.0
+    Parser       pipeline1.sample_logs.0
 
 [OUTPUT]
-    Match_Regex                   ^(pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.test_syslog_source_id_tcp|pipeline4\.test_syslog_source_id_udp)$
+    Match_Regex                   ^(default_pipeline\.syslog|pipeline1\.sample_logs)$
     Name                          stackdriver
     Retry_Limit                   3
     net.connect_timeout_log_error False

--- a/confgenerator/testdata/valid/linux/logging-processor_preserve_existing_fields/golden_fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_preserve_existing_fields/golden_fluent_bit_parser.conf
@@ -1,0 +1,4 @@
+[PARSER]
+    Format regex
+    Name   pipeline1.sample_logs.0
+    Regex  regex_pattern

--- a/confgenerator/testdata/valid/linux/logging-processor_preserve_existing_fields/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_preserve_existing_fields/golden_otel.conf
@@ -1,0 +1,442 @@
+exporters:
+  googlecloud:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+processors:
+  agentmetrics/default__pipeline_hostmetrics_0:
+    blank_label_metrics:
+    - system.cpu.utilization
+  filter/default__pipeline_hostmetrics_1:
+    metrics:
+      exclude:
+        match_type: strict
+        metric_names:
+        - system.cpu.time
+        - system.network.dropped
+        - system.filesystem.inodes.usage
+        - system.paging.faults
+        - system.disk.operation_time
+  filter/default__pipeline_hostmetrics_3:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names: []
+  filter/fluentbit_0:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+        - fluentbit_uptime
+  filter/otel_0:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+        - otelcol_process_uptime
+        - otelcol_process_memory_rss
+        - otelcol_grpc_io_client_completed_rpcs
+        - otelcol_googlecloudmonitoring_point_count
+  metricstransform/default__pipeline_hostmetrics_2:
+    transforms:
+    - action: update
+      include: system.cpu.time
+      new_name: cpu/usage_time
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: cpu
+        new_label: cpu_number
+      - action: update_label
+        label: state
+        new_label: cpu_state
+    - action: update
+      include: system.cpu.utilization
+      new_name: cpu/utilization
+      operations:
+      - action: aggregate_labels
+        aggregation_type: mean
+        label_set:
+        - state
+        - blank
+      - action: update_label
+        label: blank
+        new_label: cpu_number
+      - action: update_label
+        label: state
+        new_label: cpu_state
+    - action: update
+      include: system.cpu.load_average.1m
+      new_name: cpu/load_1m
+    - action: update
+      include: system.cpu.load_average.5m
+      new_name: cpu/load_5m
+    - action: update
+      include: system.cpu.load_average.15m
+      new_name: cpu/load_15m
+    - action: update
+      include: system.disk.read_io
+      new_name: disk/read_bytes_count
+    - action: update
+      include: system.disk.write_io
+      new_name: disk/write_bytes_count
+    - action: update
+      include: system.disk.operations
+      new_name: disk/operation_count
+    - action: update
+      include: system.disk.io_time
+      new_name: disk/io_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.weighted_io_time
+      new_name: disk/weighted_io_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.average_operation_time
+      new_name: disk/operation_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.pending_operations
+      new_name: disk/pending_operations
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.merged
+      new_name: disk/merged_operations
+    - action: update
+      include: system.filesystem.usage
+      new_name: disk/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: max
+        label_set:
+        - device
+        - state
+    - action: update
+      include: system.filesystem.utilization
+      new_name: disk/percent_used
+      operations:
+      - action: aggregate_labels
+        aggregation_type: max
+        label_set:
+        - device
+        - state
+    - action: update
+      include: system.memory.usage
+      new_name: memory/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_label_values
+        aggregated_values:
+        - slab_reclaimable
+        - slab_unreclaimable
+        aggregation_type: sum
+        label: state
+        new_value: slab
+    - action: update
+      include: system.memory.utilization
+      new_name: memory/percent_used
+      operations:
+      - action: aggregate_label_values
+        aggregated_values:
+        - slab_reclaimable
+        - slab_unreclaimable
+        aggregation_type: sum
+        label: state
+        new_value: slab
+    - action: update
+      include: system.network.io
+      new_name: interface/traffic
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.errors
+      new_name: interface/errors
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.packets
+      new_name: interface/packets
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.connections
+      new_name: network/tcp_connections
+      operations:
+      - action: toggle_scalar_data_type
+      - action: delete_label_value
+        label: protocol
+        label_value: udp
+      - action: update_label
+        label: state
+        new_label: tcp_state
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - tcp_state
+      - action: add_label
+        new_label: port
+        new_value: all
+    - action: update
+      include: system.processes.created
+      new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
+    - action: update
+      include: system.paging.usage
+      new_name: swap/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.paging.utilization
+      new_name: swap/percent_used
+    - action: insert
+      include: swap/percent_used
+      new_name: pagefile/percent_used
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - state
+    - action: update
+      include: system.paging.operations
+      new_name: swap/io
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - direction
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: in
+          value: page_in
+        - new_value: out
+          value: page_out
+    - action: update
+      include: process.cpu.time
+      new_name: processes/cpu_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1e+06
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+      - action: delete_label_value
+        label: state
+        label_value: wait
+      - action: update_label
+        label: state
+        new_label: user_or_syst
+      - action: update_label
+        label: user_or_syst
+        value_actions:
+        - new_value: syst
+          value: system
+    - action: update
+      include: process.disk.read_io
+      new_name: processes/disk/read_bytes_count
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.disk.write_io
+      new_name: processes/disk/write_bytes_count
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.memory.physical_usage
+      new_name: processes/rss_usage
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.memory.virtual_usage
+      new_name: processes/vm_usage
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/fluentbit_1:
+    transforms:
+    - action: update
+      include: fluentbit_uptime
+      new_name: agent/uptime
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: version
+        new_value: google-cloud-ops-agent-logging/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/otel_1:
+    transforms:
+    - action: update
+      include: otelcol_process_uptime
+      new_name: agent/uptime
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: version
+        new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
+    - action: update
+      include: otelcol_process_memory_rss
+      new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
+    - action: update
+      include: otelcol_grpc_io_client_completed_rpcs
+      new_name: agent/api_request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: grpc_client_status
+        new_label: state
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - state
+    - action: update
+      include: otelcol_googlecloudmonitoring_point_count
+      new_name: agent/monitoring/point_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  resourcedetection/_global_0:
+    detectors:
+    - gce
+receivers:
+  hostmetrics/default__pipeline_hostmetrics:
+    collection_interval: 60s
+    scrapers:
+      cpu: {}
+      disk: {}
+      filesystem: {}
+      load: {}
+      memory: {}
+      network: {}
+      paging: {}
+      process:
+        mute_process_name_error: true
+      processes: {}
+  prometheus/fluentbit:
+    config:
+      scrape_configs:
+      - job_name: logging-collector
+        metrics_path: /metrics
+        scrape_interval: 1m
+        static_configs:
+        - targets:
+          - 0.0.0.0:20202
+  prometheus/otel:
+    config:
+      scrape_configs:
+      - job_name: otel-collector
+        scrape_interval: 1m
+        static_configs:
+        - targets:
+          - 0.0.0.0:8888
+service:
+  pipelines:
+    metrics/default__pipeline_hostmetrics:
+      exporters:
+      - googlecloud
+      processors:
+      - agentmetrics/default__pipeline_hostmetrics_0
+      - filter/default__pipeline_hostmetrics_1
+      - metricstransform/default__pipeline_hostmetrics_2
+      - filter/default__pipeline_hostmetrics_3
+      - resourcedetection/_global_0
+      receivers:
+      - hostmetrics/default__pipeline_hostmetrics
+    metrics/fluentbit:
+      exporters:
+      - googlecloud
+      processors:
+      - filter/fluentbit_0
+      - metricstransform/fluentbit_1
+      - resourcedetection/_global_0
+      receivers:
+      - prometheus/fluentbit
+    metrics/otel:
+      exporters:
+      - googlecloud
+      processors:
+      - filter/otel_0
+      - metricstransform/otel_1
+      - resourcedetection/_global_0
+      receivers:
+      - prometheus/otel

--- a/confgenerator/testdata/valid/linux/logging-processor_preserve_existing_fields/input.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_preserve_existing_fields/input.yaml
@@ -1,0 +1,31 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Create two pipelines that use the same processors but in different
+# orders.  This is to verify that the generated Fluent Bit filters
+# appear in the correct order.
+logging:
+  receivers:
+    sample_logs:
+      type: files
+      include_paths: [ /tmp/*.log ]
+  processors:
+    regex:
+      type: parse_regex
+      regex: regex_pattern
+  service:
+    pipelines:
+      pipeline1:
+        receivers: [ sample_logs ]
+        processors: [ regex ]

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_fluent_bit_main.conf
@@ -74,10 +74,11 @@
     storage.type      filesystem
 
 [FILTER]
-    Key_Name message
-    Match    apache.apache_access
-    Name     parser
-    Parser   apache.apache_access.apache_access
+    Key_Name     message
+    Match        apache.apache_access
+    Name         parser
+    Reserve_Data True
+    Parser       apache.apache_access.apache_access
 
 [FILTER]
     Condition Key_Value_Equals host -
@@ -111,10 +112,11 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    apache.apache_error
-    Name     parser
-    Parser   apache.apache_error.apache_error
+    Key_Name     message
+    Match        apache.apache_error
+    Name         parser
+    Reserve_Data True
+    Parser       apache.apache_error.apache_error
 
 [FILTER]
     Add       logging.googleapis.com/severity EMERGENCY

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden_fluent_bit_main.conf
@@ -124,10 +124,11 @@
     storage.type      filesystem
 
 [FILTER]
-    Key_Name message
-    Match    apache_custom.apache_custom_access
-    Name     parser
-    Parser   apache_custom.apache_custom_access.apache_access
+    Key_Name     message
+    Match        apache_custom.apache_custom_access
+    Name         parser
+    Reserve_Data True
+    Parser       apache_custom.apache_custom_access.apache_access
 
 [FILTER]
     Condition Key_Value_Equals host -
@@ -161,10 +162,11 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    apache_custom.apache_custom_error
-    Name     parser
-    Parser   apache_custom.apache_custom_error.apache_error
+    Key_Name     message
+    Match        apache_custom.apache_custom_error
+    Name         parser
+    Reserve_Data True
+    Parser       apache_custom.apache_custom_error.apache_error
 
 [FILTER]
     Add       logging.googleapis.com/severity EMERGENCY
@@ -268,10 +270,11 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    apache_default.apache_default_access
-    Name     parser
-    Parser   apache_default.apache_default_access.apache_access
+    Key_Name     message
+    Match        apache_default.apache_default_access
+    Name         parser
+    Reserve_Data True
+    Parser       apache_default.apache_default_access.apache_access
 
 [FILTER]
     Condition Key_Value_Equals host -
@@ -305,10 +308,11 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    apache_default.apache_default_error
-    Name     parser
-    Parser   apache_default.apache_default_error.apache_error
+    Key_Name     message
+    Match        apache_default.apache_default_error
+    Name         parser
+    Reserve_Data True
+    Parser       apache_default.apache_default_error.apache_error
 
 [FILTER]
     Add       logging.googleapis.com/severity EMERGENCY
@@ -412,10 +416,16 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    apache_syslog_access.apache_syslog_access
-    Name     parser
-    Parser   apache_syslog_access.apache_syslog_access.0
+    Add   logging.googleapis.com/logName apache_syslog_access
+    Match apache_syslog_access.apache_syslog_access
+    Name  modify
+
+[FILTER]
+    Key_Name     message
+    Match        apache_syslog_access.apache_syslog_access
+    Name         parser
+    Reserve_Data True
+    Parser       apache_syslog_access.apache_syslog_access.0
 
 [FILTER]
     Condition Key_Value_Equals host -
@@ -444,15 +454,16 @@
     Wildcard      http_request_*
 
 [FILTER]
-    Add   logging.googleapis.com/logName apache_syslog_access
-    Match apache_syslog_access.apache_syslog_access
+    Add   logging.googleapis.com/logName apache_syslog_error
+    Match apache_syslog_error.apache_syslog_error
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    apache_syslog_error.apache_syslog_error
-    Name     parser
-    Parser   apache_syslog_error.apache_syslog_error.0
+    Key_Name     message
+    Match        apache_syslog_error.apache_syslog_error
+    Name         parser
+    Reserve_Data True
+    Parser       apache_syslog_error.apache_syslog_error.0
 
 [FILTER]
     Add       logging.googleapis.com/severity EMERGENCY
@@ -549,11 +560,6 @@
     Condition Key_Value_Equals level trace8
     Match     apache_syslog_error.apache_syslog_error
     Name      modify
-
-[FILTER]
-    Add   logging.googleapis.com/logName apache_syslog_error
-    Match apache_syslog_error.apache_syslog_error
-    Name  modify
 
 [FILTER]
     Add   logging.googleapis.com/logName syslog

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_fluent_bit_main.conf
@@ -94,10 +94,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    cassandra.cassandra_debug
-    Name     parser
-    Parser   cassandra.cassandra_debug.cassandra_debug.0
+    Key_Name     message
+    Match        cassandra.cassandra_debug
+    Name         parser
+    Reserve_Data True
+    Parser       cassandra.cassandra_debug.cassandra_debug.0
 
 [FILTER]
     Add       logging.googleapis.com/severity TRACE
@@ -141,10 +142,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    cassandra.cassandra_gc
-    Name     parser
-    Parser   cassandra.cassandra_gc.cassandra_gc.0
+    Key_Name     message
+    Match        cassandra.cassandra_gc
+    Name         parser
+    Reserve_Data True
+    Parser       cassandra.cassandra_gc.cassandra_gc.0
 
 [FILTER]
     Add   logging.googleapis.com/logName cassandra_gc
@@ -158,10 +160,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    cassandra.cassandra_system
-    Name     parser
-    Parser   cassandra.cassandra_system.cassandra_system.0
+    Key_Name     message
+    Match        cassandra.cassandra_system
+    Name         parser
+    Reserve_Data True
+    Parser       cassandra.cassandra_system.cassandra_system.0
 
 [FILTER]
     Add       logging.googleapis.com/severity TRACE

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden_fluent_bit_main.conf
@@ -169,10 +169,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    cassandra_custom.cassandra_custom_debug
-    Name     parser
-    Parser   cassandra_custom.cassandra_custom_debug.cassandra_debug.0
+    Key_Name     message
+    Match        cassandra_custom.cassandra_custom_debug
+    Name         parser
+    Reserve_Data True
+    Parser       cassandra_custom.cassandra_custom_debug.cassandra_debug.0
 
 [FILTER]
     Add       logging.googleapis.com/severity TRACE
@@ -216,10 +217,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    cassandra_custom.cassandra_custom_gc
-    Name     parser
-    Parser   cassandra_custom.cassandra_custom_gc.cassandra_gc.0
+    Key_Name     message
+    Match        cassandra_custom.cassandra_custom_gc
+    Name         parser
+    Reserve_Data True
+    Parser       cassandra_custom.cassandra_custom_gc.cassandra_gc.0
 
 [FILTER]
     Add   logging.googleapis.com/logName cassandra_custom_gc
@@ -233,10 +235,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    cassandra_custom.cassandra_custom_system
-    Name     parser
-    Parser   cassandra_custom.cassandra_custom_system.cassandra_system.0
+    Key_Name     message
+    Match        cassandra_custom.cassandra_custom_system
+    Name         parser
+    Reserve_Data True
+    Parser       cassandra_custom.cassandra_custom_system.cassandra_system.0
 
 [FILTER]
     Add       logging.googleapis.com/severity TRACE
@@ -280,10 +283,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    cassandra_default.cassandra_default_debug
-    Name     parser
-    Parser   cassandra_default.cassandra_default_debug.cassandra_debug.0
+    Key_Name     message
+    Match        cassandra_default.cassandra_default_debug
+    Name         parser
+    Reserve_Data True
+    Parser       cassandra_default.cassandra_default_debug.cassandra_debug.0
 
 [FILTER]
     Add       logging.googleapis.com/severity TRACE
@@ -327,10 +331,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    cassandra_default.cassandra_default_gc
-    Name     parser
-    Parser   cassandra_default.cassandra_default_gc.cassandra_gc.0
+    Key_Name     message
+    Match        cassandra_default.cassandra_default_gc
+    Name         parser
+    Reserve_Data True
+    Parser       cassandra_default.cassandra_default_gc.cassandra_gc.0
 
 [FILTER]
     Add   logging.googleapis.com/logName cassandra_default_gc
@@ -344,10 +349,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    cassandra_default.cassandra_default_system
-    Name     parser
-    Parser   cassandra_default.cassandra_default_system.cassandra_system.0
+    Key_Name     message
+    Match        cassandra_default.cassandra_default_system
+    Name         parser
+    Reserve_Data True
+    Parser       cassandra_default.cassandra_default_system.cassandra_system.0
 
 [FILTER]
     Add       logging.googleapis.com/severity TRACE
@@ -385,16 +391,22 @@
     Name  modify
 
 [FILTER]
+    Add   logging.googleapis.com/logName cassandra_syslog_debug
+    Match cassandra_syslog_system.cassandra_syslog_debug
+    Name  modify
+
+[FILTER]
     Match                 cassandra_syslog_system.cassandra_syslog_debug
     Multiline.Key_Content message
     Multiline.Parser      cassandra_syslog_system.cassandra_syslog_debug.0.multiline
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    cassandra_syslog_system.cassandra_syslog_debug
-    Name     parser
-    Parser   cassandra_syslog_system.cassandra_syslog_debug.0.0
+    Key_Name     message
+    Match        cassandra_syslog_system.cassandra_syslog_debug
+    Name         parser
+    Reserve_Data True
+    Parser       cassandra_syslog_system.cassandra_syslog_debug.0.0
 
 [FILTER]
     Add       logging.googleapis.com/severity TRACE
@@ -433,10 +445,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    cassandra_syslog_system.cassandra_syslog_debug
-    Name     parser
-    Parser   cassandra_syslog_system.cassandra_syslog_debug.1.0
+    Key_Name     message
+    Match        cassandra_syslog_system.cassandra_syslog_debug
+    Name         parser
+    Reserve_Data True
+    Parser       cassandra_syslog_system.cassandra_syslog_debug.1.0
 
 [FILTER]
     Add       logging.googleapis.com/severity TRACE
@@ -475,14 +488,15 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    cassandra_syslog_system.cassandra_syslog_debug
-    Name     parser
-    Parser   cassandra_syslog_system.cassandra_syslog_debug.2.0
+    Key_Name     message
+    Match        cassandra_syslog_system.cassandra_syslog_debug
+    Name         parser
+    Reserve_Data True
+    Parser       cassandra_syslog_system.cassandra_syslog_debug.2.0
 
 [FILTER]
-    Add   logging.googleapis.com/logName cassandra_syslog_debug
-    Match cassandra_syslog_system.cassandra_syslog_debug
+    Add   logging.googleapis.com/logName cassandra_syslog_gc
+    Match cassandra_syslog_system.cassandra_syslog_gc
     Name  modify
 
 [FILTER]
@@ -492,10 +506,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    cassandra_syslog_system.cassandra_syslog_gc
-    Name     parser
-    Parser   cassandra_syslog_system.cassandra_syslog_gc.0.0
+    Key_Name     message
+    Match        cassandra_syslog_system.cassandra_syslog_gc
+    Name         parser
+    Reserve_Data True
+    Parser       cassandra_syslog_system.cassandra_syslog_gc.0.0
 
 [FILTER]
     Add       logging.googleapis.com/severity TRACE
@@ -534,10 +549,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    cassandra_syslog_system.cassandra_syslog_gc
-    Name     parser
-    Parser   cassandra_syslog_system.cassandra_syslog_gc.1.0
+    Key_Name     message
+    Match        cassandra_syslog_system.cassandra_syslog_gc
+    Name         parser
+    Reserve_Data True
+    Parser       cassandra_syslog_system.cassandra_syslog_gc.1.0
 
 [FILTER]
     Add       logging.googleapis.com/severity TRACE
@@ -576,14 +592,15 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    cassandra_syslog_system.cassandra_syslog_gc
-    Name     parser
-    Parser   cassandra_syslog_system.cassandra_syslog_gc.2.0
+    Key_Name     message
+    Match        cassandra_syslog_system.cassandra_syslog_gc
+    Name         parser
+    Reserve_Data True
+    Parser       cassandra_syslog_system.cassandra_syslog_gc.2.0
 
 [FILTER]
-    Add   logging.googleapis.com/logName cassandra_syslog_gc
-    Match cassandra_syslog_system.cassandra_syslog_gc
+    Add   logging.googleapis.com/logName cassandra_syslog_system
+    Match cassandra_syslog_system.cassandra_syslog_system
     Name  modify
 
 [FILTER]
@@ -593,10 +610,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    cassandra_syslog_system.cassandra_syslog_system
-    Name     parser
-    Parser   cassandra_syslog_system.cassandra_syslog_system.0.0
+    Key_Name     message
+    Match        cassandra_syslog_system.cassandra_syslog_system
+    Name         parser
+    Reserve_Data True
+    Parser       cassandra_syslog_system.cassandra_syslog_system.0.0
 
 [FILTER]
     Add       logging.googleapis.com/severity TRACE
@@ -635,10 +653,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    cassandra_syslog_system.cassandra_syslog_system
-    Name     parser
-    Parser   cassandra_syslog_system.cassandra_syslog_system.1.0
+    Key_Name     message
+    Match        cassandra_syslog_system.cassandra_syslog_system
+    Name         parser
+    Reserve_Data True
+    Parser       cassandra_syslog_system.cassandra_syslog_system.1.0
 
 [FILTER]
     Add       logging.googleapis.com/severity TRACE
@@ -677,15 +696,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    cassandra_syslog_system.cassandra_syslog_system
-    Name     parser
-    Parser   cassandra_syslog_system.cassandra_syslog_system.2.0
-
-[FILTER]
-    Add   logging.googleapis.com/logName cassandra_syslog_system
-    Match cassandra_syslog_system.cassandra_syslog_system
-    Name  modify
+    Key_Name     message
+    Match        cassandra_syslog_system.cassandra_syslog_system
+    Name         parser
+    Reserve_Data True
+    Parser       cassandra_syslog_system.cassandra_syslog_system.2.0
 
 [FILTER]
     Add   logging.googleapis.com/logName syslog

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden_fluent_bit_main.conf
@@ -72,11 +72,12 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    couchdb.couchdb
-    Name     parser
-    Parser   couchdb.couchdb.couchdb.0
-    Parser   couchdb.couchdb.couchdb.1
+    Key_Name     message
+    Match        couchdb.couchdb
+    Name         parser
+    Reserve_Data True
+    Parser       couchdb.couchdb.couchdb.0
+    Parser       couchdb.couchdb.couchdb.1
 
 [FILTER]
     Match         couchdb.couchdb

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden_fluent_bit_main.conf
@@ -80,10 +80,11 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    elasticsearch.elasticsearch_gc
-    Name     parser
-    Parser   elasticsearch.elasticsearch_gc.elasticsearch_gc
+    Key_Name     message
+    Match        elasticsearch.elasticsearch_gc
+    Name         parser
+    Reserve_Data True
+    Parser       elasticsearch.elasticsearch_gc.elasticsearch_gc
 
 [FILTER]
     Add   logging.googleapis.com/logName elasticsearch_gc
@@ -96,10 +97,11 @@
     Rename log message
 
 [FILTER]
-    Key_Name message
-    Match    elasticsearch.elasticsearch_json
-    Name     parser
-    Parser   elasticsearch.elasticsearch_json.elasticsearch_json
+    Key_Name     message
+    Match        elasticsearch.elasticsearch_json
+    Name         parser
+    Reserve_Data True
+    Parser       elasticsearch.elasticsearch_json.elasticsearch_json
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden_fluent_bit_main.conf
@@ -111,10 +111,11 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    elasticsearch_custom.elasticsearch_gc_custom
-    Name     parser
-    Parser   elasticsearch_custom.elasticsearch_gc_custom.elasticsearch_gc
+    Key_Name     message
+    Match        elasticsearch_custom.elasticsearch_gc_custom
+    Name         parser
+    Reserve_Data True
+    Parser       elasticsearch_custom.elasticsearch_gc_custom.elasticsearch_gc
 
 [FILTER]
     Add   logging.googleapis.com/logName elasticsearch_gc_custom
@@ -127,10 +128,11 @@
     Rename log message
 
 [FILTER]
-    Key_Name message
-    Match    elasticsearch_custom.elasticsearch_json_custom
-    Name     parser
-    Parser   elasticsearch_custom.elasticsearch_json_custom.elasticsearch_json
+    Key_Name     message
+    Match        elasticsearch_custom.elasticsearch_json_custom
+    Name         parser
+    Reserve_Data True
+    Parser       elasticsearch_custom.elasticsearch_json_custom.elasticsearch_json
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG
@@ -298,10 +300,11 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    elasticsearch_default.elasticsearch_gc_default
-    Name     parser
-    Parser   elasticsearch_default.elasticsearch_gc_default.elasticsearch_gc
+    Key_Name     message
+    Match        elasticsearch_default.elasticsearch_gc_default
+    Name         parser
+    Reserve_Data True
+    Parser       elasticsearch_default.elasticsearch_gc_default.elasticsearch_gc
 
 [FILTER]
     Add   logging.googleapis.com/logName elasticsearch_gc_default
@@ -314,10 +317,11 @@
     Rename log message
 
 [FILTER]
-    Key_Name message
-    Match    elasticsearch_default.elasticsearch_json_default
-    Name     parser
-    Parser   elasticsearch_default.elasticsearch_json_default.elasticsearch_json
+    Key_Name     message
+    Match        elasticsearch_default.elasticsearch_json_default
+    Name         parser
+    Reserve_Data True
+    Parser       elasticsearch_default.elasticsearch_json_default.elasticsearch_json
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -124,15 +124,16 @@
     Name  modify
 
 [FILTER]
-    Key_Name key_5
-    Match    pipeline5.log_source_id5
-    Name     parser
-    Parser   pipeline5.log_source_id5.0
-
-[FILTER]
     Add   logging.googleapis.com/logName log_source_id5
     Match pipeline5.log_source_id5
     Name  modify
+
+[FILTER]
+    Key_Name     key_5
+    Match        pipeline5.log_source_id5
+    Name         parser
+    Reserve_Data True
+    Parser       pipeline5.log_source_id5.0
 
 [OUTPUT]
     Match_Regex                   ^(pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.log_source_id3|pipeline4\.log_source_id4|pipeline5\.log_source_id5)$

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden_fluent_bit_main.conf
@@ -71,10 +71,11 @@
     Rename log message
 
 [FILTER]
-    Key_Name message
-    Match    hadoop.hadoop
-    Name     parser
-    Parser   hadoop.hadoop.hadoop
+    Key_Name     message
+    Match        hadoop.hadoop
+    Name         parser
+    Reserve_Data True
+    Parser       hadoop.hadoop.hadoop
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden_fluent_bit_main.conf
@@ -72,10 +72,11 @@
     Rename log message
 
 [FILTER]
-    Key_Name message
-    Match    hadoop.hadoop
-    Name     parser
-    Parser   hadoop.hadoop.hadoop
+    Key_Name     message
+    Match        hadoop.hadoop
+    Name         parser
+    Reserve_Data True
+    Parser       hadoop.hadoop.hadoop
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden_fluent_bit_main.conf
@@ -71,10 +71,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    hbase.hbase_system
-    Name     parser
-    Parser   hbase.hbase_system.hbase_system.0
+    Key_Name     message
+    Match        hbase.hbase_system
+    Name         parser
+    Reserve_Data True
+    Parser       hbase.hbase_system.hbase_system.0
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden_fluent_bit_main.conf
@@ -71,10 +71,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    kafka.kafka
-    Name     parser
-    Parser   kafka.kafka.kafka.0
+    Key_Name     message
+    Match        kafka.kafka
+    Name         parser
+    Reserve_Data True
+    Parser       kafka.kafka.kafka.0
 
 [FILTER]
     Add       logging.googleapis.com/severity TRACE

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden_fluent_bit_main.conf
@@ -82,10 +82,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    kafka_custom.kafka_custom
-    Name     parser
-    Parser   kafka_custom.kafka_custom.kafka.0
+    Key_Name     message
+    Match        kafka_custom.kafka_custom
+    Name         parser
+    Reserve_Data True
+    Parser       kafka_custom.kafka_custom.kafka.0
 
 [FILTER]
     Add       logging.googleapis.com/severity TRACE
@@ -135,16 +136,22 @@
     Name  modify
 
 [FILTER]
+    Add   logging.googleapis.com/logName kafka_syslog
+    Match kafka_syslog.kafka_syslog
+    Name  modify
+
+[FILTER]
     Match                 kafka_syslog.kafka_syslog
     Multiline.Key_Content message
     Multiline.Parser      kafka_syslog.kafka_syslog.0.multiline
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    kafka_syslog.kafka_syslog
-    Name     parser
-    Parser   kafka_syslog.kafka_syslog.0.0
+    Key_Name     message
+    Match        kafka_syslog.kafka_syslog
+    Name         parser
+    Reserve_Data True
+    Parser       kafka_syslog.kafka_syslog.0.0
 
 [FILTER]
     Add       logging.googleapis.com/severity TRACE
@@ -187,11 +194,6 @@
     Match     kafka_syslog.kafka_syslog
     Name      modify
     Remove    level
-
-[FILTER]
-    Add   logging.googleapis.com/logName kafka_syslog
-    Match kafka_syslog.kafka_syslog
-    Name  modify
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|kafka_custom\.kafka_custom|kafka_syslog\.kafka_syslog)$

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden_fluent_bit_main.conf
@@ -65,10 +65,11 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    mongodb.mongodb
-    Name     parser
-    Parser   mongodb.mongodb.mongodb
+    Key_Name     message
+    Match        mongodb.mongodb
+    Name         parser
+    Reserve_Data True
+    Parser       mongodb.mongodb.mongodb
 
 [FILTER]
     Add_prefix   temp_ts_

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_fluent_bit_main.conf
@@ -93,12 +93,13 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    mysql.mysql_error
-    Name     parser
-    Parser   mysql.mysql_error.mysql_error.0
-    Parser   mysql.mysql_error.mysql_error.1
-    Parser   mysql.mysql_error.mysql_error.2
+    Key_Name     message
+    Match        mysql.mysql_error
+    Name         parser
+    Reserve_Data True
+    Parser       mysql.mysql_error.mysql_error.0
+    Parser       mysql.mysql_error.mysql_error.1
+    Parser       mysql.mysql_error.mysql_error.2
 
 [FILTER]
     Add       logging.googleapis.com/severity ERROR
@@ -160,10 +161,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    mysql.mysql_general
-    Name     parser
-    Parser   mysql.mysql_general.mysql_general.0
+    Key_Name     message
+    Match        mysql.mysql_general
+    Name         parser
+    Reserve_Data True
+    Parser       mysql.mysql_general.mysql_general.0
 
 [FILTER]
     Add   logging.googleapis.com/logName mysql_general
@@ -177,10 +179,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    mysql.mysql_slow
-    Name     parser
-    Parser   mysql.mysql_slow.mysql_slow.0
+    Key_Name     message
+    Match        mysql.mysql_slow
+    Name         parser
+    Reserve_Data True
+    Parser       mysql.mysql_slow.mysql_slow.0
 
 [FILTER]
     Add   logging.googleapis.com/logName mysql_slow

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden_fluent_bit_main.conf
@@ -168,12 +168,13 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    mysql_custom.mysql_custom_error
-    Name     parser
-    Parser   mysql_custom.mysql_custom_error.mysql_error.0
-    Parser   mysql_custom.mysql_custom_error.mysql_error.1
-    Parser   mysql_custom.mysql_custom_error.mysql_error.2
+    Key_Name     message
+    Match        mysql_custom.mysql_custom_error
+    Name         parser
+    Reserve_Data True
+    Parser       mysql_custom.mysql_custom_error.mysql_error.0
+    Parser       mysql_custom.mysql_custom_error.mysql_error.1
+    Parser       mysql_custom.mysql_custom_error.mysql_error.2
 
 [FILTER]
     Add       logging.googleapis.com/severity ERROR
@@ -235,10 +236,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    mysql_custom.mysql_custom_general
-    Name     parser
-    Parser   mysql_custom.mysql_custom_general.mysql_general.0
+    Key_Name     message
+    Match        mysql_custom.mysql_custom_general
+    Name         parser
+    Reserve_Data True
+    Parser       mysql_custom.mysql_custom_general.mysql_general.0
 
 [FILTER]
     Add   logging.googleapis.com/logName mysql_custom_general
@@ -252,10 +254,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    mysql_custom.mysql_custom_slow
-    Name     parser
-    Parser   mysql_custom.mysql_custom_slow.mysql_slow.0
+    Key_Name     message
+    Match        mysql_custom.mysql_custom_slow
+    Name         parser
+    Reserve_Data True
+    Parser       mysql_custom.mysql_custom_slow.mysql_slow.0
 
 [FILTER]
     Add   logging.googleapis.com/logName mysql_custom_slow
@@ -263,12 +266,13 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    mysql_default.mysql_default_error
-    Name     parser
-    Parser   mysql_default.mysql_default_error.mysql_error.0
-    Parser   mysql_default.mysql_default_error.mysql_error.1
-    Parser   mysql_default.mysql_default_error.mysql_error.2
+    Key_Name     message
+    Match        mysql_default.mysql_default_error
+    Name         parser
+    Reserve_Data True
+    Parser       mysql_default.mysql_default_error.mysql_error.0
+    Parser       mysql_default.mysql_default_error.mysql_error.1
+    Parser       mysql_default.mysql_default_error.mysql_error.2
 
 [FILTER]
     Add       logging.googleapis.com/severity ERROR
@@ -330,10 +334,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    mysql_default.mysql_default_general
-    Name     parser
-    Parser   mysql_default.mysql_default_general.mysql_general.0
+    Key_Name     message
+    Match        mysql_default.mysql_default_general
+    Name         parser
+    Reserve_Data True
+    Parser       mysql_default.mysql_default_general.mysql_general.0
 
 [FILTER]
     Add   logging.googleapis.com/logName mysql_default_general
@@ -347,10 +352,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    mysql_default.mysql_default_slow
-    Name     parser
-    Parser   mysql_default.mysql_default_slow.mysql_slow.0
+    Key_Name     message
+    Match        mysql_default.mysql_default_slow
+    Name         parser
+    Reserve_Data True
+    Parser       mysql_default.mysql_default_slow.mysql_slow.0
 
 [FILTER]
     Add   logging.googleapis.com/logName mysql_default_slow
@@ -358,12 +364,18 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    mysql_syslog_error.mysql_syslog_error
-    Name     parser
-    Parser   mysql_syslog_error.mysql_syslog_error.0.0
-    Parser   mysql_syslog_error.mysql_syslog_error.0.1
-    Parser   mysql_syslog_error.mysql_syslog_error.0.2
+    Add   logging.googleapis.com/logName mysql_syslog_error
+    Match mysql_syslog_error.mysql_syslog_error
+    Name  modify
+
+[FILTER]
+    Key_Name     message
+    Match        mysql_syslog_error.mysql_syslog_error
+    Name         parser
+    Reserve_Data True
+    Parser       mysql_syslog_error.mysql_syslog_error.0.0
+    Parser       mysql_syslog_error.mysql_syslog_error.0.1
+    Parser       mysql_syslog_error.mysql_syslog_error.0.2
 
 [FILTER]
     Add       logging.googleapis.com/severity ERROR
@@ -420,10 +432,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    mysql_syslog_error.mysql_syslog_error
-    Name     parser
-    Parser   mysql_syslog_error.mysql_syslog_error.1.0
+    Key_Name     message
+    Match        mysql_syslog_error.mysql_syslog_error
+    Name         parser
+    Reserve_Data True
+    Parser       mysql_syslog_error.mysql_syslog_error.1.0
 
 [FILTER]
     Match                 mysql_syslog_error.mysql_syslog_error
@@ -432,23 +445,25 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    mysql_syslog_error.mysql_syslog_error
-    Name     parser
-    Parser   mysql_syslog_error.mysql_syslog_error.2.0
+    Key_Name     message
+    Match        mysql_syslog_error.mysql_syslog_error
+    Name         parser
+    Reserve_Data True
+    Parser       mysql_syslog_error.mysql_syslog_error.2.0
 
 [FILTER]
-    Add   logging.googleapis.com/logName mysql_syslog_error
-    Match mysql_syslog_error.mysql_syslog_error
+    Add   logging.googleapis.com/logName mysql_syslog_general
+    Match mysql_syslog_error.mysql_syslog_general
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    mysql_syslog_error.mysql_syslog_general
-    Name     parser
-    Parser   mysql_syslog_error.mysql_syslog_general.0.0
-    Parser   mysql_syslog_error.mysql_syslog_general.0.1
-    Parser   mysql_syslog_error.mysql_syslog_general.0.2
+    Key_Name     message
+    Match        mysql_syslog_error.mysql_syslog_general
+    Name         parser
+    Reserve_Data True
+    Parser       mysql_syslog_error.mysql_syslog_general.0.0
+    Parser       mysql_syslog_error.mysql_syslog_general.0.1
+    Parser       mysql_syslog_error.mysql_syslog_general.0.2
 
 [FILTER]
     Add       logging.googleapis.com/severity ERROR
@@ -505,10 +520,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    mysql_syslog_error.mysql_syslog_general
-    Name     parser
-    Parser   mysql_syslog_error.mysql_syslog_general.1.0
+    Key_Name     message
+    Match        mysql_syslog_error.mysql_syslog_general
+    Name         parser
+    Reserve_Data True
+    Parser       mysql_syslog_error.mysql_syslog_general.1.0
 
 [FILTER]
     Match                 mysql_syslog_error.mysql_syslog_general
@@ -517,23 +533,25 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    mysql_syslog_error.mysql_syslog_general
-    Name     parser
-    Parser   mysql_syslog_error.mysql_syslog_general.2.0
+    Key_Name     message
+    Match        mysql_syslog_error.mysql_syslog_general
+    Name         parser
+    Reserve_Data True
+    Parser       mysql_syslog_error.mysql_syslog_general.2.0
 
 [FILTER]
-    Add   logging.googleapis.com/logName mysql_syslog_general
-    Match mysql_syslog_error.mysql_syslog_general
+    Add   logging.googleapis.com/logName mysql_syslog_slow
+    Match mysql_syslog_error.mysql_syslog_slow
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    mysql_syslog_error.mysql_syslog_slow
-    Name     parser
-    Parser   mysql_syslog_error.mysql_syslog_slow.0.0
-    Parser   mysql_syslog_error.mysql_syslog_slow.0.1
-    Parser   mysql_syslog_error.mysql_syslog_slow.0.2
+    Key_Name     message
+    Match        mysql_syslog_error.mysql_syslog_slow
+    Name         parser
+    Reserve_Data True
+    Parser       mysql_syslog_error.mysql_syslog_slow.0.0
+    Parser       mysql_syslog_error.mysql_syslog_slow.0.1
+    Parser       mysql_syslog_error.mysql_syslog_slow.0.2
 
 [FILTER]
     Add       logging.googleapis.com/severity ERROR
@@ -590,10 +608,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    mysql_syslog_error.mysql_syslog_slow
-    Name     parser
-    Parser   mysql_syslog_error.mysql_syslog_slow.1.0
+    Key_Name     message
+    Match        mysql_syslog_error.mysql_syslog_slow
+    Name         parser
+    Reserve_Data True
+    Parser       mysql_syslog_error.mysql_syslog_slow.1.0
 
 [FILTER]
     Match                 mysql_syslog_error.mysql_syslog_slow
@@ -602,15 +621,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    mysql_syslog_error.mysql_syslog_slow
-    Name     parser
-    Parser   mysql_syslog_error.mysql_syslog_slow.2.0
-
-[FILTER]
-    Add   logging.googleapis.com/logName mysql_syslog_slow
-    Match mysql_syslog_error.mysql_syslog_slow
-    Name  modify
+    Key_Name     message
+    Match        mysql_syslog_error.mysql_syslog_slow
+    Name         parser
+    Reserve_Data True
+    Parser       mysql_syslog_error.mysql_syslog_slow.2.0
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|mysql_custom\.mysql_custom_error|mysql_custom\.mysql_custom_general|mysql_custom\.mysql_custom_slow|mysql_default\.mysql_default_error|mysql_default\.mysql_default_general|mysql_default\.mysql_default_slow|mysql_syslog_error\.mysql_syslog_error|mysql_syslog_error\.mysql_syslog_general|mysql_syslog_error\.mysql_syslog_slow)$

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_fluent_bit_main.conf
@@ -79,10 +79,11 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    nginx.nginx_access
-    Name     parser
-    Parser   nginx.nginx_access.nginx_access
+    Key_Name     message
+    Match        nginx.nginx_access
+    Name         parser
+    Reserve_Data True
+    Parser       nginx.nginx_access.nginx_access
 
 [FILTER]
     Condition Key_Value_Equals host -
@@ -116,10 +117,11 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    nginx.nginx_error
-    Name     parser
-    Parser   nginx.nginx_error.nginx_error
+    Key_Name     message
+    Match        nginx.nginx_error
+    Name         parser
+    Reserve_Data True
+    Parser       nginx.nginx_error.nginx_error
 
 [FILTER]
     Add       logging.googleapis.com/severity EMERGENCY

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden_fluent_bit_main.conf
@@ -129,10 +129,11 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    nginx_custom.nginx_custom_access
-    Name     parser
-    Parser   nginx_custom.nginx_custom_access.nginx_access
+    Key_Name     message
+    Match        nginx_custom.nginx_custom_access
+    Name         parser
+    Reserve_Data True
+    Parser       nginx_custom.nginx_custom_access.nginx_access
 
 [FILTER]
     Condition Key_Value_Equals host -
@@ -166,10 +167,11 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    nginx_custom.nginx_custom_error
-    Name     parser
-    Parser   nginx_custom.nginx_custom_error.nginx_error
+    Key_Name     message
+    Match        nginx_custom.nginx_custom_error
+    Name         parser
+    Reserve_Data True
+    Parser       nginx_custom.nginx_custom_error.nginx_error
 
 [FILTER]
     Add       logging.googleapis.com/severity EMERGENCY
@@ -225,10 +227,11 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    nginx_default.nginx_default_access
-    Name     parser
-    Parser   nginx_default.nginx_default_access.nginx_access
+    Key_Name     message
+    Match        nginx_default.nginx_default_access
+    Name         parser
+    Reserve_Data True
+    Parser       nginx_default.nginx_default_access.nginx_access
 
 [FILTER]
     Condition Key_Value_Equals host -
@@ -262,10 +265,11 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    nginx_default.nginx_default_error
-    Name     parser
-    Parser   nginx_default.nginx_default_error.nginx_error
+    Key_Name     message
+    Match        nginx_default.nginx_default_error
+    Name         parser
+    Reserve_Data True
+    Parser       nginx_default.nginx_default_error.nginx_error
 
 [FILTER]
     Add       logging.googleapis.com/severity EMERGENCY
@@ -321,10 +325,16 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    nginx_syslog_access.nginx_syslog_access
-    Name     parser
-    Parser   nginx_syslog_access.nginx_syslog_access.0
+    Add   logging.googleapis.com/logName nginx_syslog_access
+    Match nginx_syslog_access.nginx_syslog_access
+    Name  modify
+
+[FILTER]
+    Key_Name     message
+    Match        nginx_syslog_access.nginx_syslog_access
+    Name         parser
+    Reserve_Data True
+    Parser       nginx_syslog_access.nginx_syslog_access.0
 
 [FILTER]
     Condition Key_Value_Equals host -
@@ -353,15 +363,16 @@
     Wildcard      http_request_*
 
 [FILTER]
-    Add   logging.googleapis.com/logName nginx_syslog_access
-    Match nginx_syslog_access.nginx_syslog_access
+    Add   logging.googleapis.com/logName nginx_syslog_error
+    Match nginx_syslog_error.nginx_syslog_error
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    nginx_syslog_error.nginx_syslog_error
-    Name     parser
-    Parser   nginx_syslog_error.nginx_syslog_error.0
+    Key_Name     message
+    Match        nginx_syslog_error.nginx_syslog_error
+    Name         parser
+    Reserve_Data True
+    Parser       nginx_syslog_error.nginx_syslog_error.0
 
 [FILTER]
     Add       logging.googleapis.com/severity EMERGENCY
@@ -410,11 +421,6 @@
     Condition Key_Value_Equals level debug
     Match     nginx_syslog_error.nginx_syslog_error
     Name      modify
-
-[FILTER]
-    Add   logging.googleapis.com/logName nginx_syslog_error
-    Match nginx_syslog_error.nginx_syslog_error
-    Name  modify
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|nginx_custom\.nginx_custom_access|nginx_custom\.nginx_custom_error|nginx_default\.nginx_default_access|nginx_default\.nginx_default_error|nginx_syslog_access\.nginx_syslog_access|nginx_syslog_error\.nginx_syslog_error)$

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden_fluent_bit_main.conf
@@ -71,10 +71,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    postgresql.postgresql_general
-    Name     parser
-    Parser   postgresql.postgresql_general.postgresql.0
+    Key_Name     message
+    Match        postgresql.postgresql_general
+    Name         parser
+    Reserve_Data True
+    Parser       postgresql.postgresql_general.postgresql.0
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden_fluent_bit_main.conf
@@ -95,10 +95,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    postgresql_custom.postgresql_custom_general
-    Name     parser
-    Parser   postgresql_custom.postgresql_custom_general.postgresql.0
+    Key_Name     message
+    Match        postgresql_custom.postgresql_custom_general
+    Name         parser
+    Reserve_Data True
+    Parser       postgresql_custom.postgresql_custom_general.postgresql.0
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG
@@ -196,10 +197,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    postgresql_default.postgresql_default_general
-    Name     parser
-    Parser   postgresql_default.postgresql_default_general.postgresql.0
+    Key_Name     message
+    Match        postgresql_default.postgresql_default_general
+    Name         parser
+    Reserve_Data True
+    Parser       postgresql_default.postgresql_default_general.postgresql.0
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG
@@ -291,16 +293,22 @@
     Name  modify
 
 [FILTER]
+    Add   logging.googleapis.com/logName postgresql_syslog_general
+    Match postgresql_syslog_error.postgresql_syslog_general
+    Name  modify
+
+[FILTER]
     Match                 postgresql_syslog_error.postgresql_syslog_general
     Multiline.Key_Content message
     Multiline.Parser      postgresql_syslog_error.postgresql_syslog_general.0.multiline
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    postgresql_syslog_error.postgresql_syslog_general
-    Name     parser
-    Parser   postgresql_syslog_error.postgresql_syslog_general.0.0
+    Key_Name     message
+    Match        postgresql_syslog_error.postgresql_syslog_general
+    Name         parser
+    Reserve_Data True
+    Parser       postgresql_syslog_error.postgresql_syslog_general.0.0
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG
@@ -385,11 +393,6 @@
     Condition Key_Value_Equals level PANIC
     Match     postgresql_syslog_error.postgresql_syslog_general
     Name      modify
-
-[FILTER]
-    Add   logging.googleapis.com/logName postgresql_syslog_general
-    Match postgresql_syslog_error.postgresql_syslog_general
-    Name  modify
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|postgresql_custom\.postgresql_custom_general|postgresql_default\.postgresql_default_general|postgresql_syslog_error\.postgresql_syslog_general)$

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden_fluent_bit_main.conf
@@ -71,10 +71,11 @@
     Rename log message
 
 [FILTER]
-    Key_Name message
-    Match    rabbitmq.rabbitmq
-    Name     parser
-    Parser   rabbitmq.rabbitmq.rabbitmq
+    Key_Name     message
+    Match        rabbitmq.rabbitmq
+    Name         parser
+    Reserve_Data True
+    Parser       rabbitmq.rabbitmq.rabbitmq
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_fluent_bit_main.conf
@@ -65,10 +65,11 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    redis.redis
-    Name     parser
-    Parser   redis.redis.redis
+    Key_Name     message
+    Match        redis.redis
+    Name         parser
+    Reserve_Data True
+    Parser       redis.redis.redis
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden_fluent_bit_main.conf
@@ -90,10 +90,11 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    redis_custom.redis_custom
-    Name     parser
-    Parser   redis_custom.redis_custom.redis
+    Key_Name     message
+    Match        redis_custom.redis_custom
+    Name         parser
+    Reserve_Data True
+    Parser       redis_custom.redis_custom.redis
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG
@@ -149,10 +150,11 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    redis_default.redis_default
-    Name     parser
-    Parser   redis_default.redis_default.redis
+    Key_Name     message
+    Match        redis_default.redis_default
+    Name         parser
+    Reserve_Data True
+    Parser       redis_default.redis_default.redis
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG
@@ -208,10 +210,16 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    redis_syslog.redis_syslog
-    Name     parser
-    Parser   redis_syslog.redis_syslog.0
+    Add   logging.googleapis.com/logName redis_syslog
+    Match redis_syslog.redis_syslog
+    Name  modify
+
+[FILTER]
+    Key_Name     message
+    Match        redis_syslog.redis_syslog
+    Name         parser
+    Reserve_Data True
+    Parser       redis_syslog.redis_syslog.0
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG
@@ -260,11 +268,6 @@
     Condition Key_Value_Equals roleChar M
     Match     redis_syslog.redis_syslog
     Name      modify
-
-[FILTER]
-    Add   logging.googleapis.com/logName redis_syslog
-    Match redis_syslog.redis_syslog
-    Name  modify
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|redis_custom\.redis_custom|redis_default\.redis_default|redis_syslog\.redis_syslog)$

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden_fluent_bit_main.conf
@@ -71,10 +71,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    solr.solr_system
-    Name     parser
-    Parser   solr.solr_system.solr_system.0
+    Key_Name     message
+    Match        solr.solr_system
+    Name         parser
+    Reserve_Data True
+    Parser       solr.solr_system.solr_system.0
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -52,26 +52,28 @@
     storage.type      filesystem
 
 [FILTER]
-    Key_Name message
-    Match    pipeline1.test_syslog_source_id_tcp
-    Name     parser
-    Parser   pipeline1.test_syslog_source_id_tcp.0
-
-[FILTER]
     Add   logging.googleapis.com/logName test_syslog_source_id_tcp
     Match pipeline1.test_syslog_source_id_tcp
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    pipeline2.test_syslog_source_id_udp
-    Name     parser
-    Parser   pipeline2.test_syslog_source_id_udp.0
+    Key_Name     message
+    Match        pipeline1.test_syslog_source_id_tcp
+    Name         parser
+    Reserve_Data True
+    Parser       pipeline1.test_syslog_source_id_tcp.0
 
 [FILTER]
     Add   logging.googleapis.com/logName test_syslog_source_id_udp
     Match pipeline2.test_syslog_source_id_udp
     Name  modify
+
+[FILTER]
+    Key_Name     message
+    Match        pipeline2.test_syslog_source_id_udp
+    Name         parser
+    Reserve_Data True
+    Parser       pipeline2.test_syslog_source_id_udp.0
 
 [OUTPUT]
     Match_Regex                   ^(pipeline1\.test_syslog_source_id_tcp|pipeline2\.test_syslog_source_id_udp)$

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden_fluent_bit_main.conf
@@ -79,10 +79,11 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    tomcat.tomcat_access
-    Name     parser
-    Parser   tomcat.tomcat_access.tomcat_access
+    Key_Name     message
+    Match        tomcat.tomcat_access
+    Name         parser
+    Reserve_Data True
+    Parser       tomcat.tomcat_access.tomcat_access
 
 [FILTER]
     Condition Key_Value_Equals host -
@@ -122,10 +123,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    tomcat.tomcat_system
-    Name     parser
-    Parser   tomcat.tomcat_system.tomcat_system.0
+    Key_Name     message
+    Match        tomcat.tomcat_system
+    Name         parser
+    Reserve_Data True
+    Parser       tomcat.tomcat_system.tomcat_system.0
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden_fluent_bit_main.conf
@@ -127,10 +127,11 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    tomcat_custom.tomcat_custom_access
-    Name     parser
-    Parser   tomcat_custom.tomcat_custom_access.tomcat_access
+    Key_Name     message
+    Match        tomcat_custom.tomcat_custom_access
+    Name         parser
+    Reserve_Data True
+    Parser       tomcat_custom.tomcat_custom_access.tomcat_access
 
 [FILTER]
     Condition Key_Value_Equals host -
@@ -170,10 +171,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    tomcat_custom.tomcat_custom_system
-    Name     parser
-    Parser   tomcat_custom.tomcat_custom_system.tomcat_system.0
+    Key_Name     message
+    Match        tomcat_custom.tomcat_custom_system
+    Name         parser
+    Reserve_Data True
+    Parser       tomcat_custom.tomcat_custom_system.tomcat_system.0
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG
@@ -222,10 +224,11 @@
     Name  modify
 
 [FILTER]
-    Key_Name message
-    Match    tomcat_default.tomcat_default_access
-    Name     parser
-    Parser   tomcat_default.tomcat_default_access.tomcat_access
+    Key_Name     message
+    Match        tomcat_default.tomcat_default_access
+    Name         parser
+    Reserve_Data True
+    Parser       tomcat_default.tomcat_default_access.tomcat_access
 
 [FILTER]
     Condition Key_Value_Equals host -
@@ -265,10 +268,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    tomcat_default.tomcat_default_system
-    Name     parser
-    Parser   tomcat_default.tomcat_default_system.tomcat_system.0
+    Key_Name     message
+    Match        tomcat_default.tomcat_default_system
+    Name         parser
+    Reserve_Data True
+    Parser       tomcat_default.tomcat_default_system.tomcat_system.0
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG
@@ -317,16 +321,22 @@
     Name  modify
 
 [FILTER]
+    Add   logging.googleapis.com/logName tomcat_syslog_access
+    Match tomcat_syslog_system.tomcat_syslog_access
+    Name  modify
+
+[FILTER]
     Match                 tomcat_syslog_system.tomcat_syslog_access
     Multiline.Key_Content message
     Multiline.Parser      tomcat_syslog_system.tomcat_syslog_access.0.multiline
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    tomcat_syslog_system.tomcat_syslog_access
-    Name     parser
-    Parser   tomcat_syslog_system.tomcat_syslog_access.0.0
+    Key_Name     message
+    Match        tomcat_syslog_system.tomcat_syslog_access
+    Name         parser
+    Reserve_Data True
+    Parser       tomcat_syslog_system.tomcat_syslog_access.0.0
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG
@@ -370,10 +380,11 @@
     Remove level
 
 [FILTER]
-    Key_Name message
-    Match    tomcat_syslog_system.tomcat_syslog_access
-    Name     parser
-    Parser   tomcat_syslog_system.tomcat_syslog_access.1
+    Key_Name     message
+    Match        tomcat_syslog_system.tomcat_syslog_access
+    Name         parser
+    Reserve_Data True
+    Parser       tomcat_syslog_system.tomcat_syslog_access.1
 
 [FILTER]
     Condition Key_Value_Equals host -
@@ -402,8 +413,8 @@
     Wildcard      http_request_*
 
 [FILTER]
-    Add   logging.googleapis.com/logName tomcat_syslog_access
-    Match tomcat_syslog_system.tomcat_syslog_access
+    Add   logging.googleapis.com/logName tomcat_syslog_system
+    Match tomcat_syslog_system.tomcat_syslog_system
     Name  modify
 
 [FILTER]
@@ -413,10 +424,11 @@
     Name                  multiline
 
 [FILTER]
-    Key_Name message
-    Match    tomcat_syslog_system.tomcat_syslog_system
-    Name     parser
-    Parser   tomcat_syslog_system.tomcat_syslog_system.0.0
+    Key_Name     message
+    Match        tomcat_syslog_system.tomcat_syslog_system
+    Name         parser
+    Reserve_Data True
+    Parser       tomcat_syslog_system.tomcat_syslog_system.0.0
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG
@@ -460,10 +472,11 @@
     Remove level
 
 [FILTER]
-    Key_Name message
-    Match    tomcat_syslog_system.tomcat_syslog_system
-    Name     parser
-    Parser   tomcat_syslog_system.tomcat_syslog_system.1
+    Key_Name     message
+    Match        tomcat_syslog_system.tomcat_syslog_system
+    Name         parser
+    Reserve_Data True
+    Parser       tomcat_syslog_system.tomcat_syslog_system.1
 
 [FILTER]
     Condition Key_Value_Equals host -
@@ -490,11 +503,6 @@
     Operation     nest
     Remove_prefix http_request_
     Wildcard      http_request_*
-
-[FILTER]
-    Add   logging.googleapis.com/logName tomcat_syslog_system
-    Match tomcat_syslog_system.tomcat_syslog_system
-    Name  modify
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|tomcat_custom\.tomcat_custom_access|tomcat_custom\.tomcat_custom_system|tomcat_default\.tomcat_default_access|tomcat_default\.tomcat_default_system|tomcat_syslog_system\.tomcat_syslog_access|tomcat_syslog_system\.tomcat_syslog_system)$

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden_fluent_bit_main.conf
@@ -71,10 +71,11 @@
     Rename log message
 
 [FILTER]
-    Key_Name message
-    Match    wildfly_system.wildfly_system
-    Name     parser
-    Parser   wildfly_system.wildfly_system.wildfly_system
+    Key_Name     message
+    Match        wildfly_system.wildfly_system
+    Name         parser
+    Reserve_Data True
+    Parser       wildfly_system.wildfly_system.wildfly_system
 
 [FILTER]
     Add       logging.googleapis.com/severity TRACE

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden_fluent_bit_main.conf
@@ -71,11 +71,12 @@
     Rename log message
 
 [FILTER]
-    Key_Name message
-    Match    zookeeper_general.zookeeper_general
-    Name     parser
-    Parser   zookeeper_general.zookeeper_general.zookeeper_general.0
-    Parser   zookeeper_general.zookeeper_general.zookeeper_general.1
+    Key_Name     message
+    Match        zookeeper_general.zookeeper_general
+    Name         parser
+    Reserve_Data True
+    Parser       zookeeper_general.zookeeper_general.zookeeper_general.0
+    Parser       zookeeper_general.zookeeper_general.zookeeper_general.1
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden_fluent_bit_main.conf
@@ -71,11 +71,12 @@
     Rename log message
 
 [FILTER]
-    Key_Name message
-    Match    zookeeper.zookeeper_general
-    Name     parser
-    Parser   zookeeper.zookeeper_general.zookeeper_general.0
-    Parser   zookeeper.zookeeper_general.zookeeper_general.1
+    Key_Name     message
+    Match        zookeeper.zookeeper_general
+    Name         parser
+    Reserve_Data True
+    Parser       zookeeper.zookeeper_general.zookeeper_general.0
+    Parser       zookeeper.zookeeper_general.zookeeper_general.1
 
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -107,15 +107,16 @@
     Name  modify
 
 [FILTER]
-    Key_Name key_5
-    Match    pipeline2.log_source_id2
-    Name     parser
-    Parser   pipeline2.log_source_id2.0
-
-[FILTER]
     Add   logging.googleapis.com/logName log_source_id2
     Match pipeline2.log_source_id2
     Name  modify
+
+[FILTER]
+    Key_Name     key_5
+    Match        pipeline2.log_source_id2
+    Name         parser
+    Reserve_Data True
+    Parser       pipeline2.log_source_id2.0
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log|pipeline1\.log_source_id1|pipeline2\.log_source_id2)$


### PR DESCRIPTION

This change moves the modify filter to before the processors.
This is useful so the processors can reference the LogName moving
forward. This will be needed for `modify_fields` and `exclude_logs`.

This change also updates the `parser` component to preserve existing
fields on the record when parsing. We do this so the LogName is not
blown away when the parser is used.
