### PR TITLE
Fix kafka download path for 3p integration test

### DIFF
--- a/integration_test/third_party_apps_data/applications/kafka/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/kafka/centos_rhel/install
@@ -2,7 +2,7 @@ set -e
 
 sudo yum install -y curl java
 sudo mkdir -p /opt/kafka/stage
-sudo curl "https://dlcdn.apache.org/kafka/3.0.1/kafka_2.12-3.0.1.tgz" -o /opt/kafka/stage/kafka.tgz
+sudo curl "https://archive.apache.org/dist/kafka/3.0.1/kafka_2.12-3.0.1.tgz" -o /opt/kafka/stage/kafka.tgz
 sudo tar -xvzf /opt/kafka/stage/kafka.tgz -C /opt/kafka --strip 1
 
 echo "KAFKA_JMX_OPTS=\"-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.net.preferIPv4Stack=true\"" | sudo tee -a /opt/kafka/bin/kafka-run-class.sh

--- a/integration_test/third_party_apps_data/applications/kafka/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/kafka/centos_rhel/install
@@ -2,7 +2,7 @@ set -e
 
 sudo yum install -y curl java
 sudo mkdir -p /opt/kafka/stage
-sudo curl "https://dlcdn.apache.org/kafka/3.0.0/kafka_2.12-3.0.0.tgz" -o /opt/kafka/stage/kafka.tgz
+sudo curl "https://dlcdn.apache.org/kafka/3.0.1/kafka_2.12-3.0.1.tgz" -o /opt/kafka/stage/kafka.tgz
 sudo tar -xvzf /opt/kafka/stage/kafka.tgz -C /opt/kafka --strip 1
 
 echo "KAFKA_JMX_OPTS=\"-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.net.preferIPv4Stack=true\"" | sudo tee -a /opt/kafka/bin/kafka-run-class.sh

--- a/integration_test/third_party_apps_data/applications/kafka/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/kafka/debian_ubuntu/install
@@ -3,7 +3,7 @@ set -e
 sudo apt-get update
 sudo apt-get install -y curl default-jre
 sudo mkdir -p /opt/kafka/stage
-sudo curl "https://dlcdn.apache.org/kafka/3.0.1/kafka_2.12-3.0.1.tgz" -o /opt/kafka/stage/kafka.tgz
+sudo curl "https://archive.apache.org/dist/kafka/3.0.1/kafka_2.12-3.0.1.tgz" -o /opt/kafka/stage/kafka.tgz
 sudo tar -xvzf /opt/kafka/stage/kafka.tgz -C /opt/kafka --strip 1
 
 echo "KAFKA_JMX_OPTS=\"-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.net.preferIPv4Stack=true\"" | sudo tee -a /opt/kafka/bin/kafka-run-class.sh

--- a/integration_test/third_party_apps_data/applications/kafka/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/kafka/debian_ubuntu/install
@@ -3,7 +3,7 @@ set -e
 sudo apt-get update
 sudo apt-get install -y curl default-jre
 sudo mkdir -p /opt/kafka/stage
-sudo curl "https://dlcdn.apache.org/kafka/3.0.0/kafka_2.12-3.0.0.tgz" -o /opt/kafka/stage/kafka.tgz
+sudo curl "https://dlcdn.apache.org/kafka/3.0.1/kafka_2.12-3.0.1.tgz" -o /opt/kafka/stage/kafka.tgz
 sudo tar -xvzf /opt/kafka/stage/kafka.tgz -C /opt/kafka --strip 1
 
 echo "KAFKA_JMX_OPTS=\"-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.net.preferIPv4Stack=true\"" | sudo tee -a /opt/kafka/bin/kafka-run-class.sh

--- a/integration_test/third_party_apps_data/applications/kafka/sles/install
+++ b/integration_test/third_party_apps_data/applications/kafka/sles/install
@@ -2,7 +2,7 @@ set -e
 
 sudo zypper install -y curl java-11-openjdk
 sudo mkdir -p /opt/kafka/stage
-sudo curl "https://dlcdn.apache.org/kafka/3.0.1/kafka_2.12-3.0.1.tgz" -o /opt/kafka/stage/kafka.tgz
+sudo curl "https://archive.apache.org/dist/kafka/3.0.1/kafka_2.12-3.0.1.tgz" -o /opt/kafka/stage/kafka.tgz
 sudo tar -xvzf /opt/kafka/stage/kafka.tgz -C /opt/kafka --strip 1
 
 echo "KAFKA_JMX_OPTS=\"-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.net.preferIPv4Stack=true\"" | sudo tee -a /opt/kafka/bin/kafka-run-class.sh

--- a/integration_test/third_party_apps_data/applications/kafka/sles/install
+++ b/integration_test/third_party_apps_data/applications/kafka/sles/install
@@ -2,7 +2,7 @@ set -e
 
 sudo zypper install -y curl java-11-openjdk
 sudo mkdir -p /opt/kafka/stage
-sudo curl "https://dlcdn.apache.org/kafka/3.0.0/kafka_2.12-3.0.0.tgz" -o /opt/kafka/stage/kafka.tgz
+sudo curl "https://dlcdn.apache.org/kafka/3.0.1/kafka_2.12-3.0.1.tgz" -o /opt/kafka/stage/kafka.tgz
 sudo tar -xvzf /opt/kafka/stage/kafka.tgz -C /opt/kafka --strip 1
 
 echo "KAFKA_JMX_OPTS=\"-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.net.preferIPv4Stack=true\"" | sudo tee -a /opt/kafka/bin/kafka-run-class.sh


### PR DESCRIPTION
Addressing https://github.com/GoogleCloudPlatform/ops-agent/issues/465 .
Appears that 3.0.0 was removed from the CDN for active apache kafka versions. Moved to using the archive & also updated to 3.0.1