### PR TITLE
Testing: document new process for authenticating tests

### DIFF
--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -4,16 +4,35 @@ Integration tests are implemented as Kokoko builds that run on each PR. The
 builds first build the Ops Agent and then run tests on that agent. The Kokoro
 builds are split up by distro.
 
-## Ops Agent Test
-
-This test exercises "core" features of the Ops Agent such as watching syslog or
-a custom log file. It is implemented in ops_agent_test.go. It can be run outside
-of Kokoro with some setup.
-
 ### Setup
 
-You will need a project to run VMs in and a service account with permissions to
-run various operations in the project. You can set up such a service account with
+You will need a GCP project to run VMs in and a GCS bucket that is used to
+transfer files onto the testing VMs. These are referred to as `${PROJECT}`
+and `${TRANSFERS_BUCKET}` in the following instructions.
+
+Follow the setup instructions for either User Credentials or
+Service Account Credentials next.
+
+### Setup (User Credentials)
+
+To give the tests credentials to be able to access google APIs as you,
+run the following command and do what it says:
+
+```
+gcloud auth application-default login
+```
+
+That's it! Now the test commands should be able to authenticate as you.
+
+NOTE: this way of using user credentials is new and may have unforseen
+problems, particularly due to which projects get used for billing.
+However, it is much easier than setting up a service account and
+rotating service account keys periodically.
+
+### Setup (Service Account Credentials)
+
+You will need a service account with permissions to run various
+operations in the project. You can set up such a service account with
 a few commands:
 
 ```
@@ -37,14 +56,14 @@ for ROLE in \
   done
 ```
 
-You will also need a GCS bucket that is used to transfer files onto
-the testing VMs. Store it in env variable `$BUCKET` and add your
-service account as principal with role "Storage Admin" to the bucket:
+You will also need to give your service account read/write permissions on
+`${TRANSFERS_BUCKET}`. To do this, register your service account as principal
+with role "Storage Admin" to the bucket:
 
 ```
 gsutil iam ch \
   "serviceAccount:service-account-$(whoami)@${PROJECT}.iam.gserviceaccount.com:roles/storage.admin" \
-  "gs://${BUCKET}"
+  "gs://${TRANSFERS_BUCKET}"
 ```
 
 Finally, download your credentials as a JSON file:
@@ -55,6 +74,17 @@ gcloud iam service-accounts keys create $HOME/credentials.json \
   --iam-account "service-account-$(whoami)@${PROJECT}.iam.gserviceaccount.com"
 ```
 
+When runninng the test commands below, you must also pass the
+environment variable
+`GOOGLE_APPLICATION_CREDENTIALS="${HOME}/credentials.json"` to the
+test command.
+
+## Ops Agent Test
+
+This test exercises "core" features of the Ops Agent such as watching syslog or
+a custom log file. It is implemented in ops_agent_test.go. It can be run outside
+of Kokoro with some setup (see above).
+
 ### Testing Command
 
 When the setup steps are complete, you can run ops_agent_test (for Linux)
@@ -63,7 +93,6 @@ like this:
 ```
 PROJECT="${PROJECT}" \
 TRANSFERS_BUCKET="${BUCKET}" \
-GOOGLE_APPLICATION_CREDENTIALS="${HOME}/credentials.json" \
 ZONE=us-central1-b \
 PLATFORMS=debian-10 \
 go test -v ops_agent_test.go \
@@ -152,8 +181,7 @@ is nearly the same, just replace `ops_agent_test.go` with
 
 ```
 PROJECT="${PROJECT}" \
-TRANSFERS_BUCKET="${BUCKET}" \
-GOOGLE_APPLICATION_CREDENTIALS="${HOME}/credentials.json" \
+TRANSFERS_BUCKET="${TRANSFERS_BUCKET}" \
 ZONE=us-central1-b \
 PLATFORMS=debian-10 \
 go test -v third_party_apps_test.go \

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -92,7 +92,7 @@ like this:
 
 ```
 PROJECT="${PROJECT}" \
-TRANSFERS_BUCKET="${BUCKET}" \
+TRANSFERS_BUCKET="${TRANSFERS_BUCKET}" \
 ZONE=us-central1-b \
 PLATFORMS=debian-10 \
 go test -v ops_agent_test.go \

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -27,7 +27,7 @@ gcloud --billing-project="${PROJECT}" auth application-default login
 
 That's it! Now the test commands should be able to authenticate as you.
 
-NOTE: this way of using user credentials is new and may have unforseen
+NOTE: this way of using user credentials is new and may have unforeseen
 problems.
 
 ### Setup (Service Account Credentials)

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -18,19 +18,17 @@ Service Account Credentials next.
 
 ### Setup (User Credentials)
 
-To give the tests credentials to be able to access google APIs as you,
+To give the tests credentials to be able to access Google APIs as you,
 run the following command and do what it says:
 
 ```
-gcloud auth application-default login
+gcloud --billing-project="${PROJECT}" auth application-default login
 ```
 
 That's it! Now the test commands should be able to authenticate as you.
 
 NOTE: this way of using user credentials is new and may have unforseen
-problems, particularly due to which projects get used for billing.
-However, it is much easier than setting up a service account and
-rotating service account keys periodically.
+problems.
 
 ### Setup (Service Account Credentials)
 

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -4,7 +4,7 @@ Integration tests are implemented as Kokoko builds that run on each PR. The
 builds first build the Ops Agent and then run tests on that agent. The Kokoro
 builds are split up by distro.
 
