### PR TITLE
integration_test: Add configuration_options field to metadata

### DIFF
--- a/integration_test/common/common.go
+++ b/integration_test/common/common.go
@@ -75,8 +75,8 @@ type InputConfiguration struct {
 }
 
 type ConfigurationOptions struct {
-	LogsConfiguration    InputConfiguration `yaml:"logs"`
-	MetricsConfiguration InputConfiguration `yaml:"metrics"`
+	LogsConfiguration    []InputConfiguration `yaml:"logs"`
+	MetricsConfiguration []InputConfiguration `yaml:"metrics"`
 }
 
 type IntegrationMetadata struct {

--- a/integration_test/common/common.go
+++ b/integration_test/common/common.go
@@ -63,6 +63,22 @@ type MinimumSupportedAgentVersion struct {
 	Metrics string `yaml:"metrics,omitempty"`
 }
 
+type ConfigurationFields struct {
+	Name        string `yaml:"name" validate:"required"`
+	Default     string `yaml:"default" validate:"required"`
+	Description string `yaml:"description" validate:"required"`
+}
+
+type InputConfiguration struct {
+	Type   string                `yaml:"type" validate:"required"`
+	Fields []ConfigurationFields `yaml:"fields" validate:"required"`
+}
+
+type ConfigurationOptions struct {
+	LogsConfiguration    InputConfiguration `yaml:"logs"`
+	MetricsConfiguration InputConfiguration `yaml:"metrics"`
+}
+
 type IntegrationMetadata struct {
 	PublicUrl                    string                       `yaml:"public_url,omitempty"`
 	ShortName                    string                       `yaml:"short_name" validate:"required"`
@@ -73,6 +89,7 @@ type IntegrationMetadata struct {
 	ExpectedMetrics              []ExpectedMetric             `yaml:"expected_metrics,omitempty"`
 	MinimumSupportedAgentVersion MinimumSupportedAgentVersion `yaml:"minimum_supported_agent_version,omitempty"`
 	SupportedAppVersion          []string                     `yaml:"supported_app_version" validate:"required"`
+	ConfigurationOptions         ConfigurationOptions         `yaml:"configuration_options" validate:"required"`
 }
 
 var validate *validator.Validate

--- a/integration_test/third_party_apps_data/applications/activemq/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/activemq/metadata.yaml
@@ -84,3 +84,31 @@ expected_metrics:
   labels:
     broker: .*
     destination: .*
+configuration_options:
+  logs:
+  - type: ""
+    fields:
+    - name: type
+      default: null
+      description: ""
+    - name: include_paths
+      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  metrics:
+  - type: apache
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache.
+    - name: server_status_url
+      default: http://localhost:80/server-status?auto
+      description: The URL exposed by the mod_status module.
+    - name: collection_interval
+      default: 60s
+      description: A time.Duration value, such as 30s or 5m.

--- a/integration_test/third_party_apps_data/applications/activemq/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/activemq/metadata.yaml
@@ -85,30 +85,21 @@ expected_metrics:
     broker: .*
     destination: .*
 configuration_options:
-  logs:
-  - type: ""
-    fields:
-    - name: type
-      default: null
-      description: ""
-    - name: include_paths
-      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
-      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
-    - name: exclude_paths
-      default: null
-      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
-    - name: wildcard_refresh_interval
-      default: 60s
-      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
-  - type: apache
+  - type: activemq
     fields:
     - name: type
       default: null
-      description: This value must be apache.
-    - name: server_status_url
-      default: http://localhost:80/server-status?auto
-      description: The URL exposed by the mod_status module.
+      description: This value must be activemq.
+    - name: endpoint
+      default: http://localhost:1099
+      description: The URL of the node to monitor.
+    - name: username
+      default: null
+      description: The configured username if JMX is configured to require authentication.
+    - name: password
+      default: null
+      description: The configured password if JMX is configured to require authentication.
     - name: collection_interval
       default: 60s
       description: A time.Duration value, such as 30s or 5m.

--- a/integration_test/third_party_apps_data/applications/apache/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/apache/metadata.yaml
@@ -124,3 +124,45 @@ expected_logs:
   - name: jsonPayload.tid
     type: string
     description: Thread ID
+configuration_options:
+  logs:
+  - type: apache_access
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache_access.
+    - name: include_paths
+      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  - type: apache_error
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache_error.
+    - name: include_paths
+      default: '[/var/log/apache2/error.log,/var/log/apache2/error_log,/var/log/httpd/error_log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  metrics:
+  - type: apache
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache.
+    - name: server_status_url
+      default: http://localhost:80/server-status?auto
+      description: The URL exposed by the mod_status module.
+    - name: collection_interval
+      default: 60s
+      description: A time.Duration value, such as 30s or 5m.

--- a/integration_test/third_party_apps_data/applications/cassandra/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/cassandra/metadata.yaml
@@ -178,14 +178,42 @@ expected_logs:
     description: Seconds the JVM took to stop threads before garbage collection
 configuration_options:
   logs:
-  - type: ""
+  - type: "cassandra_system"
     fields:
     - name: type
       default: null
-      description: ""
+      description: "The value must be cassandra_system."
     - name: include_paths
-      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
-      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+      default: '[/var/log/cassandra/system*.log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/cassandra/system*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  - type: "cassandra_debug"
+    fields:
+    - name: type
+      default: null
+      description: "The value must be cassandra_debug."
+    - name: include_paths
+      default: '[/var/log/cassandra/debug*.log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/cassandra/system*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  - type: "cassandra_gc"
+    fields:
+    - name: type
+      default: null
+      description: "The value must be cassandra_gc."
+    - name: include_paths
+      default: '[/var/log/cassandra/gc.log.*.current]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/cassandra/system*.log.
     - name: exclude_paths
       default: null
       description: A list of filesystem path patterns to exclude from the set matched by include_paths.
@@ -193,14 +221,23 @@ configuration_options:
       default: 60s
       description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
-  - type: apache
+  - type: cassandra
     fields:
     - name: type
       default: null
-      description: This value must be apache.
-    - name: server_status_url
-      default: http://localhost:80/server-status?auto
-      description: The URL exposed by the mod_status module.
+      description: 	The value must be cassandra.
+    - name: endpoint
+      default: localhost:7199
+      description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of service:jmx:<protocol>:<sap> or host:port. Values in host:port form are used to create a service URL of service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi.
+    - name: collect_jvm_metrics
+      default: true
+      description: Configures the receiver to also collect the supported JVM metrics.
+    - name: username
+      default: null
+      description: The configured username if JMX is configured to require authentication.
+    - name: password
+      default: null
+      description: The configured password if JMX is configured to require authentication.
     - name: collection_interval
       default: 60s
       description: A time.Duration value, such as 30s or 5m.

--- a/integration_test/third_party_apps_data/applications/cassandra/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/cassandra/metadata.yaml
@@ -178,11 +178,11 @@ expected_logs:
     description: Seconds the JVM took to stop threads before garbage collection
 configuration_options:
   logs:
-  - type: "cassandra_system"
+  - type: cassandra_system
     fields:
     - name: type
       default: null
-      description: "The value must be cassandra_system."
+      description: The value must be cassandra_system.
     - name: include_paths
       default: '[/var/log/cassandra/system*.log]'
       description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/cassandra/system*.log.
@@ -192,11 +192,11 @@ configuration_options:
     - name: wildcard_refresh_interval
       default: 60s
       description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
-  - type: "cassandra_debug"
+  - type: cassandra_debug
     fields:
     - name: type
       default: null
-      description: "The value must be cassandra_debug."
+      description: The value must be cassandra_debug.
     - name: include_paths
       default: '[/var/log/cassandra/debug*.log]'
       description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/cassandra/system*.log.
@@ -206,11 +206,11 @@ configuration_options:
     - name: wildcard_refresh_interval
       default: 60s
       description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
-  - type: "cassandra_gc"
+  - type: cassandra_gc
     fields:
     - name: type
       default: null
-      description: "The value must be cassandra_gc."
+      description: The value must be cassandra_gc.
     - name: include_paths
       default: '[/var/log/cassandra/gc.log.*.current]'
       description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/cassandra/system*.log.

--- a/integration_test/third_party_apps_data/applications/cassandra/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/cassandra/metadata.yaml
@@ -176,3 +176,32 @@ expected_logs:
   - name: jsonPayload.timeStopping
     type: string
     description: Seconds the JVM took to stop threads before garbage collection
+configuration_options:
+  logs:
+  - type: ""
+    fields:
+    - name: type
+      default: null
+      description: ""
+    - name: include_paths
+      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  metrics:
+  - type: apache
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache.
+    - name: server_status_url
+      default: http://localhost:80/server-status?auto
+      description: The URL exposed by the mod_status module.
+    - name: collection_interval
+      default: 60s
+      description: A time.Duration value, such as 30s or 5m.
+

--- a/integration_test/third_party_apps_data/applications/couchdb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/couchdb/metadata.yaml
@@ -91,3 +91,31 @@ expected_logs:
   - name: httpRequest
     type: object
     description: Information about the HTTP request associated with this log entry, if applicable. It's availble in access logs.
+configuration_options:
+  logs:
+  - type: ""
+    fields:
+    - name: type
+      default: null
+      description: ""
+    - name: include_paths
+      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  metrics:
+  - type: apache
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache.
+    - name: server_status_url
+      default: http://localhost:80/server-status?auto
+      description: The URL exposed by the mod_status module.
+    - name: collection_interval
+      default: 60s
+      description: A time.Duration value, such as 30s or 5m.

--- a/integration_test/third_party_apps_data/applications/couchdb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/couchdb/metadata.yaml
@@ -93,14 +93,14 @@ expected_logs:
     description: Information about the HTTP request associated with this log entry, if applicable. It's availble in access logs.
 configuration_options:
   logs:
-  - type: ""
+  - type: "couchdb"
     fields:
     - name: type
       default: null
-      description: ""
+      description: "The value must be couchdb."
     - name: include_paths
-      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
-      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+      default: '[/var/log/couchdb/couchdb.log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/couchdb*/*.log.
     - name: exclude_paths
       default: null
       description: A list of filesystem path patterns to exclude from the set matched by include_paths.
@@ -108,14 +108,20 @@ configuration_options:
       default: 60s
       description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
-  - type: apache
+  - type: couchdb
     fields:
     - name: type
       default: null
-      description: This value must be apache.
+      description: The value must be couchdb.
     - name: server_status_url
-      default: http://localhost:80/server-status?auto
-      description: The URL exposed by the mod_status module.
+      default: 	http://localhost:5984
+      description: The URL exposed by couchdb.
+    - name: username
+      default: null
+      description: The username used to connect to the server.
+    - name: password
+      default: null
+      description: The password used to connect to the server.
     - name: collection_interval
       default: 60s
       description: A time.Duration value, such as 30s or 5m.

--- a/integration_test/third_party_apps_data/applications/couchdb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/couchdb/metadata.yaml
@@ -93,11 +93,11 @@ expected_logs:
     description: Information about the HTTP request associated with this log entry, if applicable. It's availble in access logs.
 configuration_options:
   logs:
-  - type: "couchdb"
+  - type: couchdb
     fields:
     - name: type
       default: null
-      description: "The value must be couchdb."
+      description: The value must be couchdb.
     - name: include_paths
       default: '[/var/log/couchdb/couchdb.log]'
       description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/couchdb*/*.log.

--- a/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
@@ -164,11 +164,11 @@ expected_logs:
     description: 'The run of the garbage collector'
 configuration_options:
   logs:
-  - type: "elasticsearch_json"
+  - type: elasticsearch_json
     fields:
     - name: type
       default: null
-      description: "The value must be elasticsearch_json."
+      description: The value must be elasticsearch_json.
     - name: include_paths
       default: '[/var/log/elasticsearch/*_server.json, /var/log/elasticsearch/*_deprecation.json, /var/log/elasticsearch/*_index_search_slowlog.json, /var/log/elasticsearch/*_index_indexing_slowlog.json, /var/log/elasticsearch/*_audit.json]'
       description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
@@ -178,11 +178,11 @@ configuration_options:
     - name: wildcard_refresh_interval
       default: 60s
       description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
-  - type: "elasticsearch_gc"
+  - type: elasticsearch_gc
     fields:
     - name: type
       default: null
-      description: "The value must be elasticsearch_gc."
+      description: The value must be elasticsearch_gc.
     - name: include_paths
       default: '[/var/log/elasticsearch/gc.log]'
       description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.

--- a/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
@@ -164,14 +164,28 @@ expected_logs:
     description: 'The run of the garbage collector'
 configuration_options:
   logs:
-  - type: ""
+  - type: "elasticsearch_json"
     fields:
     - name: type
       default: null
-      description: ""
+      description: "The value must be elasticsearch_json."
     - name: include_paths
-      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
-      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+      default: '[/var/log/elasticsearch/*_server.json, /var/log/elasticsearch/*_deprecation.json, /var/log/elasticsearch/*_index_search_slowlog.json, /var/log/elasticsearch/*_index_indexing_slowlog.json, /var/log/elasticsearch/*_audit.json]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  - type: "elasticsearch_gc"
+    fields:
+    - name: type
+      default: null
+      description: "The value must be elasticsearch_gc."
+    - name: include_paths
+      default: '[/var/log/elasticsearch/gc.log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
     - name: exclude_paths
       default: null
       description: A list of filesystem path patterns to exclude from the set matched by include_paths.
@@ -179,14 +193,35 @@ configuration_options:
       default: 60s
       description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
-  - type: apache
+  - type: elasticsearch
     fields:
     - name: type
       default: null
-      description: This value must be apache.
-    - name: server_status_url
-      default: http://localhost:80/server-status?auto
-      description: The URL exposed by the mod_status module.
+      description: This value must be elasticsearch.
+    - name: endpoint
+      default: 	http://localhost:92002
+      description: The base URL for the Elasticsearch REST API.
     - name: collection_interval
       default: 60s
       description: A time.Duration value, such as 30s or 5m.
+    - name: username
+      default: null
+      description: Username for authentication with Elasticsearch. Required if password is set.
+    - name: password
+      default: null
+      description: Password for authentication with Elasticsearch. Required if username is set.
+    - name: insecure
+      default: true
+      description: Sets whether or not to use a secure TLS connection. If set to false, then TLS is enabled.
+    - name: insecure_skip_verify
+      default: false
+      description: Sets whether or not to skip verifying the certificate. If insecure is set to true, then the insecure_skip_verify value is not used.
+    - name: cert_file
+      default: null
+      description: Path to the TLS certificate to use for mTLS-required connections.
+    - name: key_file
+      default: null
+      description: Path to the TLS key to use for mTLS-required connections.
+    - name: ca_file
+      default: null
+      description: Path to the CA certificate. As a client, this verifies the server certificate. If empty, the receiver uses the system root CA.

--- a/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
@@ -162,3 +162,31 @@ expected_logs:
   - name: jsonPayload.gc_run
     type: number
     description: 'The run of the garbage collector'
+configuration_options:
+  logs:
+  - type: ""
+    fields:
+    - name: type
+      default: null
+      description: ""
+    - name: include_paths
+      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  metrics:
+  - type: apache
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache.
+    - name: server_status_url
+      default: http://localhost:80/server-status?auto
+      description: The URL exposed by the mod_status module.
+    - name: collection_interval
+      default: 60s
+      description: A time.Duration value, such as 30s or 5m.

--- a/integration_test/third_party_apps_data/applications/hadoop/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/hadoop/metadata.yaml
@@ -95,11 +95,11 @@ expected_logs:
     description: 'The source Java class of the log entry'
 configuration_options:
   logs:
-  - type: "hadoop"
+  - type: hadoop
     fields:
     - name: type
       default: null
-      description: "This value must be hadoop."
+      description: This value must be hadoop.
     - name: include_paths
       default: '[/opt/hadoop/logs/hadoop-*.log, /opt/hadoop/logs/yarn-*.log]'
       description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.

--- a/integration_test/third_party_apps_data/applications/hadoop/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/hadoop/metadata.yaml
@@ -93,3 +93,32 @@ expected_logs:
     value_regex: org.apache.hadoop.hdfs.server.namenode.NameNode
     type: string
     description: 'The source Java class of the log entry'
+configuration_options:
+  logs:
+  - type: ""
+    fields:
+    - name: type
+      default: null
+      description: ""
+    - name: include_paths
+      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  metrics:
+  - type: apache
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache.
+    - name: server_status_url
+      default: http://localhost:80/server-status?auto
+      description: The URL exposed by the mod_status module.
+    - name: collection_interval
+      default: 60s
+      description: A time.Duration value, such as 30s or 5m.
+

--- a/integration_test/third_party_apps_data/applications/hadoop/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/hadoop/metadata.yaml
@@ -95,14 +95,14 @@ expected_logs:
     description: 'The source Java class of the log entry'
 configuration_options:
   logs:
-  - type: ""
+  - type: "hadoop"
     fields:
     - name: type
       default: null
-      description: ""
+      description: "This value must be hadoop."
     - name: include_paths
-      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
-      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+      default: '[/opt/hadoop/logs/hadoop-*.log, /opt/hadoop/logs/yarn-*.log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
     - name: exclude_paths
       default: null
       description: A list of filesystem path patterns to exclude from the set matched by include_paths.
@@ -110,14 +110,23 @@ configuration_options:
       default: 60s
       description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
-  - type: apache
+  - type: hadoop
     fields:
     - name: type
       default: null
-      description: This value must be apache.
-    - name: server_status_url
-      default: http://localhost:80/server-status?auto
-      description: The URL exposed by the mod_status module.
+      description: 	This value must be hadoop.
+    - name: endpoint
+      default: localhost:8004
+      description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of service:jmx:<protocol>:<sap> or host:port. Values in host:port form are used to create a service URL of service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi.
+    - name: collect_jvm_metrics
+      default: true
+      description: Configures the receiver to also collect the supported JVM metrics.
+    - name: username
+      default: null
+      description: The configured username if JMX is configured to require authentication.
+    - name: password
+      default: null
+      description: The configured password if JMX is configured to require authentication.
     - name: collection_interval
       default: 60s
       description: A time.Duration value, such as 30s or 5m.

--- a/integration_test/third_party_apps_data/applications/hbase/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/hbase/metadata.yaml
@@ -362,11 +362,11 @@ expected_logs:
     description: 'source of where the log originated'
 configuration_options:
   logs:
-  - type: "hbase_system"
+  - type: hbase_system
     fields:
     - name: type
       default: null
-      description: "This value must be hbase_system."
+      description: This value must be hbase_system.
     - name: include_paths
       default: '[/opt/hbase/logs/hbase-*-regionserver-*.log, /opt/hbase/logs/hbase-*-master-*.log]'
       description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/hbase*/*.log.

--- a/integration_test/third_party_apps_data/applications/hbase/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/hbase/metadata.yaml
@@ -360,3 +360,32 @@ expected_logs:
     value_regex: master.HMaster
     type: string
     description: 'source of where the log originated'
+configuration_options:
+  logs:
+  - type: ""
+    fields:
+    - name: type
+      default: null
+      description: ""
+    - name: include_paths
+      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  metrics:
+  - type: apache
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache.
+    - name: server_status_url
+      default: http://localhost:80/server-status?auto
+      description: The URL exposed by the mod_status module.
+    - name: collection_interval
+      default: 60s
+      description: A time.Duration value, such as 30s or 5m.
+

--- a/integration_test/third_party_apps_data/applications/hbase/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/hbase/metadata.yaml
@@ -362,14 +362,14 @@ expected_logs:
     description: 'source of where the log originated'
 configuration_options:
   logs:
-  - type: ""
+  - type: "hbase_system"
     fields:
     - name: type
       default: null
-      description: ""
+      description: "This value must be hbase_system."
     - name: include_paths
-      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
-      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+      default: '[/opt/hbase/logs/hbase-*-regionserver-*.log, /opt/hbase/logs/hbase-*-master-*.log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/hbase*/*.log.
     - name: exclude_paths
       default: null
       description: A list of filesystem path patterns to exclude from the set matched by include_paths.
@@ -377,15 +377,23 @@ configuration_options:
       default: 60s
       description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
-  - type: apache
+  - type: hbase
     fields:
     - name: type
       default: null
-      description: This value must be apache.
-    - name: server_status_url
-      default: http://localhost:80/server-status?auto
-      description: The URL exposed by the mod_status module.
+      description: 	This value must be hbase.
+    - name: endpoint
+      default: localhost:10101
+      description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of service:jmx:<protocol>:<sap> or host:port. Values in host:port form are used to create a service URL of service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi.
+    - name: collect_jvm_metrics
+      default: true
+      description: Configures the receiver to also collect the supported JVM metrics.
+    - name: username
+      default: null
+      description: The configured username if JMX is configured to require authentication.
+    - name: password
+      default: null
+      description: The configured password if JMX is configured to require authentication.
     - name: collection_interval
       default: 60s
       description: A time.Duration value, such as 30s or 5m.
-

--- a/integration_test/third_party_apps_data/applications/iis/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/iis/metadata.yaml
@@ -79,3 +79,31 @@ expected_logs:
   - name: jsonPayload.user
     type: string
     description: "Authenticated username for the request"
+configuration_options:
+  logs:
+  - type: ""
+    fields:
+    - name: type
+      default: null
+      description: ""
+    - name: include_paths
+      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  metrics:
+  - type: apache
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache.
+    - name: server_status_url
+      default: http://localhost:80/server-status?auto
+      description: The URL exposed by the mod_status module.
+    - name: collection_interval
+      default: 60s
+      description: A time.Duration value, such as 30s or 5m.

--- a/integration_test/third_party_apps_data/applications/iis/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/iis/metadata.yaml
@@ -80,6 +80,21 @@ expected_logs:
     type: string
     description: "Authenticated username for the request"
 configuration_options:
+  logs:
+  - type: iis_access
+    fields:
+    - name: type
+      default: null
+      description: This value must be iis_access.
+    - name: include_paths
+      default: '['C:\inetpub\logs\LogFiles\W3SVC1\u_ex*]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `C:\inetpub\logs\LogFiles\W3SVC1\u_ex*`.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
   - type: iis
     fields:

--- a/integration_test/third_party_apps_data/applications/iis/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/iis/metadata.yaml
@@ -80,30 +80,12 @@ expected_logs:
     type: string
     description: "Authenticated username for the request"
 configuration_options:
-  logs:
-  - type: ""
-    fields:
-    - name: type
-      default: null
-      description: ""
-    - name: include_paths
-      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
-      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
-    - name: exclude_paths
-      default: null
-      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
-    - name: wildcard_refresh_interval
-      default: 60s
-      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
-  - type: apache
+  - type: iis
     fields:
     - name: type
       default: null
-      description: This value must be apache.
-    - name: server_status_url
-      default: http://localhost:80/server-status?auto
-      description: The URL exposed by the mod_status module.
+      description: This value must be iis.
     - name: collection_interval
       default: 60s
       description: A time.Duration value, such as 30s or 5m.

--- a/integration_test/third_party_apps_data/applications/jvm/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/jvm/metadata.yaml
@@ -116,30 +116,21 @@ expected_metrics:
   monitored_resource: gce_instance
   labels: {}
 configuration_options:
-  logs:
-  - type: ""
-    fields:
-    - name: type
-      default: null
-      description: ""
-    - name: include_paths
-      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
-      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
-    - name: exclude_paths
-      default: null
-      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
-    - name: wildcard_refresh_interval
-      default: 60s
-      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
-  - type: apache
+  - type: jvm
     fields:
     - name: type
       default: null
-      description: This value must be apache.
-    - name: server_status_url
-      default: http://localhost:80/server-status?auto
-      description: The URL exposed by the mod_status module.
+      description: 	This value must be jvm.
+    - name: endpoint
+      default: localhost:9999
+      description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of service:jmx:<protocol>:<sap> or host:port. Values in host:port form are used to create a service URL of service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi.
+    - name: username
+      default: null
+      description: The configured username if JMX is configured to require authentication.
+    - name: password
+      default: null
+      description: The configured password if JMX is configured to require authentication.
     - name: collection_interval
       default: 60s
       description: A time.Duration value, such as 30s or 5m.

--- a/integration_test/third_party_apps_data/applications/jvm/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/jvm/metadata.yaml
@@ -115,3 +115,32 @@ expected_metrics:
   kind: GAUGE
   monitored_resource: gce_instance
   labels: {}
+configuration_options:
+  logs:
+  - type: ""
+    fields:
+    - name: type
+      default: null
+      description: ""
+    - name: include_paths
+      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  metrics:
+  - type: apache
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache.
+    - name: server_status_url
+      default: http://localhost:80/server-status?auto
+      description: The URL exposed by the mod_status module.
+    - name: collection_interval
+      default: 60s
+      description: A time.Duration value, such as 30s or 5m.
+

--- a/integration_test/third_party_apps_data/applications/kafka/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/kafka/metadata.yaml
@@ -112,14 +112,14 @@ expected_logs:
     description: ''
 configuration_options:
   logs:
-  - type: ""
+  - type: "kafka"
     fields:
     - name: type
       default: null
-      description: ""
+      description: "The value must be kafka."
     - name: include_paths
-      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
-      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+      default: '[/var/log/kafka/*.log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/kafka*/*.log.
     - name: exclude_paths
       default: null
       description: A list of filesystem path patterns to exclude from the set matched by include_paths.
@@ -127,15 +127,23 @@ configuration_options:
       default: 60s
       description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
-  - type: apache
+  - type: kafka
     fields:
     - name: type
       default: null
-      description: This value must be apache.
-    - name: server_status_url
-      default: http://localhost:80/server-status?auto
-      description: The URL exposed by the mod_status module.
+      description: 	This value must be kafka.
+    - name: stub_status_url
+      default: localhost:9999
+      description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of service:jmx:<protocol>:<sap> or host:port. Values in host:port form are used to create a service URL of service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi.
+    - name: collect_jvm_metrics
+      default: true
+      description: Configures the receiver to also collect the supported JVM metrics.
+    - name: username
+      default: null
+      description: The configured username if JMX is configured to require authentication.
+    - name: password
+      default: null
+      description: The configured password if JMX is configured to require authentication.
     - name: collection_interval
       default: 60s
       description: A time.Duration value, such as 30s or 5m.
-

--- a/integration_test/third_party_apps_data/applications/kafka/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/kafka/metadata.yaml
@@ -110,3 +110,32 @@ expected_logs:
   - name: timestamp
     type: string
     description: ''
+configuration_options:
+  logs:
+  - type: ""
+    fields:
+    - name: type
+      default: null
+      description: ""
+    - name: include_paths
+      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  metrics:
+  - type: apache
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache.
+    - name: server_status_url
+      default: http://localhost:80/server-status?auto
+      description: The URL exposed by the mod_status module.
+    - name: collection_interval
+      default: 60s
+      description: A time.Duration value, such as 30s or 5m.
+

--- a/integration_test/third_party_apps_data/applications/kafka/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/kafka/metadata.yaml
@@ -112,11 +112,11 @@ expected_logs:
     description: ''
 configuration_options:
   logs:
-  - type: "kafka"
+  - type: kafka
     fields:
     - name: type
       default: null
-      description: "The value must be kafka."
+      description: The value must be kafka.
     - name: include_paths
       default: '[/var/log/kafka/*.log]'
       description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/kafka*/*.log.

--- a/integration_test/third_party_apps_data/applications/memcached/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/memcached/metadata.yaml
@@ -70,30 +70,15 @@ expected_metrics:
   monitored_resource: gce_instance
   labels: {}
 configuration_options:
-  logs:
-  - type: ""
-    fields:
-    - name: type
-      default: null
-      description: ""
-    - name: include_paths
-      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
-      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
-    - name: exclude_paths
-      default: null
-      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
-    - name: wildcard_refresh_interval
-      default: 60s
-      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
-  - type: apache
+  - type: memcached
     fields:
     - name: type
       default: null
-      description: This value must be apache.
-    - name: server_status_url
-      default: http://localhost:80/server-status?auto
-      description: The URL exposed by the mod_status module.
+      description: memcached.
+    - name: endpoint
+      default: localhost:3306
+      description: The URL, or Unix socket file path, for your Memcached server.
     - name: collection_interval
       default: 60s
       description: A time.Duration value, such as 30s or 5m.

--- a/integration_test/third_party_apps_data/applications/memcached/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/memcached/metadata.yaml
@@ -69,3 +69,32 @@ expected_metrics:
   kind: GAUGE
   monitored_resource: gce_instance
   labels: {}
+configuration_options:
+  logs:
+  - type: ""
+    fields:
+    - name: type
+      default: null
+      description: ""
+    - name: include_paths
+      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  metrics:
+  - type: apache
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache.
+    - name: server_status_url
+      default: http://localhost:80/server-status?auto
+      description: The URL exposed by the mod_status module.
+    - name: collection_interval
+      default: 60s
+      description: A time.Duration value, such as 30s or 5m.
+

--- a/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
@@ -102,14 +102,14 @@ expected_logs:
     description: Object containing one or more key-value pairs for any additional attributes provided
 configuration_options:
   logs:
-  - type: ""
+  - type: "mongodb"
     fields:
     - name: type
       default: null
-      description: ""
+      description: "This value must be mongodb."
     - name: include_paths
-      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
-      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+      default: '[/var/log/mongodb/mongod.log*]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/mongodb/*.log.
     - name: exclude_paths
       default: null
       description: A list of filesystem path patterns to exclude from the set matched by include_paths.
@@ -117,15 +117,35 @@ configuration_options:
       default: 60s
       description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
-  - type: apache
+  - type: mongodb
     fields:
     - name: type
       default: null
-      description: This value must be apache.
-    - name: server_status_url
-      default: http://localhost:80/server-status?auto
-      description: The URL exposed by the mod_status module.
+      description: This value must be mongodb.
+    - name: endpoint
+      default: 	http://localhost:27017
+      description: The hostname, IP address, or UNIX domain socket. A port can be specified like <hostname>:<port>. If no port is specified the default 27017 will be used.
     - name: collection_interval
       default: 60s
       description: A time.Duration value, such as 30s or 5m.
-
+    - name: username
+      default: null
+      description: Username for authentication with the MongoDB instance. Required if password is set.
+    - name: password
+      default: null
+      description: Password for authentication with the MongoDB instance. Required if username is set.
+    - name: insecure
+      default: true
+      description: Sets whether or not to use a secure TLS connection. If set to false, then TLS is enabled.
+    - name: insecure_skip_verify
+      default: false
+      description: Sets whether or not to skip verifying the certificate. If insecure is set to true, then the insecure_skip_verify value is not used.
+    - name: cert_file
+      default: null
+      description: Path to the TLS certificate to use for mTLS-required connections.
+    - name: key_file
+      default: null
+      description: Path to the TLS key to use for mTLS-required connections.
+    - name: ca_file
+      default: null
+      description: Path to the CA certificate. As a client, this verifies the server certificate. If empty, the receiver uses the system root CA.

--- a/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
@@ -102,11 +102,11 @@ expected_logs:
     description: Object containing one or more key-value pairs for any additional attributes provided
 configuration_options:
   logs:
-  - type: "mongodb"
+  - type: mongodb
     fields:
     - name: type
       default: null
-      description: "This value must be mongodb."
+      description: This value must be mongodb.
     - name: include_paths
       default: '[/var/log/mongodb/mongod.log*]'
       description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/mongodb/*.log.

--- a/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
@@ -100,3 +100,32 @@ expected_logs:
   - name: jsonPayload.attributes
     type: object (optional)
     description: Object containing one or more key-value pairs for any additional attributes provided
+configuration_options:
+  logs:
+  - type: ""
+    fields:
+    - name: type
+      default: null
+      description: ""
+    - name: include_paths
+      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  metrics:
+  - type: apache
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache.
+    - name: server_status_url
+      default: http://localhost:80/server-status?auto
+      description: The URL exposed by the mod_status module.
+    - name: collection_interval
+      default: 60s
+      description: A time.Duration value, such as 30s or 5m.
+

--- a/integration_test/third_party_apps_data/applications/mssql/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mssql/metadata.yaml
@@ -30,30 +30,12 @@ expected_metrics:
   monitored_resource: gce_instance
   labels: {}
 configuration_options:
-  logs:
-  - type: ""
-    fields:
-    - name: type
-      default: null
-      description: ""
-    - name: include_paths
-      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
-      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
-    - name: exclude_paths
-      default: null
-      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
-    - name: wildcard_refresh_interval
-      default: 60s
-      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
-  - type: apache
+  - type: mssql
     fields:
     - name: type
       default: null
-      description: This value must be apache.
-    - name: server_status_url
-      default: http://localhost:80/server-status?auto
-      description: The URL exposed by the mod_status module.
+      description: This value must be mssql.
     - name: collection_interval
       default: 60s
       description: A time.Duration value, such as 30s or 5m.

--- a/integration_test/third_party_apps_data/applications/mssql/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mssql/metadata.yaml
@@ -29,3 +29,32 @@ expected_metrics:
   kind: GAUGE
   monitored_resource: gce_instance
   labels: {}
+configuration_options:
+  logs:
+  - type: ""
+    fields:
+    - name: type
+      default: null
+      description: ""
+    - name: include_paths
+      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  metrics:
+  - type: apache
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache.
+    - name: server_status_url
+      default: http://localhost:80/server-status?auto
+      description: The URL exposed by the mod_status module.
+    - name: collection_interval
+      default: 60s
+      description: A time.Duration value, such as 30s or 5m.
+

--- a/integration_test/third_party_apps_data/applications/mysql/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mysql/metadata.yaml
@@ -261,11 +261,11 @@ expected_logs:
     description: 'The statement execution end time'
 configuration_options:
   logs:
-  - type: "mysql_error"
+  - type: mysql_error
     fields:
     - name: type
       default: null
-      description: "This value must be mysql_error."
+      description: This value must be mysql_error.
     - name: include_paths
       default: '[/var/log/mysqld.log, /var/log/mysql/mysqld.log, /var/log/mysql/error.log]'
       description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/mysql/*.log.
@@ -275,11 +275,11 @@ configuration_options:
     - name: wildcard_refresh_interval
       default: 60s
       description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
-  - type: "mysql_general"
+  - type: mysql_general
     fields:
     - name: type
       default: null
-      description: "This value must be mysql_general."
+      description: This value must be mysql_general.
     - name: include_paths
       default: '[/var/lib/mysql/${HOSTNAME}.log]'
       description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
@@ -289,11 +289,11 @@ configuration_options:
     - name: wildcard_refresh_interval
       default: 60s
       description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
-  - type: "mysql_slow"
+  - type: mysql_slow
     fields:
     - name: type
       default: null
-      description: "This value must be mysql_slow."
+      description: This value must be mysql_slow.
     - name: include_paths
       default: '[/var/lib/mysql/${HOSTNAME}-slow.log]'
       description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.

--- a/integration_test/third_party_apps_data/applications/mysql/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mysql/metadata.yaml
@@ -259,3 +259,32 @@ expected_logs:
   - name: jsonPayload.endTime
     type: string
     description: 'The statement execution end time'
+configuration_options:
+  logs:
+  - type: ""
+    fields:
+    - name: type
+      default: null
+      description: ""
+    - name: include_paths
+      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  metrics:
+  - type: apache
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache.
+    - name: server_status_url
+      default: http://localhost:80/server-status?auto
+      description: The URL exposed by the mod_status module.
+    - name: collection_interval
+      default: 60s
+      description: A time.Duration value, such as 30s or 5m.
+

--- a/integration_test/third_party_apps_data/applications/mysql/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mysql/metadata.yaml
@@ -261,14 +261,42 @@ expected_logs:
     description: 'The statement execution end time'
 configuration_options:
   logs:
-  - type: ""
+  - type: "mysql_error"
     fields:
     - name: type
       default: null
-      description: ""
+      description: "This value must be mysql_error."
     - name: include_paths
-      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
-      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+      default: '[/var/log/mysqld.log, /var/log/mysql/mysqld.log, /var/log/mysql/error.log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/mysql/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  - type: "mysql_general"
+    fields:
+    - name: type
+      default: null
+      description: "This value must be mysql_general."
+    - name: include_paths
+      default: '[/var/lib/mysql/${HOSTNAME}.log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  - type: "mysql_slow"
+    fields:
+    - name: type
+      default: null
+      description: "This value must be mysql_slow."
+    - name: include_paths
+      default: '[/var/lib/mysql/${HOSTNAME}-slow.log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
     - name: exclude_paths
       default: null
       description: A list of filesystem path patterns to exclude from the set matched by include_paths.
@@ -276,15 +304,20 @@ configuration_options:
       default: 60s
       description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
-  - type: apache
+  - type: mysql
     fields:
     - name: type
       default: null
-      description: This value must be apache.
-    - name: server_status_url
-      default: http://localhost:80/server-status?auto
-      description: The URL exposed by the mod_status module.
+      description: 	This value must be mysql.
+    - name: stub_status_url
+      default: localhost:3306
+      description: The url exposed by MySQL.
+    - name: username
+      default: null
+      description: The username used to connect to the server.
+    - name: password
+      default: null
+      description: The password used to connect to the server.
     - name: collection_interval
       default: 60s
       description: A time.Duration value, such as 30s or 5m.
-

--- a/integration_test/third_party_apps_data/applications/nginx/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/nginx/metadata.yaml
@@ -183,14 +183,28 @@ expected_logs:
     description: Referer header (optional)
 configuration_options:
   logs:
-  - type: ""
+  - type: "nginx_access"
     fields:
     - name: type
       default: null
-      description: ""
+      description: "The value must be nginx_access."
     - name: include_paths
-      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
-      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+      default: '[/var/log/nginx/access.log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  - type: "nginx_error"
+    fields:
+    - name: type
+      default: null
+      description: "The value must be nginx_error."
+    - name: include_paths
+      default: '[/var/log/nginx/error.log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
     - name: exclude_paths
       default: null
       description: A list of filesystem path patterns to exclude from the set matched by include_paths.
@@ -198,14 +212,14 @@ configuration_options:
       default: 60s
       description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
-  - type: apache
+  - type: nginx
     fields:
     - name: type
       default: null
-      description: This value must be apache.
+      description: This value must be nginx.
     - name: server_status_url
-      default: http://localhost:80/server-status?auto
-      description: The URL exposed by the mod_status module.
+      default: http://localhost/status
+      description: The URL exposed by the nginx stub status module.
     - name: collection_interval
       default: 60s
       description: A time.Duration value, such as 30s or 5m.

--- a/integration_test/third_party_apps_data/applications/nginx/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/nginx/metadata.yaml
@@ -181,3 +181,32 @@ expected_logs:
   - name: jsonPayload.referer
     type: string
     description: Referer header (optional)
+configuration_options:
+  logs:
+  - type: ""
+    fields:
+    - name: type
+      default: null
+      description: ""
+    - name: include_paths
+      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  metrics:
+  - type: apache
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache.
+    - name: server_status_url
+      default: http://localhost:80/server-status?auto
+      description: The URL exposed by the mod_status module.
+    - name: collection_interval
+      default: 60s
+      description: A time.Duration value, such as 30s or 5m.
+

--- a/integration_test/third_party_apps_data/applications/nginx/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/nginx/metadata.yaml
@@ -183,11 +183,11 @@ expected_logs:
     description: Referer header (optional)
 configuration_options:
   logs:
-  - type: "nginx_access"
+  - type: nginx_access
     fields:
     - name: type
       default: null
-      description: "The value must be nginx_access."
+      description: The value must be nginx_access.
     - name: include_paths
       default: '[/var/log/nginx/access.log]'
       description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
@@ -201,7 +201,7 @@ configuration_options:
     fields:
     - name: type
       default: null
-      description: "The value must be nginx_error."
+      description: The value must be nginx_error.
     - name: include_paths
       default: '[/var/log/nginx/error.log]'
       description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.

--- a/integration_test/third_party_apps_data/applications/postgresql/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/postgresql/metadata.yaml
@@ -64,11 +64,11 @@ expected_logs:
     description: Authenticated user for the action being logged when relevant
 configuration_options:
   logs:
-  - type: "postgresql_general"
+  - type: postgresql_general
     fields:
     - name: type
       default: null
-      description: "The value must be postgresql_general."
+      description: The value must be postgresql_general.
     - name: include_paths
       default: '[/var/log/postgresql/postgresql*.log, /var/lib/pgsql/data/log/postgresql*.log, /var/lib/pgsql/*/data/log/postgresql*.log]'
       description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.

