### PR TITLE
Fix integration markdown docs

### DIFF
--- a/docs/couchdb.md
+++ b/docs/couchdb.md
@@ -96,6 +96,5 @@ Any fields that are blank or missing will not be present in the log entry.
 | `jsonPayload.node`           | string                                                                                                                          | node instance name                     |
 | `jsonPayload.host`           | string                                                                                                                          | host instance name                     |
 | `jsonPayload.path`           | string                                                                                                                          | request path                           |
-| `jsonPayload.remote_user`    | string                                                                                                                          | user id (optional)                     |
 | `severity`                   | string ([`LogSeverity`](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity))                       | Log entry level (translated)           |
 | `timestamp`                  | string ([`Timestamp`](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp)) | Time the entry was logged              |

--- a/docs/elasticsearch.md
+++ b/docs/elasticsearch.md
@@ -93,6 +93,7 @@ The Ops Agent collects the following metrics from your Elasticsearch nodes:
 | workload.googleapis.com/elasticsearch.node.open_files                 | Gauge (INT64)      | {files}       |                         | The number of open file descriptors held by the node.                                    |
 
 Labels:
+
 | Metric Name                                                           | Label Name       | Description                    | Values                                                                           |
 |-----------------------------------------------------------------------|------------------|--------------------------------|----------------------------------------------------------------------------------|
 | workload.googleapis.com/elasticsearch.node.cache.memory.usage         | cache_name       | The name of cache.             | fielddata, query                                                                 |
@@ -124,6 +125,7 @@ If `collect_jvm_metrics` is true, the following JVM metrics are collected:
 | workload.googleapis.com/jvm.threads.count            | Gauge (INT64)      | 1    |        | The current number of threads                                                 |
 
 Labels:
+
 | Metric Name                                        | Label Name | Description                        | Values |
 |----------------------------------------------------|------------|------------------------------------|--------|
 | workload.googleapis.com/jvm.gc.collections.count   | name       | The name of the garbage collector. |        |
@@ -133,6 +135,7 @@ Labels:
 
 
 If `collect_cluster_metrics` is true, the following cluster-level metrics are collected:
+
 | Metric                                                   | Data Type     | Unit     | Labels | Description                                                                                                                                                                                    |
 |----------------------------------------------------------|---------------|----------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | workload.googleapis.com/elasticsearch.cluster.shards     | Gauge (INT64) | {shards} | state  | The number of shards in the cluster.                                                                                                                                                           |
@@ -141,6 +144,7 @@ If `collect_cluster_metrics` is true, the following cluster-level metrics are co
 | workload.googleapis.com/elasticsearch.cluster.health     | Gauge (INT64) | {status} | status | The health status of the cluster. See [the Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/cluster-health.html#cluster-health-api-desc) for more information. |
 
 Labels:
+
 | Metric Name                                          | Label Name | Description                       | Values                                       |
 |------------------------------------------------------|------------|-----------------------------------|----------------------------------------------|
 | workload.googleapis.com/elasticsearch.cluster.shards | state      | The state of the shard.           | active, relocating, initializing, unassigned |

--- a/docs/rabbitmq.md
+++ b/docs/rabbitmq.md
@@ -74,12 +74,12 @@ The Ops Agent collects the following metrics from your rabbitmq instances.
 
 | Metric                                                 | Data Type | Unit        | Labels                          | Description    |
 | ---                                                    | ---       | ---         | ---                             | ---            | 
-| rabbitmq.consumer.count | gauge | {consumers} | <ul> </ul>  | The number of consumers currently reading from the queue. |
-| rabbitmq.message.acknowledged | cumulative | {messages} | <ul> </ul>  | The number of messages acknowledged by consumers. |
-| rabbitmq.message.current | gauge | {messages} | <ul> <li>state</li> </ul>  | The total number of messages currently in the queue. |
-| rabbitmq.message.delivered | cumulative | {messages} | <ul> </ul>  | The number of messages delivered to consumers. |
-| rabbitmq.message.dropped | cumulative | {messages} | <ul> </ul>  | The number of messages dropped as unroutable. |
-| rabbitmq.message.published | cumulative | {messages} | <ul> </ul>  | The number of messages published to a queue. |
+| rabbitmq.consumer.count | gauge | {consumers} |   | The number of consumers currently reading from the queue. |
+| rabbitmq.message.acknowledged | cumulative | {messages} |   | The number of messages acknowledged by consumers. |
+| rabbitmq.message.current | gauge | {messages} | state  | The total number of messages currently in the queue. |
+| rabbitmq.message.delivered | cumulative | {messages} |   | The number of messages delivered to consumers. |
+| rabbitmq.message.dropped | cumulative | {messages} |   | The number of messages dropped as unroutable. |
+| rabbitmq.message.published | cumulative | {messages} |   | The number of messages published to a queue. |
 
 ## Labels
 

--- a/docs/redis.md
+++ b/docs/redis.md
@@ -36,14 +36,6 @@ The Ops Agent collects the following metrics from your redis servers.
 | workload.googleapis.com/redis.replication.offset                    | gauge     | 1       |        | The server's current replication o
 
 ## Logs
-<!-- TODO: Add these config options to public docs -->
-<!-- 
-insecure	            true	Sets whether or not to use a secure TLS connection. If set to false, then TLS is enabled.
-insecure_skip_verify	false	Sets whether or not to skip verifying the certificate. If insecure is set to true, then the insecure_skip_verify value is not used.
-cert_file		                Path to the TLS certificate to use for TLS-required connections.
-key_file		                Path to the TLS key to use for TLS-required connections.
-ca_file		                    Path to the CA certificate. As a client, this verifies the server certificate. If empty, the receiver uses the system root CA. -->
-
 
 Redis logs contain the following fields in the [`LogEntry`](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry):
 


### PR DESCRIPTION
- CouchDb: removes  duplicate log field entry
- Elasticsearch: fixes broken table rendering with non-gfm renderer
- RabbitMq: removes HTML list tags which are escaped by some renderers
- Redis: removes HTML TODO comment sometimes rendered as plain text