### PR TITLE
Fix sles12 builds by using checksum instead of invalid repo signature.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -181,7 +181,11 @@ RUN ./pkg/rpm/build.sh
 # Use OpenSUSE Leap 42.3 to emulate SLES 12: https://en.opensuse.org/openSUSE:Build_Service_cross_distribution_howto#Detect_a_distribution_flavor_for_special_code
 FROM opensuse/archive:42.3 AS sles12-build
 
-RUN set -x; zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros && \
+RUN set -x; \
+    # The 'OSS Update' repo signature is no longer valid, so verify the checksum instead.
+    zypper --no-gpg-check refresh 'OSS Update' && \
+    (echo 'b889b4bba03074cd66ef9c0184768f4816d4ccb1fa9ec2721c5583304c5f23d0  /var/cache/zypp/raw/OSS Update/repodata/repomd.xml' | sha256sum --check) && \
+    zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros && \
     # Remove expired root certificate.
     mv /var/lib/ca-certificates/pem/DST_Root_CA_X3.pem /etc/pki/trust/blacklist/ && \
     update-ca-certificates && \


### PR DESCRIPTION
The builds were failing with:
```
Retrieving repository 'OSS Update' metadata [...Signature verification failed for file 'repomd.xml' from repository 'OSS Update'.
```
Looks like the key used to sign `repomd.xml` could no longer be used, so this switches to using a checksum instead.

[b/234446369](http://b/234446369)