--- a/integration_test/third_party_apps_data/applications/postgresql/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/postgresql/metadata.yaml
@@ -64,14 +64,14 @@ expected_logs:
     description: Authenticated user for the action being logged when relevant
 configuration_options:
   logs:
-  - type: ""
+  - type: "postgresql_general"
     fields:
     - name: type
       default: null
-      description: ""
+      description: "The value must be postgresql_general."
     - name: include_paths
-      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
-      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+      default: '[/var/log/postgresql/postgresql*.log, /var/lib/pgsql/data/log/postgresql*.log, /var/lib/pgsql/*/data/log/postgresql*.log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
     - name: exclude_paths
       default: null
       description: A list of filesystem path patterns to exclude from the set matched by include_paths.
@@ -79,15 +79,35 @@ configuration_options:
       default: 60s
       description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
-  - type: apache
+  - type: postgresql
     fields:
     - name: type
       default: null
-      description: This value must be apache.
-    - name: server_status_url
-      default: http://localhost:80/server-status?auto
-      description: The URL exposed by the mod_status module.
+      description: This value must be postgresql.
+    - name: endpoint
+      default: /var/run/postgresql/.s.PGSQL.5432
+      description: The hostname:port or socket path starting with / used to connect to the postgresql server.
     - name: collection_interval
       default: 60s
       description: A time.Duration value, such as 30s or 5m.
