### PR TITLE
More 3p fixes

### DIFF
--- a/integration_test/third_party_apps_data/applications/hbase/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/hbase/centos_rhel/install
@@ -4,7 +4,7 @@ sudo yum -y install \
     java-1.8.0-openjdk java-1.8.0-openjdk-devel wget
 
 sudo mkdir /opt/hbase
-wget http://apache.mirror.gtcomm.net/hbase/stable/hbase-2.4.9-bin.tar.gz
+wget http://apache.mirror.gtcomm.net/hbase/2.4.9/hbase-2.4.9-bin.tar.gz
 sudo tar -xvf hbase-2.4.9-bin.tar.gz -C /opt/hbase --strip 1
 
 sudo tee /opt/hbase/conf/hbase-env.sh <<EOF

--- a/integration_test/third_party_apps_data/applications/hbase/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/hbase/debian_ubuntu/install
@@ -4,7 +4,7 @@ sudo apt-get update
 sudo apt-get install -y default-jre wget
 
 sudo mkdir /opt/hbase
-wget http://apache.mirror.gtcomm.net/hbase/stable/hbase-2.4.9-bin.tar.gz
+wget http://apache.mirror.gtcomm.net/hbase/2.4.9/hbase-2.4.9-bin.tar.gz
 sudo tar -xvf hbase-2.4.9-bin.tar.gz -C /opt/hbase --strip 1
 
 sudo tee /opt/hbase/conf/hbase-env.sh <<EOF

--- a/integration_test/third_party_apps_data/applications/hbase/sles/install
+++ b/integration_test/third_party_apps_data/applications/hbase/sles/install
@@ -1,7 +1,7 @@
 set -e
 
 sudo zypper install -y wget java-11-openjdk
-wget http://apache.mirror.gtcomm.net/hbase/stable/hbase-2.4.9-bin.tar.gz
+wget http://apache.mirror.gtcomm.net/hbase/2.4.9/hbase-2.4.9-bin.tar.gz
 sudo mkdir /opt/hbase
 sudo tar -xzf hbase-2.4.9-bin.tar.gz -C /opt/hbase --strip 1
 

--- a/integration_test/third_party_apps_data/applications/rabbitmq/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/rabbitmq/debian_ubuntu/install
@@ -20,9 +20,10 @@ case $VERSION_ID in
     ;;
   # debian
   10)
-    ;&
-  11)
     echo "deb https://packages.erlang-solutions.com/ubuntu bionic contrib" | sudo tee /etc/apt/sources.list.d/rabbitmq.list
+    ;;
+  11)
+    echo "deb https://packages.erlang-solutions.com/ubuntu focal contrib" | sudo tee /etc/apt/sources.list.d/rabbitmq.list
     ;;
   *)
     echo -n "unknown version"

--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -425,7 +425,7 @@ func TestThirdPartyApps(t *testing.T) {
 		t.Fatal(err)
 	}
 	tests := []test{}
-	platforms := strings.Split(os.Getenv("PLATFORMS"), ",")
+	platforms := []string{"debian-11"} //strings.Split(os.Getenv("PLATFORMS"), ",")
 	for _, platform := range platforms {
 		apps, err := appsToTest(agentType, platform)
 		if err != nil {

--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -425,7 +425,7 @@ func TestThirdPartyApps(t *testing.T) {
 		t.Fatal(err)
 	}
 	tests := []test{}
-	platforms := []string{"debian-11"} //strings.Split(os.Getenv("PLATFORMS"), ",")
+	platforms := strings.Split(os.Getenv("PLATFORMS"), ",")
 	for _, platform := range platforms {
 		apps, err := appsToTest(agentType, platform)
 		if err != nil {


### PR DESCRIPTION
Fix hbase download path now that 2.4.10 replaced 2.4.9 in stable directory.
Change rabbitmq source for debian 11.