### PR TITLE
flinkreceiver: update flink labels for otel v0.57.2

### DIFF
--- a/apps/flink.go
+++ b/apps/flink.go
@@ -48,10 +48,10 @@ func (r MetricsReceiverFlink) Pipelines() []otel.Pipeline {
 			otel.NormalizeSums(),
 			otel.MetricsTransform(
 				otel.AddPrefix("workload.googleapis.com"),
-				otel.UpdateMetric("flink.jvm.gc.collections.count", otel.RenameLabel("garbage_collector_name", "name")),
-				otel.UpdateMetric("flink.jvm.gc.collections.time", otel.RenameLabel("garbage_collector_name", "name")),
-				otel.UpdateMetric("flink.operator.record.count", otel.RenameLabel("operator_name", "name")),
-				otel.UpdateMetric("flink.operator.watermark.output", otel.RenameLabel("operator_name", "name")),
+				otel.UpdateMetric("flink.jvm.gc.collections.count", otel.RenameLabel("name", "garbage_collector_name")),
+				otel.UpdateMetric("flink.jvm.gc.collections.time", otel.RenameLabel("name", "garbage_collector_name")),
+				otel.UpdateMetric("flink.operator.record.count", otel.RenameLabel("name", "operator_name")),
+				otel.UpdateMetric("flink.operator.watermark.output", otel.RenameLabel("name", "operator_name")),
 			),
 			otel.TransformationMetrics(
 				otel.FlattenResourceAttribute("host.name", "host_name"),

--- a/apps/flink.go
+++ b/apps/flink.go
@@ -47,11 +47,11 @@ func (r MetricsReceiverFlink) Pipelines() []otel.Pipeline {
 		Processors: []otel.Component{
 			otel.NormalizeSums(),
 			otel.MetricsTransform(
-				otel.AddPrefix("workload.googleapis.com"),
 				otel.UpdateMetric("flink.jvm.gc.collections.count", otel.RenameLabel("name", "garbage_collector_name")),
 				otel.UpdateMetric("flink.jvm.gc.collections.time", otel.RenameLabel("name", "garbage_collector_name")),
 				otel.UpdateMetric("flink.operator.record.count", otel.RenameLabel("name", "operator_name")),
 				otel.UpdateMetric("flink.operator.watermark.output", otel.RenameLabel("name", "operator_name")),
+				otel.AddPrefix("workload.googleapis.com"),
 			),
 			otel.TransformationMetrics(
 				otel.FlattenResourceAttribute("host.name", "host_name"),

--- a/apps/flink.go
+++ b/apps/flink.go
@@ -48,6 +48,10 @@ func (r MetricsReceiverFlink) Pipelines() []otel.Pipeline {
 			otel.NormalizeSums(),
 			otel.MetricsTransform(
 				otel.AddPrefix("workload.googleapis.com"),
+				otel.UpdateMetric("flink.jvm.gc.collections.count", otel.RenameLabel("garbage_collector_name", "name")),
+				otel.UpdateMetric("flink.jvm.gc.collections.time", otel.RenameLabel("garbage_collector_name", "name")),
+				otel.UpdateMetric("flink.operator.record.count", otel.RenameLabel("operator_name", "name")),
+				otel.UpdateMetric("flink.operator.watermark.output", otel.RenameLabel("operator_name", "name")),
 			),
 			otel.TransformationMetrics(
 				otel.FlattenResourceAttribute("host.name", "host_name"),

--- a/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden_otel.conf
@@ -322,10 +322,6 @@ processors:
   metricstransform/flink_flink_1:
     transforms:
     - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: workload.googleapis.com/$${1}
-    - action: update
       include: flink.jvm.gc.collections.count
       operations:
       - action: update_label
@@ -349,6 +345,10 @@ processors:
       - action: update_label
         label: name
         new_label: operator_name
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: workload.googleapis.com/$${1}
   metricstransform/fluentbit_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden_otel.conf
@@ -325,6 +325,30 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
+    - action: update
+      include: flink.jvm.gc.collections.count
+      operations:
+      - action: update_label
+        label: garbage_collector_name
+        new_label: name
+    - action: update
+      include: flink.jvm.gc.collections.time
+      operations:
+      - action: update_label
+        label: garbage_collector_name
+        new_label: name
+    - action: update
+      include: flink.operator.record.count
+      operations:
+      - action: update_label
+        label: operator_name
+        new_label: name
+    - action: update
+      include: flink.operator.watermark.output
+      operations:
+      - action: update_label
+        label: operator_name
+        new_label: name
   metricstransform/fluentbit_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden_otel.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden_otel.conf
@@ -329,26 +329,26 @@ processors:
       include: flink.jvm.gc.collections.count
       operations:
       - action: update_label
-        label: garbage_collector_name
-        new_label: name
+        label: name
+        new_label: garbage_collector_name
     - action: update
       include: flink.jvm.gc.collections.time
       operations:
       - action: update_label
-        label: garbage_collector_name
-        new_label: name
+        label: name
+        new_label: garbage_collector_name
     - action: update
       include: flink.operator.record.count
       operations:
       - action: update_label
-        label: operator_name
-        new_label: name
+        label: name
+        new_label: operator_name
     - action: update
       include: flink.operator.watermark.output
       operations:
       - action: update_label
-        label: operator_name
-        new_label: name
+        label: name
+        new_label: operator_name
   metricstransform/fluentbit_1:
     transforms:
     - action: update

--- a/integration_test/third_party_apps_data/applications/mongodb/enable
+++ b/integration_test/third_party_apps_data/applications/mongodb/enable
@@ -11,6 +11,7 @@ metrics:
   receivers:
     mongodb:
       type: mongodb
+      insecure: true
   service:
     pipelines:
       mongo:


### PR DESCRIPTION
Flink receiver `operator_name` and `garbage_collector_name` got updated to `name`. 
Otel [pr](https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/c3a87a1bc6d38cea801f0c91152cd121a3f6e839) change of occurrence.

Also, mongodb had a change in which TLS setting was getting ignored. This Otel [pr](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/12093) reflects these changes. If you want this in another pr I can do so.