-
+    - name: username
+      default: null
+      description: The username used to connect to the server.
+    - name: password
+      default: null
+      description: The password used to connect to the server.
+    - name: insecure
+      default: true
+      description: Sets whether or not to use a secure TLS connection. If set to false, then TLS is enabled.
+    - name: insecure_skip_verify
+      default: false
+      description: Sets whether or not to skip verifying the certificate. If insecure is set to true, then the insecure_skip_verify value is not used.
+    - name: cert_file
+      default: null
+      description: Path to the TLS certificate to use for mTLS-required connections.
+    - name: key_file
+      default: null
+      description: Path to the TLS key to use for mTLS-required connections.
+    - name: ca_file
+      default: null
+      description: Path to the CA certificate. As a client, this verifies the server certificate. If empty, the receiver uses the system root CA.

--- a/integration_test/third_party_apps_data/applications/postgresql/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/postgresql/metadata.yaml
@@ -62,3 +62,32 @@ expected_logs:
   - name: jsonPayload.user
     type: string
     description: Authenticated user for the action being logged when relevant
+configuration_options:
+  logs:
+  - type: ""
+    fields:
+    - name: type
+      default: null
+      description: ""
+    - name: include_paths
+      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  metrics:
+  - type: apache
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache.
+    - name: server_status_url
+      default: http://localhost:80/server-status?auto
+      description: The URL exposed by the mod_status module.
+    - name: collection_interval
+      default: 60s
+      description: A time.Duration value, such as 30s or 5m.
+

