### PR TITLE
Added validation for duplicated network port for logging receivers

### DIFF
--- a/confgenerator/config.go
+++ b/confgenerator/config.go
@@ -392,6 +392,12 @@ func (m *loggingReceiverMap) UnmarshalYAML(unmarshal func(interface{}) error) er
 	return nil
 }
 
+// Logging receivers that listen on a port of the host
+type LoggingNetworkReceiver interface {
+	LoggingReceiver
+	GetListenPort() uint16
+}
+
 type LoggingProcessor interface {
 	Component
 	// Components returns fluentbit components that implement this procesor.
@@ -698,6 +704,7 @@ func (l *Logging) Validate(platform string) error {
 	if l.Service == nil {
 		return nil
 	}
+	portTaken := map[uint16]string{} // port -> receiverId map
 	for _, id := range sortedKeys(l.Service.Pipelines) {
 		p := l.Service.Pipelines[id]
 		if err := validateComponentKeys(l.Receivers, p.ReceiverIDs, subagent, "receiver", id); err != nil {
@@ -717,6 +724,10 @@ func (l *Logging) Validate(platform string) error {
 			return err
 		}
 		if _, err := validateComponentTypeCounts(l.Processors, p.ProcessorIDs, subagent, "processor"); err != nil {
+			return err
+		}
+		// portTaken will be modified/updated by the validation function
+		if _, err := validateReceiverPorts(portTaken, l.Receivers, p.ReceiverIDs); err != nil {
 			return err
 		}
 		if len(p.ExporterIDs) > 0 {
@@ -775,6 +786,12 @@ var (
 		"hostmetrics":             1,
 		"iis":                     1,
 		"mssql":                   1,
+	}
+
+	receiverPortLimits = map[string]bool{
+		"syslog":         true,
+		"tcp":            true,
+		"fluent_forward": true,
 	}
 )
 
@@ -863,6 +880,32 @@ func validateComponentTypeCounts(components interface{}, refs []string, subagent
 		}
 	}
 	return r, nil
+}
+
+// Validate that no two receivers are using the same port; adding new port usage to the input map `taken`
+func validateReceiverPorts(taken map[uint16]string, components interface{}, refs []string) (map[uint16]string, error) {
+	cm := reflect.ValueOf(components)
+	for _, id := range refs {
+		v := cm.MapIndex(reflect.ValueOf(id)) // For receivers, ids always exist in the component/receiver lists
+		t := v.Interface().(Component).Type()
+		if _, ok := receiverPortLimits[t]; ok {
+			// Since the type of this receiver is in the receiverPortLimits, then this receiver must be a LoggingNetworkReceiver
+			port := v.Interface().(LoggingNetworkReceiver).GetListenPort()
+			if prvId, ok := taken[port]; ok {
+				if prvId == id {
+					// One network receiver is used by two pipelines
+					return nil, fmt.Errorf("logging receiver %s listening on port %d can not be used in two pipelines.", id, port)
+				} else {
+					// Two network receivers are using the same port
+					return nil, fmt.Errorf("two logging receivers %s and %s can not listen on the same port %d.", prvId, id, port)
+				}
+			} else {
+				// Modifying the input map by adding the current port and receiverID
+				taken[port] = id
+			}
+		}
+	}
+	return taken, nil
 }
 
 func validateIncompatibleJVMReceivers(typeCounts map[string]int) error {

--- a/confgenerator/config.go
+++ b/confgenerator/config.go
@@ -788,10 +788,8 @@ var (
 		"mssql":                   1,
 	}
 
-	receiverPortLimits = map[string]bool{
-		"syslog":         true,
-		"tcp":            true,
-		"fluent_forward": true,
+	receiverPortLimits = []string{
+		"syslog", "tcp", "fluent_forward",
 	}
 )
 
@@ -883,25 +881,27 @@ func validateComponentTypeCounts(components interface{}, refs []string, subagent
 }
 
 // Validate that no two receivers are using the same port; adding new port usage to the input map `taken`
-func validateReceiverPorts(taken map[uint16]string, components interface{}, refs []string) (map[uint16]string, error) {
+func validateReceiverPorts(taken map[uint16]string, components interface{}, pipelineRIDs []string) (map[uint16]string, error) {
 	cm := reflect.ValueOf(components)
-	for _, id := range refs {
-		v := cm.MapIndex(reflect.ValueOf(id)) // For receivers, ids always exist in the component/receiver lists
+	for _, pipelineRID := range pipelineRIDs {
+		v := cm.MapIndex(reflect.ValueOf(pipelineRID)) // For receivers, ids always exist in the component/receiver lists
 		t := v.Interface().(Component).Type()
-		if _, ok := receiverPortLimits[t]; ok {
-			// Since the type of this receiver is in the receiverPortLimits, then this receiver must be a LoggingNetworkReceiver
-			port := v.Interface().(LoggingNetworkReceiver).GetListenPort()
-			if prvId, ok := taken[port]; ok {
-				if prvId == id {
-					// One network receiver is used by two pipelines
-					return nil, fmt.Errorf("logging receiver %s listening on port %d can not be used in two pipelines.", id, port)
+		for _, limitType := range receiverPortLimits {
+			if t == limitType {
+				// Since the type of this receiver is in the receiverPortLimits, then this receiver must be a LoggingNetworkReceiver
+				port := v.Interface().(LoggingNetworkReceiver).GetListenPort()
+				if portRID, ok := taken[port]; ok {
+					if portRID == pipelineRID {
+						// One network receiver is used by two pipelines
+						return nil, fmt.Errorf("logging receiver %s listening on port %d can not be used in two pipelines.", pipelineRID, port)
+					} else {
+						// Two network receivers are using the same port
+						return nil, fmt.Errorf("two logging receivers %s and %s can not listen on the same port %d.", portRID, pipelineRID, port)
+					}
 				} else {
-					// Two network receivers are using the same port
-					return nil, fmt.Errorf("two logging receivers %s and %s can not listen on the same port %d.", prvId, id, port)
+					// Modifying the input map by adding the port and receiverID of the current pipeline to mark the port as taken
+					taken[port] = pipelineRID
 				}
-			} else {
-				// Modifying the input map by adding the current port and receiverID
-				taken[port] = id
 			}
 		}
 	}

--- a/confgenerator/logging_receivers.go
+++ b/confgenerator/logging_receivers.go
@@ -176,6 +176,10 @@ func (r LoggingReceiverSyslog) Type() string {
 	return "syslog"
 }
 
+func (r LoggingReceiverSyslog) GetListenPort() uint16 {
+	return r.ListenPort
+}
+
 func (r LoggingReceiverSyslog) Components(tag string) []fluentbit.Component {
 	return []fluentbit.Component{{
 		Kind: "INPUT",
@@ -185,7 +189,7 @@ func (r LoggingReceiverSyslog) Components(tag string) []fluentbit.Component {
 			"Tag":    tag,
 			"Mode":   r.TransportProtocol,
 			"Listen": r.ListenHost,
-			"Port":   fmt.Sprintf("%d", r.ListenPort),
+			"Port":   fmt.Sprintf("%d", r.GetListenPort()),
 			"Parser": tag,
 			// https://docs.fluentbit.io/manual/administration/buffering-and-storage#input-section-configuration
 			// Buffer in disk to improve reliability.
@@ -226,12 +230,16 @@ func (r LoggingReceiverTCP) Type() string {
 	return "tcp"
 }
 
+func (r LoggingReceiverTCP) GetListenPort() uint16 {
+	if r.ListenPort == 0 {
+		r.ListenPort = 5170
+	}
+	return r.ListenPort
+}
+
 func (r LoggingReceiverTCP) Components(tag string) []fluentbit.Component {
 	if r.ListenHost == "" {
 		r.ListenHost = "127.0.0.1"
-	}
-	if r.ListenPort == 0 {
-		r.ListenPort = 5170
 	}
 
 	return []fluentbit.Component{{
@@ -241,7 +249,7 @@ func (r LoggingReceiverTCP) Components(tag string) []fluentbit.Component {
 			"Name":   "tcp",
 			"Tag":    tag,
 			"Listen": r.ListenHost,
-			"Port":   fmt.Sprintf("%d", r.ListenPort),
+			"Port":   fmt.Sprintf("%d", r.GetListenPort()),
 			"Format": r.Format,
 			// https://docs.fluentbit.io/manual/administration/buffering-and-storage#input-section-configuration
 			// Buffer in disk to improve reliability.
@@ -273,12 +281,16 @@ func (r LoggingReceiverFluentForward) Type() string {
 	return "fluent_forward"
 }
 
+func (r LoggingReceiverFluentForward) GetListenPort() uint16 {
+	if r.ListenPort == 0 {
+		r.ListenPort = 24224
+	}
+	return r.ListenPort
+}
+
 func (r LoggingReceiverFluentForward) Components(tag string) []fluentbit.Component {
 	if r.ListenHost == "" {
 		r.ListenHost = "127.0.0.1"
-	}
-	if r.ListenPort == 0 {
-		r.ListenPort = 24224
 	}
 
 	return []fluentbit.Component{{
@@ -288,7 +300,7 @@ func (r LoggingReceiverFluentForward) Components(tag string) []fluentbit.Compone
 			"Name":       "forward",
 			"Tag_Prefix": tag + ".",
 			"Listen":     r.ListenHost,
-			"Port":       fmt.Sprintf("%d", r.ListenPort),
+			"Port":       fmt.Sprintf("%d", r.GetListenPort()),
 			// https://docs.fluentbit.io/manual/administration/buffering-and-storage#input-section-configuration
 			// Buffer in disk to improve reliability.
 			"storage.type": "filesystem",

--- a/confgenerator/testdata/invalid/linux/logging-receiver_conflict_with_default_port/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_conflict_with_default_port/golden_error
@@ -1,0 +1,1 @@
+two logging receivers s1 and fluent_receiver can not listen on the same port 24224.

--- a/confgenerator/testdata/invalid/linux/logging-receiver_conflict_with_default_port/input.yaml
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_conflict_with_default_port/input.yaml
@@ -1,0 +1,13 @@
+logging:
+  receivers:
+    s1:
+      type: syslog
+      transport_protocol: tcp
+      listen_host: 0.0.0.0
+      listen_port: 24224
+    fluent_receiver:
+      type: fluent_forward
+  service:
+    pipelines:
+      p1:
+        receivers: [s1, fluent_receiver]

--- a/confgenerator/testdata/invalid/linux/logging-receiver_duplicated_port/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_duplicated_port/golden_error
@@ -1,0 +1,1 @@
+two logging receivers s1 and s2 can not listen on the same port 5140.

--- a/confgenerator/testdata/invalid/linux/logging-receiver_duplicated_port/input.yaml
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_duplicated_port/input.yaml
@@ -1,0 +1,18 @@
+logging:
+  receivers:
+    s1:
+      type: syslog
+      transport_protocol: tcp
+      listen_host: 0.0.0.0
+      listen_port: 5140      
+    s2:
+      type: syslog
+      transport_protocol: tcp
+      listen_host: 0.0.0.0
+      listen_port: 5140  
+  service:
+    pipelines:
+      p1:
+        receivers: [s1]
+      p2:
+        receivers: [s2]

--- a/confgenerator/testdata/invalid/linux/logging-receiver_duplicated_port_same_service/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_duplicated_port_same_service/golden_error
@@ -1,0 +1,1 @@
+two logging receivers s1 and s2 can not listen on the same port 5140.

--- a/confgenerator/testdata/invalid/linux/logging-receiver_duplicated_port_same_service/input.yaml
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_duplicated_port_same_service/input.yaml
@@ -1,0 +1,16 @@
+logging:
+  receivers:
+    s1:
+      type: syslog
+      transport_protocol: tcp
+      listen_host: 0.0.0.0
+      listen_port: 5140      
+    s2:
+      type: syslog
+      transport_protocol: tcp
+      listen_host: 0.0.0.0
+      listen_port: 5140  
+  service:
+    pipelines:
+      p1:
+        receivers: [s1, s2]

--- a/confgenerator/testdata/invalid/linux/logging-receiver_duplicated_syslog_receiver/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_duplicated_syslog_receiver/golden_error
@@ -1,0 +1,1 @@
+logging receiver s1 listening on port 5140 can not be used in two pipelines.

--- a/confgenerator/testdata/invalid/linux/logging-receiver_duplicated_syslog_receiver/input.yaml
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_duplicated_syslog_receiver/input.yaml
@@ -1,0 +1,13 @@
+logging:
+  receivers:
+    s1:
+      type: syslog
+      transport_protocol: tcp
+      listen_host: 0.0.0.0
+      listen_port: 5140
+  service:
+    pipelines:
+      p1:
+        receivers: [s1]
+      p2:
+        receivers: [s1]

--- a/confgenerator/testdata/invalid/linux/logging-receiver_duplicated_tcp_receiver/golden_error
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_duplicated_tcp_receiver/golden_error
@@ -1,0 +1,1 @@
+logging receiver tcp1 listening on port 15140 can not be used in two pipelines.

--- a/confgenerator/testdata/invalid/linux/logging-receiver_duplicated_tcp_receiver/input.yaml
+++ b/confgenerator/testdata/invalid/linux/logging-receiver_duplicated_tcp_receiver/input.yaml
@@ -1,0 +1,13 @@
+logging:
+  receivers:
+    tcp1:
+      type: tcp
+      format: json
+      listen_host: 0.0.0.0
+      listen_port: 15140
+  service:
+    pipelines:
+      p1:
+        receivers: [tcp1]
+      p2:
+        receivers: [tcp1]

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden_fluent_bit_main.conf
@@ -110,7 +110,7 @@
     Mode          udp
     Name          syslog
     Parser        cassandra_syslog_system.cassandra_syslog_debug
-    Port          1
+    Port          2
     Tag           cassandra_syslog_system.cassandra_syslog_debug
     storage.type  filesystem
 
@@ -120,7 +120,7 @@
     Mode          udp
     Name          syslog
     Parser        cassandra_syslog_system.cassandra_syslog_gc
-    Port          1
+    Port          3
     Tag           cassandra_syslog_system.cassandra_syslog_gc
     storage.type  filesystem
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/input.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/input.yaml
@@ -46,12 +46,12 @@ logging:
       type: syslog
       transport_protocol: udp
       listen_host: 1.1.1.1
-      listen_port: 1
+      listen_port: 2
     cassandra_syslog_gc:
       type: syslog
       transport_protocol: udp
       listen_host: 1.1.1.1
-      listen_port: 1
+      listen_port: 3
   processors:
     cassandra_syslog_system:
       type: cassandra_system

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden_fluent_bit_main.conf
@@ -134,7 +134,7 @@
     Mode          tcp
     Name          syslog
     Parser        mysql_syslog_error.mysql_syslog_general
-    Port          2
+    Port          3
     Tag           mysql_syslog_error.mysql_syslog_general
     storage.type  filesystem
 
@@ -144,7 +144,7 @@
     Mode          tcp
     Name          syslog
     Parser        mysql_syslog_error.mysql_syslog_slow
-    Port          2
+    Port          4
     Tag           mysql_syslog_error.mysql_syslog_slow
     storage.type  filesystem
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/input.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/input.yaml
@@ -45,12 +45,12 @@ logging:
       type: syslog
       transport_protocol: tcp
       listen_host: 1.1.1.1
-      listen_port: 2
+      listen_port: 3
     mysql_syslog_slow:
       type: syslog
       transport_protocol: tcp
       listen_host: 1.1.1.1
-      listen_port: 2
+      listen_port: 4
   processors:
     mysql_syslog_error:
       type: mysql_error

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden_f120d4527bd717cab023dbbe5fbdc332.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden_f120d4527bd717cab023dbbe5fbdc332.lua
@@ -1,0 +1,42 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["agent.googleapis.com/log_file_path"]
+end)();
+local __field_1 = (function()
+if record["logging.googleapis.com/labels"] == nil
+then
+return nil
+end
+return record["logging.googleapis.com/labels"]["compute.googleapis.com/resource_name"]
+end)();
+local __field_2 = (function()
+return record["logging.googleapis.com/logName"]
+end)();
+(function(value)
+record["agent.googleapis.com/log_file_path"] = value
+end)(nil);
+local v = __field_0;
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/log_file_path"] = value
+end)(v)
+local v = __field_1;
+if v == nil then v = "" end;
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["compute.googleapis.com/resource_name"] = value
+end)(v)
+local v = __field_2;
+if v == nil then v = "syslog" end;
+(function(value)
+record["logging.googleapis.com/logName"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden_f1cf5ee31d3e18e7faf2a0561c32bddb.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden_f1cf5ee31d3e18e7faf2a0561c32bddb.lua
@@ -1,0 +1,42 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["agent.googleapis.com/log_file_path"]
+end)();
+local __field_1 = (function()
+if record["logging.googleapis.com/labels"] == nil
+then
+return nil
+end
+return record["logging.googleapis.com/labels"]["compute.googleapis.com/resource_name"]
+end)();
+local __field_2 = (function()
+return record["logging.googleapis.com/logName"]
+end)();
+(function(value)
+record["agent.googleapis.com/log_file_path"] = value
+end)(nil);
+local v = __field_0;
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/log_file_path"] = value
+end)(v)
+local v = __field_1;
+if v == nil then v = "" end;
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["compute.googleapis.com/resource_name"] = value
+end)(v)
+local v = __field_2;
+if v == nil then v = "tcp_logs" end;
+(function(value)
+record["logging.googleapis.com/logName"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden_fluent_bit_main.conf
@@ -1,0 +1,97 @@
+@SET buffers_dir=/var/lib/google-cloud-ops-agent/fluent-bit/buffers
+@SET logs_dir=/var/log/google-cloud-ops-agent/subagents
+
+[SERVICE]
+    Daemon                    off
+    Flush                     1
+    Log_Level                 info
+    dns.resolver              legacy
+    storage.backlog.mem_limit 50M
+    storage.checksum          off
+    storage.max_chunks_up     128
+    storage.metrics           on
+    storage.sync              normal
+
+[INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 60
+    Scrape_On_Start True
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   5M
+    DB                ${buffers_dir}/default_pipeline_syslog
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              /var/log/messages,/var/log/syslog
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               default_pipeline.syslog
+    storage.type      filesystem
+
+[INPUT]
+    Format        json
+    Listen        1.2.3.4
+    Mem_Buf_Limit 10M
+    Name          tcp
+    Port          5678
+    Tag           tcp_pipeline.tcp_logs
+    storage.type  filesystem
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   5M
+    DB                ${buffers_dir}/ops-agent-fluent-bit
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/logging-module.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-fluent-bit
+    storage.type      memory
+
+[FILTER]
+    Match  default_pipeline.syslog
+    Name   lua
+    call   process
+    script f120d4527bd717cab023dbbe5fbdc332.lua
+
+[FILTER]
+    Match  tcp_pipeline.tcp_logs
+    Name   lua
+    call   process
+    script f1cf5ee31d3e18e7faf2a0561c32bddb.lua
+
+[OUTPUT]
+    Match_Regex                   ^(default_pipeline\.syslog|tcp_pipeline\.tcp_logs)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  20202

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden_otel.conf
@@ -1,0 +1,472 @@
+exporters:
+  googlecloud:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    retry_on_failure:
+      enabled: false
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+processors:
+  agentmetrics/default__pipeline_hostmetrics_0:
+    blank_label_metrics:
+    - system.cpu.utilization
+  filter/default__pipeline_hostmetrics_1:
+    metrics:
+      exclude:
+        match_type: strict
+        metric_names:
+        - system.cpu.time
+        - system.network.dropped
+        - system.filesystem.inodes.usage
+        - system.paging.faults
+        - system.disk.operation_time
+  filter/default__pipeline_hostmetrics_3:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names: []
+  filter/fluentbit_0:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+        - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
+        - fluentbit_stackdriver_proc_records_total
+  filter/otel_0:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+        - otelcol_process_uptime
+        - otelcol_process_memory_rss
+        - otelcol_grpc_io_client_completed_rpcs
+        - otelcol_googlecloudmonitoring_point_count
+  metricstransform/default__pipeline_hostmetrics_2:
+    transforms:
+    - action: update
+      include: system.cpu.time
+      new_name: cpu/usage_time
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: cpu
+        new_label: cpu_number
+      - action: update_label
+        label: state
+        new_label: cpu_state
+    - action: update
+      include: system.cpu.utilization
+      new_name: cpu/utilization
+      operations:
+      - action: aggregate_labels
+        aggregation_type: mean
+        label_set:
+        - state
+        - blank
+      - action: update_label
+        label: blank
+        new_label: cpu_number
+      - action: update_label
+        label: state
+        new_label: cpu_state
+    - action: update
+      include: system.cpu.load_average.1m
+      new_name: cpu/load_1m
+    - action: update
+      include: system.cpu.load_average.5m
+      new_name: cpu/load_5m
+    - action: update
+      include: system.cpu.load_average.15m
+      new_name: cpu/load_15m
+    - action: update
+      include: system.disk.read_io
+      new_name: disk/read_bytes_count
+    - action: update
+      include: system.disk.write_io
+      new_name: disk/write_bytes_count
+    - action: update
+      include: system.disk.operations
+      new_name: disk/operation_count
+    - action: update
+      include: system.disk.io_time
+      new_name: disk/io_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.weighted_io_time
+      new_name: disk/weighted_io_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.average_operation_time
+      new_name: disk/operation_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.pending_operations
+      new_name: disk/pending_operations
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.merged
+      new_name: disk/merged_operations
+    - action: update
+      include: system.filesystem.usage
+      new_name: disk/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: max
+        label_set:
+        - device
+        - state
+    - action: update
+      include: system.filesystem.utilization
+      new_name: disk/percent_used
+      operations:
+      - action: aggregate_labels
+        aggregation_type: max
+        label_set:
+        - device
+        - state
+    - action: update
+      include: system.memory.usage
+      new_name: memory/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_label_values
+        aggregated_values:
+        - slab_reclaimable
+        - slab_unreclaimable
+        aggregation_type: sum
+        label: state
+        new_value: slab
+    - action: update
+      include: system.memory.utilization
+      new_name: memory/percent_used
+      operations:
+      - action: aggregate_label_values
+        aggregated_values:
+        - slab_reclaimable
+        - slab_unreclaimable
+        aggregation_type: sum
+        label: state
+        new_value: slab
+    - action: update
+      include: system.network.io
+      new_name: interface/traffic
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.errors
+      new_name: interface/errors
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.packets
+      new_name: interface/packets
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.connections
+      new_name: network/tcp_connections
+      operations:
+      - action: toggle_scalar_data_type
+      - action: delete_label_value
+        label: protocol
+        label_value: udp
+      - action: update_label
+        label: state
+        new_label: tcp_state
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - tcp_state
+      - action: add_label
+        new_label: port
+        new_value: all
+    - action: update
+      include: system.processes.created
+      new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
+    - action: update
+      include: system.paging.usage
+      new_name: swap/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.paging.utilization
+      new_name: swap/percent_used
+    - action: insert
+      include: swap/percent_used
+      new_name: pagefile/percent_used
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - state
+    - action: update
+      include: system.paging.operations
+      new_name: swap/io
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - direction
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: in
+          value: page_in
+        - new_value: out
+          value: page_out
+    - action: update
+      include: process.cpu.time
+      new_name: processes/cpu_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1e+06
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+      - action: delete_label_value
+        label: state
+        label_value: wait
+      - action: update_label
+        label: state
+        new_label: user_or_syst
+      - action: update_label
+        label: user_or_syst
+        value_actions:
+        - new_value: syst
+          value: system
+    - action: update
+      include: process.disk.read_io
+      new_name: processes/disk/read_bytes_count
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.disk.write_io
+      new_name: processes/disk/write_bytes_count
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.memory.physical_usage
+      new_name: processes/rss_usage
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.memory.virtual_usage
+      new_name: processes/vm_usage
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/fluentbit_1:
+    transforms:
+    - action: update
+      include: fluentbit_uptime
+      new_name: agent/uptime
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: version
+        new_value: google-cloud-ops-agent-logging/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
+    - action: update
+      include: fluentbit_stackdriver_proc_records_total
+      new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/otel_1:
+    transforms:
+    - action: update
+      include: otelcol_process_uptime
+      new_name: agent/uptime
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: version
+        new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
+    - action: update
+      include: otelcol_process_memory_rss
+      new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
+    - action: update
+      include: otelcol_grpc_io_client_completed_rpcs
+      new_name: agent/api_request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: grpc_client_status
+        new_label: state
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - state
+    - action: update
+      include: otelcol_googlecloudmonitoring_point_count
+      new_name: agent/monitoring/point_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  resourcedetection/_global_0:
+    detectors:
+    - gce
+receivers:
+  hostmetrics/default__pipeline_hostmetrics:
+    collection_interval: 60s
+    scrapers:
+      cpu: {}
+      disk: {}
+      filesystem: {}
+      load: {}
+      memory: {}
+      network: {}
+      paging: {}
+      process:
+        mute_process_name_error: true
+      processes: {}
+  prometheus/fluentbit:
+    config:
+      scrape_configs:
+      - job_name: logging-collector
+        metrics_path: /metrics
+        scrape_interval: 1m
+        static_configs:
+        - targets:
+          - 0.0.0.0:20202
+  prometheus/otel:
+    config:
+      scrape_configs:
+      - job_name: otel-collector
+        scrape_interval: 1m
+        static_configs:
+        - targets:
+          - 0.0.0.0:20201
+service:
+  pipelines:
+    metrics/default__pipeline_hostmetrics:
+      exporters:
+      - googlecloud
+      processors:
+      - agentmetrics/default__pipeline_hostmetrics_0
+      - filter/default__pipeline_hostmetrics_1
+      - metricstransform/default__pipeline_hostmetrics_2
+      - filter/default__pipeline_hostmetrics_3
+      - resourcedetection/_global_0
+      receivers:
+      - hostmetrics/default__pipeline_hostmetrics
+    metrics/fluentbit:
+      exporters:
+      - googlecloud
+      processors:
+      - filter/fluentbit_0
+      - metricstransform/fluentbit_1
+      - resourcedetection/_global_0
+      receivers:
+      - prometheus/fluentbit
+    metrics/otel:
+      exporters:
+      - googlecloud
+      processors:
+      - filter/otel_0
+      - metricstransform/otel_1
+      - resourcedetection/_global_0
+      receivers:
+      - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/input.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/input.yaml
@@ -1,0 +1,35 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+logging:
+  receivers:
+    tcp_logs:
+      type: tcp
+      format: json
+      listen_host: 1.2.3.4
+      listen_port: 5678
+    tcp_logs2:
+      type: tcp
+      format: json
+      listen_host: 1.2.3.4
+      listen_port: 5678
+    tcp_syslog:
+      type: syslog
+      transport_protocol: tcp
+      listen_host: 1.2.3.4
+      listen_port: 5678
+  service:
+    pipelines:
+      tcp_pipeline:
+        receivers: [tcp_logs]

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden_fluent_bit_main.conf
@@ -93,7 +93,7 @@
     Mode          udp
     Name          syslog
     Parser        tomcat_syslog_system.tomcat_syslog_access
-    Port          1
+    Port          2
     Tag           tomcat_syslog_system.tomcat_syslog_access
     storage.type  filesystem
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/input.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/input.yaml
@@ -36,7 +36,7 @@ logging:
       type: syslog
       transport_protocol: udp
       listen_host: 1.1.1.1
-      listen_port: 1
+      listen_port: 2
   processors:
     tomcat_syslog_system:
       type: tomcat_system


### PR DESCRIPTION
[b/220128869](http://b/220128869) | P3 | Add validation failure at the Ops Agent level when there are two receivers listening on the same port
The validation added here can check for both cases: 1. two receivers using the same port and 2. one receiver used by two pipelines. 
Originally considered to use custom validator but that would require traverse the fields in the yaml tree between `service` and `receivers` sections to check receivers' port and whether the receiver is used by any pipeline. 
This current proposed solution added a new interface LoggingNetworkReceiver by extending the LoggingReceiver interface and provide the method to access the port taken by this receiver. The the validation is actually happening in the `Validate()` on the `Logging` instance.  
To validate, loop over all services/pipelines and keep track of ports used, and return the error if there is port conflict. 
Hostname is not considered in this validation; i.e., if two syslog receivers listening on `127.0.0.1:5540` and `0.0.0.0:5540` we still consider there is conflict. 