### PR TITLE
Add couchbase for 3rd party e2e tests

### DIFF
--- a/integration_test/third_party_apps_data/agent/linux/supported_applications.txt
+++ b/integration_test/third_party_apps_data/agent/linux/supported_applications.txt
@@ -1,6 +1,7 @@
 activemq
 apache
 cassandra
+couchbase
 couchdb
 elasticsearch
 flink


### PR DESCRIPTION
The specified couchbase test was missing from below PRs:
https://github.com/GoogleCloudPlatform/ops-agent/pull/671
https://github.com/GoogleCloudPlatform/ops-agent/pull/667