--- a/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
@@ -35,3 +35,32 @@ expected_logs:
   - name: jsonPayload.message
     type: string
     description: Log message
+configuration_options:
+  logs:
+  - type: ""
+    fields:
+    - name: type
+      default: null
+      description: ""
+    - name: include_paths
+      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  metrics:
+  - type: apache
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache.
+    - name: server_status_url
+      default: http://localhost:80/server-status?auto
+      description: The URL exposed by the mod_status module.
+    - name: collection_interval
+      default: 60s
+      description: A time.Duration value, such as 30s or 5m.
+

--- a/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
@@ -37,14 +37,14 @@ expected_logs:
     description: Log message
 configuration_options:
   logs:
-  - type: ""
+  - type: rabbitmq
     fields:
     - name: type
       default: null
-      description: ""
+      description: This value must be rabbitmq.
     - name: include_paths
-      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
-      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+      default: '[var/log/rabbitmq/rabbit*.log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/rabbitmq/*.log.
     - name: exclude_paths
       default: null
       description: A list of filesystem path patterns to exclude from the set matched by include_paths.
@@ -52,15 +52,35 @@ configuration_options:
       default: 60s
       description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
-  - type: apache
+  - type: rabbitmq
     fields:
     - name: type
       default: null
-      description: This value must be apache.
-    - name: server_status_url
-      default: http://localhost:80/server-status?auto
-      description: The URL exposed by the mod_status module.
+      description: This value must be rabbbitmq.
+    - name: endpoint
+      default: http://localhost:15672
+      description: The URL of the node to monitor.
     - name: collection_interval
       default: 60s
       description: A time.Duration value, such as 30s or 5m.
