### PR TITLE
Remove `minimum_supported_version` from the Vault metadata

### DIFF
--- a/integration_test/third_party_apps_data/applications/vault/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/vault/metadata.yaml
@@ -3,7 +3,6 @@ short_name: Vault
 long_name: Hashicorp Vault
 description: |-
   Vault is an identity-based secrets and encryption management system. This integration Collects Vault's audit logs.
-minimum_supported_agent_version:
 supported_app_version: ["1.6+"]
 expected_logs:
 - log_name: vault_audit


### PR DESCRIPTION
This field will be set by the post-release job once a release is done.