### PR TITLE
Internal: add kokoro config for debian 9 "stretch"

### DIFF
--- a/kokoro/config/test/ops_agent/stretch.gcl
+++ b/kokoro/config/test/ops_agent/stretch.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    platforms = ['debian-9']
+  }
+}


### PR DESCRIPTION
This will kind of fix our release process, which is expecting stretch.gcl to exist at this location. Of course, since stretch is deprecated, the test will still fail, but at least it won't fail with a missing config file error. If we decide to keep running our tests with stretch even though it's deprecated, we will need this file.