### PR TITLE
Added request_count logging self-metrics to ops-agent

### DIFF
--- a/confgenerator/agentmetrics.go
+++ b/confgenerator/agentmetrics.go
@@ -108,6 +108,7 @@ func (r AgentSelfMetrics) LoggingSubmodulePipeline() otel.Pipeline {
 				"include",
 				"strict",
 				"fluentbit_uptime",
+				"fluentbit_stackdriver_requests_total",
 			),
 			otel.MetricsTransform(
 				otel.RenameMetric("fluentbit_uptime", "agent/uptime",
@@ -116,6 +117,12 @@ func (r AgentSelfMetrics) LoggingSubmodulePipeline() otel.Pipeline {
 					otel.AddLabel("version", r.Version),
 					// remove service.version label
 					otel.AggregateLabels("sum", "version"),
+				),
+				otel.RenameMetric("fluentbit_stackdriver_requests_total", "agent/request_count",
+					// change data type from double -> int64
+					otel.ToggleScalarDataType,
+					otel.RenameLabel("status", "response_code"),
+					otel.AggregateLabels("sum"),
 				),
 				otel.AddPrefix("agent.googleapis.com"),
 			),

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -23,6 +23,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -320,6 +321,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
@@ -29,6 +29,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -326,6 +327,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -30,6 +30,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -327,6 +328,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -30,6 +30,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -327,6 +328,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
@@ -29,6 +29,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -326,6 +327,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_otel.conf
@@ -23,6 +23,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -320,6 +321,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -331,6 +332,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -331,6 +332,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
@@ -34,6 +34,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -337,6 +338,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden_otel.conf
@@ -34,6 +34,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -337,6 +338,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -331,6 +332,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -331,6 +332,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -331,6 +332,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -331,6 +332,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -331,6 +332,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -331,6 +332,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -331,6 +332,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -331,6 +332,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -331,6 +332,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/kafka_kafka_0:
     metrics:
       include:
@@ -340,6 +341,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/kafka_kafka_0:
     metrics:
       include:
@@ -340,6 +341,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/memcached_memcached_0:
     metrics:
       exclude:
@@ -331,6 +332,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -332,6 +333,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -332,6 +333,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -325,6 +326,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -368,6 +369,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
@@ -43,6 +43,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -383,6 +384,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
@@ -43,6 +43,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -383,6 +384,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
@@ -43,6 +43,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -383,6 +384,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
@@ -43,6 +43,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -383,6 +384,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -43,6 +43,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -383,6 +384,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
@@ -46,6 +46,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -386,6 +387,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
@@ -46,6 +46,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -386,6 +387,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
@@ -46,6 +46,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -386,6 +387,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
@@ -28,6 +28,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -368,6 +369,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -49,6 +49,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -389,6 +390,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -49,6 +49,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -389,6 +390,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
@@ -46,6 +46,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -386,6 +387,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
@@ -49,6 +49,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -395,6 +396,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
@@ -49,6 +49,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -395,6 +396,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -43,6 +43,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -383,6 +384,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
@@ -43,6 +43,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -383,6 +384,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
@@ -43,6 +43,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -383,6 +384,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_otel.conf
@@ -43,6 +43,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -383,6 +384,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_otel.conf
@@ -43,6 +43,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -383,6 +384,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
@@ -43,6 +43,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -383,6 +384,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
@@ -43,6 +43,7 @@ processors:
         match_type: strict
         metric_names:
         - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
   filter/otel_0:
     metrics:
       include:
@@ -383,6 +384,17 @@ processors:
         aggregation_type: sum
         label_set:
         - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
     - action: update
       include: ^(.*)$$
       match_type: regexp


### PR DESCRIPTION
Added the self metrics request_count to ops-agent.
This relays on metrics exposed by the fluentbit prometheus endpoint.