### PR TITLE
Couchbase Logs Fix: mapping of couchbase_general log severity

### DIFF
--- a/apps/couchbase.go
+++ b/apps/couchbase.go
@@ -245,7 +245,7 @@ func (lr LoggingReceiverCouchbase) Components(tag string) []fluentbit.Component 
 		LoggingProcessorParseRegexComplex: confgenerator.LoggingProcessorParseRegexComplex{
 			Parsers: []confgenerator.RegexParser{
 				{
-					Regex: `^\[(?<type>[^:]*):(?<severity>[^,]*),(?<timestamp>\d+-\d+-\d+T\d+:\d+:\d+.\d+Z),(?<node_name>[^:]*):([^:]+):(?<source>[^\]]+)\](?<message>.*)$`,
+					Regex: `^\[(?<type>[^:]*):(?<level>[^,]*),(?<timestamp>\d+-\d+-\d+T\d+:\d+:\d+.\d+Z),(?<node_name>[^:]*):([^:]+):(?<source>[^\]]+)\](?<message>.*)$`,
 					Parser: confgenerator.ParserShared{
 						TimeKey:    "timestamp",
 						TimeFormat: "%Y-%m-%dT%H:%M:%S.%L",

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden_fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden_fluent_bit_parser.conf
@@ -1,7 +1,7 @@
 [PARSER]
     Format      regex
     Name        couchbase.couchbase_general.couchbase_general.0
-    Regex       ^\[(?<type>[^:]*):(?<severity>[^,]*),(?<timestamp>\d+-\d+-\d+T\d+:\d+:\d+.\d+Z),(?<node_name>[^:]*):([^:]+):(?<source>[^\]]+)\](?<message>.*)$
+    Regex       ^\[(?<type>[^:]*):(?<level>[^,]*),(?<timestamp>\d+-\d+-\d+T\d+:\d+:\d+.\d+Z),(?<node_name>[^:]*):([^:]+):(?<source>[^\]]+)\](?<message>.*)$
     Time_Format %Y-%m-%dT%H:%M:%S.%L
     Time_Key    timestamp
 

--- a/integration_test/third_party_apps_data/applications/couchbase/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/couchbase/metadata.yaml
@@ -16,6 +16,12 @@ expected_logs:
   - name: jsonPayload.module_name
     type: string
     description: The name of the module issuing the entry
+  - name: severity
+    type: string
+    description: ''
+  - name: timestamp
+    type: string
+    description: ''
 - log_name: couchbase_http_access
   fields:
   - name: jsonPayload.message
@@ -33,6 +39,12 @@ expected_logs:
   - name: jsonPayload.status_code
     type: integer
     description: The status code of the response of the HTTP request
+  - name: severity
+    type: string
+    description: ''
+  - name: timestamp
+    type: string
+    description: ''
 - log_name: couchbase_goxdcr
   fields:
   - name: jsonPayload.message
@@ -41,6 +53,12 @@ expected_logs:
   - name: log_type
     type: string
     description: The name of the component that is issuing the cross-datacenter log
+  - name: severity
+    type: string
+    description: ''
+  - name: timestamp
+    type: string
+    description: ''
 expected_metrics:
 - type: workload.googleapis.com/couchbase.bucket.operation.count
   value_type: INT64


### PR DESCRIPTION
Noticed the field in the regex was not matching the later defined

```go
	components = append(components,
		confgenerator.LoggingProcessorModifyFields{
			Fields: map[string]*confgenerator.ModifyField{
				"severity": {
					MoveFrom: "jsonPayload.level",
					MapValues: map[string]string{
						"debug": "DEBUG",
						"info":  "INFO",
						"warn":  "WARNING",
						"error": "ERROR",
					},
					MapValuesExclusive: true,
				},
				InstrumentationSourceLabel: instrumentationSourceValue(lr.Type()),
			},
		}.Components(tag, lr.Type())...)

```