-
+    - name: username
+      default: null
+      description: The username used to connect to the server.
+    - name: password
+      default: null
+      description: The password used to connect to the server.
+    - name: insecure
+      default: true
+      description: Sets whether or not to use a secure TLS connection. If set to false, then TLS is enabled.
+    - name: insecure_skip_verify
+      default: false
+      description: Sets whether or not to skip verifying the certificate. If insecure is set to true, then the insecure_skip_verify value is not used.
+    - name: cert_file
+      default: null
+      description: Path to the TLS certificate to use for mTLS-required connections.
+    - name: key_file
+      default: null
+      description: Path to the TLS key to use for mTLS-required connections.
+    - name: ca_file
+      default: null
+      description: Path to the CA certificate. As a client, this verifies the server certificate. If empty, the receiver uses the system root CA.

--- a/integration_test/third_party_apps_data/applications/redis/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/redis/metadata.yaml
@@ -161,14 +161,14 @@ expected_logs:
     description: Process ID
 configuration_options:
   logs:
-  - type: ""
+  - type: redis
     fields:
     - name: type
       default: null
-      description: ""
+      description: This value must be redis.
     - name: include_paths
-      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
-      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+      default: '[/var/log/redis/redis-server.log, /var/log/redis_6379.log, /var/log/redis/redis.log, /var/log/redis/default.log, /var/log/redis/redis_6379.log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/redis/*.log.
     - name: exclude_paths
       default: null
       description: A list of filesystem path patterns to exclude from the set matched by include_paths.
