### PR TITLE
Testing: standardize wget options

### DIFF
--- a/integration_test/third_party_apps_data/applications/elasticsearch/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/elasticsearch/debian_ubuntu/install
@@ -3,7 +3,7 @@ set -e
 sudo apt-get update
 sudo apt-get install -y apt-transport-https wget default-jre
 
-wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
+wget --no-verbose --output-document=- https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
 echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | \
     sudo tee /etc/apt/sources.list.d/elastic-7.x.list
 


### PR DESCRIPTION
The point of this change is to use --no-verbose everywhere, which will tidy up the logs.

hbase in particular currently prints 1MB of output to the logs because it lacks --no-verbose.

I also replaced -O with --output-document because in general I much prefer longer flag names for readability.