### PR TITLE
integration_test: Create a config back up when enabling an integration

### DIFF
--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/integration_test/gce"
 	"github.com/GoogleCloudPlatform/ops-agent/integration_test/logging"
 	"github.com/GoogleCloudPlatform/ops-agent/integration_test/metadata"
+	"github.com/GoogleCloudPlatform/ops-agent/integration_test/util"
 	"google.golang.org/genproto/googleapis/monitoring/v3"
 	"gopkg.in/yaml.v2"
 
@@ -220,7 +221,7 @@ func setupOpsAgentFrom(ctx context.Context, logger *logging.DirectoryLogger, vm 
 			// services have not fully started up yet.
 			time.Sleep(startupDelay)
 		}
-		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(config), configPathForPlatform(vm.Platform)); err != nil {
+		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(config), util.ConfigPathForPlatform(vm.Platform)); err != nil {
 			return fmt.Errorf("setupOpsAgent() failed to upload config file: %v", err)
 		}
 		if _, err := gce.RunRemotely(ctx, logger.ToMainLog(), vm, "", restartCommandForPlatform(vm.Platform)); err != nil {

--- a/integration_test/third_party_apps_data/applications/active_directory_ds/enable
+++ b/integration_test/third_party_apps_data/applications/active_directory_ds/enable
@@ -1,3 +1,7 @@
+# Create a back up of the existing file so existing configurations are not lost.
+Copy-Item -Path 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml' -Destination 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml.bak'
+
+# Configure the Ops Agent.
 Add-Content 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml' "
 logging:
   receivers:

--- a/integration_test/third_party_apps_data/applications/active_directory_ds/enable
+++ b/integration_test/third_party_apps_data/applications/active_directory_ds/enable
@@ -1,5 +1,4 @@
 # Create a back up of the existing file so existing configurations are not lost.
-type nul >> 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml'
 Copy-Item -Path 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml' -Destination 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml.bak'
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/active_directory_ds/enable
+++ b/integration_test/third_party_apps_data/applications/active_directory_ds/enable
@@ -1,4 +1,5 @@
 # Create a back up of the existing file so existing configurations are not lost.
+type nul >> 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml'
 Copy-Item -Path 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml' -Destination 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml.bak'
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/activemq/enable
+++ b/integration_test/third_party_apps_data/applications/activemq/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/activemq/enable
+++ b/integration_test/third_party_apps_data/applications/activemq/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/activemq/enable
+++ b/integration_test/third_party_apps_data/applications/activemq/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/aerospike/enable
+++ b/integration_test/third_party_apps_data/applications/aerospike/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/aerospike/enable
+++ b/integration_test/third_party_apps_data/applications/aerospike/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/aerospike/enable
+++ b/integration_test/third_party_apps_data/applications/aerospike/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/apache/enable
+++ b/integration_test/third_party_apps_data/applications/apache/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/apache/enable
+++ b/integration_test/third_party_apps_data/applications/apache/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/apache/enable
+++ b/integration_test/third_party_apps_data/applications/apache/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/cassandra/enable
+++ b/integration_test/third_party_apps_data/applications/cassandra/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/cassandra/enable
+++ b/integration_test/third_party_apps_data/applications/cassandra/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/cassandra/enable
+++ b/integration_test/third_party_apps_data/applications/cassandra/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/couchbase/enable
+++ b/integration_test/third_party_apps_data/applications/couchbase/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/couchbase/enable
+++ b/integration_test/third_party_apps_data/applications/couchbase/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/couchbase/enable
+++ b/integration_test/third_party_apps_data/applications/couchbase/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/couchdb/enable
+++ b/integration_test/third_party_apps_data/applications/couchdb/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/couchdb/enable
+++ b/integration_test/third_party_apps_data/applications/couchdb/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/couchdb/enable
+++ b/integration_test/third_party_apps_data/applications/couchdb/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/elasticsearch/enable
+++ b/integration_test/third_party_apps_data/applications/elasticsearch/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/elasticsearch/enable
+++ b/integration_test/third_party_apps_data/applications/elasticsearch/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/elasticsearch/enable
+++ b/integration_test/third_party_apps_data/applications/elasticsearch/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/flink/enable
+++ b/integration_test/third_party_apps_data/applications/flink/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/flink/enable
+++ b/integration_test/third_party_apps_data/applications/flink/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/flink/enable
+++ b/integration_test/third_party_apps_data/applications/flink/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/hadoop/enable
+++ b/integration_test/third_party_apps_data/applications/hadoop/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/hadoop/enable
+++ b/integration_test/third_party_apps_data/applications/hadoop/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/hadoop/enable
+++ b/integration_test/third_party_apps_data/applications/hadoop/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/hbase/enable
+++ b/integration_test/third_party_apps_data/applications/hbase/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/hbase/enable
+++ b/integration_test/third_party_apps_data/applications/hbase/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/hbase/enable
+++ b/integration_test/third_party_apps_data/applications/hbase/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/iis/enable
+++ b/integration_test/third_party_apps_data/applications/iis/enable
@@ -5,7 +5,8 @@
 # during the test.
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+type nul >> 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml'
+Copy-Item -Path 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml' -Destination 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml.bak'
 
 # Configure the Ops Agent.
 Add-Content 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml' "

--- a/integration_test/third_party_apps_data/applications/iis/enable
+++ b/integration_test/third_party_apps_data/applications/iis/enable
@@ -5,7 +5,6 @@
 # during the test.
 
 # Create a back up of the existing file so existing configurations are not lost.
-type nul >> 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml'
 Copy-Item -Path 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml' -Destination 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml.bak'
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/iis/enable
+++ b/integration_test/third_party_apps_data/applications/iis/enable
@@ -4,6 +4,10 @@
 # the default receiver and so both receivers will be active simultaneously
 # during the test.
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 Add-Content 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml' "
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/jetty/enable
+++ b/integration_test/third_party_apps_data/applications/jetty/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/jetty/enable
+++ b/integration_test/third_party_apps_data/applications/jetty/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/jetty/enable
+++ b/integration_test/third_party_apps_data/applications/jetty/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/jvm/enable
+++ b/integration_test/third_party_apps_data/applications/jvm/enable
@@ -1,5 +1,9 @@
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/jvm/enable
+++ b/integration_test/third_party_apps_data/applications/jvm/enable
@@ -1,7 +1,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/jvm/enable
+++ b/integration_test/third_party_apps_data/applications/jvm/enable
@@ -1,6 +1,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/kafka/enable
+++ b/integration_test/third_party_apps_data/applications/kafka/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/kafka/enable
+++ b/integration_test/third_party_apps_data/applications/kafka/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/kafka/enable
+++ b/integration_test/third_party_apps_data/applications/kafka/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/memcached/enable
+++ b/integration_test/third_party_apps_data/applications/memcached/enable
@@ -1,5 +1,9 @@
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/memcached/enable
+++ b/integration_test/third_party_apps_data/applications/memcached/enable
@@ -1,7 +1,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/memcached/enable
+++ b/integration_test/third_party_apps_data/applications/memcached/enable
@@ -1,6 +1,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/mongodb/enable
+++ b/integration_test/third_party_apps_data/applications/mongodb/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/mongodb/enable
+++ b/integration_test/third_party_apps_data/applications/mongodb/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/mongodb/enable
+++ b/integration_test/third_party_apps_data/applications/mongodb/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/mssql/enable
+++ b/integration_test/third_party_apps_data/applications/mssql/enable
@@ -5,6 +5,7 @@
 # during the test.
 
 # Create a back up of the existing file so existing configurations are not lost.
+type nul >> 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml'
 Copy-Item -Path 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml' -Destination 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml.bak'
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/mssql/enable
+++ b/integration_test/third_party_apps_data/applications/mssql/enable
@@ -3,6 +3,11 @@
 # Because the v2 receiver here uses a unique ID, it does not overwrite
 # the default receiver and so both receivers will be active simultaneously
 # during the test.
+
+# Create a back up of the existing file so existing configurations are not lost.
+Copy-Item -Path 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml' -Destination 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml.bak'
+
+# Configure the Ops Agent.
 Add-Content 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml' "
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/mssql/enable
+++ b/integration_test/third_party_apps_data/applications/mssql/enable
@@ -5,7 +5,6 @@
 # during the test.
 
 # Create a back up of the existing file so existing configurations are not lost.
-type nul >> 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml'
 Copy-Item -Path 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml' -Destination 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml.bak'
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/mysql/enable
+++ b/integration_test/third_party_apps_data/applications/mysql/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/mysql/enable
+++ b/integration_test/third_party_apps_data/applications/mysql/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/mysql/enable
+++ b/integration_test/third_party_apps_data/applications/mysql/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/nginx/enable
+++ b/integration_test/third_party_apps_data/applications/nginx/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/nginx/enable
+++ b/integration_test/third_party_apps_data/applications/nginx/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/nginx/enable
+++ b/integration_test/third_party_apps_data/applications/nginx/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/postgresql/enable
+++ b/integration_test/third_party_apps_data/applications/postgresql/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/postgresql/enable
+++ b/integration_test/third_party_apps_data/applications/postgresql/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/postgresql/enable
+++ b/integration_test/third_party_apps_data/applications/postgresql/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/rabbitmq/enable
+++ b/integration_test/third_party_apps_data/applications/rabbitmq/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/rabbitmq/enable
+++ b/integration_test/third_party_apps_data/applications/rabbitmq/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/rabbitmq/enable
+++ b/integration_test/third_party_apps_data/applications/rabbitmq/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/redis/enable
+++ b/integration_test/third_party_apps_data/applications/redis/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/redis/enable
+++ b/integration_test/third_party_apps_data/applications/redis/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/redis/enable
+++ b/integration_test/third_party_apps_data/applications/redis/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/saphana/enable
+++ b/integration_test/third_party_apps_data/applications/saphana/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/saphana/enable
+++ b/integration_test/third_party_apps_data/applications/saphana/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 logging:
   receivers:

--- a/integration_test/third_party_apps_data/applications/saphana/enable
+++ b/integration_test/third_party_apps_data/applications/saphana/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/solr/enable
+++ b/integration_test/third_party_apps_data/applications/solr/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/solr/enable
+++ b/integration_test/third_party_apps_data/applications/solr/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/solr/enable
+++ b/integration_test/third_party_apps_data/applications/solr/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/tomcat/enable
+++ b/integration_test/third_party_apps_data/applications/tomcat/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/tomcat/enable
+++ b/integration_test/third_party_apps_data/applications/tomcat/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/tomcat/enable
+++ b/integration_test/third_party_apps_data/applications/tomcat/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/varnish/enable
+++ b/integration_test/third_party_apps_data/applications/varnish/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/varnish/enable
+++ b/integration_test/third_party_apps_data/applications/varnish/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/varnish/enable
+++ b/integration_test/third_party_apps_data/applications/varnish/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/vault/enable
+++ b/integration_test/third_party_apps_data/applications/vault/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/vault/enable
+++ b/integration_test/third_party_apps_data/applications/vault/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/vault/enable
+++ b/integration_test/third_party_apps_data/applications/vault/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 VAULT_TOKEN=$(grep 'Initial Root Token:' init.out | awk '{print $4}')
 
 

--- a/integration_test/third_party_apps_data/applications/wildfly/enable
+++ b/integration_test/third_party_apps_data/applications/wildfly/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/wildfly/enable
+++ b/integration_test/third_party_apps_data/applications/wildfly/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_data/applications/wildfly/enable
+++ b/integration_test/third_party_apps_data/applications/wildfly/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/zookeeper/enable
+++ b/integration_test/third_party_apps_data/applications/zookeeper/enable
@@ -3,7 +3,6 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
-# sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/zookeeper/enable
+++ b/integration_test/third_party_apps_data/applications/zookeeper/enable
@@ -3,6 +3,7 @@
 set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
+# sudo touch /etc/google-cloud-ops-agent/config.yaml 
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
 
 # Configure the Ops Agent.

--- a/integration_test/third_party_apps_data/applications/zookeeper/enable
+++ b/integration_test/third_party_apps_data/applications/zookeeper/enable
@@ -2,6 +2,10 @@
 
 set -e
 
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
 sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
 metrics:
   receivers:

--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -341,6 +341,11 @@ func runSingleTest(ctx context.Context, logger *logging.DirectoryLogger, vm *gce
 		return shouldRetry, fmt.Errorf("error installing agent: %v", err)
 	}
 
+	backupConfigFilePath := configPathForPlatform(vm.Platform) + ".bak"
+	if _, err = os.Stat(backupConfigFilePath); err != nil {
+		return nonRetryable, fmt.Errorf("error when fetching back up config file %s: %v", backupConfigFilePath, err)
+	}
+
 	if _, err = runScriptFromScriptsDir(ctx, logger, vm, path.Join("applications", app, "enable"), nil); err != nil {
 		return nonRetryable, fmt.Errorf("error enabling %s: %v", app, err)
 	}

--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/integration_test/gce"
 	"github.com/GoogleCloudPlatform/ops-agent/integration_test/logging"
 	"github.com/GoogleCloudPlatform/ops-agent/integration_test/metadata"
+	"github.com/GoogleCloudPlatform/ops-agent/integration_test/util"
 
 	"go.uber.org/multierr"
 	"gopkg.in/yaml.v2"
@@ -341,7 +342,7 @@ func runSingleTest(ctx context.Context, logger *logging.DirectoryLogger, vm *gce
 		return shouldRetry, fmt.Errorf("error installing agent: %v", err)
 	}
 
-	backupConfigFilePath := configPathForPlatform(vm.Platform) + ".bak"
+	backupConfigFilePath := util.ConfigPathForPlatform(vm.Platform) + ".bak"
 	if _, err = os.Stat(backupConfigFilePath); err != nil {
 		return nonRetryable, fmt.Errorf("error when fetching back up config file %s: %v", backupConfigFilePath, err)
 	}

--- a/integration_test/util/util.go
+++ b/integration_test/util/util.go
@@ -1,0 +1,28 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration_test
+
+package util
+
+import (
+	"github.com/GoogleCloudPlatform/ops-agent/integration_test/gce"
+)
+
+func ConfigPathForPlatform(platform string) string {
+	if gce.IsWindows(platform) {
+		return `C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml`
+	}
+	return "/etc/google-cloud-ops-agent/config.yaml"
+}


### PR DESCRIPTION
This change adds a back up config file in the `enable` scripts for every
application. It also adds a check in the integration test suite to
fail if any new application doesn't create a back up as well.