### PR TITLE
Update build process to hash jar file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -185,7 +185,7 @@ RUN set -x; \
     # The 'OSS Update' repo signature is no longer valid, so verify the checksum instead.
     zypper --no-gpg-check refresh 'OSS Update' && \
     (echo 'b889b4bba03074cd66ef9c0184768f4816d4ccb1fa9ec2721c5583304c5f23d0  /var/cache/zypp/raw/OSS Update/repodata/repomd.xml' | sha256sum --check) && \
-    zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros zip && \
+    zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros unzip zip && \
     # Remove expired root certificate.
     mv /var/lib/ca-certificates/pem/DST_Root_CA_X3.pem /etc/pki/trust/blacklist/ && \
     update-ca-certificates && \
@@ -216,7 +216,7 @@ RUN ./pkg/rpm/build.sh
 
 FROM opensuse/leap:15.1 AS sles15-build
 
-RUN set -x; zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros java-11-openjdk-devel zip && \
+RUN set -x; zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros java-11-openjdk-devel unzip zip && \
     # Add home:ptrommler:formal repo to install >3.4 bison
     zypper addrepo https://download.opensuse.org/repositories/home:ptrommler:formal/openSUSE_Leap_15.1/home:ptrommler:formal.repo && \
     zypper -n --gpg-auto-import-keys refresh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN set -x; apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
     autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
     build-essential cmake bison flex file libsystemd-dev \
-    devscripts cdbs pkg-config openjdk-11-jdk zip
+    devscripts cdbs pkg-config openjdk-11-jdk
 
 ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
 RUN set -xe; \
@@ -41,7 +41,7 @@ RUN set -x; apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
     autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
     build-essential cmake bison flex file libsystemd-dev \
-    devscripts cdbs pkg-config openjdk-11-jdk zip
+    devscripts cdbs pkg-config openjdk-11-jdk
 
 ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
 RUN set -xe; \
@@ -58,7 +58,7 @@ RUN set -x; \
     DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
     autoconf libtool libcurl4-openssl-dev libltdl-dev libssl1.0-dev libyajl-dev \
     build-essential cmake bison flex file libsystemd-dev \
-    devscripts cdbs pkg-config zip
+    devscripts cdbs pkg-config
 
 ADD https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_x64_linux_hotspot_11.0.13_8.tar.gz /tmp/OpenJDK11U-jdk_x64_linux_hotspot_11.0.13_8.tar.gz
 RUN set -xe; \
@@ -81,7 +81,7 @@ RUN set -x; apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
     autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
     build-essential cmake bison flex file libsystemd-dev \
-    devscripts cdbs pkg-config openjdk-11-jdk zip
+    devscripts cdbs pkg-config openjdk-11-jdk
 
 ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
 RUN set -xe; \
@@ -97,7 +97,7 @@ RUN set -x; apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
     autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
     build-essential cmake bison flex file libsystemd-dev \
-    devscripts cdbs pkg-config openjdk-11-jdk zip
+    devscripts cdbs pkg-config openjdk-11-jdk
 
 ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
 RUN set -xe; \
@@ -113,7 +113,7 @@ RUN set -x; apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
     autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
     build-essential cmake bison flex file libsystemd-dev \
-    devscripts cdbs pkg-config openjdk-11-jdk zip
+    devscripts cdbs pkg-config openjdk-11-jdk
 
 ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
 RUN set -xe; \
@@ -129,7 +129,7 @@ RUN set -x; apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
     autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
     build-essential cmake bison flex file libsystemd-dev \
-    devscripts cdbs pkg-config openjdk-11-jdk zip
+    devscripts cdbs pkg-config openjdk-11-jdk
 
 ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
 RUN set -xe; \
@@ -145,7 +145,7 @@ RUN set -x; yum -y update && \
     yum -y install git systemd \
     autoconf libtool libcurl-devel libtool-ltdl-devel openssl-devel yajl-devel \
     gcc gcc-c++ make bison flex file systemd-devel zlib-devel gtest-devel rpm-build java-11-openjdk-devel \
-    expect rpm-sign zip && \
+    expect rpm-sign && \
     yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     yum install -y cmake3 && \
     ln -fs cmake3 /usr/bin/cmake
