### PR TITLE
integration_test: structure cleanup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "gopls": {
+        "build.buildFlags": ["-tags=integration_test"]
+    }
+}

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -242,7 +242,8 @@ With `optional: true`, the metric will be skipped during the test. This can be u
 PROJECT="${PROJECT}" \
 GOOGLE_APPLICATION_CREDENTIALS="${HOME}/credentials.json" \
 SCRIPTS_DIR=third_party_apps_data \
-go run ./cmd/generate_expected_metrics
+go run ./cmd/generate_expected_metrics \
+-tags=integration_test
 ```
 
 This queries all metric descriptors under `workload.googleapis.com/`, `agent.googleapis.com/iis/`, and `agent.googleapis.com/mssql/`. The optional variable `FILTER` is also provided to make it quicker to test individual integrations. For example:
@@ -252,7 +253,8 @@ PROJECT="${PROJECT}" \
 GOOGLE_APPLICATION_CREDENTIALS="${HOME}/credentials.json" \
 SCRIPTS_DIR=third_party_apps_data \
 FILTER='metric.type=starts_with("workload.googleapis.com/apache")' \
-go run ./cmd/generate_expected_metrics
+go run ./cmd/generate_expected_metrics \
+-tags=integration_test
 ```
 
 Existing `expected_metrics` files are updated with any new metrics that are retrieved. Any existing metrics within the file will be overwritten with newly retrieved ones, except that existing `labels` patterns are preserved.

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -242,8 +242,7 @@ With `optional: true`, the metric will be skipped during the test. This can be u
 PROJECT="${PROJECT}" \
 GOOGLE_APPLICATION_CREDENTIALS="${HOME}/credentials.json" \
 SCRIPTS_DIR=third_party_apps_data \
-go run generate_expected_metrics.go \
- -tags=integration_test
+go run ./cmd/generate_expected_metrics
 ```
 
 This queries all metric descriptors under `workload.googleapis.com/`, `agent.googleapis.com/iis/`, and `agent.googleapis.com/mssql/`. The optional variable `FILTER` is also provided to make it quicker to test individual integrations. For example:
@@ -253,8 +252,7 @@ PROJECT="${PROJECT}" \
 GOOGLE_APPLICATION_CREDENTIALS="${HOME}/credentials.json" \
 SCRIPTS_DIR=third_party_apps_data \
 FILTER='metric.type=starts_with("workload.googleapis.com/apache")' \
-go run generate_expected_metrics.go \
- -tags=integration_test
+go run ./cmd/generate_expected_metrics
 ```
 
 Existing `expected_metrics` files are updated with any new metrics that are retrieved. Any existing metrics within the file will be overwritten with newly retrieved ones, except that existing `labels` patterns are preserved.

--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build integration_test
 
 /*

--- a/integration_test/cmd/generate_expected_metrics/generate_expected_metrics.go
+++ b/integration_test/cmd/generate_expected_metrics/generate_expected_metrics.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build integration_test
 
 /*

--- a/integration_test/common/common.go
+++ b/integration_test/common/common.go
@@ -1,3 +1,19 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration_test
+
 package common
 
 import (

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build integration_test
 
 /*
@@ -532,7 +546,7 @@ type ThreadSafeWriter struct {
 	guarded io.Writer
 }
 
-func (writer ThreadSafeWriter) Write(p []byte) (int, error) {
+func (writer *ThreadSafeWriter) Write(p []byte) (int, error) {
 	writer.mu.Lock()
 	defer writer.mu.Unlock()
 	return writer.guarded.Write(p)
@@ -572,7 +586,7 @@ func runCommand(ctx context.Context, logger *log.Logger, stdin string, args []st
 	var stderrBuilder strings.Builder
 	var interleavedBuilder strings.Builder
 
-	interleavedWriter := ThreadSafeWriter{guarded: &interleavedBuilder}
+	interleavedWriter := &ThreadSafeWriter{guarded: &interleavedBuilder}
 	cmd.Stdout = io.MultiWriter(&stdoutBuilder, interleavedWriter)
 	cmd.Stderr = io.MultiWriter(&stderrBuilder, interleavedWriter)
 

--- a/integration_test/logging/logging.go
+++ b/integration_test/logging/logging.go
@@ -1,3 +1,19 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration_test
+
 /*
 Package logging has utilities to aid in recording logs for tests.
 */

--- a/integration_test/logging/logging.go
+++ b/integration_test/logging/logging.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration_test
-
 /*
 Package logging has utilities to aid in recording logs for tests.
 */

--- a/integration_test/logging/logging_test.go
+++ b/integration_test/logging/logging_test.go
@@ -1,3 +1,19 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration_test
+
 // Unit tests for the DirectoryLogger, which is itself only used
 // for integration testing.
 

--- a/integration_test/logging/logging_test.go
+++ b/integration_test/logging/logging_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration_test
-
 // Unit tests for the DirectoryLogger, which is itself only used
 // for integration testing.
 

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build integration_test
 
 /*

--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build integration_test
 
 /*


### PR DESCRIPTION
* Added .vscode folder with settings.json, including a setting that
  enables `gopls` analysis in `integration_test`
* Separated `generate_expected_metrics.go` into a cmd folder, so `main`
  and `integration_test` packages aren't mixed in the same folder
* Added license header to all .go files
* Fixed mutex copy in gce_testing.go