### PR TITLE
Kokoro: initial checkin of GCL build configs

### DIFF
--- a/kokoro/config/build/common.gcl
+++ b/kokoro/config/build/common.gcl
@@ -1,0 +1,34 @@
+// Common configuration for Linux Ops Agent builds.
+
+import '../utils/functions.gcl' as functions
+
+template config build = {
+  build_file = 'unified_agents/kokoro/scripts/build/build_package.sh'
+
+  params {
+    package_format = null
+
+    environment {
+      PKGFORMAT = package_format
+    }
+
+    keystore_keys = []
+    artifacts = ["**/result/**", "**/out/**"]
+  }
+
+  before_action = [functions.fetch_keystore(params.keystore_keys)]
+
+  action = [
+    {
+      define_artifacts = {
+        regex = params.artifacts
+      }
+    },
+  ]
+
+  env_vars = functions.environment_variables(params.environment)
+}
+
+template config windows_build = build {
+  build_file = 'unified_agents/kokoro/scripts/build/build_package.bat'
+}

--- a/kokoro/config/build/presubmit/bullseye.gcl
+++ b/kokoro/config/build/presubmit/bullseye.gcl
@@ -1,0 +1,8 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    distro = 'bullseye'
+    package_format = 'deb'
+  }
+}

--- a/kokoro/config/build/presubmit/windows.gcl
+++ b/kokoro/config/build/presubmit/windows.gcl
@@ -1,0 +1,3 @@
+import '../common.gcl' as common
+
+config build = common.windows_build {}

--- a/kokoro/config/build/x86_64_linux/release.gcl
+++ b/kokoro/config/build/x86_64_linux/release.gcl
@@ -1,0 +1,17 @@
+import '../common.gcl' as common
+
+// Proper release builds need access to the RPM signing key. This key should not
+// be used for any presubmits triggered by external folks on unreviewed PRs from
+// GitHub. We don't want to expose the RPM signing key to any potential leak
+// from malicious PRs. Note that the key is hidden from GitHub presubmits via
+// Keystore ACLs, which is the way that this is actually enforced.
+config build = common.build {
+  params {
+    keystore_keys = super.keystore_keys + [
+      { id = 71565, name = 'rpm-signing-key' },
+    ]
+    environment {
+      SKIP_SIGNING = null
+    }
+  }
+}

--- a/kokoro/config/build/x86_64_windows/release.gcl
+++ b/kokoro/config/build/x86_64_windows/release.gcl
@@ -1,0 +1,3 @@
+import '../common.gcl' as common
+
+config build = common.windows_build {}

--- a/kokoro/config/test/common.gcl
+++ b/kokoro/config/test/common.gcl
@@ -1,0 +1,57 @@
+import '../utils/functions.gcl' as functions
+
+template config common = {
+  params = {
+    platforms = external
+    build_file = external
+
+    artifacts = []
+
+    environment = {
+      PROJECT = 'stackdriver-test-143416'
+      ZONE = 'us-central1-b'
+
+      PLATFORMS = join(platforms, ',')
+    }
+  }
+
+  build_file = params.build_file
+
+  action = [
+    {
+      define_artifacts = {
+        regex = params.artifacts
+      }
+    },
+  ]
+  env_vars = functions.environment_variables(params.environment)
+}
+
+template config go_test = common {
+  params {
+    test_suite = external
+
+    build_file = 'unified_agents/kokoro/scripts/test/go_test.sh'
+
+    environment {
+      TEST_SUITE_NAME = test_suite
+
+      // The firewall rules for our test project don't allow us to ssh/RDP
+      // from the Kokoro worker into the VM under test via the external IP
+      // address. Using the internal IP address gets around this issue though
+      // (but only because the Kokoro worker is in the same project as the VM
+      // under test).
+      USE_INTERNAL_IP = 'true'
+
+      TRANSFERS_BUCKET = 'stackdriver-test-143416-untrusted-file-transfers'
+      SERVICE_EMAIL =
+          'build-and-test-external@stackdriver-test-143416.iam.gserviceaccount.com'
+      WINRM_IN_GCS =
+          'gs://stackdriver-test-143416-untrusted-file-transfers/winrm.par'
+    }
+
+    artifacts = super.artifacts + [
+      '**/logs/**',
+    ]
+  }
+}

