### PR TITLE
Internal: fix non-ascii hyphens in source code

### DIFF
--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -119,7 +119,7 @@ func writeToWindowsEventLog(ctx context.Context, logger *log.Logger, vm *gce.VM,
 	// *somewhere*. So the workaround is to make the log source's name unique
 	// per logName.
 	source := logName + "__ops_agent_test"
-	if _, err := gce.RunRemotely(ctx, logger, vm, "", fmt.Sprintf("if(![System.Diagnostics.EventLog]::SourceExists('%s')) { New-EventLog –LogName '%s' –Source '%s' }", source, logName, source)); err != nil {
+	if _, err := gce.RunRemotely(ctx, logger, vm, "", fmt.Sprintf("if(![System.Diagnostics.EventLog]::SourceExists('%s')) { New-EventLog -LogName '%s' -Source '%s' }", source, logName, source)); err != nil {
 		return fmt.Errorf("writeToWindowsEventLog(logName=%q, payload=%q) failed to register new source %v: %v", logName, payload, source, err)
 	}
 


### PR DESCRIPTION
The "funky hyphens" seem to work OK but render strangely in test logs, like this one:

https://storage.cloud.google.com/ops-agents-public-buckets-test-logs/prod/stackdriver_agents/testing/consumer/ops_agent/presubmit_github/windows/449/20220322-104940/logs/TestLoggingAgentCrashRestart_windows-2019/main_log.txt

where this snippet renders as `New-EventLog â€“LogName 'System' â€“Source 'System__ops_agent_test' }"`