### PR TITLE
Fix segfault when metrics are missing

### DIFF
--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -1335,6 +1335,7 @@ func testDefaultMetrics(ctx context.Context, t *testing.T, logger *logging.Direc
 			series, err := gce.WaitForMetric(ctx, logger.ToMainLog(), vm, metric.Type, window, nil)
 			if err != nil {
 				t.Error(err)
+				return
 			}
 
 			err = common.AssertMetric(metric, series)


### PR DESCRIPTION
This happens because `series` is nil when the metric is missing and `AssertMetric` immediately dereferences it. The error looks like:

```
ops_agent_test.go:1337: WaitForMetric(metric=agent.googleapis.com/processes/fork_count, extraFilters=[]) failed: exhausted retries
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x44 pc=0xa55638]

goroutine 3349 [running]:
github.com/GoogleCloudPlatform/ops-agent/integration_test/common.AssertMetric(0x0, 0xc000443fa8)
	/tmpfs/src/github/unified_agents/integration_test/common/common.go:164 +0x18
command-line-arguments_test.testDefaultMetrics.func1()
	/tmpfs/src/github/unified_agents/integration_test/ops_agent_test.go:1340 +0x15f
created by command-line-arguments_test.testDefaultMetrics
	/tmpfs/src/github/unified_agents/integration_test/ops_agent_test.go:1333 +0x7e6
```