### PR TITLE
Remove duplicate entries from supported_applications.txt

### DIFF
--- a/integration_test/third_party_apps_data/agent/ops-agent/linux/supported_applications.txt
+++ b/integration_test/third_party_apps_data/agent/ops-agent/linux/supported_applications.txt
@@ -1,11 +1,9 @@
 activemq
 apache
 cassandra
-hadoop
-elasticsearch
 couchdb
-hbase
 elasticsearch
+hadoop
 hbase
 jvm
 kafka


### PR DESCRIPTION
elasticsearch and hbase were in there twice, which results in them both being tested twice. :)

I also reordered a few entries to make the list fully alphabetical instead of mostly alphabetical.