### PR TITLE
confgenerator: preserve response_code for agent self metrics

### DIFF
--- a/confgenerator/agentmetrics.go
+++ b/confgenerator/agentmetrics.go
@@ -128,12 +128,13 @@ func (r AgentSelfMetrics) LoggingSubmodulePipeline() otel.Pipeline {
 					// change data type from double -> int64
 					otel.ToggleScalarDataType,
 					otel.RenameLabel("status", "response_code"),
-					otel.AggregateLabels("sum"),
+					otel.AggregateLabels("sum", "response_code"),
 				),
 				otel.RenameMetric("fluentbit_stackdriver_proc_records_total", "agent/log_entry_count",
 					// change data type from double -> int64
 					otel.ToggleScalarDataType,
-					otel.AggregateLabels("sum"),
+					otel.RenameLabel("status", "response_code"),
+					otel.AggregateLabels("sum", "response_code"),
 				),
 				otel.AddPrefix("agent.googleapis.com"),
 			),

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_invalid_type_sqlserver/golden_otel.conf
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_invalid_type_sqlserver/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -338,15 +338,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_flink/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_flink/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_vault/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_vault/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_otel.conf
@@ -344,15 +344,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -345,15 +345,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -345,15 +345,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
@@ -344,15 +344,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_otel.conf
@@ -338,15 +338,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden_otel.conf
@@ -349,15 +349,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden_otel.conf
@@ -349,15 +349,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden_otel.conf
@@ -349,15 +349,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_otel.conf
@@ -355,15 +355,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden_otel.conf
@@ -355,15 +355,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_otel.conf
@@ -349,15 +349,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden_otel.conf
@@ -349,15 +349,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden_otel.conf
@@ -439,15 +439,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden_otel.conf
@@ -349,15 +349,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden_otel.conf
@@ -349,15 +349,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden_otel.conf
@@ -349,15 +349,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden_otel.conf
@@ -349,15 +349,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden_otel.conf
@@ -349,15 +349,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden_otel.conf
@@ -349,15 +349,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden_otel.conf
@@ -349,15 +349,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden_otel.conf
@@ -349,15 +349,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden_otel.conf
@@ -358,15 +358,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden_otel.conf
@@ -358,15 +358,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_otel.conf
@@ -349,15 +349,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_otel.conf
@@ -350,15 +350,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden_otel.conf
@@ -350,15 +350,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden_otel.conf
@@ -349,15 +349,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden_otel.conf
@@ -365,15 +365,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden_otel.conf
@@ -365,15 +365,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden_otel.conf
@@ -365,15 +365,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden_otel.conf
@@ -343,15 +343,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_otel.conf
@@ -386,15 +386,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_otel.conf
@@ -401,15 +401,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_otel.conf
@@ -401,15 +401,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden_otel.conf
@@ -401,15 +401,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden_otel.conf
@@ -401,15 +401,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_otel.conf
@@ -401,15 +401,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_otel.conf
@@ -401,15 +401,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/logging-receiver_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_iis/golden_otel.conf
@@ -401,15 +401,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_otel.conf
@@ -404,15 +404,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_otel.conf
@@ -404,15 +404,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_otel.conf
@@ -404,15 +404,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_otel.conf
@@ -386,15 +386,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_otel.conf
@@ -407,15 +407,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_otel.conf
@@ -407,15 +407,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_otel.conf
@@ -404,15 +404,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden_otel.conf
@@ -407,15 +407,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_otel.conf
@@ -413,15 +413,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_otel.conf
@@ -413,15 +413,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_otel.conf
@@ -401,15 +401,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden_otel.conf
@@ -401,15 +401,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden_otel.conf
@@ -374,15 +374,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_otel.conf
@@ -401,15 +401,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_otel.conf
@@ -401,15 +401,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden_otel.conf
@@ -401,15 +401,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden_otel.conf
@@ -395,15 +395,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_otel.conf
@@ -401,15 +401,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_otel.conf
@@ -401,15 +401,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_otel.conf
@@ -401,15 +401,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_otel.conf
@@ -401,15 +401,20 @@ processors:
         new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
-        label_set: []
+        label_set:
+        - response_code
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/integration_test/agent_metrics/metadata.yaml
+++ b/integration_test/agent_metrics/metadata.yaml
@@ -9,11 +9,8 @@ expected_metrics:
   value_type: INT64
   kind: CUMULATIVE
   monitored_resource: gce_instance
-  #  TODO(b/240439767) Remove platform specific filter once its becomes available on windows
-  platform: linux
-#  TODO(b/205585572#comment2) Add response_code when it becomes available
-#  labels:
-#    response_code: \d+
+  labels:
+    response_code: \d+
 #  TODO(b/170138116): Enable this metric once it is being collected.
 #- type: agent.googleapis.com/agent/log_entry_retry_count
 #  value_type: INT64
@@ -36,9 +33,8 @@ expected_metrics:
   value_type: INT64
   kind: CUMULATIVE
   monitored_resource: gce_instance
-#  TODO(b/205585572#comment2) Add response_code when it becomes available
-#  labels:
-#    response_code: \d+
+  labels:
+    response_code: \d+
 - type: agent.googleapis.com/agent/uptime
   value_type: INT64
   kind: CUMULATIVE


### PR DESCRIPTION
This change preserves the `response_code` label on self metrics where
appropriate. See the [spec](https://cloud.google.com/monitoring/api/metrics_opsagent#agent-agent) for more details.

Note: This requires a change in Fluent Bit befoe merging. See
https://github.com/fluent/fluent-bit/pull/5836 for more details.

Signed-off-by: Ridwan Sharif <ridwanmsharif@google.com>