@@ -176,15 +176,32 @@ configuration_options:
       default: 60s
       description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
-  - type: apache
+  - type: redis
     fields:
     - name: type
       default: null
-      description: This value must be apache.
-    - name: server_status_url
-      default: http://localhost:80/server-status?auto
-      description: The URL exposed by the mod_status module.
+      description: This value must be redis.
+    - name: address
+      default: localhost:6379
+      description: The URL exposed by Redis.
     - name: collection_interval
       default: 60s
       description: A time.Duration value, such as 30s or 5m.
-
+    - name: password
+      default: null
+      description: The password used to connect to the server.
+    - name: insecure
+      default: true
+      description: Sets whether or not to use a secure TLS connection. If set to false, then TLS is enabled.
+    - name: insecure_skip_verify
+      default: false
+      description: Sets whether or not to skip verifying the certificate. If insecure is set to true, then the insecure_skip_verify value is not used.
+    - name: cert_file
+      default: null
+      description: Path to the TLS certificate to use for mTLS-required connections.
+    - name: key_file
+      default: null
+      description: Path to the TLS key to use for mTLS-required connections.
+    - name: ca_file
+      default: null
+      description: Path to the CA certificate. As a client, this verifies the server certificate. If empty, the receiver uses the system root CA.

--- a/integration_test/third_party_apps_data/applications/redis/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/redis/metadata.yaml
@@ -159,3 +159,32 @@ expected_logs:
   - name: jsonPayload.pid
     type: number
     description: Process ID
