### PR TITLE
Prototype implementation for multiple exporters

### DIFF
--- a/apps/apache.go
+++ b/apps/apache.go
@@ -57,6 +57,7 @@ func (r MetricsReceiverApache) Pipelines() []otel.Pipeline {
 				otel.AddPrefix("workload.googleapis.com"),
 			),
 		},
+		Exporter: otel.ExporterKindCustom,
 	}}
 }
 

--- a/apps/hostmetrics.go
+++ b/apps/hostmetrics.go
@@ -299,6 +299,7 @@ func (r MetricsReceiverHostmetrics) Pipelines() []otel.Pipeline {
 				otel.AddPrefix("agent.googleapis.com"),
 			),
 		},
+		Exporter: otel.ExporterKindSystem,
 	}}
 }
 

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -68,22 +68,33 @@ func (uc *UnifiedConfig) GenerateOtelConfig(hostInfo *host.InfoStat) (string, er
 				"detectors": []string{"gce"},
 			},
 		}},
-		Exporter: otel.Component{
-			Type: "googlecloud",
-			Config: map[string]interface{}{
-				"user_agent": userAgent,
-				"metric": map[string]interface{}{
-					// Receivers are responsible for sending fully-qualified metric names.
-					// NB: If a receiver fails to send a full URL, OT will add the prefix `workload.googleapis.com/{metric_name}`.
-					// TODO(b/197129428): Write a test to make sure this doesn't happen.
-					"prefix": "",
-					// OT calls CreateMetricDescriptor by default. Skip because we want
-					// descriptors to be created implicitly with new time series.
-					"skip_create_descriptor": true,
-					// Omit instrumentation labels, which break agent metrics.
-					"instrumentation_library_labels": false,
-					// Omit service labels, which break agent metrics.
-					"service_resource_labels": false,
+		Exporters: map[otel.ExporterKind]otel.Component{
+			otel.ExporterKindSystem: {
+				Type: "googlecloud",
+				Config: map[string]interface{}{
+					"user_agent": userAgent,
+					"metric": map[string]interface{}{
+						// Receivers are responsible for sending fully-qualified metric names.
+						// NB: If a receiver fails to send a full URL, OT will add the prefix `workload.googleapis.com/{metric_name}`.
+						// TODO(b/197129428): Write a test to make sure this doesn't happen.
+						"prefix": "",
+						// OT calls CreateMetricDescriptor by default. Skip because we want
+						// descriptors to be created implicitly with new time series.
+						"skip_create_descriptor": true,
+						// Omit instrumentation labels, which break agent metrics.
+						"instrumentation_library_labels": false,
+						// Omit service labels, which break agent metrics.
+						"service_resource_labels": false,
+					},
+				},
+			},
+			otel.ExporterKindCustom: {
+				Type: "googlecloud",
+				Config: map[string]interface{}{
+					"user_agent": userAgent,
+					"metric": map[string]interface{}{
+						"prefix": "",
+					},
 				},
 			},
 		},

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -411,7 +415,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -421,7 +425,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -430,7 +434,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -417,7 +421,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -428,7 +432,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -437,7 +441,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -418,7 +422,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -429,7 +433,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -438,7 +442,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -418,7 +422,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -429,7 +433,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -438,7 +442,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -417,7 +421,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -428,7 +432,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -437,7 +441,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -411,7 +415,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -421,7 +425,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -430,7 +434,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -428,7 +432,7 @@ service:
   pipelines:
     metrics/activemq_activemq:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/activemq_activemq_0
       - metricstransform/activemq_activemq_1
@@ -437,7 +441,7 @@ service:
       - jmx/activemq_activemq
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -448,7 +452,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -457,7 +461,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -428,7 +432,7 @@ service:
   pipelines:
     metrics/activemq_activemq:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/activemq_activemq_0
       - metricstransform/activemq_activemq_1
@@ -437,7 +441,7 @@ service:
       - jmx/activemq_activemq
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -448,7 +452,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -457,7 +461,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -432,7 +436,7 @@ service:
   pipelines:
     metrics/apache_apache:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/apache_apache_0
       - normalizesums/apache_apache_1
@@ -442,7 +446,7 @@ service:
       - apache/apache_apache
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -453,7 +457,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -462,7 +466,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -432,7 +436,7 @@ service:
   pipelines:
     metrics/apache_apache:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/apache_apache_0
       - normalizesums/apache_apache_1
@@ -442,7 +446,7 @@ service:
       - apache/apache_apache
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -453,7 +457,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -462,7 +466,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -430,7 +434,7 @@ service:
   pipelines:
     metrics/cassandra_cassandra:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/cassandra_cassandra_0
       - metricstransform/cassandra_cassandra_1
@@ -439,7 +443,7 @@ service:
       - jmx/cassandra_cassandra
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -450,7 +454,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -459,7 +463,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -430,7 +434,7 @@ service:
   pipelines:
     metrics/cassandra_cassandra:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/cassandra_cassandra_0
       - metricstransform/cassandra_cassandra_1
@@ -439,7 +443,7 @@ service:
       - jmx/cassandra_cassandra
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -450,7 +454,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -459,7 +463,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -428,7 +432,7 @@ service:
   pipelines:
     metrics/couchdb_couchdb:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/couchdb_couchdb_0
       - metricstransform/couchdb_couchdb_1
@@ -437,7 +441,7 @@ service:
       - couchdb/couchdb_couchdb
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -448,7 +452,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -457,7 +461,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -416,7 +420,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -427,7 +431,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -436,7 +440,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -433,7 +437,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -444,7 +448,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/elasticsearch_elasticsearch:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/elasticsearch_elasticsearch_0
       - metricstransform/elasticsearch_elasticsearch_1
@@ -453,7 +457,7 @@ service:
       - elasticsearch/elasticsearch_elasticsearch
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -462,7 +466,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -433,7 +437,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -444,7 +448,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/elasticsearch_elasticsearch:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/elasticsearch_elasticsearch_0
       - metricstransform/elasticsearch_elasticsearch_1
@@ -453,7 +457,7 @@ service:
       - elasticsearch/elasticsearch_elasticsearch
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -462,7 +466,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -433,7 +437,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -444,7 +448,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/elasticsearch_elasticsearch:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/elasticsearch_elasticsearch_0
       - metricstransform/elasticsearch_elasticsearch_1
@@ -453,7 +457,7 @@ service:
       - elasticsearch/elasticsearch_elasticsearch
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -462,7 +466,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -433,7 +437,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -444,7 +448,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/elasticsearch_elasticsearch:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/elasticsearch_elasticsearch_0
       - metricstransform/elasticsearch_elasticsearch_1
@@ -453,7 +457,7 @@ service:
       - elasticsearch/elasticsearch_elasticsearch
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -462,7 +466,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -456,7 +460,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -467,7 +471,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/elasticsearch_elasticsearch:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/elasticsearch_elasticsearch_0
       - metricstransform/elasticsearch_elasticsearch_1
@@ -476,7 +480,7 @@ service:
       - elasticsearch/elasticsearch_elasticsearch
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -485,7 +489,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -435,7 +439,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -446,7 +450,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/elasticsearch_elasticsearch:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/elasticsearch_elasticsearch_0
       - metricstransform/elasticsearch_elasticsearch_1
@@ -455,7 +459,7 @@ service:
       - elasticsearch/elasticsearch_elasticsearch
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -464,7 +468,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -430,7 +434,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -441,7 +445,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -450,7 +454,7 @@ service:
       - prometheus/fluentbit
     metrics/hadoop_hadoop:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/hadoop_hadoop_0
       - metricstransform/hadoop_hadoop_1
@@ -459,7 +463,7 @@ service:
       - jmx/hadoop_hadoop
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -430,7 +434,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -441,7 +445,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -450,7 +454,7 @@ service:
       - prometheus/fluentbit
     metrics/hadoop_hadoop:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/hadoop_hadoop_0
       - metricstransform/hadoop_hadoop_1
@@ -459,7 +463,7 @@ service:
       - jmx/hadoop_hadoop
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -437,7 +441,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -448,7 +452,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -457,7 +461,7 @@ service:
       - prometheus/fluentbit
     metrics/hbase__pipeline_hbase__metrics:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/hbase__pipeline_hbase__metrics_0
       - metricstransform/hbase__pipeline_hbase__metrics_1
@@ -466,7 +470,7 @@ service:
       - jmx/hbase__pipeline_hbase__metrics
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -437,7 +441,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -448,7 +452,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -457,7 +461,7 @@ service:
       - prometheus/fluentbit
     metrics/hbase__pipeline_hbase__metrics:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/hbase__pipeline_hbase__metrics_0
       - metricstransform/hbase__pipeline_hbase__metrics_1
@@ -466,7 +470,7 @@ service:
       - jmx/hbase__pipeline_hbase__metrics
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -428,7 +432,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -439,7 +443,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -448,7 +452,7 @@ service:
       - prometheus/fluentbit
     metrics/jvm_jvm:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/jvm_jvm_0
       - metricstransform/jvm_jvm_1
@@ -457,7 +461,7 @@ service:
       - jmx/jvm_jvm
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -430,7 +434,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -441,7 +445,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -450,7 +454,7 @@ service:
       - prometheus/fluentbit
     metrics/jvm_jvm:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/jvm_jvm_0
       - metricstransform/jvm_jvm_1
@@ -459,7 +463,7 @@ service:
       - jmx/jvm_jvm
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -428,7 +432,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -439,7 +443,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -448,7 +452,7 @@ service:
       - prometheus/fluentbit
     metrics/jvm_jvm:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/jvm_jvm_0
       - metricstransform/jvm_jvm_1
@@ -457,7 +461,7 @@ service:
       - jmx/jvm_jvm
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -445,7 +449,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -456,7 +460,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -465,7 +469,7 @@ service:
       - prometheus/fluentbit
     metrics/kafka_kafka:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/kafka_kafka_0
       - normalizesums/kafka_kafka_1
@@ -475,7 +479,7 @@ service:
       - jmx/kafka_kafka
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -445,7 +449,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -456,7 +460,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -465,7 +469,7 @@ service:
       - prometheus/fluentbit
     metrics/kafka_kafka:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/kafka_kafka_0
       - normalizesums/kafka_kafka_1
@@ -475,7 +479,7 @@ service:
       - jmx/kafka_kafka
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -432,7 +436,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -443,7 +447,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -452,7 +456,7 @@ service:
       - prometheus/fluentbit
     metrics/memcached_memcached:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/memcached_memcached_0
       - normalizesums/memcached_memcached_1
@@ -462,7 +466,7 @@ service:
       - memcached/memcached_memcached
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -432,7 +436,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -443,7 +447,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -452,7 +456,7 @@ service:
       - prometheus/fluentbit
     metrics/mongodb_mongodb:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/mongodb_mongodb_0
       - metricstransform/mongodb_mongodb_1
@@ -461,7 +465,7 @@ service:
       - mongodb/mongodb_mongodb
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -430,7 +434,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -441,7 +445,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -450,7 +454,7 @@ service:
       - prometheus/fluentbit
     metrics/mongodb_mongodb:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/mongodb_mongodb_0
       - metricstransform/mongodb_mongodb_1
@@ -459,7 +463,7 @@ service:
       - mongodb/mongodb_mongodb
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -449,7 +453,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -460,7 +464,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -469,7 +473,7 @@ service:
       - prometheus/fluentbit
     metrics/mysql_mysql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/mysql_mysql_0
       - metricstransform/mysql_mysql_1
@@ -478,7 +482,7 @@ service:
       - mysql/mysql_mysql
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -426,7 +430,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -437,7 +441,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -446,7 +450,7 @@ service:
       - prometheus/fluentbit
     metrics/nginx_nginx:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/nginx_nginx_0
       - metricstransform/nginx_nginx_1
@@ -455,7 +459,7 @@ service:
       - nginx/nginx_nginx
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -426,7 +430,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -437,7 +441,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -446,7 +450,7 @@ service:
       - prometheus/fluentbit
     metrics/nginx_nginx:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/nginx_nginx_0
       - metricstransform/nginx_nginx_1
@@ -455,7 +459,7 @@ service:
       - nginx/nginx_nginx
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -429,7 +433,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -440,7 +444,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -449,7 +453,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1
@@ -458,7 +462,7 @@ service:
       - prometheus/otel
     metrics/postgresql_postgresql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/postgresql_postgresql_0
       - metricstransform/postgresql_postgresql_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -431,7 +435,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -442,7 +446,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -451,7 +455,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1
@@ -460,7 +464,7 @@ service:
       - prometheus/otel
     metrics/postgresql_postgresql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/postgresql_postgresql_0
       - metricstransform/postgresql_postgresql_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -432,7 +436,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -443,7 +447,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -452,7 +456,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1
@@ -461,7 +465,7 @@ service:
       - prometheus/otel
     metrics/postgresql_postgresql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/postgresql_postgresql_0
       - metricstransform/postgresql_postgresql_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -435,7 +439,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -446,7 +450,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -455,7 +459,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1
@@ -464,7 +468,7 @@ service:
       - prometheus/otel
     metrics/postgresql_postgresql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/postgresql_postgresql_0
       - metricstransform/postgresql_postgresql_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -430,7 +434,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -441,7 +445,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -450,7 +454,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1
@@ -459,7 +463,7 @@ service:
       - prometheus/otel
     metrics/rabbitmq_rabbitmq:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/rabbitmq_rabbitmq_0
       - metricstransform/rabbitmq_rabbitmq_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -430,7 +434,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -441,7 +445,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -450,7 +454,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1
@@ -459,7 +463,7 @@ service:
       - prometheus/otel
     metrics/rabbitmq_rabbitmq:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/rabbitmq_rabbitmq_0
       - metricstransform/rabbitmq_rabbitmq_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -431,7 +435,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -442,7 +446,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -451,7 +455,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1
@@ -460,7 +464,7 @@ service:
       - prometheus/otel
     metrics/rabbitmq_rabbitmq:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/rabbitmq_rabbitmq_0
       - metricstransform/rabbitmq_rabbitmq_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -434,7 +438,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -445,7 +449,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -454,7 +458,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1
@@ -463,7 +467,7 @@ service:
       - prometheus/otel
     metrics/rabbitmq_rabbitmq:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/rabbitmq_rabbitmq_0
       - metricstransform/rabbitmq_rabbitmq_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -437,7 +441,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -448,7 +452,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -457,7 +461,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1
@@ -466,7 +470,7 @@ service:
       - prometheus/otel
     metrics/redis_redis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/redis_redis_0
       - normalizesums/redis_redis_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -437,7 +441,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -448,7 +452,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -457,7 +461,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1
@@ -466,7 +470,7 @@ service:
       - prometheus/otel
     metrics/redis_redis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/redis_redis_0
       - normalizesums/redis_redis_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -430,7 +434,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -441,7 +445,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -450,7 +454,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1
@@ -459,7 +463,7 @@ service:
       - prometheus/otel
     metrics/solr_solr:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/solr_solr_0
       - metricstransform/solr_solr_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -430,7 +434,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -441,7 +445,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -450,7 +454,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1
@@ -459,7 +463,7 @@ service:
       - prometheus/otel
     metrics/tomcat_tomcat:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/tomcat_tomcat_0
       - metricstransform/tomcat_tomcat_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -430,7 +434,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -441,7 +445,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -450,7 +454,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1
@@ -459,7 +463,7 @@ service:
       - prometheus/otel
     metrics/tomcat_tomcat:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/tomcat_tomcat_0
       - metricstransform/tomcat_tomcat_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -427,7 +431,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -438,7 +442,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -447,7 +451,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1
@@ -456,7 +460,7 @@ service:
       - prometheus/otel
     metrics/varnish_varnish:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/varnish_varnish_0
       - metricstransform/varnish_varnish_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -432,7 +436,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -443,7 +447,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -452,7 +456,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1
@@ -461,7 +465,7 @@ service:
       - prometheus/otel
     metrics/wildfly_wildfly:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/wildfly_wildfly_0
       - metricstransform/wildfly_wildfly_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -432,7 +436,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -443,7 +447,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -452,7 +456,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1
@@ -461,7 +465,7 @@ service:
       - prometheus/otel
     metrics/wildfly_wildfly:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/wildfly_wildfly_0
       - metricstransform/wildfly_wildfly_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -426,7 +430,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -437,7 +441,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -446,7 +450,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1
@@ -455,7 +459,7 @@ service:
       - prometheus/otel
     metrics/zookeeper_zookeeper:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/zookeeper_zookeeper_0
       - metricstransform/zookeeper_zookeeper_1

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -426,7 +430,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -437,7 +441,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -446,7 +450,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1
@@ -455,7 +459,7 @@ service:
       - prometheus/otel
     metrics/zookeeper_zookeeper:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/zookeeper_zookeeper_0
       - metricstransform/zookeeper_zookeeper_1

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -492,7 +496,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -502,7 +506,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/default__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_iis_0
       - casttosum/default__pipeline_iis_1
@@ -512,7 +516,7 @@ service:
       - windowsperfcounters/default__pipeline_iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_mssql_0
       - resourcedetection/_global_0
@@ -520,7 +524,7 @@ service:
       - windowsperfcounters/default__pipeline_mssql
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -529,7 +533,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -507,7 +511,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -518,7 +522,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/default__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_iis_0
       - casttosum/default__pipeline_iis_1
@@ -529,7 +533,7 @@ service:
       - windowsperfcounters/default__pipeline_iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_mssql_0
       - filter/default__pipeline_mssql_1
@@ -538,7 +542,7 @@ service:
       - windowsperfcounters/default__pipeline_mssql
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -547,7 +551,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -507,7 +511,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -518,7 +522,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/default__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_iis_0
       - casttosum/default__pipeline_iis_1
@@ -529,7 +533,7 @@ service:
       - windowsperfcounters/default__pipeline_iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_mssql_0
       - filter/default__pipeline_mssql_1
@@ -538,7 +542,7 @@ service:
       - windowsperfcounters/default__pipeline_mssql
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -547,7 +551,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -507,7 +511,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -518,7 +522,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/default__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_iis_0
       - casttosum/default__pipeline_iis_1
@@ -529,7 +533,7 @@ service:
       - windowsperfcounters/default__pipeline_iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_mssql_0
       - filter/default__pipeline_mssql_1
@@ -538,7 +542,7 @@ service:
       - windowsperfcounters/default__pipeline_mssql
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -547,7 +551,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -507,7 +511,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -518,7 +522,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/default__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_iis_0
       - casttosum/default__pipeline_iis_1
@@ -529,7 +533,7 @@ service:
       - windowsperfcounters/default__pipeline_iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_mssql_0
       - filter/default__pipeline_mssql_1
@@ -538,7 +542,7 @@ service:
       - windowsperfcounters/default__pipeline_mssql
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -547,7 +551,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -507,7 +511,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -518,7 +522,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/default__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_iis_0
       - casttosum/default__pipeline_iis_1
@@ -529,7 +533,7 @@ service:
       - windowsperfcounters/default__pipeline_iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_mssql_0
       - filter/default__pipeline_mssql_1
@@ -538,7 +542,7 @@ service:
       - windowsperfcounters/default__pipeline_mssql
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -547,7 +551,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -507,7 +511,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -518,7 +522,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/default__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_iis_0
       - casttosum/default__pipeline_iis_1
@@ -529,7 +533,7 @@ service:
       - windowsperfcounters/default__pipeline_iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_mssql_0
       - filter/default__pipeline_mssql_1
@@ -538,7 +542,7 @@ service:
       - windowsperfcounters/default__pipeline_mssql
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -547,7 +551,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/windows/logging-receiver_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_iis/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -507,7 +511,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -518,7 +522,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/default__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_iis_0
       - casttosum/default__pipeline_iis_1
@@ -529,7 +533,7 @@ service:
       - windowsperfcounters/default__pipeline_iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_mssql_0
       - filter/default__pipeline_mssql_1
@@ -538,7 +542,7 @@ service:
       - windowsperfcounters/default__pipeline_mssql
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -547,7 +551,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -510,7 +514,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -521,7 +525,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/default__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_iis_0
       - casttosum/default__pipeline_iis_1
@@ -532,7 +536,7 @@ service:
       - windowsperfcounters/default__pipeline_iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_mssql_0
       - filter/default__pipeline_mssql_1
@@ -541,7 +545,7 @@ service:
       - windowsperfcounters/default__pipeline_mssql
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -550,7 +554,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -510,7 +514,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -521,7 +525,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/default__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_iis_0
       - casttosum/default__pipeline_iis_1
@@ -532,7 +536,7 @@ service:
       - windowsperfcounters/default__pipeline_iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_mssql_0
       - filter/default__pipeline_mssql_1
@@ -541,7 +545,7 @@ service:
       - windowsperfcounters/default__pipeline_mssql
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -550,7 +554,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -510,7 +514,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -521,7 +525,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/default__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_iis_0
       - casttosum/default__pipeline_iis_1
@@ -532,7 +536,7 @@ service:
       - windowsperfcounters/default__pipeline_iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_mssql_0
       - filter/default__pipeline_mssql_1
@@ -541,7 +545,7 @@ service:
       - windowsperfcounters/default__pipeline_mssql
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -550,7 +554,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -492,7 +496,7 @@ service:
   pipelines:
     metrics/another__another__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/another__another__pipeline_iis_0
       - casttosum/another__another__pipeline_iis_1
@@ -502,7 +506,7 @@ service:
       - windowsperfcounters/another__another__pipeline_iis
     metrics/another__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/another__pipeline_mssql_0
       - resourcedetection/_global_0
@@ -510,7 +514,7 @@ service:
       - windowsperfcounters/another__pipeline_mssql
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -520,7 +524,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -529,7 +533,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -513,7 +517,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -524,7 +528,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/default__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_iis_0
       - casttosum/default__pipeline_iis_1
@@ -535,7 +539,7 @@ service:
       - windowsperfcounters/default__pipeline_iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_mssql_0
       - filter/default__pipeline_mssql_1
@@ -544,7 +548,7 @@ service:
       - windowsperfcounters/default__pipeline_mssql
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -553,7 +557,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -513,7 +517,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -524,7 +528,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/default__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_iis_0
       - casttosum/default__pipeline_iis_1
@@ -535,7 +539,7 @@ service:
       - windowsperfcounters/default__pipeline_iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_mssql_0
       - filter/default__pipeline_mssql_1
@@ -544,7 +548,7 @@ service:
       - windowsperfcounters/default__pipeline_mssql
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -553,7 +557,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -510,7 +514,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -521,7 +525,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/default__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_iis_0
       - casttosum/default__pipeline_iis_1
@@ -532,7 +536,7 @@ service:
       - windowsperfcounters/default__pipeline_iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_mssql_0
       - filter/default__pipeline_mssql_1
@@ -541,7 +545,7 @@ service:
       - windowsperfcounters/default__pipeline_mssql
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -550,7 +554,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -523,7 +527,7 @@ service:
   pipelines:
     metrics/apache__pipeline_apache__metrics:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/apache__pipeline_apache__metrics_0
       - normalizesums/apache__pipeline_apache__metrics_1
@@ -533,7 +537,7 @@ service:
       - apache/apache__pipeline_apache__metrics
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -544,7 +548,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/default__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_iis_0
       - casttosum/default__pipeline_iis_1
@@ -555,7 +559,7 @@ service:
       - windowsperfcounters/default__pipeline_iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_mssql_0
       - filter/default__pipeline_mssql_1
@@ -564,7 +568,7 @@ service:
       - windowsperfcounters/default__pipeline_mssql
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -573,7 +577,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -523,7 +527,7 @@ service:
   pipelines:
     metrics/apache__pipeline_apache__metrics:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/apache__pipeline_apache__metrics_0
       - normalizesums/apache__pipeline_apache__metrics_1
@@ -533,7 +537,7 @@ service:
       - apache/apache__pipeline_apache__metrics
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -544,7 +548,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/default__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_iis_0
       - casttosum/default__pipeline_iis_1
@@ -555,7 +559,7 @@ service:
       - windowsperfcounters/default__pipeline_iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_mssql_0
       - filter/default__pipeline_mssql_1
@@ -564,7 +568,7 @@ service:
       - windowsperfcounters/default__pipeline_mssql
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -573,7 +577,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -507,7 +511,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -518,7 +522,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/default__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_iis_0
       - casttosum/default__pipeline_iis_1
@@ -529,7 +533,7 @@ service:
       - windowsperfcounters/default__pipeline_iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_mssql_0
       - filter/default__pipeline_mssql_1
@@ -538,7 +542,7 @@ service:
       - windowsperfcounters/default__pipeline_mssql
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -547,7 +551,7 @@ service:
       - prometheus/fluentbit
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -519,7 +523,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -530,7 +534,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/default__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_iis_0
       - casttosum/default__pipeline_iis_1
@@ -541,7 +545,7 @@ service:
       - windowsperfcounters/default__pipeline_iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_mssql_0
       - filter/default__pipeline_mssql_1
@@ -550,7 +554,7 @@ service:
       - windowsperfcounters/default__pipeline_mssql
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -559,7 +563,7 @@ service:
       - prometheus/fluentbit
     metrics/jvmpipeline_jvmmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/jvmpipeline_jvmmetrics_0
       - metricstransform/jvmpipeline_jvmmetrics_1
@@ -568,7 +572,7 @@ service:
       - jmx/jvmpipeline_jvmmetrics
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -519,7 +523,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -530,7 +534,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/default__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_iis_0
       - casttosum/default__pipeline_iis_1
@@ -541,7 +545,7 @@ service:
       - windowsperfcounters/default__pipeline_iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_mssql_0
       - filter/default__pipeline_mssql_1
@@ -550,7 +554,7 @@ service:
       - windowsperfcounters/default__pipeline_mssql
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -559,7 +563,7 @@ service:
       - prometheus/fluentbit
     metrics/jvmpipeline_jvmmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/jvmpipeline_jvmmetrics_0
       - metricstransform/jvmpipeline_jvmmetrics_1
@@ -568,7 +572,7 @@ service:
       - jmx/jvmpipeline_jvmmetrics
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -540,7 +544,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -551,7 +555,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/default__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_iis_0
       - casttosum/default__pipeline_iis_1
@@ -562,7 +566,7 @@ service:
       - windowsperfcounters/default__pipeline_iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_mssql_0
       - filter/default__pipeline_mssql_1
@@ -571,7 +575,7 @@ service:
       - windowsperfcounters/default__pipeline_mssql
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -580,7 +584,7 @@ service:
       - prometheus/fluentbit
     metrics/mysqlpipeline_mysqlmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/mysqlpipeline_mysqlmetrics_0
       - metricstransform/mysqlpipeline_mysqlmetrics_1
@@ -589,7 +593,7 @@ service:
       - mysql/mysqlpipeline_mysqlmetrics
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -540,7 +544,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -551,7 +555,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/default__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_iis_0
       - casttosum/default__pipeline_iis_1
@@ -562,7 +566,7 @@ service:
       - windowsperfcounters/default__pipeline_iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_mssql_0
       - filter/default__pipeline_mssql_1
@@ -571,7 +575,7 @@ service:
       - windowsperfcounters/default__pipeline_mssql
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -580,7 +584,7 @@ service:
       - prometheus/fluentbit
     metrics/mysqlpipeline_mysqlmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/mysqlpipeline_mysqlmetrics_0
       - metricstransform/mysqlpipeline_mysqlmetrics_1
@@ -589,7 +593,7 @@ service:
       - mysql/mysqlpipeline_mysqlmetrics
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -517,7 +521,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -528,7 +532,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/default__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_iis_0
       - casttosum/default__pipeline_iis_1
@@ -539,7 +543,7 @@ service:
       - windowsperfcounters/default__pipeline_iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_mssql_0
       - filter/default__pipeline_mssql_1
@@ -548,7 +552,7 @@ service:
       - windowsperfcounters/default__pipeline_mssql
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -557,7 +561,7 @@ service:
       - prometheus/fluentbit
     metrics/nginxpipeline_nginxmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/nginxpipeline_nginxmetrics_0
       - metricstransform/nginxpipeline_nginxmetrics_1
@@ -566,7 +570,7 @@ service:
       - nginx/nginxpipeline_nginxmetrics
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
@@ -1,5 +1,9 @@
 exporters:
-  googlecloud:
+  googlecloud/custom:
+    metric:
+      prefix: ""
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system:
     metric:
       instrumentation_library_labels: false
       prefix: ""
@@ -517,7 +521,7 @@ service:
   pipelines:
     metrics/default__pipeline_hostmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/system
       processors:
       - agentmetrics/default__pipeline_hostmetrics_0
       - filter/default__pipeline_hostmetrics_1
@@ -528,7 +532,7 @@ service:
       - hostmetrics/default__pipeline_hostmetrics
     metrics/default__pipeline_iis:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_iis_0
       - casttosum/default__pipeline_iis_1
@@ -539,7 +543,7 @@ service:
       - windowsperfcounters/default__pipeline_iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - metricstransform/default__pipeline_mssql_0
       - filter/default__pipeline_mssql_1
@@ -548,7 +552,7 @@ service:
       - windowsperfcounters/default__pipeline_mssql
     metrics/fluentbit:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/fluentbit_0
       - metricstransform/fluentbit_1
@@ -557,7 +561,7 @@ service:
       - prometheus/fluentbit
     metrics/nginxpipeline_nginxmetrics:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - normalizesums/nginxpipeline_nginxmetrics_0
       - metricstransform/nginxpipeline_nginxmetrics_1
@@ -566,7 +570,7 @@ service:
       - nginx/nginxpipeline_nginxmetrics
     metrics/otel:
       exporters:
-      - googlecloud
+      - googlecloud/custom
       processors:
       - filter/otel_0
       - metricstransform/otel_1


### PR DESCRIPTION
Just testing out an idea to address the issue of wanting more granular exporter configs on a per-receiver basis. This adds support for the notion of multiple (still static/singleton as before) kinds of exporters that each metrics receiver can choose from. For now there are only two: `system` and `custom`, for `agent` and `workload` metrics respectively.