### PR TITLE
Refactors the shared structs/methods which configure and return a pipeline for JMX Receivers

### DIFF
--- a/apps/activemq.go
+++ b/apps/activemq.go
@@ -22,8 +22,6 @@ import (
 type MetricsReceiverActivemq struct {
 	confgenerator.ConfigComponent `yaml:",inline"`
 
-	confgenerator.MetricsReceiverShared `yaml:",inline"`
-
 	Endpoint                               string `yaml:"endpoint" validate:"omitempty,hostname_port|startswith=service:jmx:"`
 	Username                               string `yaml:"username" validate:"required_with=Password"`
 	Password                               string `yaml:"password" validate:"required_with=Username"`
@@ -42,17 +40,17 @@ func (r MetricsReceiverActivemq) Pipelines() []otel.Pipeline {
 
 	targetSystem := "activemq"
 
-	return r.MetricsReceiverSharedJVM.JVMConfig(
-		targetSystem,
-		defaultActivemqEndpoint,
-		r.CollectionIntervalString(),
-		[]otel.Component{
-			otel.NormalizeSums(),
-			otel.MetricsTransform(
-				otel.AddPrefix("workload.googleapis.com"),
-			),
-		},
-	)
+	return r.MetricsReceiverSharedJVM.
+		WithDefaultEndpoint(defaultActivemqEndpoint).
+		ConfigurePipelines(
+			targetSystem,
+			[]otel.Component{
+				otel.NormalizeSums(),
+				otel.MetricsTransform(
+					otel.AddPrefix("workload.googleapis.com"),
+				),
+			},
+		)
 }
 
 func init() {

--- a/apps/cassandra.go
+++ b/apps/cassandra.go
@@ -23,8 +23,6 @@ import (
 type MetricsReceiverCassandra struct {
 	confgenerator.ConfigComponent `yaml:",inline"`
 
-	confgenerator.MetricsReceiverShared `yaml:",inline"`
-
 	confgenerator.MetricsReceiverSharedJVM `yaml:",inline"`
 
 	confgenerator.MetricsReceiverSharedCollectJVM `yaml:",inline"`
@@ -39,17 +37,17 @@ func (r MetricsReceiverCassandra) Type() string {
 func (r MetricsReceiverCassandra) Pipelines() []otel.Pipeline {
 	targetSystem := "cassandra"
 
-	return r.MetricsReceiverSharedJVM.JVMConfig(
-		r.TargetSystemString(targetSystem),
-		defaultCassandraEndpoint,
-		r.CollectionIntervalString(),
-		[]otel.Component{
-			otel.NormalizeSums(),
-			otel.MetricsTransform(
-				otel.AddPrefix("workload.googleapis.com"),
-			),
-		},
-	)
+	return r.MetricsReceiverSharedJVM.
+		WithDefaultEndpoint(defaultCassandraEndpoint).
+		ConfigurePipelines(
+			r.TargetSystemString(targetSystem),
+			[]otel.Component{
+				otel.NormalizeSums(),
+				otel.MetricsTransform(
+					otel.AddPrefix("workload.googleapis.com"),
+				),
+			},
+		)
 }
 
 func init() {

--- a/apps/hadoop.go
+++ b/apps/hadoop.go
@@ -24,7 +24,6 @@ import (
 
 type MetricsReceiverHadoop struct {
 	confgenerator.ConfigComponent                 `yaml:",inline"`
-	confgenerator.MetricsReceiverShared           `yaml:",inline"`
 	confgenerator.MetricsReceiverSharedJVM        `yaml:",inline"`
 	confgenerator.MetricsReceiverSharedCollectJVM `yaml:",inline"`
 }
@@ -41,17 +40,17 @@ func (r MetricsReceiverHadoop) Pipelines() []otel.Pipeline {
 		targetSystem = fmt.Sprintf("%s,%s", targetSystem, "jvm")
 	}
 
-	return r.MetricsReceiverSharedJVM.JVMConfig(
-		targetSystem,
-		defaultHadoopEndpoint,
-		r.CollectionIntervalString(),
-		[]otel.Component{
-			otel.NormalizeSums(),
-			otel.MetricsTransform(
-				otel.AddPrefix("workload.googleapis.com"),
-			),
-		},
-	)
+	return r.MetricsReceiverSharedJVM.
+		WithDefaultEndpoint(defaultHadoopEndpoint).
+		ConfigurePipelines(
+			targetSystem,
+			[]otel.Component{
+				otel.NormalizeSums(),
+				otel.MetricsTransform(
+					otel.AddPrefix("workload.googleapis.com"),
+				),
+			},
+		)
 }
 
 func init() {

--- a/apps/jvm.go
+++ b/apps/jvm.go
@@ -22,8 +22,6 @@ import (
 type MetricsReceiverJVM struct {
 	confgenerator.ConfigComponent `yaml:",inline"`
 
-	confgenerator.MetricsReceiverShared `yaml:",inline"`
-
 	confgenerator.MetricsReceiverSharedJVM `yaml:",inline"`
 }
 
@@ -34,17 +32,17 @@ func (r MetricsReceiverJVM) Type() string {
 }
 
 func (r MetricsReceiverJVM) Pipelines() []otel.Pipeline {
-	return r.MetricsReceiverSharedJVM.JVMConfig(
-		"jvm",
-		defaultJVMEndpoint,
-		r.CollectionIntervalString(),
-		[]otel.Component{
-			otel.NormalizeSums(),
-			otel.MetricsTransform(
-				otel.AddPrefix("workload.googleapis.com"),
-			),
-		},
-	)
+	return r.MetricsReceiverSharedJVM.
+		WithDefaultEndpoint(defaultJVMEndpoint).
+		ConfigurePipelines(
+			"jvm",
+			[]otel.Component{
+				otel.NormalizeSums(),
+				otel.MetricsTransform(
+					otel.AddPrefix("workload.googleapis.com"),
+				),
+			},
+		)
 }
 
 func init() {

--- a/apps/solr.go
+++ b/apps/solr.go
@@ -23,8 +23,6 @@ import (
 type MetricsReceiverSolr struct {
 	confgenerator.ConfigComponent `yaml:",inline"`
 
-	confgenerator.MetricsReceiverShared `yaml:",inline"`
-
 	confgenerator.MetricsReceiverSharedJVM `yaml:",inline"`
 }
 
@@ -37,17 +35,17 @@ func (r MetricsReceiverSolr) Type() string {
 func (r MetricsReceiverSolr) Pipelines() []otel.Pipeline {
 	targetSystem := "solr"
 
-	return r.MetricsReceiverSharedJVM.JVMConfig(
-		targetSystem,
-		defaultSolrEndpoint,
-		r.CollectionIntervalString(),
-		[]otel.Component{
-			otel.NormalizeSums(),
-			otel.MetricsTransform(
-				otel.AddPrefix("workload.googleapis.com"),
-			),
-		},
-	)
+	return r.MetricsReceiverSharedJVM.
+		WithDefaultEndpoint(defaultSolrEndpoint).
+		ConfigurePipelines(
+			targetSystem,
+			[]otel.Component{
+				otel.NormalizeSums(),
+				otel.MetricsTransform(
+					otel.AddPrefix("workload.googleapis.com"),
+				),
+			},
+		)
 }
 
 func init() {

--- a/apps/tomcat.go
+++ b/apps/tomcat.go
@@ -23,8 +23,6 @@ import (
 type MetricsReceiverTomcat struct {
 	confgenerator.ConfigComponent `yaml:",inline"`
 
-	confgenerator.MetricsReceiverShared `yaml:",inline"`
-
 	confgenerator.MetricsReceiverSharedJVM `yaml:",inline"`
 
 	confgenerator.MetricsReceiverSharedCollectJVM `yaml:",inline"`
@@ -39,17 +37,17 @@ func (r MetricsReceiverTomcat) Type() string {
 func (r MetricsReceiverTomcat) Pipelines() []otel.Pipeline {
 	targetSystem := "tomcat"
 
-	return r.MetricsReceiverSharedJVM.JVMConfig(
-		r.TargetSystemString(targetSystem),
-		defaultTomcatEndpoint,
-		r.CollectionIntervalString(),
-		[]otel.Component{
-			otel.NormalizeSums(),
-			otel.MetricsTransform(
-				otel.AddPrefix("workload.googleapis.com"),
-			),
-		},
-	)
+	return r.MetricsReceiverSharedJVM.
+		WithDefaultEndpoint(defaultTomcatEndpoint).
+		ConfigurePipelines(
+			r.TargetSystemString(targetSystem),
+			[]otel.Component{
+				otel.NormalizeSums(),
+				otel.MetricsTransform(
+					otel.AddPrefix("workload.googleapis.com"),
+				),
+			},
+		)
 }
 
 func init() {

--- a/confgenerator/config.go
+++ b/confgenerator/config.go
@@ -436,16 +436,26 @@ func (m MetricsReceiverSharedTLS) TLSConfig(defaultInsecure bool) map[string]int
 }
 
 type MetricsReceiverSharedJVM struct {
+	MetricsReceiverShared `yaml:",inline"`
+
 	Endpoint string `yaml:"endpoint" validate:"omitempty,hostname_port|startswith=service:jmx:"`
 	Username string `yaml:"username" validate:"required_with=Password"`
 	Password string `yaml:"password" validate:"required_with=Username"`
 }
 
-func (m MetricsReceiverSharedJVM) JVMConfig(targetSystem string, defaultEndpoint string, collectionIntervalString string, processors []otel.Component) []otel.Pipeline {
+// WithDefaultEndpoint overrides the MetricReceiverSharedJVM's Endpoint if it is empty.
+// It then returns a new MetricReceiverSharedJVM with this change.
+func (m MetricsReceiverSharedJVM) WithDefaultEndpoint(defaultEndpoint string) MetricsReceiverSharedJVM {
 	if m.Endpoint == "" {
 		m.Endpoint = defaultEndpoint
 	}
 
+	return m
+}
+
+// ConfigurePipelines sets up a Receiver using the MetricsReceiverSharedJVM and the targetSystem.
+// This is used alongside the passed in processors to return a single Pipeline in an array.
+func (m MetricsReceiverSharedJVM) ConfigurePipelines(targetSystem string, processors []otel.Component) []otel.Pipeline {
 	jarPath, err := FindJarPath()
 	if err != nil {
 		log.Printf(`Encountered an error discovering the location of the JMX Metrics Exporter, %v`, err)
@@ -453,7 +463,7 @@ func (m MetricsReceiverSharedJVM) JVMConfig(targetSystem string, defaultEndpoint
 
 	config := map[string]interface{}{
 		"target_system":       targetSystem,
-		"collection_interval": collectionIntervalString,
+		"collection_interval": m.CollectionIntervalString(),
 		"endpoint":            m.Endpoint,
 		"jar_path":            jarPath,
 	}


### PR DESCRIPTION
This refactor is necessary for the WildFly Receiver update in order to allow for a new defaultAdditionalJars config option. With this pattern we can easily add more defaults in the future without having to refactor the pipeline builder method each time.

Adds MetricsReceiverShared struct to MetricsReceiverSharedJVM struct since it will always need it.
This also allows the ConfigurePipelines method to remove the collection interval argument.
Then added a new method "WithDefaultEndpoint" for MetricsReceiverSharedJVM and removed the defaultEndpoint
argument from the ConfigurePipelines method. This allows for a more extensible pattern where
new defaults do not have to chnage the ConfigurePipeline's method signature.
Lastly made changes to the various application go files which currently make use of these methods/structs.