### PR TITLE
Remove dead function findMetricName()

### DIFF
--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -109,17 +109,6 @@ func appsToTest(platform string) ([]string, error) {
 	return apps, nil
 }
 
-// findMetricName reads which metric to query from the metric_name.txt file
-// corresponding to the given application. The file is allowed to be empty,
-// and if so, the test is skipped.
-func findMetricName(app string) (string, error) {
-	contents, err := readFileFromScriptsDir(path.Join("applications", app, "metric_name.txt"))
-	if err != nil {
-		return "", fmt.Errorf("could not read metric_name.txt: %v", err)
-	}
-	return strings.TrimSpace(string(contents)), nil
-}
-
 const (
 	retryable    = true
 	nonRetryable = false


### PR DESCRIPTION
This function is not used anymore now that https://github.com/GoogleCloudPlatform/ops-agent/pull/456 has been merged.