### PR TITLE
Install a newer version of mysql-apt-config

### DIFF
--- a/integration_test/third_party_apps_data/applications/mysql/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/mysql/debian_ubuntu/install
@@ -3,16 +3,10 @@ set -e
 sudo apt update
 sudo apt install -y wget
 
-function add_apt_key() {
-  # From https://dev.mysql.com/doc/mysql-apt-repo-quick-guide/en/#repo-qg-apt-repo-manual-setup
-  sudo apt-key adv --keyserver "$@" --recv-keys 3A79BD29
-}
-add_apt_key pgp.mit.edu || add_apt_key keyserver.ubuntu.com
-
-wget https://dev.mysql.com/get/mysql-apt-config_0.8.14-1_all.deb
+wget https://dev.mysql.com/get/mysql-apt-config_0.8.22-1_all.deb
 # DEBIAN_FRONTEND=noninteractive gets us around a problematic prompt:
 # http://screen/g4PsZtaXjBX
-sudo DEBIAN_FRONTEND=noninteractive dpkg -i mysql-apt-config_0.8.14-1_all.deb
+sudo DEBIAN_FRONTEND=noninteractive dpkg -i mysql-apt-config_0.8.22-1_all.deb
 sudo apt update
 sudo debconf-set-selections <<< 'mysql-community-server mysql-server/default-auth-override select Use Legacy Authentication Method (Retain MySQL 5.x Compatibility)'
 


### PR DESCRIPTION
This avoids the need to fetch the updated repo key in a separate step.