--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -1,0 +1,158 @@
+// These are the shared lists of test images organized by distro family and
+// grouped by the most fine-grained build artifact (in this case, the
+// per-distro monitoring agent package).
+
+// A representation of a test distro.
+local template _distro {
+  // Human-readable name.
+  name = external
+  // List of release images.
+  release = external
+  // The representative image to be used in presubmit (defaults to none).
+  // Presubmits usually smoke test only the oldest and newest OS families from
+  // a certain OS to speed up presubmit tests and reduce flakiness. The full
+  // set will be tested by the nightly jobs.
+  presubmit = null
+}
+
+local template _family {
+  distros = external
+  // Extract the release image lists for all distros in a given family.
+  releases = sort_asc(flatten(map(lambda d_: d_.release, distros.values())))
+  // Extract the presubmit images for all distros in a given family.
+  presubmits = sort_asc(
+    filter(is_string, map(lambda d_: d_.presubmit, distros.values())))
+}
+
+// DEB Linux distros.
+debian = _family {
+  distros = {
+    stretch = _distro {
+      name = 'Debian 9'
+      release = ['debian-9']
+      presubmit = 'debian-9'
+    }
+    buster = _distro {
+      name = 'Debian 10'
+      release = ['debian-10']
+      presubmit = 'debian-10'
+    }
+    bullseye = _distro {
+      name = 'Debian 11'
+      release = ['debian-11']
+    }
+  }
+}
+ubuntu = _family {
+  distros = {
+    bionic = _distro {
+      name = 'Ubuntu 18.04 Bionic'
+      release = [
+        'ubuntu-1804-lts',
+        'ubuntu-minimal-1804-lts',
+      ]
+      presubmit = 'ubuntu-1804-lts'
+    }
+    focal = _distro {
+      name = 'Ubuntu 20.04 Focal'
+      release = [
+        'ubuntu-2004-lts',
+        'ubuntu-minimal-2004-lts',
+      ]
+      presubmit = 'ubuntu-minimal-2004-lts'
+    }
+    impish = _distro {
+      name = 'Ubuntu 21.10 Impish'
+      release = [
+        'ubuntu-2110',
+        'ubuntu-minimal-2110',
+      ]
+    }
+    jammy = _distro {
+      name = 'Ubuntu 22.04 Jammy'
+      release = [
+        'ubuntu-2204-lts',
+        'ubuntu-minimal-2204-lts',
+      ]
+    }
+  }
+}
+
+// RPM Linux distros.
+centos = _family {
+  distros = {
+    centos7 = _distro {
+      name = 'CentOS 7'
+      release = [
+        // CentOS.
+        'centos-7',
+        // RHEL.
+        'rhel-7',
+        'rhel-7-6-sap-ha',
+        'rhel-7-7-sap-ha',
+        'rhel-7-9-sap-ha',
+      ]
+      presubmit = 'centos-7'
+    }
+    centos8 = _distro {
+      name = 'CentOS 8'
+      release = [
+        // CentOS.
+        'centos-8',
+        // RHEL.
+        'rhel-8',
+        'rhel-8-1-sap-ha',
+        'rhel-8-2-sap-ha',
+        'rhel-8-4-sap-ha',
+        // Rocky.
+        'rocky-linux-8',
+      ]
+      presubmit = 'rocky-linux-8'
+    }
+  }
+}
+sles = _family {
+  distros = {
+    sles12 = _distro {
+      name = 'SLES 12'
+      release = [
+        'sles-12',
+        'sles-12-sp3-sap',
+        'sles-12-sp4-sap',
+        'sles-12-sp5-sap',
+      ]
+      presubmit = 'sles-12'
+    }
+    sles15 = _distro {
+      name = 'SLES 15'
+      release = [
+        'sles-15',
+        'sles-15-sap',
+        'sles-15-sp1-sap',
+        'sles-15-sp2-sap',
+        'opensuse-leap',
+        'opensuse-leap-15-2',
+      ]
+      presubmit = 'sles-15'
+    }
+  }
+}
+
+// Windows distros.
+windows = _family {
+  distros = {
+    windows = _distro {
+      name = 'Windows'
+      release = [
+        'windows-2012-r2',
+        'windows-2012-r2-core',
+        'windows-2016',
+        'windows-2016-core',
+        'windows-2019',
+        'windows-2019-core',
+        'windows-20h2-core',
+      ]
+      presubmit = 'windows-2016'
+    }
+  }
+}