+configuration_options:
+  logs:
+  - type: ""
+    fields:
+    - name: type
+      default: null
+      description: ""
+    - name: include_paths
+      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  metrics:
+  - type: apache
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache.
+    - name: server_status_url
+      default: http://localhost:80/server-status?auto
+      description: The URL exposed by the mod_status module.
+    - name: collection_interval
+      default: 60s
+      description: A time.Duration value, such as 30s or 5m.
+

--- a/integration_test/third_party_apps_data/applications/solr/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/solr/metadata.yaml
@@ -145,14 +145,14 @@ expected_logs:
     description: Exception related to the log, including detailed stacktrace where provided
 configuration_options:
   logs:
-  - type: ""
+  - type: solr_system
     fields:
     - name: type
       default: null
-      description: ""
+      description: The value must be solr_system.
     - name: include_paths
-      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
-      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+      default: '[/var/solr/logs/solr.log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
     - name: exclude_paths
       default: null
       description: A list of filesystem path patterns to exclude from the set matched by include_paths.
@@ -160,15 +160,20 @@ configuration_options:
       default: 60s
       description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
-  - type: apache
+  - type: solr
     fields:
     - name: type
       default: null
-      description: This value must be apache.
-    - name: server_status_url
-      default: http://localhost:80/server-status?auto
-      description: The URL exposed by the mod_status module.
+      description: This value must be solr.
+    - name: endpoint
+      default: localhost:18983
+      description: The JMX Service URL or host and port used to construct the Service URL. Must be in the form of host:port. Values in host:port form will be used to create a Service URL of service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi.
+    - name: username
+      default: null
+      description: The configured username if JMX is configured to require authentication..
+    - name: password
+      default: null
+      description: The configured password if JMX is configured to require authentication.
     - name: collection_interval
       default: 60s
       description: A time.Duration value, such as 30s or 5m.
-

--- a/integration_test/third_party_apps_data/applications/solr/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/solr/metadata.yaml
@@ -143,3 +143,32 @@ expected_logs:
   - name: jsonPayload.exception
     type: string
     description: Exception related to the log, including detailed stacktrace where provided