@@ -168,7 +168,7 @@ RUN set -x; yum -y update && \
     yum -y install git systemd \
     autoconf libtool libcurl-devel libtool-ltdl-devel openssl-devel yajl-devel \
     gcc gcc-c++ make cmake bison flex file systemd-devel zlib-devel gtest-devel rpm-build systemd-rpm-macros java-11-openjdk-devel \
-    expect rpm-sign zip
+    expect rpm-sign
 
 ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
 RUN set -xe; \
@@ -185,7 +185,7 @@ RUN set -x; \
     # The 'OSS Update' repo signature is no longer valid, so verify the checksum instead.
     zypper --no-gpg-check refresh 'OSS Update' && \
     (echo 'b889b4bba03074cd66ef9c0184768f4816d4ccb1fa9ec2721c5583304c5f23d0  /var/cache/zypp/raw/OSS Update/repodata/repomd.xml' | sha256sum --check) && \
-    zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros zip && \
+    zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros && \
     # Remove expired root certificate.
     mv /var/lib/ca-certificates/pem/DST_Root_CA_X3.pem /etc/pki/trust/blacklist/ && \
     update-ca-certificates && \
@@ -216,7 +216,7 @@ RUN ./pkg/rpm/build.sh
 
 FROM opensuse/leap:15.1 AS sles15-build
 
-RUN set -x; zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros java-11-openjdk-devel zip && \
+RUN set -x; zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros java-11-openjdk-devel && \
     # Add home:ptrommler:formal repo to install >3.4 bison
     zypper addrepo https://download.opensuse.org/repositories/home:ptrommler:formal/openSUSE_Leap_15.1/home:ptrommler:formal.repo && \
     zypper -n --gpg-auto-import-keys refresh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN set -x; apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
     autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
     build-essential cmake bison flex file libsystemd-dev \
-    devscripts cdbs pkg-config openjdk-11-jdk
+    devscripts cdbs pkg-config openjdk-11-jdk zip
 
 ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
 RUN set -xe; \
@@ -41,7 +41,7 @@ RUN set -x; apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
     autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
     build-essential cmake bison flex file libsystemd-dev \
-    devscripts cdbs pkg-config openjdk-11-jdk
+    devscripts cdbs pkg-config openjdk-11-jdk zip
 
 ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
 RUN set -xe; \
@@ -58,7 +58,7 @@ RUN set -x; \
     DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
     autoconf libtool libcurl4-openssl-dev libltdl-dev libssl1.0-dev libyajl-dev \
     build-essential cmake bison flex file libsystemd-dev \
-    devscripts cdbs pkg-config
+    devscripts cdbs pkg-config zip
 
 ADD https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_x64_linux_hotspot_11.0.13_8.tar.gz /tmp/OpenJDK11U-jdk_x64_linux_hotspot_11.0.13_8.tar.gz
 RUN set -xe; \
@@ -81,7 +81,7 @@ RUN set -x; apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
     autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
     build-essential cmake bison flex file libsystemd-dev \
-    devscripts cdbs pkg-config openjdk-11-jdk
+    devscripts cdbs pkg-config openjdk-11-jdk zip
 
 ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
 RUN set -xe; \
@@ -97,7 +97,7 @@ RUN set -x; apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
     autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
     build-essential cmake bison flex file libsystemd-dev \
-    devscripts cdbs pkg-config openjdk-11-jdk
+    devscripts cdbs pkg-config openjdk-11-jdk zip
 
 ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
 RUN set -xe; \
@@ -113,7 +113,7 @@ RUN set -x; apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
     autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
     build-essential cmake bison flex file libsystemd-dev \
-    devscripts cdbs pkg-config openjdk-11-jdk
+    devscripts cdbs pkg-config openjdk-11-jdk zip
 
 ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
 RUN set -xe; \
@@ -129,7 +129,7 @@ RUN set -x; apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
     autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
     build-essential cmake bison flex file libsystemd-dev \
-    devscripts cdbs pkg-config openjdk-11-jdk
+    devscripts cdbs pkg-config openjdk-11-jdk zip
 
 ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
 RUN set -xe; \
