### PR TITLE
Add LogEntry severity and sourceLocation mappings in systemd_journald receiver.

### DIFF
--- a/confgenerator/logging_receivers.go
+++ b/confgenerator/logging_receivers.go
@@ -344,7 +344,7 @@ func (r LoggingReceiverSystemd) Type() string {
 }
 
 func (r LoggingReceiverSystemd) Components(tag string) []fluentbit.Component {
-	return []fluentbit.Component{{
+	input := []fluentbit.Component{{
 		Kind: "INPUT",
 		Config: map[string]string{
 			// https://docs.fluentbit.io/manual/pipeline/inputs/systemd
@@ -353,6 +353,65 @@ func (r LoggingReceiverSystemd) Components(tag string) []fluentbit.Component {
 			"DB":   DBPath(tag),
 		},
 	}}
+	input = append(input, fluentbit.Component{
+		Kind: "FILTER",
+		Config: map[string]string{
+			"Match":  tag,
+			"Name":   "modify",
+			"Rename": "MESSAGE message",
+		},
+	})
+	filters := fluentbit.TranslationComponents(tag, "PRIORITY", "logging.googleapis.com/severity", false,
+		[]struct{ SrcVal, DestVal string }{
+			{"7", "DEBUG"},
+			{"6", "INFO"},
+			{"5", "NOTICE"},
+			{"4", "WARNING"},
+			{"3", "ERROR"},
+			{"2", "CRITICAL"},
+			{"1", "ALERT"},
+			{"0", "EMERGENCY"},
+		})
+	input = append(input, filters...)
+	input = append(input, fluentbit.Component{
+		Kind: "FILTER",
+		Config: map[string]string{
+			"Name":      "modify",
+			"Match":     tag,
+			"Condition": fmt.Sprintf("Key_exists %s", "CODE_FILE"),
+			"Copy":      fmt.Sprintf("CODE_FILE %s", "logging.googleapis.com/sourceLocation/file"),
+		},
+	})
+	input = append(input, fluentbit.Component{
+		Kind: "FILTER",
+		Config: map[string]string{
+			"Name":      "modify",
+			"Match":     tag,
+			"Condition": fmt.Sprintf("Key_exists %s", "CODE_FUNC"),
+			"Copy":      fmt.Sprintf("CODE_FUNC %s", "logging.googleapis.com/sourceLocation/function"),
+		},
+	})
+	input = append(input, fluentbit.Component{
+		Kind: "FILTER",
+		Config: map[string]string{
+			"Name":      "modify",
+			"Match":     tag,
+			"Condition": fmt.Sprintf("Key_exists %s", "CODE_LINE"),
+			"Copy":      fmt.Sprintf("CODE_LINE %s", "logging.googleapis.com/sourceLocation/line"),
+		},
+	})
+	input = append(input, fluentbit.Component{
+		Kind: "FILTER",
+		Config: map[string]string{
+			"Name":          "nest",
+			"Match":         tag,
+			"Operation":     "nest",
+			"Wildcard":      "logging.googleapis.com/sourceLocation/*",
+			"Nest_under":    "logging.googleapis.com/sourceLocation",
+			"Remove_prefix": "logging.googleapis.com/sourceLocation/",
+		},
+	})
+	return input
 }
 
 func init() {

--- a/confgenerator/logging_receivers.go
+++ b/confgenerator/logging_receivers.go
@@ -353,14 +353,6 @@ func (r LoggingReceiverSystemd) Components(tag string) []fluentbit.Component {
 			"DB":   DBPath(tag),
 		},
 	}}
-	input = append(input, fluentbit.Component{
-		Kind: "FILTER",
-		Config: map[string]string{
-			"Match":  tag,
-			"Name":   "modify",
-			"Rename": "MESSAGE message",
-		},
-	})
 	filters := fluentbit.TranslationComponents(tag, "PRIORITY", "logging.googleapis.com/severity", false,
 		[]struct{ SrcVal, DestVal string }{
 			{"7", "DEBUG"},

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_fluent_bit_main.conf
@@ -56,11 +56,6 @@
     Name  modify
 
 [FILTER]
-    Match  systemd_pipeline.systemd_logs
-    Name   modify
-    Rename MESSAGE message
-
-[FILTER]
     Add       logging.googleapis.com/severity DEBUG
     Condition Key_Value_Equals PRIORITY 7
     Match     systemd_pipeline.systemd_logs

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_fluent_bit_main.conf
@@ -56,6 +56,85 @@
     Name  modify
 
 [FILTER]
+    Match  systemd_pipeline.systemd_logs
+    Name   modify
+    Rename MESSAGE message
+
+[FILTER]
+    Add       logging.googleapis.com/severity DEBUG
+    Condition Key_Value_Equals PRIORITY 7
+    Match     systemd_pipeline.systemd_logs
+    Name      modify
+
+[FILTER]
+    Add       logging.googleapis.com/severity INFO
+    Condition Key_Value_Equals PRIORITY 6
+    Match     systemd_pipeline.systemd_logs
+    Name      modify
+
+[FILTER]
+    Add       logging.googleapis.com/severity NOTICE
+    Condition Key_Value_Equals PRIORITY 5
+    Match     systemd_pipeline.systemd_logs
+    Name      modify
+
+[FILTER]
+    Add       logging.googleapis.com/severity WARNING
+    Condition Key_Value_Equals PRIORITY 4
+    Match     systemd_pipeline.systemd_logs
+    Name      modify
+
+[FILTER]
+    Add       logging.googleapis.com/severity ERROR
+    Condition Key_Value_Equals PRIORITY 3
+    Match     systemd_pipeline.systemd_logs
+    Name      modify
+
+[FILTER]
+    Add       logging.googleapis.com/severity CRITICAL
+    Condition Key_Value_Equals PRIORITY 2
+    Match     systemd_pipeline.systemd_logs
+    Name      modify
+
+[FILTER]
+    Add       logging.googleapis.com/severity ALERT
+    Condition Key_Value_Equals PRIORITY 1
+    Match     systemd_pipeline.systemd_logs
+    Name      modify
+
+[FILTER]
+    Add       logging.googleapis.com/severity EMERGENCY
+    Condition Key_Value_Equals PRIORITY 0
+    Match     systemd_pipeline.systemd_logs
+    Name      modify
+
+[FILTER]
+    Condition Key_exists CODE_FILE
+    Copy      CODE_FILE logging.googleapis.com/sourceLocation/file
+    Match     systemd_pipeline.systemd_logs
+    Name      modify
+
+[FILTER]
+    Condition Key_exists CODE_FUNC
+    Copy      CODE_FUNC logging.googleapis.com/sourceLocation/function
+    Match     systemd_pipeline.systemd_logs
+    Name      modify
+
+[FILTER]
+    Condition Key_exists CODE_LINE
+    Copy      CODE_LINE logging.googleapis.com/sourceLocation/line
+    Match     systemd_pipeline.systemd_logs
+    Name      modify
+
+[FILTER]
+    Match         systemd_pipeline.systemd_logs
+    Name          nest
+    Nest_under    logging.googleapis.com/sourceLocation
+    Operation     nest
+    Remove_prefix logging.googleapis.com/sourceLocation/
+    Wildcard      logging.googleapis.com/sourceLocation/*
+
+[FILTER]
     Add   logging.googleapis.com/logName systemd_logs
     Match systemd_pipeline.systemd_logs
     Name  modify


### PR DESCRIPTION
Transform keys from journald JSON to Cloud Logging JSON. This adds
severity and sourceLocation to the logging JSON. 
Previously the json would have only the fields in the jsonPayload key, for example:
```
{
  "jsonPayload": {
    "MESSAGE": "error message here",
    "PRIORITY": "0"
    "CODE_FILE": "main.go"
    "CODE_FUNC": "main_func",
    "CODE_LINE": "100",
  },
  "resource": {},
  "timestamp": "2022-03-31T17:36:59.521960Z",
  "logName": "projects/sample-prj/logs/systemdreceiver",
  "receiveTimestamp": "2022-03-31T17:37:00.742917663Z"
}
```
Now, we populate the Cloud Logging JSON fields:
```
{
  "jsonPayload": {
    "MESSAGE": "error message here",
    "PRIORITY": "0",
    "CODE_FILE": "main.go"
    "CODE_FUNC": "main_func",
    "CODE_LINE": "100",
  },
  "severity": "EMERGENCY",
  "resource": {},
  "timestamp": "2022-03-31T17:36:59.521960Z",
  "logName": "projects/sample-prj/logs/systemdreceiver",
  "receiveTimestamp": "2022-03-31T17:37:00.742917663Z"
  "sourceLocation": {
       "file": "main.go"
       "function": "main_func"
       "line": "100"
    }
}
```

Fixes https://github.com/GoogleCloudPlatform/ops-agent/issues/256