### PR TITLE
Get apache test passing under Ubuntu and CentOS

### DIFF
--- a/integration_test/third_party_apps_data/applications/apache/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/apache/metadata.yaml
@@ -75,7 +75,7 @@ expected_logs:
 - log_name: apache_access
   fields:
   - name: httpRequest.remoteIp
-    value_regex: ::1
+    value_regex: ::1|127.0.0.1
     type: string
     description: The IP address (IPv4 or IPv6) of the client that issued the HTTP request
   - name: httpRequest.requestUrl
@@ -99,7 +99,7 @@ expected_logs:
 - log_name: apache_error
   fields:
   - name: jsonPayload.client
-    value_regex: ::1
+    value_regex: ::1|127.0.0.1:[0-9]+
     type: string
     description: Client IP address (optional)
   - name: jsonPayload.level

--- a/integration_test/third_party_apps_data/test_config.yaml
+++ b/integration_test/third_party_apps_data/test_config.yaml
@@ -1,18 +1,20 @@
 per_application_overrides:
   apache:
+    # TODO: reenable distros incrementally.
+    platforms_to_skip:
+      - sles-12
+      - sles-15
+  cassandra:
     # Skip all platforms listed above except debian-10 for now.
     # New applications should use platforms_to_skip sparingly
     # if at all.
     # TODO: reenable application+distro pairs incrementally.
     platforms_to_skip: &common_skips
       - centos-7
-      - centos-8
       - rocky-linux-8
       - sles-12
       - sles-15
       - ubuntu-2004-lts
-  cassandra:
-    platforms_to_skip: *common_skips
   jvm:
     platforms_to_skip: *common_skips
   mysql:


### PR DESCRIPTION
Just needed a few tweaks to the expected logs regexes.