@@ -145,7 +145,7 @@ RUN set -x; yum -y update && \
     yum -y install git systemd \
     autoconf libtool libcurl-devel libtool-ltdl-devel openssl-devel yajl-devel \
     gcc gcc-c++ make bison flex file systemd-devel zlib-devel gtest-devel rpm-build java-11-openjdk-devel \
-    expect rpm-sign && \
+    expect rpm-sign zip && \
     yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     yum install -y cmake3 && \
     ln -fs cmake3 /usr/bin/cmake
@@ -168,7 +168,7 @@ RUN set -x; yum -y update && \
     yum -y install git systemd \
     autoconf libtool libcurl-devel libtool-ltdl-devel openssl-devel yajl-devel \
     gcc gcc-c++ make cmake bison flex file systemd-devel zlib-devel gtest-devel rpm-build systemd-rpm-macros java-11-openjdk-devel \
-    expect rpm-sign
+    expect rpm-sign zip
 
 ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
 RUN set -xe; \
@@ -185,7 +185,7 @@ RUN set -x; \
     # The 'OSS Update' repo signature is no longer valid, so verify the checksum instead.
     zypper --no-gpg-check refresh 'OSS Update' && \
     (echo 'b889b4bba03074cd66ef9c0184768f4816d4ccb1fa9ec2721c5583304c5f23d0  /var/cache/zypp/raw/OSS Update/repodata/repomd.xml' | sha256sum --check) && \
-    zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros && \
+    zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros zip && \
     # Remove expired root certificate.
     mv /var/lib/ca-certificates/pem/DST_Root_CA_X3.pem /etc/pki/trust/blacklist/ && \
     update-ca-certificates && \
@@ -216,7 +216,7 @@ RUN ./pkg/rpm/build.sh
 
 FROM opensuse/leap:15.1 AS sles15-build
 
-RUN set -x; zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros java-11-openjdk-devel && \
+RUN set -x; zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros java-11-openjdk-devel zip && \
     # Add home:ptrommler:formal repo to install >3.4 bison
     zypper addrepo https://download.opensuse.org/repositories/home:ptrommler:formal/openSUSE_Leap_15.1/home:ptrommler:formal.repo && \
     zypper -n --gpg-auto-import-keys refresh && \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -121,13 +121,15 @@ RUN cmake --build . --config Release; `
 # TODO: Do something with /work/out/bin/fluent-bit.{exe,dll}
 
 ###############################################################################
-# Build JMX Project
+# Build Go code in one container to exploit Go build caching
 ###############################################################################
 
-FROM base as javacontrib
+FROM base as gobuilder
 
-# Both of these are necessary for the nebula release plugin's options
-COPY .git /work/.git
+###############################################################################
+# Build JMX Project hereso it can be hashed for
+# build flags for operations-collector
+###############################################################################
 
 ADD https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x64_windows_hotspot_11.0.12_7.msi /local/jdk-11-windows-x64.msi
 RUN Start-Process -Wait 'msiexec' -ArgumentList '/i C:\local\jdk-11-windows-x64.msi ADDLOCAL=FeatureMain INSTALLDIR=C:\Java\ /log c:\java_install64.log'
@@ -136,16 +138,11 @@ COPY submodules/opentelemetry-java-contrib /work/submodules/opentelemetry-java-c
 
 WORKDIR /work/submodules/opentelemetry-java-contrib
 
-# Build & test systems do not always check out git history for submodules, so the properties assigned
-# here allow the nebula release process to function properly in that state
 RUN ./gradlew --no-daemon :jmx-metrics:build; `
     Copy-Item -Path jmx-metrics/build/libs/opentelemetry-jmx-metrics-*-SNAPSHOT.jar -Destination /work/out/bin/opentelemetry-java-contrib-jmx-metrics.jar;
 
