### PR TITLE
open source scripts used for build and test on Kokoro

### DIFF
--- a/kokoro/README.md
+++ b/kokoro/README.md
@@ -1,0 +1,5 @@
+# Kokoro Infrastructure
+
+The contents of this directory are currently unused but they will be executed by
+Kokoro at a later date. They are very similar to the scripts that are currently
+executed by Kokoro.

--- a/kokoro/scripts/build/build_package.bat
+++ b/kokoro/scripts/build/build_package.bat
@@ -1,0 +1,5 @@
+@ECHO OFF
+
+PowerShell.exe -Command "& %KOKORO_ARTIFACTS_DIR%/github/unified_agents/kokoro/scripts/build/build_package.ps1"
+
+exit %ERRORLEVEL%

--- a/kokoro/scripts/build/build_package.ps1
+++ b/kokoro/scripts/build/build_package.ps1
@@ -1,0 +1,26 @@
+Set-PSDebug -Trace 1
+$ErrorActionPreference = 'Stop'
+
+# Invokes the first argument, expected to be an external program,
+# passing it the rest of the arguments. Throws an error if the program
+# finishes with a nonzero exit code.
+function Invoke-Program() {
+  & $Args[0] $Args[1..$Args.Length]
+  if ( $LastExitCode -ne 0 ) {
+    throw "failed: $Args"
+  }
+}
+
+$tag = 'build'
+$name = 'build-result'
+
+# Disable Windows Defender antivirus for improved build speed.
+Set-MpPreference -Force -DisableRealtimeMonitoring $true
+# Disable Windows Defender firewall for improved build speed.
+Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
+
+Set-Location "$env:KOKORO_ARTIFACTS_DIR/github/unified_agents/"
+Invoke-Program git submodule update --init
+Invoke-Program docker build -t $tag -f './Dockerfile.windows' .
+Invoke-Program docker create --name $name $tag
+Invoke-Program docker cp "${name}:/work/out" $env:KOKORO_ARTIFACTS_DIR

