### PR TITLE
Remove support for Ubuntu 21.10 Impish Indri

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,22 +91,6 @@ COPY . /work
 WORKDIR /work
 RUN ./pkg/deb/build.sh
 
-FROM ubuntu:impish AS impish-build
-
-RUN set -x; apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
-    autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
-    build-essential cmake bison flex file libsystemd-dev \
-    devscripts cdbs pkg-config openjdk-11-jdk zip
-
-ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
-RUN set -xe; \
-    tar -xf /tmp/go1.17.linux-amd64.tar.gz -C /usr/local
-
-COPY . /work
-WORKDIR /work
-RUN ./pkg/deb/build.sh
-
 FROM ubuntu:focal AS focal-build
 
 RUN set -x; apt-get update && \
@@ -249,10 +233,6 @@ FROM scratch AS jammy
 COPY --from=jammy-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-jammy.tgz
 COPY --from=jammy-build /google-cloud-ops-agent*.deb /
 
-FROM scratch AS impish
-COPY --from=impish-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-impish.tgz
-COPY --from=impish-build /google-cloud-ops-agent*.deb /
-
 FROM scratch AS focal
 COPY --from=focal-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-focal.tgz
 COPY --from=focal-build /google-cloud-ops-agent*.deb /
@@ -281,7 +261,6 @@ FROM scratch
 COPY --from=bullseye /* /
 COPY --from=buster /* /
 COPY --from=stretch /* /
-COPY --from=impish /* /
 COPY --from=focal /* /
 COPY --from=bionic /* /
 COPY --from=centos7 /* /

--- a/apps/elasticsearch.go
+++ b/apps/elasticsearch.go
@@ -105,7 +105,7 @@ func (p LoggingProcessorElasticsearchJson) Components(tag, uid string) []fluentb
 	c := []fluentbit.Component{}
 
 	// sample log line:
-	// {"type": "server", "timestamp": "2022-01-17T18:31:47,365Z", "level": "INFO", "component": "o.e.n.Node", "cluster.name": "elasticsearch", "node.name": "ubuntu-impish", "message": "initialized" }
+	// {"type": "server", "timestamp": "2022-01-17T18:31:47,365Z", "level": "INFO", "component": "o.e.n.Node", "cluster.name": "elasticsearch", "node.name": "ubuntu-jammy", "message": "initialized" }
 	// Logs are formatted based on configuration (log4j);
 	// See https://artifacts.elastic.co/javadoc/org/elasticsearch/elasticsearch/7.16.2/org/elasticsearch/common/logging/ESJsonLayout.html
 	// for general layout, and https://www.elastic.co/guide/en/elasticsearch/reference/current/logging.html for general configuration of logging

--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -61,13 +61,6 @@ ubuntu = _family {
       ]
       presubmit = 'ubuntu-minimal-2004-lts'
     }
-    impish = _distro {
-      name = 'Ubuntu 21.10 Impish'
-      release = [
-        'ubuntu-2110',
-        'ubuntu-minimal-2110',
-      ]
-    }
     jammy = _distro {
       name = 'Ubuntu 22.04 Jammy'
       release = [

--- a/kokoro/config/test/ops_agent/release/impish.gcl
+++ b/kokoro/config/test/ops_agent/release/impish.gcl
@@ -1,8 +1,0 @@
-import '../common.gcl' as common
-import '../../image_lists.gcl' as image_lists
-
-config build = common.ops_agent_test {
-  params {
-    platforms = image_lists.ubuntu.distros.impish.release
-  }
-}


### PR DESCRIPTION
This PR removes support for Ubuntu 21.10 Impish Indri since it is end of life as of last week.