### PR TITLE
Update Dockerfile.windows with changes missed in #607.

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -127,7 +127,6 @@ RUN cmake --build . --config Release; `
 FROM base as javacontrib
 
 # Both of these are necessary for the nebula release plugin's options
-COPY BUILD_CONFIG /work/BUILD_CONFIG
 COPY .git /work/.git
 
 ADD https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x64_windows_hotspot_11.0.12_7.msi /local/jdk-11-windows-x64.msi
@@ -139,9 +138,8 @@ WORKDIR /work/submodules/opentelemetry-java-contrib
 
 # Build & test systems do not always check out git history for submodules, so the properties assigned
 # here allow the nebula release process to function properly in that state
-RUN Get-Content /work/BUILD_CONFIG | Where-Object length | ForEach-Object { Invoke-Expression "`$env:$_" }; `
-    ./gradlew --no-daemon :jmx-metrics:build \"-Pgit.root=$pwd/../../.git\" \"-Prelease.version=$env:JMX_METRICS_JAR_VERSION\" \"-Prelease.disableGitChecks=true\"; `
-    Copy-Item -Path jmx-metrics/build/libs/opentelemetry-jmx-metrics-$env:JMX_METRICS_JAR_VERSION.jar -Destination /work/out/bin/opentelemetry-java-contrib-jmx-metrics.jar;
+RUN ./gradlew --no-daemon :jmx-metrics:build; `
+    Copy-Item -Path jmx-metrics/build/libs/opentelemetry-jmx-metrics-*-SNAPSHOT.jar -Destination /work/out/bin/opentelemetry-java-contrib-jmx-metrics.jar;
 
 ###############################################################################
 # Build Go code in one container to exploit Go build caching


### PR DESCRIPTION
#607 included changes that altered build flags for gradle because of an [upstream change](https://github.com/open-telemetry/opentelemetry-java-contrib/pull/274) -- unclear whether this was necessary for the purpose of the PR or not (to add a metrics receiver for Jetty). These changes were only made for the Linux build, but not Windows, breaking the Windows builds. 

See https://github.com/GoogleCloudPlatform/ops-agent/pull/607/files#r880772695

Fixes http://b/234486247