### PR TITLE
TestHTTPRequestLog: write both logs at file upload

### DIFF
--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -465,8 +465,8 @@ func TestHTTPRequestLog(t *testing.T) {
 		}
 
 		// Log with HTTP request data nested under "logging.googleapis.com/httpRequest".
-		newHTTPRequestKey := confgenerator.HttpRequestKey
-		newHTTPRequestLogId := "new_request_log"
+		const newHTTPRequestKey = confgenerator.HttpRequestKey
+		const newHTTPRequestLogId = "new_request_log"
 		newLogBody := map[string]interface{}{
 			"logId":           newHTTPRequestLogId,
 			newHTTPRequestKey: httpRequestBody,
@@ -477,8 +477,8 @@ func TestHTTPRequestLog(t *testing.T) {
 		}
 
 		// Log with HTTP request data nested under "logging.googleapis.com/http_request".
-		oldHTTPRequestKey := "logging.googleapis.com/http_request"
-		oldHTTPRequestLogId := "old_request_log"
+		const oldHTTPRequestKey = "logging.googleapis.com/http_request"
+		const oldHTTPRequestLogId = "old_request_log"
 		oldLogBody := map[string]interface{}{
 			"logId":           oldHTTPRequestLogId,
 			oldHTTPRequestKey: httpRequestBody,

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -466,8 +466,7 @@ func TestHTTPRequestLog(t *testing.T) {
 		}
 
 		// Log with HTTP request data nested under "logging.googleapis.com/httpRequest".
-		// const newHTTPRequestKey = confgenerator.HttpRequestKey
-		const newHTTPRequestKey = "logging.googleapis.com/http_request"
+		const newHTTPRequestKey = confgenerator.HttpRequestKey
 		const newHTTPRequestLogId = "new_request_log"
 		newLogBody := map[string]interface{}{
 			"logId":           newHTTPRequestLogId,
@@ -479,8 +478,7 @@ func TestHTTPRequestLog(t *testing.T) {
 		}
 
 		// Log with HTTP request data nested under "logging.googleapis.com/http_request".
-		// const oldHTTPRequestKey = "logging.googleapis.com/http_request"
-		const oldHTTPRequestKey = confgenerator.HttpRequestKey
+		const oldHTTPRequestKey = "logging.googleapis.com/http_request"
 		const oldHTTPRequestLogId = "old_request_log"
 		oldLogBody := map[string]interface{}{
 			"logId":           oldHTTPRequestLogId,
@@ -515,13 +513,12 @@ func TestHTTPRequestLog(t *testing.T) {
 
 		isKeyInPayload := func(httpRequestKey string, entry *cloudlogging.Entry) bool {
 			payload := entry.Payload.(*structpb.Struct)
-			foundKey := false
-			for key := range payload.GetFields() {
-				if key == httpRequestKey {
-					foundKey = true
+			for k := range payload.GetFields() {
+				if k == httpRequestKey {
+					return true
 				}
 			}
-			return foundKey
+			return false
 		}
 
 		// Test that the new documented field, "logging.googleapis.com/httpRequest", will be


### PR DESCRIPTION
Performing multiple `gce.UploadContent` operations fails for some
Windows platforms, as the second log read ends up a weird jumble of
characters. This PR adjusts `TestHTTPRequestLog` so the two logs are
written at the same time at upload.