### PR TITLE
Testing: add experimental build configs for all missing distros

### DIFF
--- a/kokoro/config/build/presubmit/buster.gcl
+++ b/kokoro/config/build/presubmit/buster.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'buster'
+      PKGFORMAT = 'deb'
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/centos7.gcl
+++ b/kokoro/config/build/presubmit/centos7.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'centos7'
+      PKGFORMAT = 'rpm'
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/focal.gcl
+++ b/kokoro/config/build/presubmit/focal.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'focal'
+      PKGFORMAT = 'deb'
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/rockylinux8.gcl
+++ b/kokoro/config/build/presubmit/rockylinux8.gcl
@@ -1,0 +1,12 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      // centos8 actually resolves to "rockylinux:8" in the Dockerfile:
+      // https://github.com/GoogleCloudPlatform/ops-agent/blob/72488e91d2f5dbd5ba5dc8c30f493deb7802dc09/Dockerfile#L163
+      DISTRO = 'centos8'
+      PKGFORMAT = 'rpm'
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/saphana.gcl
+++ b/kokoro/config/build/presubmit/saphana.gcl
@@ -1,0 +1,11 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      // The testing image is based on SLES 15, see b/230338826.
+      DISTRO = 'sles15'
+      PKGFORMAT = 'rpm'
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/sles12.gcl
+++ b/kokoro/config/build/presubmit/sles12.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'sles12'
+      PKGFORMAT = 'rpm'
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/sles15.gcl
+++ b/kokoro/config/build/presubmit/sles15.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'sles15'
+      PKGFORMAT = 'rpm'
+    }
+  }
+}

--- a/kokoro/config/test/ops_agent/buster.gcl
+++ b/kokoro/config/test/ops_agent/buster.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    platforms = ['debian-10']
+  }
+}

--- a/kokoro/config/test/ops_agent/centos7.gcl
+++ b/kokoro/config/test/ops_agent/centos7.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    platforms = ['centos-7']
+  }
+}

--- a/kokoro/config/test/ops_agent/focal.gcl
+++ b/kokoro/config/test/ops_agent/focal.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    platforms = ['ubuntu-2004-lts']
+  }
+}

--- a/kokoro/config/test/ops_agent/release/bionic.gcl
+++ b/kokoro/config/test/ops_agent/release/bionic.gcl
@@ -3,7 +3,6 @@ import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.windows.distros.windows.release +
-                ['windows-20h2-core']
+    platforms = image_lists.ubuntu.distros.bionic.release
   }
 }

--- a/kokoro/config/test/ops_agent/release/buster.gcl
+++ b/kokoro/config/test/ops_agent/release/buster.gcl
@@ -3,7 +3,6 @@ import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.windows.distros.windows.release +
-                ['windows-20h2-core']
+    platforms = image_lists.debian.distros.buster.release
   }
 }

--- a/kokoro/config/test/ops_agent/release/centos7.gcl
+++ b/kokoro/config/test/ops_agent/release/centos7.gcl
@@ -3,7 +3,6 @@ import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.windows.distros.windows.release +
-                ['windows-20h2-core']
+    platforms = image_lists.centos.distros.centos7.release
   }
 }

--- a/kokoro/config/test/ops_agent/release/centos8.gcl
+++ b/kokoro/config/test/ops_agent/release/centos8.gcl
@@ -1,0 +1,16 @@
+import '../common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    // TODO(b/217189970): Change back to 
+    // image_lists.centos.distros.centos8.release once centos-8 is gone.
+    platforms = [
+      'rhel-8',
+      'rhel-8-1-sap-ha',
+      'rhel-8-2-sap-ha',
+      'rhel-8-4-sap-ha',
+      'rocky-linux-8',
+    ]
+  }
+}

--- a/kokoro/config/test/ops_agent/release/focal.gcl
+++ b/kokoro/config/test/ops_agent/release/focal.gcl
@@ -3,7 +3,6 @@ import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.windows.distros.windows.release +
-                ['windows-20h2-core']
+    platforms = image_lists.ubuntu.distros.focal.release
   }
 }

--- a/kokoro/config/test/ops_agent/release/impish.gcl
+++ b/kokoro/config/test/ops_agent/release/impish.gcl
@@ -3,7 +3,6 @@ import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.windows.distros.windows.release +
-                ['windows-20h2-core']
+    platforms = image_lists.ubuntu.distros.impish.release
   }
 }

--- a/kokoro/config/test/ops_agent/release/jammy.gcl
+++ b/kokoro/config/test/ops_agent/release/jammy.gcl
@@ -3,7 +3,6 @@ import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.windows.distros.windows.release +
-                ['windows-20h2-core']
+    platforms = image_lists.ubuntu.distros.jammy.release
   }
 }

--- a/kokoro/config/test/ops_agent/release/sles12.gcl
+++ b/kokoro/config/test/ops_agent/release/sles12.gcl
@@ -3,7 +3,6 @@ import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.windows.distros.windows.release +
-                ['windows-20h2-core']
+    platforms = image_lists.sles.distros.sles12.release
   }
 }

--- a/kokoro/config/test/ops_agent/release/sles15.gcl
+++ b/kokoro/config/test/ops_agent/release/sles15.gcl
@@ -3,7 +3,6 @@ import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.windows.distros.windows.release +
-                ['windows-20h2-core']
+    platforms = image_lists.sles.distros.sles15.release
   }
 }

--- a/kokoro/config/test/ops_agent/release/windows.gcl
+++ b/kokoro/config/test/ops_agent/release/windows.gcl
@@ -3,7 +3,6 @@ import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.windows.distros.windows.release +
-                ['windows-20h2-core']
+    platforms = image_lists.windows.distros.windows.release
   }
 }

