### PR TITLE
Add Makefile, override auto test command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+test:
+	go test ./...
+
+test_confgenerator:
+	go test -mod=mod github.com/GoogleCloudPlatform/ops-agent/confgenerator
+
+test_metadata:
+	go test -mod=mod github.com/GoogleCloudPlatform/ops-agent/integration_test/metadata
+
+update_golden:
+	go test -mod=mod github.com/GoogleCloudPlatform/ops-agent/confgenerator -update_golden

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,21 @@
+# Copyright 2022 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTICE: This file is purely for automation of development tasks. 
+# No guarantee is made for these commands, and no dependencies should be made on any
+# targets. Building the Ops Agent should be done through the Dockerfile.
+
 test:
 	go test ./...
 

--- a/debian/rules
+++ b/debian/rules
@@ -9,6 +9,8 @@ override_dh_auto_configure:
 	true
 override_dh_auto_build:
 	true
+override_dh_auto_test:
+	true
 override_dh_strip_nondeterminism:
 	dh_strip_nondeterminism -X.jar
 override_dh_auto_install:


### PR DESCRIPTION
This PR is another attempt to add a Makefile to help with some development processes, mainly quickly running specific test commands and scripts. It should hopefully reduce some development toil spent trying to manually run commands, especially for testing.

Previously this did not work because `dh_auto_test` tried to detect a `make test` target and run it when we don't want to. This PR also adds `override_dh_auto_test`, since this command was not actually doing anything for us when there was no Makefile previously.