### PR TITLE
Enforce metadata.yaml validations

### DIFF
--- a/integration_test/cmd/generate_expected_metrics/generate_expected_metrics.go
+++ b/integration_test/cmd/generate_expected_metrics/generate_expected_metrics.go
@@ -208,7 +208,7 @@ func readExpectedMetrics(app string) (expectedMetricsMap, error) {
 	metricsByType := make(expectedMetricsMap)
 	expectedMetrics := metadata.ExpectedMetrics
 	for _, m := range expectedMetrics {
-		m := m
+		m := *m
 		if _, ok := metricsByType[m.Type]; ok {
 			return nil, fmt.Errorf("duplicate expected_metrics type in %s/metadata.yaml: %s", app, m.Type)
 		}
@@ -225,9 +225,9 @@ func writeExpectedMetrics(app string, metrics expectedMetricsMap) error {
 	if err != nil {
 		return err
 	}
-	expectedMetrics := make([]common.ExpectedMetric, 0)
+	expectedMetrics := make([]*common.ExpectedMetric, 0)
 	for _, m := range metrics {
-		expectedMetrics = append(expectedMetrics, m)
+		expectedMetrics = append(expectedMetrics, &m)
 	}
 	sort.Slice(expectedMetrics, func(i, j int) bool { return expectedMetrics[i].Type < expectedMetrics[j].Type })
 	metadata.ExpectedMetrics = expectedMetrics

--- a/integration_test/common/common.go
+++ b/integration_test/common/common.go
@@ -19,7 +19,6 @@ package common
 import (
 	"fmt"
 
-	"github.com/go-playground/validator/v10"
 	"go.uber.org/multierr"
 )
 
@@ -39,28 +38,28 @@ type ExpectedMetric struct {
 	// Patterns are RE2 regular expressions.
 	Labels map[string]string `yaml:"labels" validate:"required"`
 	// If Optional is true, the test for this metric will be skipped.
-	Optional bool `yaml:"optional,omitempty" validate:"excluded_with=Representative"`
+	Optional bool `yaml:"optional" validate:"excluded_with=Representative"`
 	// Exactly one metric in each expected_metrics.yaml must
 	// have Representative set to true. This metric can be used
 	// to test that the integration is enabled.
-	Representative bool `yaml:"representative,omitempty" validate:"excluded_with=Optional"`
+	Representative bool `yaml:"representative" validate:"excluded_with=Optional"`
 }
 
 type LogFields struct {
 	Name        string `yaml:"name" validate:"required"`
-	ValueRegex  string `yaml:"value_regex,omitempty"`
+	ValueRegex  string `yaml:"value_regex"`
 	Type        string `yaml:"type" validate:"required"`
 	Description string `yaml:"description" validate:"required"`
 }
 
 type ExpectedLog struct {
-	LogName string      `yaml:"log_name" validate:"required"`
-	Fields  []LogFields `yaml:"fields" validate:"required"`
+	LogName string       `yaml:"log_name" validate:"required"`
+	Fields  []*LogFields `yaml:"fields" validate:"required"`
 }
 
 type MinimumSupportedAgentVersion struct {
-	Logging string `yaml:"logging,omitempty"`
-	Metrics string `yaml:"metrics,omitempty"`
+	Logging string `yaml:"logging"`
+	Metrics string `yaml:"metrics"`
 }
 
 type ConfigurationFields struct {
@@ -70,43 +69,33 @@ type ConfigurationFields struct {
 }
 
 type InputConfiguration struct {
-	Type   string                `yaml:"type" validate:"required"`
-	Fields []ConfigurationFields `yaml:"fields" validate:"required"`
+	Type   string                 `yaml:"type" validate:"required"`
+	Fields []*ConfigurationFields `yaml:"fields" validate:"required"`
 }
 
 type ConfigurationOptions struct {
-	LogsConfiguration    []InputConfiguration `yaml:"logs"`
-	MetricsConfiguration []InputConfiguration `yaml:"metrics"`
+	LogsConfiguration    []*InputConfiguration `yaml:"logs" validate:"required_without=MetricsConfiguration"`
+	MetricsConfiguration []*InputConfiguration `yaml:"metrics" validate:"required_without=LogsConfiguration"`
 }
 
 type IntegrationMetadata struct {
-	PublicUrl                    string                       `yaml:"public_url,omitempty"`
+	PublicUrl                    string                       `yaml:"public_url"`
 	ShortName                    string                       `yaml:"short_name" validate:"required"`
 	LongName                     string                       `yaml:"long_name" validate:"required"`
 	Description                  string                       `yaml:"description" validate:"required"`
-	ConfigureIntegration         string                       `yaml:"configure_integration,omitempty"`
-	ExpectedLogs                 []ExpectedLog                `yaml:"expected_logs,omitempty"`
-	ExpectedMetrics              []ExpectedMetric             `yaml:"expected_metrics,omitempty"`
-	MinimumSupportedAgentVersion MinimumSupportedAgentVersion `yaml:"minimum_supported_agent_version,omitempty"`
-	SupportedAppVersion          []string                     `yaml:"supported_app_version" validate:"required"`
-	ConfigurationOptions         ConfigurationOptions         `yaml:"configuration_options" validate:"required"`
-	RestartAfterInstall          bool                         `yaml:"restart_after_install,omitempty"`
+	ConfigurationOptions         *ConfigurationOptions        `yaml:"configuration_options" validate:"required"`
+	ConfigureIntegration         string                       `yaml:"configure_integration"`
+	ExpectedLogs                 []*ExpectedLog               `yaml:"expected_logs"`
+	ExpectedMetrics              []*ExpectedMetric            `yaml:"expected_metrics"`
+	MinimumSupportedAgentVersion MinimumSupportedAgentVersion `yaml:"minimum_supported_agent_version"`
+	SupportedAppVersion          []string                     `yaml:"supported_app_version" validate:"required,unique,min=1"`
+	RestartAfterInstall          bool                         `yaml:"restart_after_install"`
 }
-
-var validate *validator.Validate
 
 // ValidateMetrics checks that all enum fields have valid values and that
 // there is exactly one representative metric in the slice.
-func ValidateMetrics(metrics []ExpectedMetric) error {
+func ValidateMetrics(metrics []*ExpectedMetric) error {
 	var err error
-
-	// Field validation, one-by-one for better error messages
-	for _, m := range metrics {
-		vErr := validate.Struct(m)
-		if vErr != nil {
-			err = multierr.Append(err, fmt.Errorf("%s: %v", m.Type, vErr))
-		}
-	}
 
 	// Representative validation
 	representativeCount := 0
@@ -128,8 +117,4 @@ func SliceContains(slice []string, toFind string) bool {
 		}
 	}
 	return false
-}
-
-func init() {
-	validate = validator.New()
 }

--- a/integration_test/third_party_apps_data/applications/varnish/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/varnish/metadata.yaml
@@ -82,7 +82,7 @@ configuration_options:
       description: This value must be varnish.
     - name: cache_dir
       default: null
-      description: This specifies the cache dir instance name to use when collecting metrics. If not specified, this will default to the host. 
+      description: This specifies the cache dir instance name to use when collecting metrics. If not specified, this will default to the host.
     - name: exec_dir
       default: null
       description: The directory where the varnishadm and varnishstat executables are located. If not provided, will default to relying on the executables being in the user's PATH.


### PR DESCRIPTION
Test Evidence with [varnish metadata.yaml](https://github.com/GoogleCloudPlatform/ops-agent/blob/b31172323743f23177c5ab605fc9c33425041f34/integration_test/third_party_apps_data/applications/varnish/metadata.yaml#L1)
```
2022/04/28 14:07:24 impacted apps: map[]
=== RUN   TestThirdPartyApps/debian-10/varnish
=== PAUSE TestThirdPartyApps/debian-10/varnish
=== CONT  TestThirdPartyApps/debian-10/varnish
    third_party_apps_test.go:566: Test logs: /tmp/731947741/TestThirdPartyApps_debian-10_varnish
    third_party_apps_test.go:568: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F3255385600635136305&project=stackdriver-kubernetes-1337
2022/04/28 14:07:55 Attempt 1 of debian-10 test of varnish finished with err=could not validate contents of metadata.yaml: Key: 'IntegrationMetadata.Description' Error:Field validation for 'Description' failed on the 'required' tag
Key: 'IntegrationMetadata.ConfigurationOptions' Error:Field validation for 'ConfigurationOptions' failed on the 'required' tag
Key: 'IntegrationMetadata.SupportedAppVersion' Error:Field validation for 'SupportedAppVersion' failed on the 'required' tag, retryable=false
    third_party_apps_test.go:579: Non-retryable error: could not validate contents of metadata.yaml: Key: 'IntegrationMetadata.Description' Error:Field validation for 'Description' failed on the 'required' tag
        Key: 'IntegrationMetadata.ConfigurationOptions' Error:Field validation for 'ConfigurationOptions' failed on the 'required' tag
        Key: 'IntegrationMetadata.SupportedAppVersion' Error:Field validation for 'SupportedAppVersion' failed on the 'required' tag
--- FAIL: TestThirdPartyApps (0.02s)
    --- FAIL: TestThirdPartyApps/debian-10/varnish (55.26s)
FAIL
FAIL	command-line-arguments	55.568s
FAIL
```