### PR TITLE
Use correct httpRequest key in all integrations

### DIFF
--- a/apps/couchdb.go
+++ b/apps/couchdb.go
@@ -112,7 +112,7 @@ func (p LoggingProcessorCouchdb) Components(tag string, uid string) []fluentbit.
 			"Match":         tag,
 			"Operation":     "nest",
 			"Wildcard":      "http_request_*",
-			"Nest_under":    "logging.googleapis.com/http_request",
+			"Nest_under":    confgenerator.HttpRequestKey,
 			"Remove_prefix": "http_request_",
 		},
 	})

--- a/apps/iis.go
+++ b/apps/iis.go
@@ -206,7 +206,7 @@ func (p *LoggingProcessorIisAccess) Components(tag, uid string) []fluentbit.Comp
 				"Match":         tag,
 				"Operation":     "nest",
 				"Wildcard":      "http_request_*",
-				"Nest_under":    "logging.googleapis.com/http_request",
+				"Nest_under":    confgenerator.HttpRequestKey,
 				"Remove_prefix": "http_request_",
 			},
 		},

--- a/confgenerator/filter/internal/ast/ast.go
+++ b/confgenerator/filter/internal/ast/ast.go
@@ -52,7 +52,10 @@ var logEntryRootStructMapToFluentBit = map[string]string{
 	"labels":         "logging.googleapis.com/labels",
 	"operation":      "logging.googleapis.com/operation",
 	"sourceLocation": "logging.googleapis.com/sourceLocation",
-	"httpRequest":    "logging.googleapis.com/httpRequest",
+	// TODO: This needs to be the same as confgenerator.HttpRequestKey. Importing
+	// that package here results in a circular import. That should move somewhere
+	// better, and once it does we can use that here.
+	"httpRequest": "logging.googleapis.com/httpRequest",
 }
 
 func (m Target) fluentBitPath() ([]string, error) {

--- a/confgenerator/filter/internal/ast/ast.go
+++ b/confgenerator/filter/internal/ast/ast.go
@@ -52,7 +52,7 @@ var logEntryRootStructMapToFluentBit = map[string]string{
 	"labels":         "logging.googleapis.com/labels",
 	"operation":      "logging.googleapis.com/operation",
 	"sourceLocation": "logging.googleapis.com/sourceLocation",
-	"httpRequest":    "logging.googleapis.com/http_request",
+	"httpRequest":    "logging.googleapis.com/httpRequest",
 }
 
 func (m Target) fluentBitPath() ([]string, error) {

--- a/confgenerator/filter/internal/ast/ast_test.go
+++ b/confgenerator/filter/internal/ast/ast_test.go
@@ -54,7 +54,7 @@ func TestValidPath(t *testing.T) {
 		{
 			Target{"httpRequest", "status"},
 			"httpRequest.status",
-			[]string{"logging.googleapis.com/http_request", "status"},
+			[]string{"logging.googleapis.com/httpRequest", "status"},
 		},
 		{
 			Target{"sourceLocation", "line"},

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_fluent_bit_main.conf
@@ -204,7 +204,7 @@
     Wildcard   *
 
 [FILTER]
-    Condition Key_value_matches $record['logging.googleapis.com/http_request']['method'] GET
+    Condition Key_value_matches $record['logging.googleapis.com/httpRequest']['method'] GET
     Match     p1.sample_logs
     Name      modify
     Set       __match_0_0 1

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden_fluent_bit_main.conf
@@ -81,7 +81,7 @@
 [FILTER]
     Match         couchdb.couchdb
     Name          nest
-    Nest_under    logging.googleapis.com/http_request
+    Nest_under    logging.googleapis.com/httpRequest
     Operation     nest
     Remove_prefix http_request_
     Wildcard      http_request_*

--- a/confgenerator/testdata/valid/windows/logging-receiver_iis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_iis/golden_fluent_bit_main.conf
@@ -134,7 +134,7 @@
 [FILTER]
     Match         iis.iis_access
     Name          nest
-    Nest_under    logging.googleapis.com/http_request
+    Nest_under    logging.googleapis.com/httpRequest
     Operation     nest
     Remove_prefix http_request_
     Wildcard      http_request_*


### PR DESCRIPTION
The original PR that adjusted the Ops Agent to use this feature was made before these integrations were available, so I overlooked them when I went to finally merge it. This PR adjusts the http request key for the new integrations I had forgotten.