--- a/kokoro/config/test/ops_agent/bullseye.gcl
+++ b/kokoro/config/test/ops_agent/bullseye.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    platforms = ['debian-11']
+  }
+}

--- a/kokoro/config/test/ops_agent/common.gcl
+++ b/kokoro/config/test/ops_agent/common.gcl
@@ -1,0 +1,7 @@
+import '../common.gcl' as common
+
+template config ops_agent_test = common.go_test {
+  params {
+    test_suite = 'ops_agent_test'
+  }
+}

--- a/kokoro/config/test/ops_agent/release/bullseye.gcl
+++ b/kokoro/config/test/ops_agent/release/bullseye.gcl
@@ -1,0 +1,8 @@
+import '../common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.debian.distros.bullseye.release
+  }
+}

--- a/kokoro/config/test/ops_agent/release/windows.gcl
+++ b/kokoro/config/test/ops_agent/release/windows.gcl
@@ -1,0 +1,8 @@
+import '../common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.windows.distros.windows.release
+  }
+}

--- a/kokoro/config/test/ops_agent/windows.gcl
+++ b/kokoro/config/test/ops_agent/windows.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    platforms = [
+      'windows-2012-r2',
+      'windows-2019',
+    ]
+  }
+}

--- a/kokoro/config/test/third_party_apps/bullseye.gcl
+++ b/kokoro/config/test/third_party_apps/bullseye.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['debian-11']
+  }
+}

--- a/kokoro/config/test/third_party_apps/common.gcl
+++ b/kokoro/config/test/third_party_apps/common.gcl
@@ -1,0 +1,7 @@
+import '../common.gcl' as common
+
+template config third_party_apps_test = common.go_test {
+  params {
+    test_suite = 'third_party_apps_test'
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/bullseye.gcl
+++ b/kokoro/config/test/third_party_apps/release/bullseye.gcl
@@ -1,0 +1,7 @@
+import '../common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['debian-11']
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/windows.gcl
+++ b/kokoro/config/test/third_party_apps/release/windows.gcl
@@ -1,0 +1,11 @@
+import '../common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = [
+      'windows-2012-r2',
+      'windows-2019',
+      'sql-std-2019-win-2019',
+    ]
+  }
+}

--- a/kokoro/config/test/third_party_apps/windows.gcl
+++ b/kokoro/config/test/third_party_apps/windows.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = [
+      'windows-2012-r2',
+      'windows-2019',
+    ]
+  }
+}

--- a/kokoro/config/utils/functions.gcl
+++ b/kokoro/config/utils/functions.gcl
@@ -1,0 +1,33 @@
+// Convert a map or a tuple into Kokoro environment variables.
+//
+// Example usage:
+//  environment_variables(['foo': 'bar', 'x': 'y'])
+//  environment_variables({foo = 'bar', x = 'y'})
+// Returns
+//  [{key = 'foo', value = 'bar'}, {key = 'x', value = 'y'}]
+environment_variables = lambda vars_: {
+  assert is_map(vars_) || is_tuple(vars_)
+  ret = map(lambda x_: { key = x_[0], value = x_[1] }, vars_.items())
+}.ret
+
+// Create a fetch_keystore action with the given resources.
+//
+// Example usage:
+//  fetch_keystore([[123, 'name']])
+//  fetch_keystore([{id = 123, name = 'name'}])
+// Returns
+//  [{fetch_keystore = {keystore_resource = [{keystore_config_id = 123, keyname = 'name'}]}}]
+fetch_keystore = lambda keys_: {
+  fetch_keystore = {
+    keystore_resource = map(lambda x_: cond(
+      is_tuple(x_),
+      {
+        keystore_config_id = x_.id
+        keyname = x_.name
+      },
+      {
+        keystore_config_id = x_[0]
+        keyname = x_[1]
+      }), keys_)
+  }
+}


### PR DESCRIPTION
This is a straight-up copy of the internal temp_open_sourcing directory, which recently got permission to be open-sourced.

Just the Windows and Bullseye configs came over for now, the plan is to fix issues with this minimal set first, then expand out to the full set of distros by copying the files from github, not by copying the rest of the files over from google's internal source system.