### PR TITLE
Also skip "sqlserver" tests on non-SQL windows

### DIFF
--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -113,6 +113,7 @@ func appsToTest(platform string) ([]string, error) {
 	}
 	if gce.IsWindows(platform) && !strings.HasPrefix(platform, "sql-") {
 		apps = removeFromSlice(apps, "mssql")
+		apps = removeFromSlice(apps, "sqlserver")
 	}
 	return apps, nil
 }


### PR DESCRIPTION
This is to prepare for https://github.com/GoogleCloudPlatform/ops-agent/pull/542, which adds a new application called sqlserver. I think we want to skip that application on vanilla windows, like windows-2019, right?

PS this PR maybe should be part of https://github.com/GoogleCloudPlatform/ops-agent/pull/542, but separately like this is fine too.