### PR TITLE
Internal: fix build_package.ps1 for release builds

### DIFF
--- a/kokoro/scripts/build/build_package.ps1
+++ b/kokoro/scripts/build/build_package.ps1
@@ -23,12 +23,12 @@ Set-MpPreference -Force -DisableRealtimeMonitoring $true -ErrorAction Continue
 # Try to disable Windows Defender firewall for improved build speed.
 Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False -ErrorAction Continue
 
-$gitDir = 'github'
-if (Test-Path env:KOKORO_GOB_COMMIT_URL_unified_agents) {
-  $gitDir = 'git'
+if (Test-Path -Path "$env:KOKORO_ARTIFACTS_DIR/git/unified_agents") {
+  Set-Location "$env:KOKORO_ARTIFACTS_DIR/git/unified_agents"
 }
-
-Set-Location "$env:KOKORO_ARTIFACTS_DIR/$gitDir/unified_agents"
+else {
+  Set-Location "$env:KOKORO_ARTIFACTS_DIR/github/unified_agents"
+}
 
 # Record OPS_AGENT_REPO_HASH so that we can later run tests from the
 # same commit that the agent was built from. This only applies to the

--- a/kokoro/scripts/build/build_package.ps1
+++ b/kokoro/scripts/build/build_package.ps1
@@ -23,8 +23,9 @@ Set-MpPreference -Force -DisableRealtimeMonitoring $true -ErrorAction Continue
 # Try to disable Windows Defender firewall for improved build speed.
 Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False -ErrorAction Continue
 
-if (Test-Path -Path "$env:KOKORO_ARTIFACTS_DIR/git/unified_agents") {
-  Set-Location "$env:KOKORO_ARTIFACTS_DIR/git/unified_agents"
+$gitOnBorgLocation = "$env:KOKORO_ARTIFACTS_DIR/git/unified_agents"
+if (Test-Path -Path $gitOnBorgLocation) {
+  Set-Location $gitOnBorgLocation
 }
 else {
   Set-Location "$env:KOKORO_ARTIFACTS_DIR/github/unified_agents"


### PR DESCRIPTION
Fix release builds when they are run solely from git.

For some reason, `KOKORO_GOB_COMMIT_URL_unified_agents` isn't set for release builds when run from git on borg (instead it's  just `KOKORO_GOB_COMMIT_URL`), I guess because I removed all but one SCM from the job config.

This fix looks at where the files are physically located, which is a more direct way to get to the actual files and doesn't expose us to weird decisions on the part of the kokoro team about which variables to set.

This is resurrecting an earlier draft of this code.