### PR TITLE
Fix up recently added third-party application metadata files.

### DIFF
--- a/integration_test/common/common.go
+++ b/integration_test/common/common.go
@@ -81,11 +81,11 @@ type ConfigurationOptions struct {
 
 type IntegrationMetadata struct {
 	PublicUrl                    string                       `yaml:"public_url"`
-	AppUrl                       string                       `yaml:"app_url" validate:"required"`
-	ShortName                    string                       `yaml:"short_name" validate:"required"`
-	LongName                     string                       `yaml:"long_name" validate:"required"`
+	AppUrl                       string                       `yaml:"app_url" validate:"required,url"`
+	ShortName                    string                       `yaml:"short_name" validate:"required,excludesall=‘’“”"`
+	LongName                     string                       `yaml:"long_name" validate:"required,excludesall=‘’“”"`
 	LogoPath                     string                       `yaml:"logo_path"`
-	Description                  string                       `yaml:"description" validate:"required"`
+	Description                  string                       `yaml:"description" validate:"required,excludesall=‘’“”"`
 	ConfigurationOptions         *ConfigurationOptions        `yaml:"configuration_options" validate:"required"`
 	ConfigureIntegration         string                       `yaml:"configure_integration"`
 	ExpectedLogs                 []*ExpectedLog               `yaml:"expected_logs" validate:"dive"`
@@ -93,7 +93,7 @@ type IntegrationMetadata struct {
 	MinimumSupportedAgentVersion MinimumSupportedAgentVersion `yaml:"minimum_supported_agent_version"`
 	SupportedAppVersion          []string                     `yaml:"supported_app_version" validate:"required,unique,min=1"`
 	RestartAfterInstall          bool                         `yaml:"restart_after_install"`
-	Troubleshoot                 string                       `yaml:"troubleshoot"`
+	Troubleshoot                 string                       `yaml:"troubleshoot" validate:"excludesall=‘’“”"`
 }
 
 func SliceContains(slice []string, toFind string) bool {

--- a/integration_test/common/testdata/integration-metadata_app-url_not-a-url/golden_error
+++ b/integration_test/common/testdata/integration-metadata_app-url_not-a-url/golden_error
@@ -1,0 +1,1 @@
+Key: 'IntegrationMetadata.AppUrl' Error:Field validation for 'AppUrl' failed on the 'url' tag

--- a/integration_test/common/testdata/integration-metadata_app-url_not-a-url/input.yaml
+++ b/integration_test/common/testdata/integration-metadata_app-url_not-a-url/input.yaml
@@ -1,0 +1,31 @@
+app_url: "example.google.com/"
+short_name: OpsAgent
+long_name: Cloud OpsAgent
+description: |-
+  Example description
+minimum_supported_agent_version:
+  metrics: 1.0.0
+  logging: 1.0.0
+supported_app_version: ["Example0"]
+expected_metrics:
+- type: example.googleapis.com/example.example1
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+  labels:
+    broker: .*
+    destination: .*
+  representative: true
+expected_logs:
+- log_name: examplelog
+  fields:
+  - name: jsonPayload.message
+    value_regex: '(example):'
+    type: string
+    description: null
+configuration_options:
+  metrics:
+  - type: example
+    fields:
+    - name: type
+      description: description for type

--- a/integration_test/common/testdata/integration-metadata_description_bad-quotes/golden_error
+++ b/integration_test/common/testdata/integration-metadata_description_bad-quotes/golden_error
@@ -1,0 +1,1 @@
+Key: 'IntegrationMetadata.Description' Error:Field validation for 'Description' failed on the 'excludesall' tag

--- a/integration_test/common/testdata/integration-metadata_description_bad-quotes/input.yaml
+++ b/integration_test/common/testdata/integration-metadata_description_bad-quotes/input.yaml
@@ -1,0 +1,31 @@
+app_url: "https://example.google.com/"
+short_name: OpsAgent
+long_name: Cloud OpsAgent
+description: |-
+  ‘Example’ “description”
+minimum_supported_agent_version:
+  metrics: 1.0.0
+  logging: 1.0.0
+supported_app_version: ["Example0"]
+expected_metrics:
+- type: example.googleapis.com/example.example1
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+  labels:
+    broker: .*
+    destination: .*
+  representative: true
+expected_logs:
+- log_name: examplelog
+  fields:
+  - name: jsonPayload.message
+    value_regex: '(example):'
+    type: string
+    description: null
+configuration_options:
+  metrics:
+  - type: example
+    fields:
+    - name: type
+      description: description for type

--- a/integration_test/common/testdata/integration-metadata_long-name_bad-quotes/golden_error
+++ b/integration_test/common/testdata/integration-metadata_long-name_bad-quotes/golden_error
@@ -1,0 +1,1 @@
+Key: 'IntegrationMetadata.LongName' Error:Field validation for 'LongName' failed on the 'excludesall' tag

--- a/integration_test/common/testdata/integration-metadata_long-name_bad-quotes/input.yaml
+++ b/integration_test/common/testdata/integration-metadata_long-name_bad-quotes/input.yaml
@@ -1,0 +1,31 @@
+app_url: "https://example.google.com/"
+short_name: OpsAgent
+long_name: Cloud “Ops”Agent
+description: |-
+  Example description
+minimum_supported_agent_version:
+  metrics: 1.0.0
+  logging: 1.0.0
+supported_app_version: ["Example0"]
+expected_metrics:
+- type: example.googleapis.com/example.example1
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+  labels:
+    broker: .*
+    destination: .*
+  representative: true
+expected_logs:
+- log_name: examplelog
+  fields:
+  - name: jsonPayload.message
+    value_regex: '(example):'
+    type: string
+    description: null
+configuration_options:
+  metrics:
+  - type: example
+    fields:
+    - name: type
+      description: description for type

--- a/integration_test/common/testdata/integration-metadata_short-name_bad-quotes/golden_error
+++ b/integration_test/common/testdata/integration-metadata_short-name_bad-quotes/golden_error
@@ -1,0 +1,1 @@
+Key: 'IntegrationMetadata.ShortName' Error:Field validation for 'ShortName' failed on the 'excludesall' tag

--- a/integration_test/common/testdata/integration-metadata_short-name_bad-quotes/input.yaml
+++ b/integration_test/common/testdata/integration-metadata_short-name_bad-quotes/input.yaml
@@ -1,0 +1,31 @@
+app_url: "https://example.google.com/"
+short_name: ‘Ops’Agent
+long_name: Cloud OpsAgent
+description: |-
+  Example description
+minimum_supported_agent_version:
+  metrics: 1.0.0
+  logging: 1.0.0
+supported_app_version: ["Example0"]
+expected_metrics:
+- type: example.googleapis.com/example.example1
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+  labels:
+    broker: .*
+    destination: .*
+  representative: true
+expected_logs:
+- log_name: examplelog
+  fields:
+  - name: jsonPayload.message
+    value_regex: '(example):'
+    type: string
+    description: null
+configuration_options:
+  metrics:
+  - type: example
+    fields:
+    - name: type
+      description: description for type

--- a/integration_test/common/testdata/integration-metadata_troubleshoot_bad-quotes/golden_error
+++ b/integration_test/common/testdata/integration-metadata_troubleshoot_bad-quotes/golden_error
@@ -1,0 +1,1 @@
+Key: 'IntegrationMetadata.Troubleshoot' Error:Field validation for 'Troubleshoot' failed on the 'excludesall' tag

--- a/integration_test/common/testdata/integration-metadata_troubleshoot_bad-quotes/input.yaml
+++ b/integration_test/common/testdata/integration-metadata_troubleshoot_bad-quotes/input.yaml
@@ -1,0 +1,33 @@
+app_url: "https://example.google.com/"
+short_name: OpsAgent
+long_name: Cloud OpsAgent
+description: |-
+  Example description
+minimum_supported_agent_version:
+  metrics: 1.0.0
+  logging: 1.0.0
+supported_app_version: ["Example0"]
+troubleshoot: |-
+  Just “run” the thing
+expected_metrics:
+- type: example.googleapis.com/example.example1
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+  labels:
+    broker: .*
+    destination: .*
+  representative: true
+expected_logs:
+- log_name: examplelog
+  fields:
+  - name: jsonPayload.message
+    value_regex: '(example):'
+    type: string
+    description: null
+configuration_options:
+  metrics:
+  - type: example
+    fields:
+    - name: type
+      description: description for type

--- a/integration_test/third_party_apps_data/applications/flink/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/flink/metadata.yaml
@@ -1,8 +1,9 @@
 app_url: "https://flink.apache.org/"
 short_name: Flink
 long_name: Apache Flink
-logo_path: ""
-description: The Apache Flink integration collects client, jobmanager and taskmanager logs and parses them into a JSON payload. The result includes fields for source, level, and message.
+description: |-
+  The Apache Flink integration collects client, jobmanager and taskmanager logs and parses them into a JSON payload.
+  The result includes fields for source, level, and message.
 supported_app_version: ["1.13.6", "1.14.4"]
 configure_integration: ""
 expected_metrics:

--- a/integration_test/third_party_apps_data/applications/saphana/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/saphana/metadata.yaml
@@ -1,10 +1,9 @@
+app_url: "https://www.sap.com/products/hana.html"
 short_name: HANA
 long_name: SAP HANA
-app_url: "https://www.sap.com/products/hana.html"
 description: |-
-  The SAP HANA integration collects SAP HANA metrics and logs. The metrics are collected by by querying
-  relevant monitoring views. The trace logs collected are parsed into a structured log for
-  consumption in Google Cloud Logging.
+  The SAP HANA integration collects SAP HANA metrics and logs. The metrics are collected by querying
+  relevant monitoring views. This integration writes structured trace logs.
 configure_integration: |-
   To collect metrics, a monitoring user requires `SELECT` access to the relevant monitoring views. The following sql
   script should create a monitoring role and apply it to a monitoring user if executed by

--- a/integration_test/third_party_apps_data/applications/vault/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/vault/metadata.yaml
@@ -2,7 +2,7 @@ app_url: "https://www.vaultproject.io/"
 short_name: Vault
 long_name: Hashicorp Vault
 description: |-
-  Vault is an identity-based secrets and encryption management system. This integration Collects Vault's audit logs.
+  Vault is an identity-based secrets and encryption management system. This integration collects Vault's audit logs.
 supported_app_version: ["1.6+"]
 expected_logs:
 - log_name: vault_audit
@@ -18,21 +18,21 @@ expected_logs:
   - name: jsonPayload.request.path
     value_regex: sys\/audit\/test
     type: string
-    description: 'The requested Vault path for operation.'
+    description: The requested Vault path for operation.
   - name: jsonPayload.request.operation
     value_regex: update
     type: string
-    description: "This is the type of operation which corresponds to path capabilities and is expected to be one of: `create`, `read`, `update`, `delete`, or `list`."
+    description: This is the type of operation which corresponds to path capabilities and is expected to be one of: `create`, `read`, `update`, `delete`, or `list`.
   - name: jsonPayload.type
     value_regex: request
     type: string
-    description: 'the type of audit log.'
+    description: The type of audit log.
   - name: jsonPayload.error
     type: string
-    description: If an error occurred with the request, the error message is included in this field’s value.
+    description: If an error occurred with the request, the error message is included in this field's value.
   - name: jsonPayload.auth.client_token
     type: string
-    description: This is an HMAC of the client’s token ID.
+    description: This is an HMAC of the client's token ID.
   - name: jsonPayload.auth.accessor
     type: string
     description: This is an HMAC of the client token accessor.
@@ -53,7 +53,7 @@ expected_logs:
     description: This is the unique request identifier.
   - name: jsonPayload.request.client_token
     type: string
-    description: "This is an HMAC of the client's token ID."
+    description: This is an HMAC of the client's token ID.
   - name: jsonPayload.request.client_token_accessor
     type: string
     description: This is an HMAC of the client token accessor.
@@ -62,7 +62,7 @@ expected_logs:
     description: The data object will contain secret data in key/value pairs.
   - name: jsonPayload.request.policy_override
     type: boolean
-    description: this is true when a soft-mandatory policy override was requested.
+    description: This is `true` when a soft-mandatory policy override was requested.
   - name: jsonPayload.request.remote_address
     type: string
     description: The IP address of the client making the request.
@@ -74,19 +74,19 @@ expected_logs:
     description: Additional HTTP headers specified by the client as part of the request.
   - name: jsonPayload.response.data.creation_time
     type: string
-    description: RFC3339 format timestamp of the token’s creation.
+    description: RFC 3339 format timestamp of the token's creation.
   - name: jsonPayload.response.data.creation_ttl
     type: string
     description: Token creation TTL in seconds.
   - name: jsonPayload.response.data.expire_time
     type: string
-    description: RFC3339 format timestamp representing the moment this token will expire.
+    description: RFC 3339 format timestamp representing the moment this token will expire.
   - name: jsonPayload.response.data.explicit_max_ttl
     type: string
-    description: Explicit token maximum TTL value as seconds (‘0’ when not set).
+    description: Explicit token maximum TTL value as seconds ("0" when not set).
   - name: jsonPayload.response.data.issue_time
     type: string
-    description: RFC3339 format timestamp.
+    description: RFC 3339 format timestamp.
   - name: jsonPayload.response.data.num_uses
     type: number
     description: If the token is limited to a number of uses, that value will be represented here.


### PR DESCRIPTION
- Consistent order of fields
- Consistent quoting
- Get rid of Unicode quotes
- Remove empty fields
- Minor text tweaks

Also add validation for Unicode quotes and URL formatting.