-### Setup
+## Setup
 
 You will need a GCP project to run VMs in and a GCS bucket that is used to
 transfer files onto the testing VMs. These are referred to as `${PROJECT}`

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -19,7 +19,9 @@ Service Account Credentials next.
 ### Setup (User Credentials)
 
 To give the tests credentials to be able to access Google APIs as you,
-run the following command and do what it says:
+run the following command and do what it says (it may ask you to run
+a command on a separate machine if your main machine doesn't have the
+ability to open a browser window):
 
 ```
 gcloud --billing-project="${PROJECT}" auth application-default login

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -10,6 +10,9 @@ You will need a GCP project to run VMs in and a GCS bucket that is used to
 transfer files onto the testing VMs. These are referred to as `${PROJECT}`
 and `${TRANSFERS_BUCKET}` in the following instructions.
 
+You will need gcloud installed. Run `gcloud auth login` if you haven't
+done so already.
+
 Follow the setup instructions for either User Credentials or
 Service Account Credentials next.
 

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -13,8 +13,8 @@ and `${TRANSFERS_BUCKET}` in the following instructions.
 You will need gcloud installed. Run `gcloud auth login` if you haven't
 done so already.
 
-Follow the setup instructions for either User Credentials or
-Service Account Credentials next.
+Next, follow the setup instructions for either User Credentials or
+Service Account Credentials.
 
 ### Setup (User Credentials)
 

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -6,7 +6,7 @@ Package gce holds various helpers for testing the agents on GCE.
 To run a test based on this library, you can either:
 
 * use Kokoro by triggering automated presubmits on your change, or
-* use "go test" directly, after performing the setup steps described 
+* use "go test" directly, after performing the setup steps described
   in README.md.
 
 NOTE: When testing Windows VMs without using Kokoro, PROJECT needs to be

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -3,16 +3,11 @@
 /*
 Package gce holds various helpers for testing the agents on GCE.
 
-To run a test based on this library, you can use Kokoro by triggering
-automated presubmits on your change.
+To run a test based on this library, you can either:
 
-NOTE: This needs the $HOME/credentials.json file to exist. If it doesn't,
-    please run the commands at go/sdi-service-accounts#setup to generate it.
-    Your service account needs to have "Storage Object Viewer" and
-    "Storage Object Creator" permissions on the GCS bucket TRANSFERS_BUCKET.
-
-NOTE: This requires gcloud login to generate the $HOME/.config/gcloud directory.
-    Run "gcloud auth login" if you have not yet logged in.
+* use Kokoro by triggering automated presubmits on your change, or
+* use "go test" directly, after performing the setup steps described 
+  in README.md.
 
 NOTE: When testing Windows VMs without using Kokoro, PROJECT needs to be
     a project whose firewall allows WinRM connections.
@@ -22,23 +17,21 @@ NOTE: When testing Windows VMs without using Kokoro, PROJECT needs to be
 NOTE: This command does not actually build the Ops Agent. To test the latest
     Ops Agent code, first build and upload a package to Rapture. Then look up
     the REPO_SUFFIX for that build and add it as an environment variable to the
-    command below; for example: REPO_SUFFIX=20210805-2
+    command below; for example: REPO_SUFFIX=20210805-2. You can also use
+	AGENT_PACKAGES_IN_GCS, for details see README.md.
 
 PROJECT=dev_project \
     ZONE=us-central1-b \
-    GOOGLE_APPLICATION_CREDENTIALS=$HOME/credentials.json \
     PLATFORMS=debian-10,centos-8,rhel-8-1-sap-ha,sles-15,ubuntu-2004-lts,windows-2012-r2,windows-2019 \
     go test -v ops_agent_test.go \
-    -test.parallel=1000 \
-    -timeout=3h
+	-test.parallel=1000 \
+	-tags=integration_test \
+    -timeout=4h
 
 This library needs the following environment variables to be defined:
 
 PROJECT: What GCP project to use.
 ZONE: What GCP zone to run in.
-GOOGLE_APPLICATION_CREDENTIALS: Path to a credentials file for interacting with
-    some GCP services. All gcloud commands actually use a different set of
-    credentials, those in CLOUDSDK_CONFIG (unfortunately).
 WINRM_PAR_PATH: (required for Windows) Path to winrm.par, used to connect to
     Windows VMs.
 

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -18,7 +18,7 @@ AGENT_PACKAGES_IN_GCS: If provided, a URL for a directory in GCS containing
 		AGENTS_TO_TEST must have its own subdirectory, so for example this would be
 		a valid structure inside AGENT_PACKAGES_IN_GCS if
 		AGENTS_TO_TEST=metrics,ops_agent:
-		├── metrics
+	├── metrics
     │   ├── collectd-4.5.6.deb
     │   ├── collectd-4.5.6.rpm
     │   └── otel-collector-0.1.2.goo


### PR DESCRIPTION
The new process:

* is easier to set up
* uses the same account for the storage/monitoring/logging APIs as the gcloud commands
* avoids the need to pass GOOGLE_APPLICATION_CREDENTIALS in to the test command, and
* best of all, avoids the need to create new service account keys every N months.