### PR TITLE
Revert back to old exporter

### DIFF
--- a/cmd/ops_agent_windows/main_windows.go
+++ b/cmd/ops_agent_windows/main_windows.go
@@ -108,7 +108,6 @@ func initServices() error {
 			filepath.Join(base, "google-cloud-metrics-agent_windows_amd64.exe"),
 			[]string{
 				"--config=" + filepath.Join(configOutDir, `otel\otel.yaml`),
-				"--feature-gates=exporter.googlecloud.OTLPDirect",
 			},
 		},
 		{

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -77,13 +77,6 @@ func (uc *UnifiedConfig) GenerateOtelConfig(hostInfo *host.InfoStat) (string, er
 					// NB: If a receiver fails to send a full URL, OT will add the prefix `workload.googleapis.com/{metric_name}`.
 					// TODO(b/197129428): Write a test to make sure this doesn't happen.
 					"prefix": "",
-					// OT calls CreateMetricDescriptor by default. Skip because we want
-					// descriptors to be created implicitly with new time series.
-					"skip_create_descriptor": true,
-					// Omit instrumentation labels, which break agent metrics.
-					"instrumentation_library_labels": false,
-					// Omit service labels, which break agent metrics.
-					"service_resource_labels": false,
 				},
 			},
 		},

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/windows/logging-receiver_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_iis/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
@@ -1,10 +1,7 @@
 exporters:
   googlecloud:
     metric:
-      instrumentation_library_labels: false
       prefix: ""
-      service_resource_labels: false
-      skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/default__pipeline_hostmetrics_0:

--- a/systemd/google-cloud-ops-agent-opentelemetry-collector.service
+++ b/systemd/google-cloud-ops-agent-opentelemetry-collector.service
@@ -24,7 +24,7 @@ StateDirectory=google-cloud-ops-agent/opentelemetry-collector
 LogsDirectory=google-cloud-ops-agent/subagents
 Type=simple
 ExecStartPre=@PREFIX@/libexec/google_cloud_ops_agent_engine -service=otel -in @SYSCONFDIR@/google-cloud-ops-agent/config.yaml -logs ${LOGS_DIRECTORY}
-ExecStart=@PREFIX@/subagents/opentelemetry-collector/otelopscol --config=${RUNTIME_DIRECTORY}/otel.yaml --feature-gates=exporter.googlecloud.OTLPDirect
+ExecStart=@PREFIX@/subagents/opentelemetry-collector/otelopscol --config=${RUNTIME_DIRECTORY}/otel.yaml
 Restart=always
 # For debugging:
 RuntimeDirectoryPreserve=yes


### PR DESCRIPTION
We need the ability to skip CreateMetricDescriptor for system metrics only, which we can't feasibly do with the new exporter. Reverting back to the old exporter until we come up with a plan.