### PR TITLE
Bump Windows OpenSSL version to 1.1.1o

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -61,7 +61,7 @@ RUN Write-Host ('Installing Visual C++ Redistributable Package'); `
 ARG OPENSSL_INSTALLER=Win64OpenSSL-1_1_1o.msi
 # SHA256 hash from win32_openssl_hashes.json in https://github.com/slproweb/opensslhashes.
 # DO NOT FORGET to change this hash when changing the MSI.
-ARG OPENSSL_SHA256=66dc0e2536d688255247d90644acb8cf3d55c80b8a9d393aa5f03229e891949b
+ARG OPENSSL_SHA256=97829a01cf0bd3ea30d555671007ebf1cf5ffe2c00b6b7a10a5fa80e1026fa7f
 ADD https://slproweb.com/download/$OPENSSL_INSTALLER /local/$OPENSSL_INSTALLER
 
 RUN $ExpectedHash = $env:OPENSSL_SHA256; `

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -61,7 +61,7 @@ RUN Write-Host ('Installing Visual C++ Redistributable Package'); `
 ARG OPENSSL_INSTALLER=Win64OpenSSL-1_1_1o.msi
 # SHA256 hash from win32_openssl_hashes.json in https://github.com/slproweb/opensslhashes.
 # DO NOT FORGET to change this hash when changing the MSI.
-ARG OPENSSL_SHA256=97829a01cf0bd3ea30d555671007ebf1cf5ffe2c00b6b7a10a5fa80e1026fa7f
+ARG OPENSSL_SHA256=6c6179a9fd6097132f302daca3bfff2bd81a540d5681dde4edd9022124185368
 ADD https://slproweb.com/download/$OPENSSL_INSTALLER /local/$OPENSSL_INSTALLER
 
 RUN $ExpectedHash = $env:OPENSSL_SHA256; `

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -58,7 +58,7 @@ RUN Write-Host ('Installing Visual C++ Redistributable Package'); `
 #
 # Install OpenSSL
 # This must be done after installing Visual Studio
-ARG OPENSSL_INSTALLER=Win64OpenSSL-1_1_1n.msi
+ARG OPENSSL_INSTALLER=Win64OpenSSL-1_1_1o.msi
 # SHA256 hash from win32_openssl_hashes.json in https://github.com/slproweb/opensslhashes.
 # DO NOT FORGET to change this hash when changing the MSI.
 ARG OPENSSL_SHA256=66dc0e2536d688255247d90644acb8cf3d55c80b8a9d393aa5f03229e891949b


### PR DESCRIPTION
This is to fix the Windows build, which is currently broken