### PR TITLE
Remove erroneous log field in hbase doc

### DIFF
--- a/docs/hbase.md
+++ b/docs/hbase.md
@@ -138,6 +138,5 @@ System logs contain the following fields in the [`LogEntry`](https://cloud.googl
 | `jsonPayload.source` | string | source of where the log originated |
 | `jsonPayload.message` | string | Log message, including detailed stacktrace where provided |
 | `severity` | string ([`LogSeverity`](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity)) | Log entry level (translated) |
-| `wildcard_refresh_interval` | `60s` | The interval at which wildcard file paths in `include_paths` are refreshed. Specified as a time interval parsable by [time.ParseDuration](https://pkg.go.dev/time#ParseDuration). Must be a multiple of 1s.|
 
 Any fields that are blank or missing will not be present in the log entry.


### PR DESCRIPTION
Looks like this is a logging config option that was copied into the log fields table by mistake.