### PR TITLE
Remove "for more information"

### DIFF
--- a/integration_test/third_party_apps_data/applications/mysql/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mysql/metadata.yaml
@@ -10,10 +10,6 @@ description: |-
   parsed for their error code and subsystem. Slow-query logs are parsed into
   key-value pairs that describe the performance of a query, including query time
   and rows examined.
-
-  For more information about MySQL/MariaDB, see
-  [mysql.com](http://www.mysql.com/){: .external}
-  and [mariadb.org](https://mariadb.org/){: .external}.
 configure_integration: |-
   MariaDB is a community-developed, commercially supported fork of the MySQL
   relational database management system (RDBMS). To collect logs and metrics for


### PR DESCRIPTION
Remove "for more information" this will be provided within the google doc generator by using the app_url for the link