### PR TITLE
Workaround for failing couchdb tests

### DIFF
--- a/integration_test/third_party_apps_data/applications/couchdb/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/couchdb/debian_ubuntu/install
@@ -9,7 +9,7 @@ echo "deb [signed-by=/usr/share/keyrings/couchdb-archive-keyring.gpg] https://ap
     | sudo tee /etc/apt/sources.list.d/couchdb.list >/dev/null
 
 sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y couchdb
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y couchdb=3.2.1~focal
 
 cat << EOF > local.ini
 [couchdb]


### PR DESCRIPTION
3.2.2 fails during installation and we're not sure why yet. Until we resolve the failure, pin to 3.2.1 for now to unblock our tests. Filed https://github.com/apache/couchdb/issues/4001 upstream to address the failure.