-###############################################################################
-# Build Go code in one container to exploit Go build caching
-###############################################################################
-
-FROM base as gobuilder
+RUN powershell -Command Get-FileHash /work/out/bin/opentelemetry-java-contrib-jmx-metrics.jar -Algorithm SHA256 | `
+    Select-Object -ExpandProperty Hash | Out-File -FilePath /work/jarhash.sha256
 
 ###############################################################################
 # Build OT collector
@@ -155,7 +152,10 @@ COPY submodules/opentelemetry-operations-collector /work/submodules/opentelemetr
 
 WORKDIR /work/submodules/opentelemetry-operations-collector
 
-RUN go build -o bin/google-cloud-metrics-agent_windows_amd64.exe ./cmd/otelopscol; `
+RUN FOR /F %A IN ('type /work/jarhash.sha256') DO `
+    go build -o bin/google-cloud-metrics-agent_windows_amd64.exe `
+    -ldflags "-X github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver.MetricsGathererHash=%~A" `
+     ./cmd/otelopscol; `
     Copy-Item -Path bin/google-cloud-metrics-agent_windows_amd64.exe -Destination /work/out/bin/;
 
 ###############################################################################

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -127,8 +127,8 @@ RUN cmake --build . --config Release; `
 FROM base as gobuilder
 
 ###############################################################################
-# Build JMX Project hereso it can be hashed for
-# build flags for operations-collector
+# Build JMX Project here so it can be hashed for
+# a required build flag to support jmx receiver in operations-collector
 ###############################################################################
 
 ADD https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x64_windows_hotspot_11.0.12_7.msi /local/jdk-11-windows-x64.msi
@@ -141,9 +141,6 @@ WORKDIR /work/submodules/opentelemetry-java-contrib
 RUN ./gradlew --no-daemon :jmx-metrics:build; `
     Copy-Item -Path jmx-metrics/build/libs/opentelemetry-jmx-metrics-*-SNAPSHOT.jar -Destination /work/out/bin/opentelemetry-java-contrib-jmx-metrics.jar;
 
-RUN powershell -Command Get-FileHash /work/out/bin/opentelemetry-java-contrib-jmx-metrics.jar -Algorithm SHA256 | `
-    Select-Object -ExpandProperty Hash | Out-File -FilePath /work/jarhash.sha256
-
 ###############################################################################
 # Build OT collector
 ###############################################################################
@@ -152,9 +149,9 @@ COPY submodules/opentelemetry-operations-collector /work/submodules/opentelemetr
 
 WORKDIR /work/submodules/opentelemetry-operations-collector
 
-RUN FOR /F %A IN ('type /work/jarhash.sha256') DO `
+RUN $JarHash = Get-FileHash /work/out/bin/opentelemetry-java-contrib-jmx-metrics.jar -Algorithm SHA256 | Select -Expand Hash; `
     go build -o bin/google-cloud-metrics-agent_windows_amd64.exe `
