### PR TITLE
Disable gpg check for centos install of couchdb until rpm is fixed

### DIFF
--- a/integration_test/third_party_apps_data/applications/couchdb/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/couchdb/centos_rhel/install
@@ -28,7 +28,7 @@ EOF
     ;;
 esac
 
-sudo yum install -y couchdb
+sudo yum install -y --nogpgcheck couchdb
 
 cat << EOF > local.ini
 [couchdb]


### PR DESCRIPTION
See https://github.com/GoogleCloudPlatform/ops-agent/issues/434 for context