### PR TITLE
Change all dlcdn.apache links to archive.apache

### DIFF
--- a/integration_test/third_party_apps_data/applications/cassandra/sles/install
+++ b/integration_test/third_party_apps_data/applications/cassandra/sles/install
@@ -15,8 +15,7 @@ sudo zypper -n refresh
 sudo zypper -n install java-1_8_0-openjdk java-1_8_0-openjdk-devel
 
 # There is no official or even semi-official zypper package for cassandra
-curl -OL https://dlcdn.apache.org/cassandra/4.0.1/apache-cassandra-4.0.1-bin.tar.gz
-# TODO - compare to curl -L https://downloads.apache.org/cassandra/4.0.1/apache-cassandra-4.0.1-bin.tar.gz.sha256
+curl -OL https://archive.apache.org/dist/cassandra/4.0.1/apache-cassandra-4.0.1-bin.tar.gz
 
 tar xzvf apache-cassandra-4.0.1-bin.tar.gz
 mv apache-cassandra-4.0.1 apache-cassandra

--- a/integration_test/third_party_apps_data/applications/flink/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/flink/centos_rhel/install
@@ -3,7 +3,7 @@ set -e
 sudo yum -y install \
     java-1.8.0-openjdk java-1.8.0-openjdk-devel curl
 
-curl -L -o flink.tgz https://dlcdn.apache.org/flink/flink-1.14.4/flink-1.14.4-bin-scala_2.11.tgz
+curl -L -o flink.tgz https://archive.apache.org/dist/flink/flink-1.14.4/flink-1.14.4-bin-scala_2.11.tgz
 
 sudo mkdir /opt/flink
 sudo tar -xzf flink.tgz -C /opt/flink --strip-components 1

--- a/integration_test/third_party_apps_data/applications/flink/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/flink/debian_ubuntu/install
@@ -3,7 +3,7 @@ set -e
 sudo apt-get update
 sudo apt-get install -y curl default-jre
 
-curl -L -o flink.tgz https://dlcdn.apache.org/flink/flink-1.14.4/flink-1.14.4-bin-scala_2.11.tgz
+curl -L -o flink.tgz https://archive.apache.org/dist/flink/flink-1.14.4/flink-1.14.4-bin-scala_2.11.tgz
 
 sudo mkdir /opt/flink
 sudo tar -xzf flink.tgz -C /opt/flink --strip-components 1

--- a/integration_test/third_party_apps_data/applications/flink/sles/install
+++ b/integration_test/third_party_apps_data/applications/flink/sles/install
@@ -2,7 +2,7 @@ set -e
 
 sudo zypper install -y curl java-11-openjdk
 
-curl -L -o flink.tgz https://dlcdn.apache.org/flink/flink-1.14.4/flink-1.14.4-bin-scala_2.11.tgz
+curl -L -o flink.tgz https://archive.apache.org/dist/flink/flink-1.14.4/flink-1.14.4-bin-scala_2.11.tgz
 
 sudo mkdir /opt/flink
 sudo tar -xzf flink.tgz -C /opt/flink --strip-components 1

--- a/integration_test/third_party_apps_data/applications/hadoop/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/hadoop/centos_rhel/install
@@ -8,7 +8,7 @@ sudo mkdir -p \
     /opt/volume/datanode \
     /opt/volume/namenode
 
-wget --no-verbose https://dlcdn.apache.org/hadoop/common/hadoop-3.3.1/hadoop-3.3.1.tar.gz
+wget --no-verbose https://archive.apache.org/dist/hadoop/common/hadoop-3.3.1/hadoop-3.3.1.tar.gz
 sudo tar -xf hadoop-3.3.1.tar.gz -C /opt/hadoop --strip 1
 
 JAVA_HOME="$(dirname "$(dirname "$(readlink "$(readlink "$(which javac)")")")")"

--- a/integration_test/third_party_apps_data/applications/hadoop/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/hadoop/debian_ubuntu/install
@@ -8,7 +8,7 @@ sudo mkdir -p \
     /opt/volume/datanode \
     /opt/volume/namenode
 
-wget --no-verbose https://dlcdn.apache.org/hadoop/common/hadoop-3.3.1/hadoop-3.3.1.tar.gz
+wget --no-verbose https://archive.apache.org/dist/hadoop/common/hadoop-3.3.1/hadoop-3.3.1.tar.gz
 sudo tar -xf hadoop-3.3.1.tar.gz -C /opt/hadoop --strip 1
 
 JAVA_HOME="$(dirname "$(dirname "$(readlink "$(readlink "$(which javac)")")")")"

--- a/integration_test/third_party_apps_data/applications/hadoop/sles/install
+++ b/integration_test/third_party_apps_data/applications/hadoop/sles/install
@@ -7,7 +7,7 @@ sudo mkdir -p \
     /opt/volume/datanode \
     /opt/volume/namenode
 
-wget --no-verbose https://dlcdn.apache.org/hadoop/common/hadoop-3.3.1/hadoop-3.3.1.tar.gz
+wget --no-verbose https://archive.apache.org/dist/hadoop/common/hadoop-3.3.1/hadoop-3.3.1.tar.gz
 sudo tar -xf hadoop-3.3.1.tar.gz -C /opt/hadoop --strip 1
 
 JAVA_HOME="$(dirname "$(dirname "$(readlink "$(readlink "$(which javac)")")")")"

--- a/integration_test/third_party_apps_data/applications/zookeeper/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/zookeeper/centos_rhel/install
@@ -4,7 +4,7 @@ sudo yum install -y curl java
 
 sudo mkdir -p /opt/zookeeper/stage
 sudo curl \
-    "https://dlcdn.apache.org/zookeeper/zookeeper-3.7.1/apache-zookeeper-3.7.1-bin.tar.gz" \
+    "https://archive.apache.org/dist/zookeeper/zookeeper-3.7.1/apache-zookeeper-3.7.1-bin.tar.gz" \
     -o /opt/zookeeper/stage/zk.tgz
 sudo tar -xvzf /opt/zookeeper/stage/zk.tgz -C /opt/zookeeper --strip 1
 

--- a/integration_test/third_party_apps_data/applications/zookeeper/sles/install
+++ b/integration_test/third_party_apps_data/applications/zookeeper/sles/install
@@ -4,7 +4,7 @@ sudo zypper install -y curl java-11-openjdk
 
 sudo mkdir -p /opt/zookeeper/stage
 sudo curl \
-    "https://dlcdn.apache.org/zookeeper/zookeeper-3.7.1/apache-zookeeper-3.7.1-bin.tar.gz" \
+    "https://archive.apache.org/dist/zookeeper/zookeeper-3.7.1/apache-zookeeper-3.7.1-bin.tar.gz" \
     -o /opt/zookeeper/stage/zk.tgz
 sudo tar -xvzf /opt/zookeeper/stage/zk.tgz -C /opt/zookeeper --strip 1
 


### PR DESCRIPTION
Flink tests were breaking from another link to dlcdn where the patch version has been replaced with a newer one, so I thought we'd just skip waiting for these other sources to become unavailable and point to the archive that shouldn't go away.