### PR TITLE
Upgrade hbase

### DIFF
--- a/integration_test/third_party_apps_data/applications/hbase/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/hbase/centos_rhel/install
@@ -1,13 +1,16 @@
 set -e
+set -o pipefail
 
-HBASE_VERSION=$(curl https://apache.mirror.gtcomm.net/hbase/stable/ | grep --extended-regexp 'hbase-[0-9.]+-bin.tar.gz' | grep --extended-regexp --only-matching '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+HBASE_VERSION=$(curl https://apache.mirror.gtcomm.net/hbase/stable/ \
+    | grep --extended-regexp --only-matching 'hbase-[0-9.]+-bin.tar.gz' \
+    | grep --extended-regexp --only-matching --max-count=1 --color=never '[0-9]+\.[0-9]+\.[0-9]+')
 
 sudo yum -y install \
     java-1.8.0-openjdk java-1.8.0-openjdk-devel wget
 
 sudo mkdir /opt/hbase
-wget http://apache.mirror.gtcomm.net/hbase/$HBASE_VERSION/hbase-$HBASE_VERSION-bin.tar.gz
-sudo tar -xvf hbase-$HBASE_VERSION-bin.tar.gz -C /opt/hbase --strip 1
+wget http://apache.mirror.gtcomm.net/hbase/"$HBASE_VERSION"/hbase-"$HBASE_VERSION"-bin.tar.gz
+sudo tar -xvf hbase-"$HBASE_VERSION"-bin.tar.gz -C /opt/hbase --strip 1
 
 sudo tee /opt/hbase/conf/hbase-env.sh <<EOF
 export HBASE_JMX_BASE="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"

--- a/integration_test/third_party_apps_data/applications/hbase/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/hbase/centos_rhel/install
@@ -1,11 +1,13 @@
 set -e
 
+HBASE_VERSION=2.4.10
+
 sudo yum -y install \
     java-1.8.0-openjdk java-1.8.0-openjdk-devel wget
 
 sudo mkdir /opt/hbase
-wget http://apache.mirror.gtcomm.net/hbase/2.4.9/hbase-2.4.9-bin.tar.gz
-sudo tar -xvf hbase-2.4.9-bin.tar.gz -C /opt/hbase --strip 1
+wget http://apache.mirror.gtcomm.net/hbase/$HBASE_VERSION/hbase-$HBASE_VERSION-bin.tar.gz
+sudo tar -xvf hbase-$HBASE_VERSION-bin.tar.gz -C /opt/hbase --strip 1
 
 sudo tee /opt/hbase/conf/hbase-env.sh <<EOF
 export HBASE_JMX_BASE="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"

--- a/integration_test/third_party_apps_data/applications/hbase/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/hbase/centos_rhel/install
@@ -1,6 +1,6 @@
 set -e
 