+configuration_options:
+  logs:
+  - type: ""
+    fields:
+    - name: type
+      default: null
+      description: ""
+    - name: include_paths
+      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  metrics:
+  - type: apache
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache.
+    - name: server_status_url
+      default: http://localhost:80/server-status?auto
+      description: The URL exposed by the mod_status module.
+    - name: collection_interval
+      default: 60s
+      description: A time.Duration value, such as 30s or 5m.
+

--- a/integration_test/third_party_apps_data/applications/tomcat/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/tomcat/metadata.yaml
@@ -119,14 +119,28 @@ expected_logs:
     description: Authenticated username for the request
 configuration_options:
   logs:
-  - type: ""
+  - type: tomcat_system
     fields:
     - name: type
       default: null
-      description: ""
+      description: The value must be tomcat_system.
     - name: include_paths
-      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
-      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+      default: '[/opt/tomcat/logs/catalina.out]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  - type: tomcat_access
+    fields:
+    - name: type
+      default: null
+      description: The value must be tomcat_access.
+    - name: include_paths
+      default: '[/opt/tomcat/logs/localhost_access_log.*.txt]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
     - name: exclude_paths
       default: null
       description: A list of filesystem path patterns to exclude from the set matched by include_paths.
@@ -134,15 +148,23 @@ configuration_options:
       default: 60s
       description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
-  - type: apache
+  - type: tomcat
     fields:
     - name: type
       default: null
-      description: This value must be apache.
-    - name: server_status_url
-      default: http://localhost:80/server-status?auto
-      description: The URL exposed by the mod_status module.
+      description: 	This value must be tomcat.
+    - name: endpoint
+      default: localhost:8050
+      description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of service:jmx:<protocol>:<sap> or host:port. Values in host:port form are used to create a service URL of service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi.
+    - name: collect_jvm_metrics
+      default: true
+      description: Configures the receiver to also collect the supported JVM metrics.
+    - name: username
+      default: null
+      description: The configured username if JMX is configured to require authentication.
+    - name: password
+      default: null
+      description: The configured password if JMX is configured to require authentication.
     - name: collection_interval
       default: 60s
       description: A time.Duration value, such as 30s or 5m.
-

--- a/integration_test/third_party_apps_data/applications/tomcat/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/tomcat/metadata.yaml
@@ -117,3 +117,32 @@ expected_logs:
   - name: jsonPayload.user
     type: string
     description: Authenticated username for the request
+configuration_options:
+  logs:
+  - type: ""
+    fields:
+    - name: type
+      default: null
+      description: ""
+    - name: include_paths
+      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  metrics:
+  - type: apache
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache.
+    - name: server_status_url
+      default: http://localhost:80/server-status?auto
+      description: The URL exposed by the mod_status module.
+    - name: collection_interval
+      default: 60s
+      description: A time.Duration value, such as 30s or 5m.
+

--- a/integration_test/third_party_apps_data/applications/wildfly/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/wildfly/metadata.yaml
@@ -132,3 +132,32 @@ expected_logs:
     value_regex: org.jboss.as
     type: string
     description: Source where the log originated
+configuration_options:
+  logs:
+  - type: ""
+    fields:
+    - name: type
+      default: null
+      description: ""
+    - name: include_paths
+      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  metrics:
+  - type: apache
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache.
+    - name: server_status_url
+      default: http://localhost:80/server-status?auto
+      description: The URL exposed by the mod_status module.
+    - name: collection_interval
+      default: 60s
+      description: A time.Duration value, such as 30s or 5m.
+

--- a/integration_test/third_party_apps_data/applications/wildfly/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/wildfly/metadata.yaml
@@ -134,14 +134,14 @@ expected_logs:
     description: Source where the log originated
 configuration_options:
   logs:
-  - type: ""
+  - type: wildfly_system
     fields:
     - name: type
       default: null
-      description: ""
+      description: The value must be wildfly_system.
     - name: include_paths
-      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
-      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+      default: '[/opt/wildfly/standalone/log/server.log, /opt/wildfly/domain/servers/*/log/server.log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/wildfly*/*.log.
     - name: exclude_paths
       default: null
       description: A list of filesystem path patterns to exclude from the set matched by include_paths.
@@ -149,15 +149,23 @@ configuration_options:
       default: 60s
       description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
-  - type: apache
+  - type: wildfly
     fields:
     - name: type
       default: null
-      description: This value must be apache.
-    - name: server_status_url
-      default: http://localhost:80/server-status?auto
-      description: The URL exposed by the mod_status module.
+      description: 	This value must be wildfly.
+    - name: endpoint
+      default: service:jmx:remote+http://localhost:9990
+      description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of service:jmx:<protocol>:<sap> or host:port. Values in host:port form are used to create a service URL of service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi.
+    - name: username
+      default: null
+      description: The configured username if JMX is configured to require authentication.
+    - name: password
+      default: null
+      description: The configured password if JMX is configured to require authentication.
+    - name: additional_jars
+      default: /opt/wildfly/bin/client/jboss-client.jar
+      description: The path to the jboss-client.jar file, which is required to monitor WildFly through JMX.
     - name: collection_interval
       default: 60s
       description: A time.Duration value, such as 30s or 5m.
-

--- a/integration_test/third_party_apps_data/applications/zookeeper/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/zookeeper/metadata.yaml
@@ -104,3 +104,32 @@ expected_logs:
   - name: jsonPayload.myid
     type: number
     description: Numeric ID of the Zookeeper instance
+configuration_options:
+  logs:
+  - type: ""
+    fields:
+    - name: type
+      default: null
+      description: ""
+    - name: include_paths
+      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+    - name: exclude_paths
+      default: null
+      description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+    - name: wildcard_refresh_interval
+      default: 60s
+      description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+  metrics:
+  - type: apache
+    fields:
+    - name: type
+      default: null
+      description: This value must be apache.
+    - name: server_status_url
+      default: http://localhost:80/server-status?auto
+      description: The URL exposed by the mod_status module.
+    - name: collection_interval
+      default: 60s
+      description: A time.Duration value, such as 30s or 5m.
+

--- a/integration_test/third_party_apps_data/applications/zookeeper/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/zookeeper/metadata.yaml
@@ -106,14 +106,14 @@ expected_logs:
     description: Numeric ID of the Zookeeper instance
 configuration_options:
   logs:
-  - type: ""
+  - type: zookeeper_general
     fields:
     - name: type
       default: null
-      description: ""
+      description: The value must be zookeeper_general.
     - name: include_paths
-      default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
-      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+      default: '[/opt/zookeeper/logs/zookeeper-*.out, /var/log/zookeeper/zookeeper.log]'
+      description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/zookeeper*/*.log.
     - name: exclude_paths
       default: null
       description: A list of filesystem path patterns to exclude from the set matched by include_paths.
@@ -121,14 +121,14 @@ configuration_options:
       default: 60s
       description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
-  - type: apache
+  - type: zookeeper
     fields:
     - name: type
       default: null
-      description: This value must be apache.
-    - name: server_status_url
-      default: http://localhost:80/server-status?auto
-      description: The URL exposed by the mod_status module.
+      description: This value must be zookeeper.
+    - name: endpoint
+      default: localhost:2181
+      description: The URL exposed by ZooKeeper.
     - name: collection_interval
       default: 60s
       description: A time.Duration value, such as 30s or 5m.


### PR DESCRIPTION
This change does the following:
- Adds configuration_options field to metadata.yaml for all 3rd party Application
- Makes this a required field moving forward