### PR TITLE
Refer to archive for solr install

### DIFF
--- a/integration_test/third_party_apps_data/applications/solr/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/solr/centos_rhel/install
@@ -12,7 +12,7 @@ sudo yum install -y \
 
 curl -L -o \
     solr-8.11.1.tgz \
-    https://downloads.apache.org/lucene/solr/8.11.1/solr-8.11.1.tgz
+    https://archive.apache.org/dist/lucene/solr/8.11.1/solr-8.11.1.tgz
 
 tar -xzf \
     solr-8.11.1.tgz \

--- a/integration_test/third_party_apps_data/applications/solr/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/solr/debian_ubuntu/install
@@ -6,7 +6,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 
 curl -L -o \
     solr-8.11.1.tgz \
-    https://downloads.apache.org/lucene/solr/8.11.1/solr-8.11.1.tgz
+    https://archive.apache.org/dist/lucene/solr/8.11.1/solr-8.11.1.tgz
 
 tar -xzf \
     solr-8.11.1.tgz \

--- a/integration_test/third_party_apps_data/applications/solr/sles/install
+++ b/integration_test/third_party_apps_data/applications/solr/sles/install
@@ -5,7 +5,7 @@ sudo zypper install -y \
 
 curl -L -o \
     solr-8.11.1.tgz \
-    https://downloads.apache.org/lucene/solr/8.11.1/solr-8.11.1.tgz
+    https://archive.apache.org/dist/lucene/solr/8.11.1/solr-8.11.1.tgz
 
 tar -xzf \
     solr-8.11.1.tgz \


### PR DESCRIPTION
Missed one using downloads, rather than dlcdn. This should be the last one, but apparently today was release day for all kinds of projects.