### PR TITLE
Testing: add ExtraCreateArguments option for creating VMs

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1530,7 +1530,7 @@ type VMOptions struct {
 	MachineType string
 	// Optional. If provided, these arguments are appended on to the end
 	// of the "gcloud compute instances create" command.
-	ExtraCreateArguments string[]
+	ExtraCreateArguments []string
 }
 
 // SetupVM creates a new VM according to the given options.

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -941,7 +941,7 @@ func attemptCreateInstance(ctx context.Context, logger *log.Logger, options VMOp
 		"--network=" + vm.Network,
 		"--format=json",
 	}
-	args = append(args, options.ExtraCreateArguments)
+	args = append(args, options.ExtraCreateArguments...)
 	if len(newMetadata) > 0 {
 		// The --metadata flag can't be empty, so we have to have a special case
 		// to omit the flag completely when the newMetadata map is empty.

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -941,6 +941,7 @@ func attemptCreateInstance(ctx context.Context, logger *log.Logger, options VMOp
 		"--network=" + vm.Network,
 		"--format=json",
 	}
+	args = append(args, options.ExtraCreateArguments)
 	if len(newMetadata) > 0 {
 		// The --metadata flag can't be empty, so we have to have a special case
 		// to omit the flag completely when the newMetadata map is empty.
@@ -1527,6 +1528,9 @@ type VMOptions struct {
 	// Optional. If missing, the default is e2-standard-4.
 	// Overridden by INSTANCE_SIZE if that environment variable is set.
 	MachineType string
+	// Optional. If provided, these arguments are appended on to the end
+	// of the "gcloud compute instances create" command.
+	ExtraCreateArguments string[]
 }
 
 // SetupVM creates a new VM according to the given options.

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -941,7 +941,6 @@ func attemptCreateInstance(ctx context.Context, logger *log.Logger, options VMOp
 		"--network=" + vm.Network,
 		"--format=json",
 	}
-	args = append(args, options.ExtraCreateArguments...)
 	if len(newMetadata) > 0 {
 		// The --metadata flag can't be empty, so we have to have a special case
 		// to omit the flag completely when the newMetadata map is empty.
@@ -953,6 +952,7 @@ func attemptCreateInstance(ctx context.Context, logger *log.Logger, options VMOp
 	if email := os.Getenv("SERVICE_EMAIL"); email != "" {
 		args = append(args, "--service-account="+email)
 	}
+	args = append(args, options.ExtraCreateArguments...)
 
 	output, err := RunGcloud(ctx, logger, "", args)
 	if err != nil {


### PR DESCRIPTION
This is to allow me to experiment with turning on Cloud NAT on Kokoro, which should allow us to avoid IN_USE_ADDRESSES quota exhaustion errors (fingers crossed).