### PR TITLE
Add a 20s sleep before installing Windows services.

### DIFF
--- a/pkg/goo/maint.ps1
+++ b/pkg/goo/maint.ps1
@@ -44,6 +44,8 @@ if ($Action -eq "install") {
      else {
          Write-Host "Keep [$configFilePath] as-is because a file with that name already exists."
      }
+     # Sleep for 20s before installing services to allow previous service deletion to complete.
+     Start-Sleep -s 20
 }
 
 & "$InstallDir\bin\google-cloud-ops-agent.exe" "--$Action"


### PR DESCRIPTION
This is to accommodate delayed service deletion on upgrades.

b/227212680