### PR TITLE
Testing: use the correct service account for release builds

### DIFF
--- a/kokoro/config/test/common.gcl
+++ b/kokoro/config/test/common.gcl
@@ -43,9 +43,16 @@ template config go_test = common {
       // under test).
       USE_INTERNAL_IP = 'true'
 
+      // TRANSFERS_BUCKET and SERVICE_EMAIL are always modified as a pair.
+      // when the build is running trusted (reviewed) code, it's OK to set
+      // this to 'stackdriver-test-143416-file-transfers' and use
+      // 'build-and-test@'. When running unreviewed code, leave both at their
+      // default values. go/sdi-kokoro-security is an internal doc that talks
+      // about how this is set up.
       TRANSFERS_BUCKET = 'stackdriver-test-143416-untrusted-file-transfers'
       SERVICE_EMAIL =
           'build-and-test-external@stackdriver-test-143416.iam.gserviceaccount.com'
+
       WINRM_IN_GCS = 'gs://stackdriver-test-143416-winrm/winrm.par'
     }
 

--- a/kokoro/config/test/ops_agent/release/bionic.gcl
+++ b/kokoro/config/test/ops_agent/release/bionic.gcl
@@ -1,4 +1,4 @@
-import '../common.gcl' as common
+import 'common.gcl' as common
 import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {

--- a/kokoro/config/test/ops_agent/release/bullseye.gcl
+++ b/kokoro/config/test/ops_agent/release/bullseye.gcl
@@ -1,4 +1,4 @@
-import '../common.gcl' as common
+import 'common.gcl' as common
 import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {

--- a/kokoro/config/test/ops_agent/release/buster.gcl
+++ b/kokoro/config/test/ops_agent/release/buster.gcl
@@ -1,4 +1,4 @@
-import '../common.gcl' as common
+import 'common.gcl' as common
 import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {

--- a/kokoro/config/test/ops_agent/release/centos7.gcl
+++ b/kokoro/config/test/ops_agent/release/centos7.gcl
@@ -1,4 +1,4 @@
-import '../common.gcl' as common
+import 'common.gcl' as common
 import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {

--- a/kokoro/config/test/ops_agent/release/centos8.gcl
+++ b/kokoro/config/test/ops_agent/release/centos8.gcl
@@ -1,4 +1,4 @@
-import '../common.gcl' as common
+import 'common.gcl' as common
 import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {

--- a/kokoro/config/test/ops_agent/release/common.gcl
+++ b/kokoro/config/test/ops_agent/release/common.gcl
@@ -3,7 +3,7 @@ import '../common.gcl' as common
 template config ops_agent_test = common.ops_agent_test {
   params {
     environment {
-      // The release builds run with slightly elevated privileges.
+      // The release builds run as a different service account.
       TRANSFERS_BUCKET = 'stackdriver-test-143416-file-transfers'
       SERVICE_EMAIL =
           'build-and-test@stackdriver-test-143416.iam.gserviceaccount.com'

--- a/kokoro/config/test/ops_agent/release/common.gcl
+++ b/kokoro/config/test/ops_agent/release/common.gcl
@@ -1,0 +1,12 @@
+import '../common.gcl' as common
+
+template config ops_agent_test = common.ops_agent_test {
+  params {
+    environment {
+      // The release builds run with slightly elevated privileges.
+      TRANSFERS_BUCKET = 'stackdriver-test-143416-file-transfers'
+      SERVICE_EMAIL =
+          'build-and-test@stackdriver-test-143416.iam.gserviceaccount.com'
+    }
+  }
+}

--- a/kokoro/config/test/ops_agent/release/focal.gcl
+++ b/kokoro/config/test/ops_agent/release/focal.gcl
@@ -1,4 +1,4 @@
-import '../common.gcl' as common
+import 'common.gcl' as common
 import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {

--- a/kokoro/config/test/ops_agent/release/jammy.gcl
+++ b/kokoro/config/test/ops_agent/release/jammy.gcl
@@ -1,4 +1,4 @@
-import '../common.gcl' as common
+import 'common.gcl' as common
 import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {

--- a/kokoro/config/test/ops_agent/release/sles12.gcl
+++ b/kokoro/config/test/ops_agent/release/sles12.gcl
@@ -1,4 +1,4 @@
-import '../common.gcl' as common
+import 'common.gcl' as common
 import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {

--- a/kokoro/config/test/ops_agent/release/sles15.gcl
+++ b/kokoro/config/test/ops_agent/release/sles15.gcl
@@ -1,4 +1,4 @@
-import '../common.gcl' as common
+import 'common.gcl' as common
 import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {

--- a/kokoro/config/test/ops_agent/release/windows.gcl
+++ b/kokoro/config/test/ops_agent/release/windows.gcl
@@ -1,4 +1,4 @@
-import '../common.gcl' as common
+import 'common.gcl' as common
 import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {

--- a/kokoro/config/test/third_party_apps/release/bullseye.gcl
+++ b/kokoro/config/test/third_party_apps/release/bullseye.gcl
@@ -1,4 +1,4 @@
-import '../common.gcl' as common
+import 'common.gcl' as common
 
 config build = common.third_party_apps_test {
   params {

--- a/kokoro/config/test/third_party_apps/release/buster.gcl
+++ b/kokoro/config/test/third_party_apps/release/buster.gcl
@@ -1,4 +1,4 @@
-import '../common.gcl' as common
+import 'common.gcl' as common
 
 config build = common.third_party_apps_test {
   params {

--- a/kokoro/config/test/third_party_apps/release/centos7.gcl
+++ b/kokoro/config/test/third_party_apps/release/centos7.gcl
@@ -1,4 +1,4 @@
-import '../common.gcl' as common
+import 'common.gcl' as common
 
 config build = common.third_party_apps_test {
   params {

--- a/kokoro/config/test/third_party_apps/release/common.gcl
+++ b/kokoro/config/test/third_party_apps/release/common.gcl
@@ -3,7 +3,7 @@ import '../common.gcl' as common
 template config third_party_apps_test = common.third_party_apps_test {
   params {
     environment {
-      // The release builds run with slightly elevated privileges.
+      // The release builds run as a different service account.
       TRANSFERS_BUCKET = 'stackdriver-test-143416-file-transfers'
       SERVICE_EMAIL =
           'build-and-test@stackdriver-test-143416.iam.gserviceaccount.com'

--- a/kokoro/config/test/third_party_apps/release/common.gcl
+++ b/kokoro/config/test/third_party_apps/release/common.gcl
@@ -1,0 +1,12 @@
+import '../common.gcl' as common
+
+template config third_party_apps_test = common.third_party_apps_test {
+  params {
+    environment {
+      // The release builds run with slightly elevated privileges.
+      TRANSFERS_BUCKET = 'stackdriver-test-143416-file-transfers'
+      SERVICE_EMAIL =
+          'build-and-test@stackdriver-test-143416.iam.gserviceaccount.com'
+    }
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/focal.gcl
+++ b/kokoro/config/test/third_party_apps/release/focal.gcl
@@ -1,4 +1,4 @@
-import '../common.gcl' as common
+import 'common.gcl' as common
 
 config build = common.third_party_apps_test {
   params {

--- a/kokoro/config/test/third_party_apps/release/rockylinux8.gcl
+++ b/kokoro/config/test/third_party_apps/release/rockylinux8.gcl
@@ -1,4 +1,4 @@
-import '../common.gcl' as common
+import 'common.gcl' as common
 
 config build = common.third_party_apps_test {
   params {

--- a/kokoro/config/test/third_party_apps/release/saphana.gcl
+++ b/kokoro/config/test/third_party_apps/release/saphana.gcl
@@ -1,4 +1,4 @@
-import '../common.gcl' as common
+import 'common.gcl' as common
 
 config build = common.third_party_apps_test {
   params {

--- a/kokoro/config/test/third_party_apps/release/sles12.gcl
+++ b/kokoro/config/test/third_party_apps/release/sles12.gcl
@@ -1,4 +1,4 @@
-import '../common.gcl' as common
+import 'common.gcl' as common
 
 config build = common.third_party_apps_test {
   params {

--- a/kokoro/config/test/third_party_apps/release/sles15.gcl
+++ b/kokoro/config/test/third_party_apps/release/sles15.gcl
@@ -1,4 +1,4 @@
-import '../common.gcl' as common
+import 'common.gcl' as common
 
 config build = common.third_party_apps_test {
   params {

--- a/kokoro/config/test/third_party_apps/release/windows.gcl
+++ b/kokoro/config/test/third_party_apps/release/windows.gcl
@@ -1,4 +1,4 @@
-import '../common.gcl' as common
+import 'common.gcl' as common
 
 config build = common.third_party_apps_test {
   params {


### PR DESCRIPTION
This should fix a build break for release builds, which are running as `build-and-test@` but have the environment variable `SERVICE_EMAIL` set to `build-and-test-external@`. Note: a future improvement would be to autodetect the currently running service account and use that instead of having to set the SERVICE_EMAIL correctly in all the different configs.