### PR TITLE
Update SLES install for tomcat

### DIFF
--- a/integration_test/third_party_apps_data/applications/tomcat/sles/install
+++ b/integration_test/third_party_apps_data/applications/tomcat/sles/install
@@ -10,6 +10,41 @@ Environment="JAVA_OPTS=-Djava.awt.headless=true"
 EOFdBy=multi-user.target
 EOF
 
+mkdir -p /usr/share/tomcat/webapps/ROOT
+
+sudo cat >> /usr/share/tomcat/webapps/ROOT/index.html << EOF
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DoCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+   "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>Apache Tomcat</title>
+</head>
+
+<body>
+<h1>It works !</h1>
+
+<p>If you're seeing this page via a web browser, it means you've setup Tomcat successfully. Congratulations!</p>
+ 
+<p>This is the default Tomcat home page. It can be found on the local filesystem at: <code>/var/lib/tomcat9/webapps/ROOT/index.html</code></p>
+
+<p>Tomcat veterans might be pleased to learn that this system instance of Tomcat is installed with <code>CATALINA_HOME</code> in <code>/usr/share/tomcat9</code> and <code>CATALINA_BASE</code> in <code>/var/lib/tomcat9</code>, following the rules from <code>/usr/share/doc/tomcat9-common/RUNNING.txt.gz</code>.</p>
+
+<p>You might consider installing the following packages, if you haven't already done so:</p>
+
+<p><b>tomcat9-docs</b>: This package installs a web application that allows to browse the Tomcat 9 documentation locally. Once installed, you can access it by clicking <a href="docs/">here</a>.</p>
+
+<p><b>tomcat9-examples</b>: This package installs a web application that allows to access the Tomcat 9 Servlet and JSP examples. Once installed, you can access it by clicking <a href="examples/">here</a>.</p>
+
+<p><b>tomcat9-admin</b>: This package installs two web applications that can help managing this Tomcat instance. Once installed, you can access the <a href="manager/html">manager webapp</a> and the <a href="host-manager/html">host-manager webapp</a>.</p>
+
+<p>NOTE: For security reasons, using the manager webapp is restricted to users with role "manager-gui". The host-manager webapp is restricted to users with role "admin-gui". Users are defined in <code>/etc/tomcat9/tomcat-users.xml</code>.</p>
+
+</body>
+</html>
+EOF
+
+
 sudo systemctl daemon-reload
 sudo service tomcat restart
 sleep 60

--- a/integration_test/third_party_apps_data/applications/tomcat/sles/install
+++ b/integration_test/third_party_apps_data/applications/tomcat/sles/install
@@ -12,39 +12,8 @@ EOF
 
 mkdir -p /usr/share/tomcat/webapps/ROOT
 
-sudo cat >> /usr/share/tomcat/webapps/ROOT/index.html << EOF
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DoCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-   "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-    <title>Apache Tomcat</title>
-</head>
-
-<body>
-<h1>It works !</h1>
-
-<p>If you're seeing this page via a web browser, it means you've setup Tomcat successfully. Congratulations!</p>
+sudo touch /usr/share/tomcat/webapps/ROOT/index.html
  
-<p>This is the default Tomcat home page. It can be found on the local filesystem at: <code>/var/lib/tomcat9/webapps/ROOT/index.html</code></p>
-
-<p>Tomcat veterans might be pleased to learn that this system instance of Tomcat is installed with <code>CATALINA_HOME</code> in <code>/usr/share/tomcat9</code> and <code>CATALINA_BASE</code> in <code>/var/lib/tomcat9</code>, following the rules from <code>/usr/share/doc/tomcat9-common/RUNNING.txt.gz</code>.</p>
-
-<p>You might consider installing the following packages, if you haven't already done so:</p>
-
-<p><b>tomcat9-docs</b>: This package installs a web application that allows to browse the Tomcat 9 documentation locally. Once installed, you can access it by clicking <a href="docs/">here</a>.</p>
-
-<p><b>tomcat9-examples</b>: This package installs a web application that allows to access the Tomcat 9 Servlet and JSP examples. Once installed, you can access it by clicking <a href="examples/">here</a>.</p>
-
-<p><b>tomcat9-admin</b>: This package installs two web applications that can help managing this Tomcat instance. Once installed, you can access the <a href="manager/html">manager webapp</a> and the <a href="host-manager/html">host-manager webapp</a>.</p>
-
-<p>NOTE: For security reasons, using the manager webapp is restricted to users with role "manager-gui". The host-manager webapp is restricted to users with role "admin-gui". Users are defined in <code>/etc/tomcat9/tomcat-users.xml</code>.</p>
-
-</body>
-</html>
-EOF
-
-
 sudo systemctl daemon-reload
 sudo service tomcat restart
 sleep 60


### PR DESCRIPTION
Updated sles install for tomcat to fix an issue where the metric `tomcat.sessions` wasn't being generated due to no default page existing.