### PR TITLE
Testing: fix mysql test failure

### DIFF
--- a/integration_test/third_party_apps_data/applications/mysql/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mysql/metadata.yaml
@@ -68,7 +68,7 @@ expected_metrics:
   kind: CUMULATIVE
   monitored_resource: gce_instance
   labels:
-    kind: writes|written
+    kind: writes|pages_written
 - type: workload.googleapis.com/mysql.handlers
   value_type: INT64
   kind: CUMULATIVE


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/ops-agent/pull/719 changed the label matching to be a full match instead of a partial match, and that caused mysql tests to fail with `workload.googleapis.com/mysql.double_writes: error: label value does not match pattern. label=kind, pattern=writes|written, value=pages_written` errors.

Looking at metrics explorer, everything is either "writes" or "pages_written", so i deleted "written" from the list of possible values.