--- a/kokoro/config/test/ops_agent/rockylinux8.gcl
+++ b/kokoro/config/test/ops_agent/rockylinux8.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    platforms = ['rocky-linux-8']
+  }
+}

--- a/kokoro/config/test/ops_agent/sles12.gcl
+++ b/kokoro/config/test/ops_agent/sles12.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    platforms = ['sles-12']
+  }
+}

--- a/kokoro/config/test/ops_agent/sles15.gcl
+++ b/kokoro/config/test/ops_agent/sles15.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    platforms = ['sles-15']
+  }
+}

--- a/kokoro/config/test/third_party_apps/buster.gcl
+++ b/kokoro/config/test/third_party_apps/buster.gcl
@@ -2,9 +2,6 @@ import 'common.gcl' as common
 
 config build = common.third_party_apps_test {
   params {
-    platforms = [
-      'windows-2012-r2',
-      'sql-std-2019-win-2019',
-    ]
+    platforms = ['debian-10']
   }
 }

--- a/kokoro/config/test/third_party_apps/centos7.gcl
+++ b/kokoro/config/test/third_party_apps/centos7.gcl
@@ -2,9 +2,6 @@ import 'common.gcl' as common
 
 config build = common.third_party_apps_test {
   params {
-    platforms = [
-      'windows-2012-r2',
-      'sql-std-2019-win-2019',
-    ]
+    platforms = ['centos-7']
   }
 }

--- a/kokoro/config/test/third_party_apps/focal.gcl
+++ b/kokoro/config/test/third_party_apps/focal.gcl
@@ -2,9 +2,6 @@ import 'common.gcl' as common
 
 config build = common.third_party_apps_test {
   params {
-    platforms = [
-      'windows-2012-r2',
-      'sql-std-2019-win-2019',
-    ]
+    platforms = ['ubuntu-2004-lts']
   }
 }

--- a/kokoro/config/test/third_party_apps/release/buster.gcl
+++ b/kokoro/config/test/third_party_apps/release/buster.gcl
@@ -1,0 +1,7 @@
+import '../common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['debian-10']
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/centos7.gcl
+++ b/kokoro/config/test/third_party_apps/release/centos7.gcl
@@ -1,0 +1,7 @@
+import '../common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['centos-7']
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/focal.gcl
+++ b/kokoro/config/test/third_party_apps/release/focal.gcl
@@ -1,0 +1,7 @@
+import '../common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['ubuntu-2004-lts']
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/rockylinux8.gcl
+++ b/kokoro/config/test/third_party_apps/release/rockylinux8.gcl
@@ -1,0 +1,7 @@
+import '../common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['rocky-linux-8']
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/saphana.gcl
+++ b/kokoro/config/test/third_party_apps/release/saphana.gcl
@@ -1,0 +1,13 @@
+import '../common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    // Created in b/230338826.
+    platforms = ['sles-15-sp3-sap-saphana']
+
+    environment {
+      // These instances need a lot of RAM.
+      INSTANCE_SIZE = 'n2-highmem-8'
+    }
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/sles12.gcl
+++ b/kokoro/config/test/third_party_apps/release/sles12.gcl
@@ -1,0 +1,7 @@
+import '../common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['sles-12']
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/sles15.gcl
+++ b/kokoro/config/test/third_party_apps/release/sles15.gcl
@@ -1,0 +1,7 @@
+import '../common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['sles-15']
+  }
+}

--- a/kokoro/config/test/third_party_apps/rockylinux8.gcl
+++ b/kokoro/config/test/third_party_apps/rockylinux8.gcl
@@ -2,9 +2,6 @@ import 'common.gcl' as common
 
 config build = common.third_party_apps_test {
   params {
-    platforms = [
-      'windows-2012-r2',
-      'sql-std-2019-win-2019',
-    ]
+    platforms = ['rocky-linux-8']
   }
 }

--- a/kokoro/config/test/third_party_apps/saphana.gcl
+++ b/kokoro/config/test/third_party_apps/saphana.gcl
@@ -1,0 +1,13 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    // Created in b/230338826.
+    platforms = ['sles-15-sp3-sap-saphana']
+
+    environment {
+      // These instances need a lot of RAM.
+      INSTANCE_SIZE = 'n2-highmem-8'
+    }
+  }
+}

--- a/kokoro/config/test/third_party_apps/sles12.gcl
+++ b/kokoro/config/test/third_party_apps/sles12.gcl
@@ -2,9 +2,6 @@ import 'common.gcl' as common
 
 config build = common.third_party_apps_test {
   params {
-    platforms = [
-      'windows-2012-r2',
-      'sql-std-2019-win-2019',
-    ]
+    platforms = ['sles-12']
   }
 }

--- a/kokoro/config/test/third_party_apps/sles15.gcl
+++ b/kokoro/config/test/third_party_apps/sles15.gcl
@@ -2,9 +2,6 @@ import 'common.gcl' as common
 
 config build = common.third_party_apps_test {
   params {
-    platforms = [
-      'windows-2012-r2',
-      'sql-std-2019-win-2019',
-    ]
+    platforms = ['sles-15']
   }
 }

--- a/kokoro/config/test/third_party_apps/windows.gcl
+++ b/kokoro/config/test/third_party_apps/windows.gcl
@@ -4,7 +4,7 @@ config build = common.third_party_apps_test {
   params {
     platforms = [
       'windows-2012-r2',
-      'sql-std-2019-win-2019',
+      'windows-2019',
     ]
   }
 }


### PR DESCRIPTION
Fleshes out the build configs for all missing distros. These configs are still unused but hopefully will start being used sometime this week.

I created this PR by copying and modifying open-source code only. I did not copy any internal code into this PR.