### PR TITLE
Re-enabled gpg check for centos install of couchdb

### DIFF
--- a/integration_test/third_party_apps_data/applications/couchdb/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/couchdb/centos_rhel/install
@@ -28,7 +28,7 @@ EOF
     ;;
 esac
 
-sudo yum install -y --nogpgcheck couchdb
+sudo yum install -y couchdb
 
 cat << EOF > local.ini
 [couchdb]


### PR DESCRIPTION
Reverts GoogleCloudPlatform/ops-agent#443 as https://github.com/apache/couchdb/issues/3949 was resolved.

Had to re-make https://github.com/GoogleCloudPlatform/ops-agent/pull/449 as the github UI authored it from my personal email which isn't in the CLA.