### PR TITLE
Testing: fixes for build/test scripts

### DIFF
--- a/kokoro/scripts/build/build_package.sh
+++ b/kokoro/scripts/build/build_package.sh
@@ -40,10 +40,10 @@ sudo DOCKER_BUILDKIT=1 docker build . \
   --target "${DISTRO}-build" \
   -t build_image
 
-SIGNING_DIR="kokoro/scripts/build/signing"
+SIGNING_DIR="$(pwd)/kokoro/scripts/build/signing"
 if [[ "${PKGFORMAT}" == "rpm" && "${SKIP_SIGNING}" != "true" ]]; then
   RPM_SIGNING_KEY="${KOKORO_KEYSTORE_DIR}/71565_rpm-signing-key"
-  cp "${RPM_SIGNING_KEY}" "$SIGNING_DIR/signing-key"
+  cp "${RPM_SIGNING_KEY}" "${SIGNING_DIR}/signing-key"
 fi
 
 sudo docker run \

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -88,6 +88,8 @@ if [[ -n "${TEST_SOURCE_PIPER_LOCATION-}" ]]; then
   go mod init "${TEST_SUITE_NAME}"
   go get github.com/GoogleCloudPlatform/ops-agent@master
   go mod tidy -compat=1.17
+else
+  cd integration_test
 fi
 
 if [[ "${TEST_SUITE_NAME}" == "os_config_test" ]]; then


### PR DESCRIPTION
1. use absolute path for SIGNING_DIR, because docker complains when this path isn't an absolute path.
2. cd into the integration_test directory in `go_test.sh` to fix "no required module provides package ops_agent_test.go" error.