### PR TITLE
Testing: add retries for "currently unavailable" GCE errors

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1088,6 +1088,8 @@ func CreateInstance(origCtx context.Context, logger *log.Logger, options VMOptio
 		return strings.Contains(err.Error(), "Quota") ||
 			// Rarely, instance creation fails due to internal errors in the compute API.
 			strings.Contains(err.Error(), "Internal error") ||
+			// Instance creation can also fail due to service unavailability.
+			strings.Contains(err.Error(), "currently unavailable") ||
 			// Windows instances sometimes fail to initialize WinRM: b/185923886.
 			strings.Contains(err.Error(), winRMDummyCommandMessage) ||
 			// SLES instances sometimes fail to be ssh-able: b/186426190


### PR DESCRIPTION
Example failure: https://source.cloud.google.com/results/invocations/36653ad6-197f-4f3c-9596-84b709f9fb57/targets/logs/tests;group=command-line-arguments;test=TestMetricsAgentCrashRestart%2Fdebian-11;row=2