### PR TITLE
apps/flink: We also support FLink v1.12.5

### DIFF
--- a/integration_test/third_party_apps_data/applications/flink/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/flink/metadata.yaml
@@ -18,7 +18,7 @@ long_name: Apache Flink
 description: |-
   The Apache Flink integration collects client, jobmanager and taskmanager logs and parses them into a JSON payload.
   The result includes fields for source, level, and message.
-supported_app_version: ["1.13.6", "1.14.4"]
+supported_app_version: ["1.12.5", "1.13.6", "1.14.4"]
 configure_integration: ""
 expected_metrics:
   - type: workload.googleapis.com/flink.jvm.cpu.load


### PR DESCRIPTION
[b/261044342](http://b/261044342) | P3 | Test and document support for Flink v1.12.5 in the Ops Agent

Our integration works with this version as well. See
https://github.com/GoogleCloudPlatform/ops-agent/pull/756 for more
information about the passing run.