-    -ldflags "-X github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver.MetricsGathererHash=%~A" `
+    -ldflags \"-X github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver.MetricsGathererHash=$JarHash\" `
      ./cmd/otelopscol; `
     Copy-Item -Path bin/google-cloud-metrics-agent_windows_amd64.exe -Destination /work/out/bin/;
 
@@ -185,6 +182,5 @@ COPY . /work
 
 COPY --from=fluentbit /work/out /work/out
 COPY --from=gobuilder /work/out /work/out
-COPY --from=javacontrib /work/out /work/out
 
 RUN & .\pkg\goo\build.ps1 -DestDir /work/out;

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -149,7 +149,7 @@ COPY submodules/opentelemetry-operations-collector /work/submodules/opentelemetr
 
 WORKDIR /work/submodules/opentelemetry-operations-collector
 
-RUN $JarHash = Get-FileHash /work/out/bin/opentelemetry-java-contrib-jmx-metrics.jar -Algorithm SHA256 | Select -Expand Hash; `
+RUN $JarHash = (Get-FileHash /work/out/bin/opentelemetry-java-contrib-jmx-metrics.jar -Algorithm SHA256 | Select -Expand Hash).toLower(); `
     go build -o bin/google-cloud-metrics-agent_windows_amd64.exe `
     -ldflags \"-X github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver.MetricsGathererHash=$JarHash\" `
      ./cmd/otelopscol; `

--- a/build.sh
+++ b/build.sh
@@ -45,9 +45,16 @@ fi
 function build_otel() {
   cd submodules/opentelemetry-java-contrib
   mkdir -p "$DESTDIR$subagentdir/opentelemetry-collector/"
-  mv LICENSE LICENSE.apache
   ./gradlew --no-daemon :jmx-metrics:build
   cp jmx-metrics/build/libs/opentelemetry-jmx-metrics-*-SNAPSHOT.jar "$DESTDIR$subagentdir/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar"
+
+  # Rename LICENSE file because it causes issues with file hash consistency
+  # due to an unknown issue with the debuild/rpmbuild processes
+  mkdir ./META-INF
+  unzip -j "$DESTDIR$subagentdir/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar" "META-INF/LICENSE" -d ./META-INF
+  zip -d "$DESTDIR$subagentdir/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar" "META-INF/LICENSE"
+  mv ./META-INF/LICENSE ./META-INF/LICENSE.renamed
+  zip -u "$DESTDIR$subagentdir/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar" "META-INF/LICENSE.renamed"
 
   cd ../opentelemetry-operations-collector
   # Using array assignment to drop the filename from the sha256sum output

--- a/build.sh
+++ b/build.sh
@@ -45,7 +45,12 @@ fi
 function build_otel() {
   cd submodules/opentelemetry-operations-collector
   mkdir -p "$DESTDIR$subagentdir/opentelemetry-collector"
-  go build -o "$DESTDIR$subagentdir/opentelemetry-collector/otelopscol" ./cmd/otelopscol
+
+  # Using array assignment to drop the filename from the hash
+  JAR_SHA_256=($(sha256sum "$DESTDIR$subagentdir/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar"))
+  go build -o "$DESTDIR$subagentdir/opentelemetry-collector/otelopscol" \
+    -ldflags "-X github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver.MetricsGathererHash=${JAR_SHA_256}" \
+    ./cmd/otelopscol
 }
 
 function build_otel_jmx() {
@@ -104,8 +109,8 @@ function build_systemd() {
   done
 }
 
-(build_otel)
 (build_otel_jmx)
+(build_otel)
 (build_fluentbit)
 (build_opsagent)
 (build_systemd)

--- a/build.sh
+++ b/build.sh
@@ -48,13 +48,14 @@ function build_otel() {
   ./gradlew --no-daemon :jmx-metrics:build
   cp jmx-metrics/build/libs/opentelemetry-jmx-metrics-*-SNAPSHOT.jar "$DESTDIR$subagentdir/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar"
 
-  # Rename LICENSE file because it causes issues with file hash consistency
-  # due to an unknown issue with the debuild/rpmbuild processes
+  # Rename LICENSE file because it causes issues with file hash consistency due to an unknown
+  # issue with the debuild/rpmbuild processes. Something is unzipping the jar in a case-insensitive
+  # environment and having a conflict between the LICENSE file and license/ directory, leading to a changed jar file
   mkdir ./META-INF
   unzip -j "$DESTDIR$subagentdir/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar" "META-INF/LICENSE" -d ./META-INF
-  zip -d "$DESTDIR$subagentdir/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar" "META-INF/LICENSE"
+  tar --delete -f "$DESTDIR$subagentdir/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar" "META-INF/LICENSE"
   mv ./META-INF/LICENSE ./META-INF/LICENSE.renamed
-  zip -u "$DESTDIR$subagentdir/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar" "META-INF/LICENSE.renamed"
+  tar -rf "$DESTDIR$subagentdir/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar" "META-INF/LICENSE.renamed"
 
   cd ../opentelemetry-operations-collector
   # Using array assignment to drop the filename from the sha256sum output

--- a/build.sh
+++ b/build.sh
@@ -45,6 +45,7 @@ fi
 function build_otel() {
   cd submodules/opentelemetry-java-contrib
   mkdir -p "$DESTDIR$subagentdir/opentelemetry-collector/"
+  mv LICENSE LICENSE.apache
   ./gradlew --no-daemon :jmx-metrics:build
   cp jmx-metrics/build/libs/opentelemetry-jmx-metrics-*-SNAPSHOT.jar "$DESTDIR$subagentdir/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar"
 

--- a/build.sh
+++ b/build.sh
@@ -53,7 +53,7 @@ function build_otel() {
   # environment and having a conflict between the LICENSE file and license/ directory, leading to a changed jar file
   mkdir ./META-INF
   unzip -j "$DESTDIR$subagentdir/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar" "META-INF/LICENSE" -d ./META-INF
-  zip --d "$DESTDIR$subagentdir/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar" "META-INF/LICENSE"
+  zip -d "$DESTDIR$subagentdir/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar" "META-INF/LICENSE"
   mv ./META-INF/LICENSE ./META-INF/LICENSE.renamed
   zip -u "$DESTDIR$subagentdir/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar" "META-INF/LICENSE.renamed"
 

--- a/build.sh
+++ b/build.sh
@@ -53,9 +53,9 @@ function build_otel() {
   # environment and having a conflict between the LICENSE file and license/ directory, leading to a changed jar file
   mkdir ./META-INF
   unzip -j "$DESTDIR$subagentdir/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar" "META-INF/LICENSE" -d ./META-INF
-  tar --delete -f "$DESTDIR$subagentdir/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar" "META-INF/LICENSE"
+  zip --d "$DESTDIR$subagentdir/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar" "META-INF/LICENSE"
   mv ./META-INF/LICENSE ./META-INF/LICENSE.renamed
-  tar -rf "$DESTDIR$subagentdir/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar" "META-INF/LICENSE.renamed"
+  zip -u "$DESTDIR$subagentdir/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar" "META-INF/LICENSE.renamed"
 
   cd ../opentelemetry-operations-collector
   # Using array assignment to drop the filename from the sha256sum output

--- a/debian/rules
+++ b/debian/rules
@@ -9,6 +9,8 @@ override_dh_auto_configure:
 	true
 override_dh_auto_build:
 	true
+override_dh_strip_nondeterminism:
+	dh_strip_nondeterminism -X.jar
 override_dh_auto_install:
 	CODE_VERSION=$(code_version) BUILD_DISTRO=$(DEB_DISTRIBUTION) DESTDIR=$$PWD/debian/google-cloud-ops-agent ./build.sh
 

--- a/integration_test/third_party_apps_data/applications/rabbitmq/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/rabbitmq/debian_ubuntu/install
@@ -8,31 +8,30 @@ sudo apt-get install -y \
     debian-keyring \
     debian-archive-keyring 
     
+curl -1sLf "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc" | sudo gpg --dearmor | \
+    sudo apt-key add -
 
-curl -s https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc | \
+curl -1sLf "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf77f1eda57ebb1cc" | sudo gpg --dearmor | \
     sudo apt-key add -
 
 source /etc/os-release
 case $VERSION_ID in
   # ubuntu
   20.04)
-    echo "deb https://packages.erlang-solutions.com/ubuntu focal contrib" | sudo tee /etc/apt/sources.list.d/rabbitmq.list
+    echo "deb http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/rabbitmq.list
     ;;
   # debian
   10)
-    echo "deb https://packages.erlang-solutions.com/ubuntu bionic contrib" | sudo tee /etc/apt/sources.list.d/rabbitmq.list
+    echo "deb http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu bionic main" | sudo tee /etc/apt/sources.list.d/rabbitmq.list
     ;;
   11)
-    echo "deb https://packages.erlang-solutions.com/ubuntu focal contrib" | sudo tee /etc/apt/sources.list.d/rabbitmq.list
+    echo "deb http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/rabbitmq.list
     ;;
   *)
     echo -n "unknown version"
     exit 1
     ;;
 esac
-
-sudo apt-get update
-sudo apt-get install -y erlang
 
 curl -s \
     https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.deb.sh | \

--- a/pkg/rpm/google-cloud-ops-agent.spec
+++ b/pkg/rpm/google-cloud-ops-agent.spec
@@ -9,6 +9,9 @@
 %endif
 %endif
 
+# Disabling stripping to prevent changing jar hash
+%global __os_install_post %{nil}
+
 Name: google-cloud-ops-agent
 Version: %{package_version}
 Release: 1%{?dist}


### PR DESCRIPTION
This PR updates the build to meet the expectations of the new jmx receiver changes that require the jar file to always be a known release (or hash provided to the build process).

Also resolves an issue with rabbitmq integration tests where an older version of erlang was the only one provided, and the version of rabbitmq that would support it is no longer offered by the rabbitmq repository.

Validated on windows, windows tests are currently broken for other reasons.