### PR TITLE
confgenerator: change otel self-metric port

### DIFF
--- a/confgenerator/agentmetrics.go
+++ b/confgenerator/agentmetrics.go
@@ -14,13 +14,18 @@
 
 package confgenerator
 
-import "github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
+)
 
 // AgentSelfMetrics provides the agent.googleapis.com/agent/ metrics.
 // It is never referenced in the config file, and instead is forcibly added in confgenerator.go.
 // Therefore, it does not need to implement any interfaces.
 type AgentSelfMetrics struct {
 	Version string
+	Port    int
 }
 
 func (r AgentSelfMetrics) MetricsSubmodulePipeline() otel.Pipeline {
@@ -34,7 +39,7 @@ func (r AgentSelfMetrics) MetricsSubmodulePipeline() otel.Pipeline {
 						"scrape_interval": "1m",
 						"static_configs": []map[string]interface{}{{
 							// TODO(b/196990135): Customization for the port number
-							"targets": []string{"0.0.0.0:8888"},
+							"targets": []string{fmt.Sprintf("0.0.0.0:%d", r.Port)},
 						}},
 					}},
 				},
@@ -97,7 +102,7 @@ func (r AgentSelfMetrics) LoggingSubmodulePipeline() otel.Pipeline {
 						"metrics_path":    "/metrics",
 						"static_configs": []map[string]interface{}{{
 							// TODO(b/196990135): Customization for the port number
-							"targets": []string{"0.0.0.0:20202"},
+							"targets": []string{fmt.Sprintf("0.0.0.0:%d", r.Port)},
 						}},
 					}},
 				},

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -48,12 +48,12 @@ func (uc *UnifiedConfig) GenerateOtelConfig(hostInfo *host.InfoStat) (string, er
 
 	pipelines["otel"] = AgentSelfMetrics{
 		Version: metricVersionLabel,
-		Port:    20201,
+		Port:    otel.MetricsPort,
 	}.MetricsSubmodulePipeline()
 
 	pipelines["fluentbit"] = AgentSelfMetrics{
 		Version: loggingVersionLabel,
-		Port:    20202,
+		Port:    fluentbit.MetricsPort,
 	}.LoggingSubmodulePipeline()
 
 	if uc.Metrics.Service.LogLevel == "" {
@@ -140,7 +140,7 @@ func (l *Logging) generateFluentbitComponents(userAgent string, hostInfo *host.I
 	}
 	service := fluentbit.Service{LogLevel: l.Service.LogLevel}
 	out = append(out, service.Component())
-	out = append(out, service.MetricsComponent())
+	out = append(out, fluentbit.MetricsInputComponent())
 
 	if l != nil && l.Service != nil {
 		// Type for sorting.
@@ -233,7 +233,7 @@ func (l *Logging) generateFluentbitComponents(userAgent string, hostInfo *host.I
 	}.Components("ops-agent-fluent-bit")...)
 
 	out = append(out, stackdriverOutputComponent("ops-agent-fluent-bit", userAgent))
-	out = append(out, prometheusExporterOutputComponent())
+	out = append(out, fluentbit.MetricsOutputComponent())
 
 	return out, nil
 }

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -48,10 +48,12 @@ func (uc *UnifiedConfig) GenerateOtelConfig(hostInfo *host.InfoStat) (string, er
 
 	pipelines["otel"] = AgentSelfMetrics{
 		Version: metricVersionLabel,
+		Port:    20201,
 	}.MetricsSubmodulePipeline()
 
 	pipelines["fluentbit"] = AgentSelfMetrics{
 		Version: loggingVersionLabel,
+		Port:    20202,
 	}.LoggingSubmodulePipeline()
 
 	if uc.Metrics.Service.LogLevel == "" {

--- a/confgenerator/fluentbit/metrics.go
+++ b/confgenerator/fluentbit/metrics.go
@@ -16,7 +16,7 @@ package fluentbit
 
 import "strconv"
 
-var MetricsPort = 20202
+const MetricsPort = 20202
 
 func MetricsInputComponent() Component {
 	return Component{

--- a/confgenerator/fluentbit/metrics.go
+++ b/confgenerator/fluentbit/metrics.go
@@ -1,0 +1,43 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fluentbit
+
+import "strconv"
+
+var MetricsPort = 20202
+
+func MetricsInputComponent() Component {
+	return Component{
+		Kind: "INPUT",
+		Config: map[string]string{
+			"Name":            "fluentbit_metrics",
+			"Scrape_On_Start": "True",
+			"Scrape_Interval": "60",
+		},
+	}
+}
+
+func MetricsOutputComponent() Component {
+	return Component{
+		Kind: "OUTPUT",
+		Config: map[string]string{
+			// https://docs.fluentbit.io/manual/pipeline/outputs/prometheus-exporter
+			"Name":  "prometheus_exporter",
+			"Match": "*",
+			"host":  "0.0.0.0",
+			"port":  strconv.Itoa(MetricsPort),
+		},
+	}
+}

--- a/confgenerator/fluentbit/service.go
+++ b/confgenerator/fluentbit/service.go
@@ -49,14 +49,3 @@ func (s Service) Component() Component {
 		},
 	}
 }
-
-func (s Service) MetricsComponent() Component {
-	return Component{
-		Kind: "INPUT",
-		Config: map[string]string{
-			"Name":            "fluentbit_metrics",
-			"Scrape_On_Start": "True",
-			"Scrape_Interval": "60",
-		},
-	}
-}

--- a/confgenerator/logging.go
+++ b/confgenerator/logging.go
@@ -77,17 +77,3 @@ func stackdriverOutputComponent(match, userAgent string) fluentbit.Component {
 		},
 	}
 }
-
-// prometheusExporterOutputComponent generates a component that outputs to metrics prometheus format.
-func prometheusExporterOutputComponent() fluentbit.Component {
-	return fluentbit.Component{
-		Kind: "OUTPUT",
-		Config: map[string]string{
-			// https://docs.fluentbit.io/manual/pipeline/outputs/prometheus-exporter
-			"Name":  "prometheus_exporter",
-			"Match": "*",
-			"host":  "0.0.0.0",
-			"port":  "20202",
-		},
-	}
-}

--- a/confgenerator/otel/modular.go
+++ b/confgenerator/otel/modular.go
@@ -22,7 +22,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-var MetricsPort = 20201
+const MetricsPort = 20201
 
 // Pipeline represents a single OT receiver and zero or more processors that must be chained after that receiver.
 type Pipeline struct {

--- a/confgenerator/otel/modular.go
+++ b/confgenerator/otel/modular.go
@@ -22,6 +22,8 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+var MetricsPort = 20201
+
 // Pipeline represents a single OT receiver and zero or more processors that must be chained after that receiver.
 type Pipeline struct {
 	Receiver   Component
@@ -76,14 +78,17 @@ func (c ModularConfig) Generate() (string, error) {
 	processors := map[string]interface{}{}
 	exporters := map[string]interface{}{}
 	pipelines := map[string]interface{}{}
-	service := map[string]interface{}{
+	service := map[string]map[string]interface{}{
 		"pipelines": pipelines,
+		"telemetry": {
+			"metrics": map[string]interface{}{
+				"address": fmt.Sprintf("0.0.0.0:%d", MetricsPort),
+			},
+		},
 	}
 	if c.LogLevel != "info" {
-		service["telemetry"] = map[string]interface{}{
-			"logs": map[string]interface{}{
-				"level": c.LogLevel,
-			},
+		service["telemetry"]["logs"] = map[string]interface{}{
+			"level": c.LogLevel,
 		}
 	}
 

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -403,7 +403,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -434,3 +434,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
@@ -443,3 +443,5 @@ service:
   telemetry:
     logs:
       level: debug
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
@@ -441,3 +441,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
@@ -409,7 +409,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -410,7 +410,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -442,3 +442,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -410,7 +410,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -442,3 +442,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
@@ -441,3 +441,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
@@ -409,7 +409,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_otel.conf
@@ -403,7 +403,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_otel.conf
@@ -434,3 +434,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden_otel.conf
@@ -461,3 +461,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden_otel.conf
@@ -420,7 +420,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/activemq_activemq:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden_otel.conf
@@ -461,3 +461,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden_otel.conf
@@ -420,7 +420,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/activemq_activemq:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
@@ -466,3 +466,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
@@ -424,7 +424,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/apache_apache:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden_otel.conf
@@ -466,3 +466,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden_otel.conf
@@ -424,7 +424,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/apache_apache:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
@@ -422,7 +422,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/cassandra_cassandra:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
@@ -463,3 +463,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden_otel.conf
@@ -422,7 +422,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/cassandra_cassandra:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden_otel.conf
@@ -463,3 +463,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden_otel.conf
@@ -420,7 +420,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/couchdb_couchdb:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden_otel.conf
@@ -461,3 +461,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -408,7 +408,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -440,3 +440,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden_otel.conf
@@ -466,3 +466,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden_otel.conf
@@ -425,7 +425,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden_otel.conf
@@ -466,3 +466,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden_otel.conf
@@ -425,7 +425,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden_otel.conf
@@ -466,3 +466,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden_otel.conf
@@ -425,7 +425,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden_otel.conf
@@ -466,3 +466,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden_otel.conf
@@ -425,7 +425,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden_otel.conf
@@ -448,7 +448,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden_otel.conf
@@ -489,3 +489,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden_otel.conf
@@ -427,7 +427,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden_otel.conf
@@ -468,3 +468,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden_otel.conf
@@ -422,7 +422,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden_otel.conf
@@ -463,3 +463,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden_otel.conf
@@ -422,7 +422,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden_otel.conf
@@ -463,3 +463,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden_otel.conf
@@ -429,7 +429,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden_otel.conf
@@ -470,3 +470,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden_otel.conf
@@ -429,7 +429,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden_otel.conf
@@ -470,3 +470,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
@@ -420,7 +420,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
@@ -461,3 +461,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
@@ -422,7 +422,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
@@ -463,3 +463,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden_otel.conf
@@ -420,7 +420,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden_otel.conf
@@ -461,3 +461,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden_otel.conf
@@ -479,3 +479,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden_otel.conf
@@ -437,7 +437,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden_otel.conf
@@ -479,3 +479,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden_otel.conf
@@ -437,7 +437,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_otel.conf
@@ -424,7 +424,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_otel.conf
@@ -466,3 +466,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden_otel.conf
@@ -424,7 +424,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden_otel.conf
@@ -465,3 +465,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden_otel.conf
@@ -422,7 +422,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden_otel.conf
@@ -463,3 +463,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_otel.conf
@@ -421,7 +421,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_otel.conf
@@ -462,3 +462,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
@@ -459,3 +459,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
@@ -418,7 +418,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden_otel.conf
@@ -459,3 +459,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden_otel.conf
@@ -418,7 +418,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden_otel.conf
@@ -421,7 +421,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden_otel.conf
@@ -462,3 +462,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql_postgresql
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden_otel.conf
@@ -464,3 +464,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql_postgresql
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden_otel.conf
@@ -423,7 +423,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden_otel.conf
@@ -424,7 +424,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden_otel.conf
@@ -465,3 +465,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql_postgresql
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden_otel.conf
@@ -468,3 +468,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql_postgresql
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden_otel.conf
@@ -427,7 +427,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden_otel.conf
@@ -415,7 +415,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   rabbitmq/rabbitmq_rabbitmq:
     collection_interval: 60s
     endpoint: http://localhost:15672

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden_otel.conf
@@ -463,3 +463,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq_rabbitmq
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden_otel.conf
@@ -415,7 +415,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   rabbitmq/rabbitmq_rabbitmq:
     collection_interval: 30s
     endpoint: http://localhost:15672

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden_otel.conf
@@ -463,3 +463,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq_rabbitmq
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden_otel.conf
@@ -464,3 +464,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq_rabbitmq
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden_otel.conf
@@ -415,7 +415,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   rabbitmq/rabbitmq_rabbitmq:
     collection_interval: 30s
     endpoint: http://localhost:15672

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden_otel.conf
@@ -467,3 +467,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq_rabbitmq
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden_otel.conf
@@ -415,7 +415,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   rabbitmq/rabbitmq_rabbitmq:
     collection_interval: 30s
     endpoint: http://localhost:15672

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_otel.conf
@@ -422,7 +422,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   redis/redis_redis:
     collection_interval: 60s
     endpoint: localhost:6379

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_otel.conf
@@ -471,3 +471,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - redis/redis_redis
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden_otel.conf
@@ -422,7 +422,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   redis/redis_redis:
     collection_interval: 30s
     endpoint: localhost:6379

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden_otel.conf
@@ -471,3 +471,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - redis/redis_redis
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden_otel.conf
@@ -422,7 +422,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden_otel.conf
@@ -463,3 +463,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - jmx/solr_solr
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden_otel.conf
@@ -463,3 +463,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - jmx/tomcat_tomcat
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden_otel.conf
@@ -422,7 +422,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden_otel.conf
@@ -463,3 +463,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - jmx/tomcat_tomcat
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden_otel.conf
@@ -422,7 +422,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden_otel.conf
@@ -424,7 +424,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden_otel.conf
@@ -465,3 +465,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - jmx/wildfly_wildfly
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden_otel.conf
@@ -424,7 +424,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden_otel.conf
@@ -465,3 +465,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - jmx/wildfly_wildfly
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden_otel.conf
@@ -459,3 +459,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - zookeeper/zookeeper_zookeeper
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden_otel.conf
@@ -415,7 +415,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   zookeeper/zookeeper_zookeeper:
     collection_interval: 60s
     endpoint: localhost:2181

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden_otel.conf
@@ -459,3 +459,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - zookeeper/zookeeper_zookeeper
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden_otel.conf
@@ -415,7 +415,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   zookeeper/zookeeper_zookeeper:
     collection_interval: 60s
     endpoint: localhost:2181

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -452,7 +452,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   windowsperfcounters/default__pipeline_iis:
     collection_interval: 60s
     perfcounters:

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -533,3 +533,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
@@ -467,7 +467,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   windowsperfcounters/default__pipeline_iis:
     collection_interval: 60s
     perfcounters:

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
@@ -551,3 +551,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
@@ -467,7 +467,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   windowsperfcounters/default__pipeline_iis:
     collection_interval: 60s
     perfcounters:

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
@@ -551,3 +551,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
@@ -467,7 +467,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   windowsperfcounters/default__pipeline_iis:
     collection_interval: 60s
     perfcounters:

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
@@ -551,3 +551,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
@@ -467,7 +467,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   windowsperfcounters/default__pipeline_iis:
     collection_interval: 60s
     perfcounters:

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
@@ -551,3 +551,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -467,7 +467,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   windowsperfcounters/default__pipeline_iis:
     collection_interval: 60s
     perfcounters:

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -551,3 +551,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
@@ -470,7 +470,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   windowsperfcounters/default__pipeline_iis:
     collection_interval: 60s
     perfcounters:

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
@@ -554,3 +554,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
@@ -470,7 +470,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   windowsperfcounters/default__pipeline_iis:
     collection_interval: 60s
     perfcounters:

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
@@ -554,3 +554,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
@@ -470,7 +470,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   windowsperfcounters/default__pipeline_iis:
     collection_interval: 60s
     perfcounters:

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
@@ -554,3 +554,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
@@ -452,7 +452,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   windowsperfcounters/another__another__pipeline_iis:
     collection_interval: 60s
     perfcounters:

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
@@ -533,3 +533,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -557,3 +557,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -473,7 +473,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   windowsperfcounters/default__pipeline_iis:
     collection_interval: 60s
     perfcounters:

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -557,3 +557,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -473,7 +473,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   windowsperfcounters/default__pipeline_iis:
     collection_interval: 60s
     perfcounters:

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
@@ -470,7 +470,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   windowsperfcounters/default__pipeline_iis:
     collection_interval: 60s
     perfcounters:

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
@@ -554,3 +554,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
@@ -577,3 +577,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
@@ -483,7 +483,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   windowsperfcounters/default__pipeline_iis:
     collection_interval: 60s
     perfcounters:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
@@ -577,3 +577,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
@@ -483,7 +483,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   windowsperfcounters/default__pipeline_iis:
     collection_interval: 60s
     perfcounters:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -467,7 +467,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   windowsperfcounters/default__pipeline_iis:
     collection_interval: 60s
     perfcounters:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -551,3 +551,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
@@ -479,7 +479,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   windowsperfcounters/default__pipeline_iis:
     collection_interval: 60s
     perfcounters:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
@@ -572,3 +572,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
@@ -479,7 +479,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   windowsperfcounters/default__pipeline_iis:
     collection_interval: 60s
     perfcounters:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
@@ -572,3 +572,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_otel.conf
@@ -480,7 +480,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   windowsperfcounters/default__pipeline_iis:
     collection_interval: 60s
     perfcounters:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_otel.conf
@@ -573,3 +573,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_otel.conf
@@ -480,7 +480,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   windowsperfcounters/default__pipeline_iis:
     collection_interval: 60s
     perfcounters:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_otel.conf
@@ -573,3 +573,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
@@ -477,7 +477,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   windowsperfcounters/default__pipeline_iis:
     collection_interval: 60s
     perfcounters:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
@@ -570,3 +570,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
@@ -477,7 +477,7 @@ receivers:
         scrape_interval: 1m
         static_configs:
         - targets:
-          - 0.0.0.0:8888
+          - 0.0.0.0:20201
   windowsperfcounters/default__pipeline_iis:
     collection_interval: 60s
     perfcounters:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
@@ -570,3 +570,6 @@ service:
       - resourcedetection/_global_0
       receivers:
       - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201


### PR DESCRIPTION
Port 8888 is popular with a number of applications such as Tomcat,
Jetty, Apache Druid, etc. Until we finish designing dynamic port choice,
this PR will change port 8888 to something far less common. I've opted
to change it to 20201, to be closer to the fluent-bit default of 20202.

[EDIT] Not quite enough for #461 — that asks for user-level customization.