### PR TITLE
metadata: add configuration_options for varnish and add validation

### DIFF
--- a/integration_test/third_party_apps_data/applications/varnish/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/varnish/metadata.yaml
@@ -64,3 +64,20 @@ expected_metrics:
   labels:
     operation: .*
 expected_logs:
+configuration_options:
+  metrics:
+  - type: varnish
+    fields:
+    - name: type
+      default: null
+      description: This value must be varnish.
+    - name: cache_dir
+      default: null
+      description: This specifies the cache dir instance name to use when collecting metrics. If not specified, this will default to the host. 
+    - name: exec_dir
+      default: null
+      description: The directory where the varnishadm and varnishstat executables are located. If not provided, will default to relying on the executables being in the user's PATH.
+    - name: collection_interval
+      default: 60s
+      description: A time.Duration value, such as 30s or 5m.
+

--- a/integration_test/third_party_apps_data/applications/varnish/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/varnish/metadata.yaml
@@ -1,5 +1,15 @@
 short_name: varnish
 long_name: Varnish HTTP Cache
+description: |-
+  The Varnish integration collects cache and session metrics.
+  It monitors the number of objects entering and exiting the cache,
+  as well as the number of sessions and backend connections.
+  The integration also collects Varnish access logs and parses them
+  into a standardized json payload.
+
+  For more information about Varnish, see
+  [Varnish HTTP Cache](https://varnish-cache.org/).
+supported_app_version: ["6.x", "7.0.x"]
 expected_metrics:
 - type: workload.googleapis.com/varnish.backend.connection.count
   value_type: INT64
@@ -63,7 +73,6 @@ expected_metrics:
   monitored_resource: gce_instance
   labels:
     operation: .*
-expected_logs:
 configuration_options:
   metrics:
   - type: varnish
@@ -80,4 +89,3 @@ configuration_options:
     - name: collection_interval
       default: 60s
       description: A time.Duration value, such as 30s or 5m.
-

--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/integration_test/common"
 	"github.com/GoogleCloudPlatform/ops-agent/integration_test/gce"
 	"github.com/GoogleCloudPlatform/ops-agent/integration_test/logging"
+	"github.com/go-playground/validator/v10"
 
 	"go.uber.org/multierr"
 	"gopkg.in/yaml.v2"
@@ -377,6 +378,12 @@ func runSingleTest(ctx context.Context, logger *logging.DirectoryLogger, vm *gce
 			return nonRetryable, fmt.Errorf("could not unmarshal contents of metadata.yaml: %v", err)
 		}
 		logger.ToMainLog().Printf("Parsed metadata.yaml: %+v", metadata)
+	}
+
+	// Validate the metadata.
+	validate := validator.New()
+	if err = validate.Struct(metadata); err != nil {
+		return nonRetryable, err
 	}
 
 	if metadata.RestartAfterInstall {

--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -50,7 +50,6 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/integration_test/common"
 	"github.com/GoogleCloudPlatform/ops-agent/integration_test/gce"
 	"github.com/GoogleCloudPlatform/ops-agent/integration_test/logging"
-	"github.com/go-playground/validator/v10"
 
 	"go.uber.org/multierr"
 	"gopkg.in/yaml.v2"
@@ -378,12 +377,6 @@ func runSingleTest(ctx context.Context, logger *logging.DirectoryLogger, vm *gce
 			return nonRetryable, fmt.Errorf("could not unmarshal contents of metadata.yaml: %v", err)
 		}
 		logger.ToMainLog().Printf("Parsed metadata.yaml: %+v", metadata)
-	}
-
-	// Validate the metadata.
-	validate := validator.New()
-	if err = validate.Struct(metadata); err != nil {
-		return nonRetryable, err
 	}
 
 	if metadata.RestartAfterInstall {


### PR DESCRIPTION
This change adds in the configuration option for Varnish and adds validation enforcement for new receivers.