### PR TITLE
Fix some 3p integration tests

### DIFF
--- a/integration_test/third_party_apps_data/applications/activemq/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/activemq/debian_ubuntu/install
@@ -6,6 +6,8 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 
 sudo sed -i 's/useJmx="false"/useJmx="true"/g' /etc/activemq/instances-available/main/activemq.xml 
 
+sudo sed -i 's/dataDirectory="${activemq.base}\/data">/dataDirectory="${activemq.base}\/data">\n\n            <managementContext>\n                <managementContext createConnector="true" connectorPort="1099"\/>\n            <\/managementContext>/g' /etc/activemq/instances-available/main/activemq.xml
+
 sudo ln -s /etc/activemq/instances-available/main /etc/activemq/instances-enabled/main
 
 sudo systemctl daemon-reload

--- a/integration_test/third_party_apps_data/applications/apache/expected_logs.yaml
+++ b/integration_test/third_party_apps_data/applications/apache/expected_logs.yaml
@@ -5,7 +5,7 @@ log_entries:
     httpRequest.requestUrl: "/forbidden.html"
     httpRequest.protocol: "HTTP/1.1"
     httpRequest.requestMethod: "GET"
-    httpRequest.userAgent: "curl/7.64.0"
+    httpRequest.userAgent: "curl/.*"
 - log_name: "apache_error"
   field_matchers:
     jsonPayload.client: "::1"

--- a/integration_test/third_party_apps_data/applications/couchdb/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/couchdb/centos_rhel/install
@@ -28,7 +28,7 @@ EOF
     ;;
 esac
 
-sudo yum install -y couchdb
+sudo yum install -y --nogpgcheck couchdb
 
 cat << EOF > local.ini
 [couchdb]

--- a/integration_test/third_party_apps_data/applications/rabbitmq/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/rabbitmq/debian_ubuntu/install
@@ -14,12 +14,14 @@ curl -s https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc | \
 
 source /etc/os-release
 case $VERSION_ID in
+  # ubuntu
   20.04)
-    # ubuntu
     echo "deb https://packages.erlang-solutions.com/ubuntu focal contrib" | sudo tee /etc/apt/sources.list.d/rabbitmq.list
     ;;
+  # debian
   10)
-    # debian
+    ;&
+  11)
     echo "deb https://packages.erlang-solutions.com/ubuntu bionic contrib" | sudo tee /etc/apt/sources.list.d/rabbitmq.list
     ;;
   *)


### PR DESCRIPTION
- Update expected logs for apache 3p to handle changing curl versions, looking to resolve https://github.com/GoogleCloudPlatform/ops-agent/issues/444 and have it be future proof.
- Update install script for rabbitmq to resolve https://github.com/GoogleCloudPlatform/ops-agent/issues/446
- Update install script for activemq to always set up managementContext, this wasn't being done automatically in whatever version debian-11 gets from apt-get. Resolves https://github.com/GoogleCloudPlatform/ops-agent/issues/447