--- a/kokoro/scripts/build/build_package.sh
+++ b/kokoro/scripts/build/build_package.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# cd to the root of the git repo containing this script.
+cd "$(readlink -f "$(dirname "$0")")"
+cd "$(git rev-parse --show-toplevel)"
+
+# Source the common scripts.
+source "kokoro/scripts/utils/common.sh"
+
+set -e
+set -x
+set -o pipefail
+
+RESULT_DIR=${RESULT_DIR:-"${KOKORO_ARTIFACTS_DIR}/result"}
+export RESULT_DIR
+
+git_track_hash . "OPS_AGENT_REPO_HASH"
+OPS_AGENT_REPO_HASH="$(extract_git_hash .)"
+# Submodules aren't cloned by kokoro for github repos.
+git submodule update --init --recursive
+
+. VERSION
+export_to_sponge_config "PACKAGE_VERSION" "${PKG_VERSION}"
+
+# From https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired-2
+# to fix issues like b/227486796.
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+
+# Install Docker.
+# https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+  | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get -y update
+sudo apt-get -y install docker-ce docker-ce-cli containerd.io
+
+sudo DOCKER_BUILDKIT=1 docker build . \
+  --target "${DISTRO}-build" \
+  -t build_image
+
+SIGNING_DIR="kokoro/scripts/build/signing"
+if [[ "${PKGFORMAT}" == "rpm" && "${SKIP_SIGNING}" != "true" ]]; then
+  RPM_SIGNING_KEY="${KOKORO_KEYSTORE_DIR}/71565_rpm-signing-key"
+  cp "${RPM_SIGNING_KEY}" "$SIGNING_DIR/signing-key"
+fi
+
+sudo docker run \
+  -i \
+  -v "${RESULT_DIR}":/artifacts \
+  -v "${SIGNING_DIR}":/signing \
+  build_image \
+  bash <<EOF
+    cp /google-cloud-ops-agent*.${PKGFORMAT} /artifacts
+
+    if [[ "${PKGFORMAT}" == "rpm" && "${SKIP_SIGNING}" != "true" ]]; then
+      bash /signing/sign.sh /artifacts/*.rpm
+    fi
+EOF

--- a/kokoro/scripts/build/signing/sign-helper.exp
+++ b/kokoro/scripts/build/signing/sign-helper.exp
@@ -1,0 +1,16 @@
+#!/usr/bin/expect -f
+
+# Sign RPM packages using a key with an empty passphrase. The environment
+# variable GPG_NAME must contain the key name ("Real Name <email@example.org").
+# That private key must exist in GPG.
+
+spawn rpm --define "_gpg_name $env(GPG_NAME)" --resign {*}$argv
+expect {
+  -exact "Enter pass phrase: " { send -- "\r"; expect eof }
+  # GnuPG 2 does not prompt for a passphrase when it's empty.
+  eof {}
+}
+
+# Return the exit status of the spawned command.
+catch wait result
+exit [lindex $result 3]

--- a/kokoro/scripts/build/signing/sign.sh
+++ b/kokoro/scripts/build/signing/sign.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+KEY_NAME="Google Cloud Packages RPM Signing Key <gc-team@google.com>"
+KEY_PATH="/signing/signing-key"
+
+gpg --import "$KEY_PATH"
+GPG_NAME="$KEY_NAME" expect /signing/sign-helper.exp -- "$@"
+

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+# This script needs the following environment variables to be defined:
+# 1. various KOKORO_* variables
+# 2. TEST_SUITE_NAME: name of the test file, minus the .go suffix. For example,
+#    ops_agent_test or third_party_apps_test.
+# 3. WINRM_PAR_BLAZE_PATH: path to a copy of winrm.par to use for testing.
+#
+# And also the following, documented at the top of gce_testing.go and
+# $TEST_SUITE_NAME.go:
+# 1. PROJECT
+# 2. ZONE
+# 3. TRANSFERS_BUCKET
+#
+# If TEST_SOURCE_PIPER_LOCATION is defined, this script will look for test
+# sources in there, otherwise it will look in GitHub.
+#
+# In addition, the following test suites need additional env variables:
+# collectd_third_party_apps_test:
+#   * SCRIPTS_DR: path to scripts to use for installing/configuring apps.
+# install_scripts_test:
+#   * AGENTS_TO_TEST: comma-separated list of agents to test.
+#   * SCRIPTS_DR: path to installation scripts to test.
+# os_config_test:
+#   * GCLOUD_LITE_BLAZE_PATH: path to just-built copy of gcloud_lite to use fors
+#     testing.
+
+set -e
+set -u
+set -x
+set -o pipefail
+
+# cd to the root of the git repo containing this script ($0).
+cd "$(readlink -f "$(dirname "$0")")"
+cd ../../../
+
+# source the common utilities, for track_flakiness.
+source kokoro/scripts/utils/common.sh
+
+track_flakiness
+
+# If a built agent was passed in from Kokoro directly, use that. The file will
+# always be in KOKORO_GFILE_DIR, though it may not be in the same subdirectory,
+# so we have to search for it.
+if [[ -d "${KOKORO_GFILE_DIR}" ]]; then
+  BUILT_AGENT_PATH=$(find "${KOKORO_GFILE_DIR}" -type f -name "google-cloud-ops-agent*" | head -n 1)
+  if [[ ! -z "${BUILT_AGENT_PATH}" ]]; then
+    RESULT_DIR="$(dirname "${BUILT_AGENT_PATH}")"
+
+    # Upload the agent packages to GCS.
+    AGENT_PACKAGES_IN_GCS="gs://${TRANSFERS_BUCKET}/agent_packages/${KOKORO_BUILD_ID}"
+    gsutil cp -r "${RESULT_DIR}/*" "${AGENT_PACKAGES_IN_GCS}/"
+
+    # AGENT_PACKAGES_IN_GCS is used to tell Ops Agent integration tests
+    # (https://github.com/GoogleCloudPlatform/ops-agent/tree/master/integration_test)
+    # to install and use this custom build of the agent instead.
+    export AGENT_PACKAGES_IN_GCS
+  fi
+fi
+
+LOGS_DIR="${KOKORO_ARTIFACTS_DIR}/logs"
+mkdir -p "${LOGS_DIR}"
+
+# Uninstall Kokoro's old version of go.
+sudo rm -rf /usr/local/go
+# Kokoro's value of GOPATH does not work with modern versions of go.
+# GOPATH is semi-deprecated nowadays too.
+unset GOPATH
+
+# Download and install a newer version of go.
+wget --quiet --output-document=/dev/stdout https://golang.org/dl/go1.17.linux-amd64.tar.gz | \
+  sudo tar --directory /usr/local -xzf /dev/stdin
+
+PATH=$PATH:/usr/local/go/bin
+
+# Install a utility for producing XML test results.
+go install github.com/jstemmer/go-junit-report@latest
+
+if [[ -n "${TEST_SOURCE_PIPER_LOCATION-}" ]]; then
+  if [[ -n "${SCRIPTS_DIR-}" ]]; then
+    SCRIPTS_DIR="${KOKORO_PIPER_DIR}/${SCRIPTS_DIR}"
+    export SCRIPTS_DIR
+  fi
+
+  cd "${KOKORO_PIPER_DIR}/${TEST_SOURCE_PIPER_LOCATION}/${TEST_SUITE_NAME}"
+
+  # Make a module containing the latest dependencies from GitHub.
+  go mod init "${TEST_SUITE_NAME}"
+  go get github.com/GoogleCloudPlatform/ops-agent@master
+  go mod tidy -compat=1.17
+fi
+
+if [[ "${TEST_SUITE_NAME}" == "os_config_test" ]]; then
+  GCLOUD_TO_TEST="${KOKORO_BLAZE_DIR}/${GCLOUD_LITE_BLAZE_PATH}"
+  export GCLOUD_TO_TEST
+fi
+
+WINRM_PAR_PATH="${KOKORO_BLAZE_DIR}/${WINRM_PAR_BLAZE_PATH}"
+export WINRM_PAR_PATH
+
+STDERR_STDOUT_FILE="${KOKORO_ARTIFACTS_DIR}/test_stderr_stdout.txt"
+function produce_xml() {
+  cat "${STDERR_STDOUT_FILE}" | "$(go env GOPATH)/bin/go-junit-report" > "${LOGS_DIR}/sponge_log.xml"
+}
+# Always run produce_xml on exit, whether the test passes or fails.
+trap produce_xml EXIT
+
+# Boost the max number of open files from 1024 to 1 million.
+ulimit -n 1000000
+
+# Set up some command line flags for "go test".
+args=(
+  -test.parallel=1000
+  -tags=integration_test
+  -timeout=3h
+)
+if [[ "${SHORT:-false}" == "true" ]]; then
+  args+=( "-test.short" )
+fi
+
+TEST_UNDECLARED_OUTPUTS_DIR="${LOGS_DIR}" \
+  go test -v "${TEST_SUITE_NAME}.go" \
+  "${args[@]}" \
+  2>&1 \
+  | tee "${STDERR_STDOUT_FILE}"

--- a/kokoro/scripts/utils/common.sh
+++ b/kokoro/scripts/utils/common.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+set -x
+set -o pipefail
+
+CUSTOM_SPONGE_CONFIG="${KOKORO_ARTIFACTS_DIR}/custom_sponge_config.csv"
+
+# A convenience function to store a key/value pair in the Sponge invocation
+# configuration. To propagate the key/value pair from Sponge to a Rapid custom
+# field, also add the key to sponge_config_keys in the workflow spec.
+function export_to_sponge_config() {
+  local key="${1}"
+  local value="${2}"
+  printf "${key},${value}\n" >> "${CUSTOM_SPONGE_CONFIG}"
+}
+
+# A convenience function to extract the HEAD commit hash of a given repo.
+function extract_git_hash() {
+  local repo="${1}"
+  git -C "$(basename "${repo}")" rev-parse HEAD
+}
+
+# A convenience function to store the HEAD commit hash in the Sponge invocation
+# configuration. To propagate the hash from Sponge to a Rapid custom field, also
+# add the repo_var to sponge_config_keys in the workflow spec.
+function git_track_hash() {
+  local repo="${1}"
+  local repo_var="${2}"
+  hash="$(extract_git_hash "${repo}")"
+  export_to_sponge_config "${repo_var}" "${hash}"
+}
+
+# Track Flakiness for Non-Google3 projects by exporting the vars described
+# in go/ng3-flakiness to Sponge.
+function track_flakiness()
+{
+  # Inherit job type from root job in job chains/groups.
+  local job_type="${KOKORO_ROOT_JOB_TYPE:-$KOKORO_JOB_TYPE}"
+
+  if [[ "${job_type}" == "PRESUBMIT_GITHUB" ]]; then
+    # Exit early, we don't track flakiness for presubmits.
+    return
+  elif [[ "${job_type}" == "CONTINUOUS_INTEGRATION" ]]; then
+    export_to_sponge_config "ng3_job_type" "POSTSUBMIT"
+  elif [[ "${job_type}" == "RELEASE" ]]; then
+    export_to_sponge_config "ng3_job_type" "PERIODIC"
+  fi
+  export_to_sponge_config "ng3_project_id" "cloud-ops-agent"
+  export_to_sponge_config "ng3_commit" "${KOKORO_GIT_COMMIT_unified_agents}"
+  export_to_sponge_config "ng3_cl_target_branch" "master"
+  export_to_sponge_config "ng3_test_type" "INTEGRATION"
+  export_to_sponge_config "ng3_sponge_url" "https://fusion2.corp.google.com/invocations/${KOKORO_BUILD_ID}"
+}


### PR DESCRIPTION
These are slightly modified copies of internal scripts used for building and testing on Kokoro. Specifically, they are exact copies of the scripts in the internal "temp_open_sourcing" directory.

They will sit in the ops-agent repo unused at first, but the plan is to switch github presubmits and then release builds to pull these scripts instead of the internal ones, and then we can delete (most of) the internal ones. The scripts common.sh, sign.sh, and sign-helper.exp will continue to exist in both places.