-HBASE_VERSION=2.4.10
+HBASE_VERSION=$(curl https://apache.mirror.gtcomm.net/hbase/stable/ | grep --extended-regexp 'hbase-[0-9.]+-bin.tar.gz' | grep --extended-regexp --only-matching '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
 
 sudo yum -y install \
     java-1.8.0-openjdk java-1.8.0-openjdk-devel wget

--- a/integration_test/third_party_apps_data/applications/hbase/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/hbase/debian_ubuntu/install
@@ -3,9 +3,11 @@ set -e
 sudo apt-get update
 sudo apt-get install -y default-jre wget
 
+HBASE_VERSION=$(curl https://apache.mirror.gtcomm.net/hbase/stable/ | grep --extended-regexp 'hbase-[0-9.]+-bin.tar.gz' | grep --extended-regexp --only-matching '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+
 sudo mkdir /opt/hbase
-wget http://apache.mirror.gtcomm.net/hbase/2.4.9/hbase-2.4.9-bin.tar.gz
-sudo tar -xvf hbase-2.4.9-bin.tar.gz -C /opt/hbase --strip 1
+wget http://apache.mirror.gtcomm.net/hbase/$HBASE_VERSION/hbase-$HBASE_VERSION-bin.tar.gz
+sudo tar -xvf hbase-$HBASE_VERSION-bin.tar.gz -C /opt/hbase --strip 1
 
 sudo tee /opt/hbase/conf/hbase-env.sh <<EOF
 export HBASE_JMX_BASE="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"

--- a/integration_test/third_party_apps_data/applications/hbase/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/hbase/debian_ubuntu/install
@@ -1,13 +1,16 @@
 set -e
+set -o pipefail
 
 sudo apt-get update
 sudo apt-get install -y default-jre wget
 
-HBASE_VERSION=$(curl https://apache.mirror.gtcomm.net/hbase/stable/ | grep --extended-regexp 'hbase-[0-9.]+-bin.tar.gz' | grep --extended-regexp --only-matching '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+HBASE_VERSION=$(curl https://apache.mirror.gtcomm.net/hbase/stable/ \
+    | grep --extended-regexp --only-matching 'hbase-[0-9.]+-bin.tar.gz' \
+    | grep --extended-regexp --only-matching --max-count=1 --color=never '[0-9]+\.[0-9]+\.[0-9]+')
 
 sudo mkdir /opt/hbase
-wget http://apache.mirror.gtcomm.net/hbase/$HBASE_VERSION/hbase-$HBASE_VERSION-bin.tar.gz
-sudo tar -xvf hbase-$HBASE_VERSION-bin.tar.gz -C /opt/hbase --strip 1
+wget http://apache.mirror.gtcomm.net/hbase/"$HBASE_VERSION"/hbase-"$HBASE_VERSION"-bin.tar.gz
+sudo tar -xvf hbase-"$HBASE_VERSION"-bin.tar.gz -C /opt/hbase --strip 1
 
 sudo tee /opt/hbase/conf/hbase-env.sh <<EOF
 export HBASE_JMX_BASE="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"

--- a/integration_test/third_party_apps_data/applications/hbase/sles/install
+++ b/integration_test/third_party_apps_data/applications/hbase/sles/install
@@ -1,9 +1,12 @@
 set -e
 
 sudo zypper install -y wget java-11-openjdk
-wget http://apache.mirror.gtcomm.net/hbase/2.4.9/hbase-2.4.9-bin.tar.gz
+
+HBASE_VERSION=$(curl https://apache.mirror.gtcomm.net/hbase/stable/ | grep --extended-regexp 'hbase-[0-9.]+-bin.tar.gz' | grep --extended-regexp --only-matching '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+
+wget http://apache.mirror.gtcomm.net/hbase/$HBASE_VERSION/hbase-$HBASE_VERSION-bin.tar.gz
 sudo mkdir /opt/hbase
-sudo tar -xzf hbase-2.4.9-bin.tar.gz -C /opt/hbase --strip 1
+sudo tar -xzf hbase-$HBASE_VERSION-bin.tar.gz -C /opt/hbase --strip 1
 
 sudo tee /opt/hbase/conf/hbase-env.sh <<EOF
 export HBASE_JMX_BASE="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"

--- a/integration_test/third_party_apps_data/applications/hbase/sles/install
+++ b/integration_test/third_party_apps_data/applications/hbase/sles/install
@@ -1,12 +1,15 @@
 set -e
+set -o pipefail
 
 sudo zypper install -y wget java-11-openjdk
 
-HBASE_VERSION=$(curl https://apache.mirror.gtcomm.net/hbase/stable/ | grep --extended-regexp 'hbase-[0-9.]+-bin.tar.gz' | grep --extended-regexp --only-matching '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+HBASE_VERSION=$(curl https://apache.mirror.gtcomm.net/hbase/stable/ \
+    | grep --extended-regexp --only-matching 'hbase-[0-9.]+-bin.tar.gz' \
+    | grep --extended-regexp --only-matching --max-count=1 --color=never '[0-9]+\.[0-9]+\.[0-9]+')
 
-wget http://apache.mirror.gtcomm.net/hbase/$HBASE_VERSION/hbase-$HBASE_VERSION-bin.tar.gz
+wget http://apache.mirror.gtcomm.net/hbase/"$HBASE_VERSION"/hbase-"$HBASE_VERSION"-bin.tar.gz
 sudo mkdir /opt/hbase
-sudo tar -xzf hbase-$HBASE_VERSION-bin.tar.gz -C /opt/hbase --strip 1
+sudo tar -xzf hbase-"$HBASE_VERSION"-bin.tar.gz -C /opt/hbase --strip 1
 
 sudo tee /opt/hbase/conf/hbase-env.sh <<EOF
 export HBASE_JMX_BASE="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"


### PR DESCRIPTION
<s>2.4.9 seems to have been fully replaced by 2.4.10.</s> Actually let's try Martijn's idea of automatically grabbing the latest stable version.