### PR TITLE
integration_test: make the expected_log tests more robust

### DIFF
--- a/integration_test/metadata/integration_metadata.go
+++ b/integration_test/metadata/integration_metadata.go
@@ -54,6 +54,7 @@ type LogFields struct {
 	ValueRegex  string `yaml:"value_regex"`
 	Type        string `yaml:"type" validate:"required"`
 	Description string `yaml:"description" validate:"excludesall=‘’“”"`
+	Optional    bool   `yaml:"optional,omitempty"`
 }
 
 type ExpectedLog struct {

--- a/integration_test/third_party_apps_data/applications/active_directory_ds/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/active_directory_ds/metadata.yaml
@@ -76,6 +76,9 @@ expected_logs:
   - name: jsonPayload.StringInserts
     type: "[]string"
     description: "Dynamic string data that was used to construct the log message."
+  - name: severity
+    type: string
+    description: ''
 expected_metrics:
 - type: workload.googleapis.com/active_directory.ds.bind.rate
   value_type: DOUBLE

--- a/integration_test/third_party_apps_data/applications/active_directory_ds/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/active_directory_ds/metadata.yaml
@@ -29,7 +29,7 @@ expected_logs:
 - log_name: active_directory_ds
   fields:
   - name: jsonPayload.Message
-    value_regex: '^Microsoft Active Directory Domain Services startup complete.*'
+    value_regex: (?s)^Microsoft Active Directory Domain Services startup complete.* # The (?s) part will make the . match with newline as well. See https://github.com/google/re2/blob/main/doc/syntax.txt#L65,L68 
     type: string
     description: "The log message."
   - name: jsonPayload.RecordNumber
@@ -73,6 +73,7 @@ expected_logs:
     value_regex: '^$'
     type: string
     description: "Extra event-specific data included with the log."
+    optional: true
   - name: jsonPayload.StringInserts
     type: "[]string"
     description: "Dynamic string data that was used to construct the log message."

--- a/integration_test/third_party_apps_data/applications/apache/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/apache/metadata.yaml
@@ -121,7 +121,7 @@ expected_logs:
 - log_name: apache_error
   fields:
   - name: jsonPayload.client
-    value_regex: ::1|127.0.0.1:[0-9]+
+    value_regex: ((::1)|(127.0.0.1)):[0-9]+ # Parentheses are required here since the regexp library and Cloud Monitoring regex match differently.
     type: string
     description: Client IP address (optional)
   - name: jsonPayload.level

--- a/integration_test/third_party_apps_data/applications/apache/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/apache/metadata.yaml
@@ -79,24 +79,43 @@ expected_logs:
     value_regex: ::1|127.0.0.1
     type: string
     description: The IP address (IPv4 or IPv6) of the client that issued the HTTP request
+    optional: true
   - name: httpRequest.requestUrl
     value_regex: /forbidden.html
     type: string
     description: Request URL (typically just the path part of the URL)
+    optional: true
   - name: httpRequest.protocol
     value_regex: HTTP/1.1
     type: string
     description: Protocol used for the request
+    optional: true
   - name: httpRequest.requestMethod
     value_regex: GET
     type: string
     description: HTTP method
+    optional: true
+  - name: httpRequest.status
+    type: number
+    description: HTTP status code
+    optional: true
+  - name: httpRequest.responseSize
+    type: string
+    description: ''
+    optional: true
+  - name: httpRequest.userAgent
+    type: string
+    description: ''
+    optional: true
   - name: jsonPayload.host
     type: string
     description: Contents of the Host header
   - name: jsonPayload.user
     type: string
     description: Authenticated username for the request
+  - name: severity
+    type: string
+    description: ''
 - log_name: apache_error
   fields:
   - name: jsonPayload.client
@@ -125,6 +144,9 @@ expected_logs:
   - name: jsonPayload.tid
     type: string
     description: Thread ID
+  - name: severity
+    type: string
+    description: ''
 configuration_options:
   logs:
   - type: apache_access

--- a/integration_test/third_party_apps_data/applications/apache/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/apache/metadata.yaml
@@ -110,9 +110,11 @@ expected_logs:
   - name: jsonPayload.host
     type: string
     description: Contents of the Host header
+    optional: true
   - name: jsonPayload.user
     type: string
     description: Authenticated username for the request
+    optional: true
   - name: severity
     type: string
     description: ''
@@ -126,6 +128,7 @@ expected_logs:
     value_regex: error
     type: string
     description: Log entry level
+    optional: true
   - name: jsonPayload.module
     value_regex: core
     type: string

--- a/integration_test/third_party_apps_data/applications/cassandra/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/cassandra/metadata.yaml
@@ -126,6 +126,9 @@ expected_logs:
   - name: jsonPayload.lineNumber
     type: string
     description: Line number of the source file where the log originated
+  - name: severity
+    type: string
+    description: ''
 - log_name: cassandra_debug
   fields:
   - name: jsonPayload.message
@@ -147,6 +150,9 @@ expected_logs:
   - name: jsonPayload.lineNumber
     type: string
     description: Line number of the source file where the log originated
+  - name: severity
+    type: string
+    description: ''
 - log_name: cassandra_gc
   fields:
   - name: jsonPayload.message
@@ -162,6 +168,9 @@ expected_logs:
   - name: jsonPayload.timeStopping
     type: string
     description: Seconds the JVM took to stop threads before garbage collection
+  - name: severity
+    type: string
+    description: ''
 configuration_options:
   logs:
   - type: cassandra_system

--- a/integration_test/third_party_apps_data/applications/couchbase/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/couchbase/metadata.yaml
@@ -47,7 +47,7 @@ expected_logs:
   - name: jsonPayload.method
     type: string
     description: The HTTP method of the request
-  - name: jsonPayload.responseSize
+  - name: jsonPayload.response_size
     type: string
     description: The HTTP response size
     optional: true

--- a/integration_test/third_party_apps_data/applications/couchbase/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/couchbase/metadata.yaml
@@ -10,6 +10,7 @@ expected_logs:
   - name: jsonPayload.message
     type: string
     description: "Log message"
+    optional: true
   - name: jsonPayload.node_name
     type: string
     description: The name of the node issuing the log message

--- a/integration_test/third_party_apps_data/applications/couchbase/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/couchbase/metadata.yaml
@@ -16,6 +16,15 @@ expected_logs:
   - name: jsonPayload.module_name
     type: string
     description: The name of the module issuing the entry
+    optional: true
+  - name: jsonPayload.source
+    type: string
+    description: ''
+    optional: true
+  - name: jsonPayload.type
+    type: string
+    description: ''
+    optional: true
   - name: severity
     type: string
     description: ''
@@ -30,12 +39,22 @@ expected_logs:
   - name: jsonPayload.client_ip
     type: string
     description: The IP address of the client invoking the HTTP request
+    optional: true
   - name: jsonPayload.user
     type: string
     description: The name of the user making the HTTP request if basic auth is used.
+    optional: true
   - name: jsonPayload.method
     type: string
     description: The HTTP method of the request
+  - name: jsonPayload.responseSize
+    type: string
+    description: The HTTP response size
+    optional: true
+  - name: jsonPayload.path
+    type: string
+    description: ''
+    optional: true
   - name: jsonPayload.status_code
     type: integer
     description: The status code of the response of the HTTP request
@@ -50,6 +69,10 @@ expected_logs:
   - name: jsonPayload.message
     type: string
     description: "Log message"
+  - name: jsonPayload.log_type
+    type: string
+    description: ''
+    optional: true
   - name: log_type
     type: string
     description: The name of the component that is issuing the cross-datacenter log

--- a/integration_test/third_party_apps_data/applications/couchdb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/couchdb/metadata.yaml
@@ -84,6 +84,10 @@ expected_logs:
   - name: jsonPayload.host
     type: string
     description: host instance name
+  - name: jsonPayload.level
+    type: string
+    description: Log entry level
+    optional: true
   - name: httpRequest.serverIp
     value_regex: "localhost:5984"
     type: string

--- a/integration_test/third_party_apps_data/applications/couchdb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/couchdb/metadata.yaml
@@ -88,20 +88,36 @@ expected_logs:
     value_regex: "localhost:5984"
     type: string
     description: "The server's IP and port that was requested"
+    optional: true
   - name: httpRequest.remoteIp
     value_regex: "127.0.0.1"
     type: string
     description: "IP of the client that made the request"
+    optional: true
   - name: httpRequest.requestMethod
     value_regex: GET
     type: string
     description: "HTTP method"
+    optional: true
   - name: httpRequest.requestSize
     type: number
     description: "HTTP request size"
+    optional: true
   - name: httpRequest.status
     type: number
     description: "HTTP status code"
+    optional: true
+  - name: httpRequest.responseSize
+    type: string
+    description: ''
+    optional: true
+  - name: httpRequest.userAgent
+    type: string
+    description: ''
+    optional: true
+  - name: severity
+    type: string
+    description: ''
 configuration_options:
   logs:
   - type: couchdb

--- a/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
@@ -135,15 +135,27 @@ expected_logs:
   - name: jsonPayload.cluster.name
     type: string
     description: 'The name of the cluster emitting the log record'
+    optional: true
   - name: jsonPayload.cluster.uuid
     type: string
     description: 'The uuid of the cluster emitting the log record'
+    optional: true
   - name: jsonPayload.node.name
     type: string
     description: 'The name of the node emitting the log record'
+    optional: true
   - name: jsonPayload.node.uuid
     type: string
     description: 'The uuid of the node emitting the log record'
+    optional: true
+  - name: jsonPayload.cluster
+    type: string
+    description: 'The cluster emitting the log record'
+    optional: true
+  - name: jsonPayload.node
+    type: string
+    description: 'The node emitting the log record'
+    optional: true
   - name: jsonPayload.level
     type: string
     description: Log entry level
@@ -164,6 +176,7 @@ expected_logs:
   - name: jsonPayload.gc_run
     type: number
     description: 'The run of the garbage collector'
+    optional: true
   - name: severity
     type: string
     description: ''

--- a/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
@@ -144,6 +144,10 @@ expected_logs:
   - name: jsonPayload.node.uuid
     type: string
     description: 'The uuid of the node emitting the log record'
+  - name: jsonPayload.level
+    type: string
+    description: Log entry level
+    optional: true
   - name: severity
     type: string
     description: ''

--- a/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
@@ -144,6 +144,9 @@ expected_logs:
   - name: jsonPayload.node.uuid
     type: string
     description: 'The uuid of the node emitting the log record'
+  - name: severity
+    type: string
+    description: ''
 - log_name: elasticsearch_gc
   fields:
   - name: jsonPayload.message
@@ -157,6 +160,9 @@ expected_logs:
   - name: jsonPayload.gc_run
     type: number
     description: 'The run of the garbage collector'
+  - name: severity
+    type: string
+    description: ''
 configuration_options:
   logs:
   - type: elasticsearch_json

--- a/integration_test/third_party_apps_data/applications/flink/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/flink/metadata.yaml
@@ -258,6 +258,10 @@ expected_logs:
     value_regex: org.apache.flink.runtime.entrypoint.ClusterEntrypoint
     type: string
     description: ''
+  - name: jsonPayload.level
+    type: string
+    description: Log entry level
+    optional: true
   - name: severity
     type: string
     description: ''

--- a/integration_test/third_party_apps_data/applications/hadoop/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/hadoop/metadata.yaml
@@ -93,6 +93,10 @@ expected_logs:
     value_regex: org.apache.hadoop.hdfs.server.namenode.NameNode
     type: string
     description: 'The source Java class of the log entry'
+  - name: jsonPayload.severity
+    type: string
+    description: Log entry level
+    optional: true
   - name: severity
     type: string
     description: ''

--- a/integration_test/third_party_apps_data/applications/hadoop/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/hadoop/metadata.yaml
@@ -86,7 +86,7 @@ expected_logs:
 - log_name: hadoop
   fields:
   - name: jsonPayload.message
-    value_regex: STARTUP_MSG:.*
+    value_regex: (?s)STARTUP_MSG:.* # The (?s) part will make the . match with newline as well. See https://github.com/google/re2/blob/main/doc/syntax.txt#L65,L68
     type: string
     description: 'Log message'
   - name: jsonPayload.source

--- a/integration_test/third_party_apps_data/applications/hadoop/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/hadoop/metadata.yaml
@@ -93,6 +93,9 @@ expected_logs:
     value_regex: org.apache.hadoop.hdfs.server.namenode.NameNode
     type: string
     description: 'The source Java class of the log entry'
+  - name: severity
+    type: string
+    description: ''
 configuration_options:
   logs:
   - type: hadoop

--- a/integration_test/third_party_apps_data/applications/hbase/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/hbase/metadata.yaml
@@ -357,6 +357,9 @@ expected_logs:
     value_regex: master.HMaster
     type: string
     description: 'source of where the log originated'
+  - name: severity
+    type: string
+    description: ''
 configuration_options:
   logs:
   - type: hbase_system

--- a/integration_test/third_party_apps_data/applications/hbase/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/hbase/metadata.yaml
@@ -357,6 +357,10 @@ expected_logs:
     value_regex: master.HMaster
     type: string
     description: 'source of where the log originated'
+  - name: jsonPayload.level
+    type: string
+    description: Log entry level
+    optional: true
   - name: severity
     type: string
     description: ''

--- a/integration_test/third_party_apps_data/applications/iis/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/iis/metadata.yaml
@@ -149,6 +149,7 @@ expected_logs:
   - name: jsonPayload.user
     type: string
     description: "Authenticated username for the request"
+    optional: true
   - name: severity
     type: string
     description: ''

--- a/integration_test/third_party_apps_data/applications/iis/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/iis/metadata.yaml
@@ -104,28 +104,39 @@ expected_logs:
     value_regex: "::1:80"
     type: string
     description: "The server's IP and port that was requested"
+    optional: true
   - name: httpRequest.remoteIp
     value_regex: "::1"
     type: string
     description: "IP of the client that made the request"
+    optional: true
   - name: httpRequest.requestUrl
     value_regex: '/forbidden\?something=something'
     type: string
     description: "Request URL (typically just the path part of the URL)"
+    optional: true
   - name: httpRequest.requestMethod
     value_regex: GET
     type: string
     description: "HTTP method"
+    optional: true
   - name: httpRequest.status
     type: number
     description: "HTTP status code"
+    optional: true
   - name: httpRequest.userAgent
     value_regex: 'Mozilla\/5\.0\+\(Windows\+NT;\+Windows\+NT\+\d+\.\d+;\+en\-US\)\+WindowsPowerShell\/\d+\.\d+\.\d+\.\d+'
     type: string
     description: "Contents of the `User-Agent` header"
+    optional: true
   - name: httpRequest.referer
     type: string
     description: "Contents of the `Referer` header"
+    optional: true
+  - name: httpRequest.userAgent
+    type: string
+    description: ""
+    optional: true
   - name: jsonPayload.sc_substatus
     type: string
     description: "The server's IP and port that was requested"
@@ -138,6 +149,9 @@ expected_logs:
   - name: jsonPayload.user
     type: string
     description: "Authenticated username for the request"
+  - name: severity
+    type: string
+    description: ''
 configuration_options:
   logs:
   - type: iis_access

--- a/integration_test/third_party_apps_data/applications/jetty/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/jetty/metadata.yaml
@@ -52,29 +52,35 @@ expected_logs:
   - name: httpRequest.remoteIp
     type: string
     description: ''
+    optional: true
   - name: httpRequest.requestUrl
     value_regex: \/forbidden.html\?something=something
     type: string
     description: ''
+    optional: true
   - name: httpRequest.protocol
     value_regex: HTTP\/1.1
     type: string
     description: ''
+    optional: true
   - name: httpRequest.requestMethod
     value_regex: GET
     type: string
     description: ''
+    optional: true
   - name: httpRequest.userAgent
     value_regex: curl\/.*
     type: string
     description: ''
+    optional: true
   - name: httpRequest.responseSize
     type: string
     description: ''
-  - name: httpRequest.userAgent
+    optional: true
+  - name: httpRequest.status
     type: string
     description: ''
-  - name: httpRequest.status
+  - name: severity
     type: string
     description: ''
 configuration_options:

--- a/integration_test/third_party_apps_data/applications/kafka/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/kafka/metadata.yaml
@@ -100,6 +100,10 @@ expected_logs:
     value_regex: kafka.zookeeper.ZooKeeperClient
     type: string
     description: ''
+  - name: jsonPayload.level
+    type: string
+    description: Log entry level
+    optional: true
   - name: severity
     type: string
     description: ''

--- a/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
@@ -99,6 +99,9 @@ expected_logs:
   - name: jsonPayload.attributes
     type: object (optional)
     description: Object containing one or more key-value pairs for any additional attributes provided
+  - name: severity
+    type: string
+    description: ''
 configuration_options:
   logs:
   - type: mongodb

--- a/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
@@ -99,6 +99,10 @@ expected_logs:
   - name: jsonPayload.attributes
     type: object (optional)
     description: Object containing one or more key-value pairs for any additional attributes provided
+  - name: jsonPayload.s
+    type: string
+    description: Log entry level
+    optional: true
   - name: severity
     type: string
     description: ''

--- a/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
@@ -90,6 +90,7 @@ expected_logs:
   - name: jsonPayload.ctx
     type: string
     description: The name of the thread issuing the log statement
+    optional: true
   - name: jsonPayload.id
     type: number
     description: Log ID
@@ -99,7 +100,16 @@ expected_logs:
   - name: jsonPayload.attributes
     type: object (optional)
     description: Object containing one or more key-value pairs for any additional attributes provided
+    optional: true
   - name: jsonPayload.s
+    type: string
+    description: Log entry level
+    optional: true
+  - name: jsonPayload.context
+    type: string
+    description: ''
+    optional: true
+  - name: jsonPayload.severity
     type: string
     description: Log entry level
     optional: true

--- a/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
@@ -101,10 +101,6 @@ expected_logs:
     type: object (optional)
     description: Object containing one or more key-value pairs for any additional attributes provided
     optional: true
-  - name: jsonPayload.s
-    type: string
-    description: Log entry level
-    optional: true
   - name: jsonPayload.context
     type: string
     description: ''

--- a/integration_test/third_party_apps_data/applications/mysql/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mysql/metadata.yaml
@@ -129,6 +129,7 @@ expected_logs:
     value_regex: System
     type: string
     description: 'Log entry level'
+    optional: true
   - name: jsonPayload.message
     value_regex: .*InnoDB initialization has started.*
     type: string
@@ -165,7 +166,7 @@ expected_logs:
 - log_name: mysql_slow
   fields:
   - name: jsonPayload.message
-    value_regex: .*select table_catalog, table_schema, table_name from information_schema.tables.*
+    value_regex: (?s).*select table_catalog, table_schema, table_name from information_schema.tables.* # The (?s) part will make the . match with newline as well. See https://github.com/google/re2/blob/main/doc/syntax.txt#L65,L68
     type: string
     description: 'Full text of the query'
   - name: jsonPayload.user
@@ -183,6 +184,7 @@ expected_logs:
   - name: jsonPayload.ipAddress
     type: string
     description: 'Address of the database instance'
+    optional: true
   - name: jsonPayload.tid
     type: number
     description: 'Thread ID where the query was logged'

--- a/integration_test/third_party_apps_data/applications/mysql/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mysql/metadata.yaml
@@ -258,6 +258,10 @@ expected_logs:
   - name: severity
     type: string
     description: ''
+  - name: jsonPayload.level
+    type: string
+    description: Log entry level
+    optional: true
 configuration_options:
   logs:
   - type: mysql_error

--- a/integration_test/third_party_apps_data/applications/mysql/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mysql/metadata.yaml
@@ -143,6 +143,9 @@ expected_logs:
   - name: jsonPayload.errorCode
     type: string
     description: 'MySQL error code associated with the log'
+  - name: severity
+    type: string
+    description: ''
 - log_name: mysql_general
   fields:
   - name: jsonPayload.message
@@ -156,6 +159,9 @@ expected_logs:
   - name: jsonPayload.tid
     type: number
     description: 'Thread ID where the log originated'
+  - name: severity
+    type: string
+    description: ''
 - log_name: mysql_slow
   fields:
   - name: jsonPayload.message
@@ -249,6 +255,9 @@ expected_logs:
   - name: jsonPayload.endTime
     type: string
     description: 'The statement execution end time'
+  - name: severity
+    type: string
+    description: ''
 configuration_options:
   logs:
   - type: mysql_error

--- a/integration_test/third_party_apps_data/applications/nginx/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/nginx/metadata.yaml
@@ -159,6 +159,10 @@ expected_logs:
   - name: jsonPayload.user
     type: string
     description: Authenticated username for the request
+  - name: jsonPayload.level
+    type: string
+    description: Log entry level
+    optional: true
   - name: severity
     type: string
     description: ''

--- a/integration_test/third_party_apps_data/applications/nginx/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/nginx/metadata.yaml
@@ -144,6 +144,15 @@ expected_logs:
     type: string
     description: ''
     optional: true
+  - name: httpRequest.requestMethod
+    value_regex: GET
+    type: string
+    description: ''
+    optional: true
+  - name: httpRequest.status
+    type: string
+    description: ''
+    optional: true
   - name: jsonPayload.host
     type: string
     description: Contents of the Host header (usually not reported by nginx)

--- a/integration_test/third_party_apps_data/applications/nginx/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/nginx/metadata.yaml
@@ -156,9 +156,11 @@ expected_logs:
   - name: jsonPayload.host
     type: string
     description: Contents of the Host header (usually not reported by nginx)
+    optional: true
   - name: jsonPayload.user
     type: string
     description: Authenticated username for the request
+    optional: true
   - name: jsonPayload.level
     type: string
     description: Log entry level
@@ -176,6 +178,7 @@ expected_logs:
     value_regex: error
     type: string
     description: Log entry level
+    optional: true
   - name: jsonPayload.message
     value_regex: .*Permission denied.*
     type: string
@@ -196,18 +199,23 @@ expected_logs:
   - name: jsonPayload.server
     type: string
     description: Nginx server name (optional)
+    optional: true
   - name: jsonPayload.subrequest
     type: string
     description: Nginx subrequest (optional)
+    optional: true
   - name: jsonPayload.upstream
     type: string
     description: Upstream request URI (optional)
+    optional: true
   - name: jsonPayload.host
     type: string
     description: Host header (optional)
+    optional: true
   - name: jsonPayload.referer
     type: string
     description: Referer header (optional)
+    optional: true
   - name: severity
     type: string
     description: ''

--- a/integration_test/third_party_apps_data/applications/nginx/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/nginx/metadata.yaml
@@ -126,16 +126,33 @@ expected_logs:
     value_regex: ::1
     type: string
     description: "The IP address (IPv4 or IPv6) of the client that issued the HTTP request. This field can include port information. Examples: 192.168.1.1, 10.0.0.1:80, FE80::0202:B3FF:FE1E:8329."
+    optional: true
   - name: httpRequest.requestUrl
-    value_regex: /forbidden.html
+    value_regex: .*/forbidden.html
     type: string
+    optional: true
     description: "The scheme (http, https), the host name, the path and the query portion of the URL that was requested. Example: http://example.com/some/info?color=red."
+  - name: httpRequest.responseSize
+    type: string
+    description: ''
+    optional: true
+  - name: httpRequest.userAgent
+    type: string
+    description: ''
+    optional: true
+  - name: httpRequest.referer
+    type: string
+    description: ''
+    optional: true
   - name: jsonPayload.host
     type: string
     description: Contents of the Host header (usually not reported by nginx)
   - name: jsonPayload.user
     type: string
     description: Authenticated username for the request
+  - name: severity
+    type: string
+    description: ''
 - log_name: nginx_error
   fields:
   - name: jsonPayload.client
@@ -178,6 +195,9 @@ expected_logs:
   - name: jsonPayload.referer
     type: string
     description: Referer header (optional)
+  - name: severity
+    type: string
+    description: ''
 configuration_options:
   logs:
   - type: nginx_access

--- a/integration_test/third_party_apps_data/applications/postgresql/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/postgresql/metadata.yaml
@@ -62,6 +62,9 @@ expected_logs:
   - name: jsonPayload.user
     type: string
     description: Authenticated user for the action being logged when relevant
+  - name: severity
+    type: string
+    description: ''
 configuration_options:
   logs:
   - type: postgresql_general

--- a/integration_test/third_party_apps_data/applications/postgresql/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/postgresql/metadata.yaml
@@ -59,8 +59,10 @@ expected_logs:
   - name: jsonPayload.role
     type: string
     description: Authenticated role for the action being logged when relevant
+    optional: true
   - name: jsonPayload.user
     type: string
+    optional: true
     description: Authenticated user for the action being logged when relevant
   - name: severity
     type: string

--- a/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
@@ -34,6 +34,10 @@ expected_logs:
   - name: jsonPayload.message
     type: string
     description: Log message
+  - name: jsonPayload.severity
+    type: string
+    description: Log entry level
+    optional: true
   - name: severity
     type: string
     description: ''

--- a/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
@@ -31,6 +31,7 @@ expected_logs:
   - name: jsonPayload.process_id
     type: string
     description: The process ID issuing the log
+    optional: true
   - name: jsonPayload.message
     type: string
     description: Log message

--- a/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
@@ -34,6 +34,9 @@ expected_logs:
   - name: jsonPayload.message
     type: string
     description: Log message
+  - name: severity
+    type: string
+    description: ''
 configuration_options:
   logs:
   - type: rabbitmq

--- a/integration_test/third_party_apps_data/applications/redis/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/redis/metadata.yaml
@@ -136,6 +136,9 @@ expected_logs:
   - name: jsonPayload.pid
     type: number
     description: Process ID
+  - name: severity
+    type: string
+    description: ''
 configuration_options:
   logs:
   - type: redis

--- a/integration_test/third_party_apps_data/applications/saphana/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/saphana/metadata.yaml
@@ -382,14 +382,17 @@ expected_logs:
   - name: jsonPayload.connection_id
     type: number
     description: ID of the connection where the message originated, if message was logged within the scope of a connection
+    optional: true
   - name: jsonPayload.transaction_id
     type: number
     description: ID of the transaction where the message originated, if message was logged within the scope of a transaction
+    optional: true
   - name: jsonPayload.update_transaction_id
     type: number
     description: ID of the update transaction where the message originated, if message was logged within the scope of an update transaction
+    optional: true
   - name: jsonPayload.message
-    value_regex: "==== Starting hdbpreprocessor, version 2.*"
+    value_regex: (?s)==== Starting hdbpreprocessor, version 2.* # The (?s) part will make the . match with newline as well. See https://github.com/google/re2/blob/main/doc/syntax.txt#L65,L68
     type: string
     description: Log message
   - name: jsonPayload.severity_flag

--- a/integration_test/third_party_apps_data/applications/saphana/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/saphana/metadata.yaml
@@ -392,6 +392,10 @@ expected_logs:
     value_regex: "==== Starting hdbpreprocessor, version 2.*"
     type: string
     description: Log message
+  - name: jsonPayload.severity_flag
+    type: string
+    description: Log entry level
+    optional: true
   - name: sourceLocation.file
     value_regex: "TraceStream.cpp"
     type: string

--- a/integration_test/third_party_apps_data/applications/saphana/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/saphana/metadata.yaml
@@ -399,6 +399,9 @@ expected_logs:
   - name: sourceLocation.line
     type: number
     description: Line within the source file
+  - name: severity
+    type: string
+    description: ''
 configuration_options:
   metrics:
   - type: saphana

--- a/integration_test/third_party_apps_data/applications/solr/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/solr/metadata.yaml
@@ -143,6 +143,9 @@ expected_logs:
   - name: jsonPayload.exception
     type: string
     description: Exception related to the log, including detailed stacktrace where provided
+  - name: severity
+    type: string
+    description: ''
 configuration_options:
   logs:
   - type: solr_system

--- a/integration_test/third_party_apps_data/applications/solr/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/solr/metadata.yaml
@@ -131,18 +131,27 @@ expected_logs:
   - name: jsonPayload.collection
     type: string
     description: Solr collection related to the log
+    optional: true
+  - name: jsonPayload.level
+    type: string
+    description: ''
+    optional: true
   - name: jsonPayload.shard
     type: string
     description: Solr shard related to the log
+    optional: true
   - name: jsonPayload.replica
     type: string
     description: Solr replica related to the log
+    optional: true
   - name: jsonPayload.core
     type: string
     description: Solr core related to the log
+    optional: true
   - name: jsonPayload.exception
     type: string
     description: Exception related to the log, including detailed stacktrace where provided
+    optional: true
   - name: severity
     type: string
     description: ''

--- a/integration_test/third_party_apps_data/applications/tomcat/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/tomcat/metadata.yaml
@@ -81,7 +81,7 @@ expected_logs:
 - log_name: tomcat_system
   fields:
   - name: jsonPayload.message
-    value_regex: org.apache.catalina.startup.Catalina.start Server start-up.*
+    value_regex: org.apache.catalina.startup.Catalina.start Server startup.*
     type: string
     description: Log message, including detailed stacktrace where provided
   - name: jsonPayload.module

--- a/integration_test/third_party_apps_data/applications/tomcat/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/tomcat/metadata.yaml
@@ -125,6 +125,10 @@ expected_logs:
     type: string
     description: ''
     optional: true
+  - name: httpRequest.status
+    type: string
+    description: ''
+    optional: true
   - name: jsonPayload.host
     type: string
     description: Contents of the Host header

--- a/integration_test/third_party_apps_data/applications/tomcat/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/tomcat/metadata.yaml
@@ -92,6 +92,10 @@ expected_logs:
     value_regex: org.apache.catalina.startup.Catalina.start
     type: string
     description: source of where the log originated
+  - name: jsonPayload.level
+    type: string
+    description: Log entry level
+    optional: true
   - name: severity
     type: string
     description: ''

--- a/integration_test/third_party_apps_data/applications/tomcat/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/tomcat/metadata.yaml
@@ -81,7 +81,7 @@ expected_logs:
 - log_name: tomcat_system
   fields:
   - name: jsonPayload.message
-    value_regex: org.apache.catalina.startup.Catalina.start Server startup*
+    value_regex: org.apache.catalina.startup.Catalina.start Server start-up.*
     type: string
     description: Log message, including detailed stacktrace where provided
   - name: jsonPayload.module
@@ -136,12 +136,14 @@ expected_logs:
   - name: jsonPayload.host
     type: string
     description: Contents of the Host header
+    optional: true
   - name: jsonPayload.user
     type: string
     optional: true
   - name: severity
     type: string
     description: ''
+    optional: true
 configuration_options:
   logs:
   - type: tomcat_system

--- a/integration_test/third_party_apps_data/applications/tomcat/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/tomcat/metadata.yaml
@@ -92,30 +92,48 @@ expected_logs:
     value_regex: org.apache.catalina.startup.Catalina.start
     type: string
     description: source of where the log originated
+  - name: severity
+    type: string
+    description: ''
 - log_name: tomcat_access
   fields:
   - name: httpRequest.remoteIp
     value_regex: 127.0.0.1
     type: string
     description: ''
+    optional: true
   - name: httpRequest.requestUrl
     value_regex: /forbidden.html
     type: string
     description: ''
+    optional: true
   - name: httpRequest.protocol
     value_regex: HTTP/1.1
     type: string
     description: ''
+    optional: true
   - name: httpRequest.requestMethod
     value_regex: GET
     type: string
     description: ''
+    optional: true
+  - name: httpRequest.responseSize
+    type: string
+    description: ''
+    optional: true
+  - name: httpRequest.userAgent
+    type: string
+    description: ''
+    optional: true
   - name: jsonPayload.host
     type: string
     description: Contents of the Host header
   - name: jsonPayload.user
     type: string
-    description: Authenticated username for the request
+    optional: true
+  - name: severity
+    type: string
+    description: ''
 configuration_options:
   logs:
   - type: tomcat_system

--- a/integration_test/third_party_apps_data/applications/varnish/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/varnish/metadata.yaml
@@ -114,10 +114,12 @@ expected_logs:
     value_regex: 127.0.0.1
     type: string
     description: The IP address (IPv4 or IPv6) of the client that issued the HTTP request
+    optional: true
   - name: httpRequest.requestMethod
     value_regex: GET
     type: string
     description: HTTP method
+    optional: true
   - name: jsonPayload.host
     type: string
     description: Contents of the Host header
@@ -128,20 +130,29 @@ expected_logs:
     value_regex: /forbidden.html
     type: string
     description: Request URL (typically just the path part of the URL
+    optional: true
   - name: httpRequest.protocol
     value_regex: HTTP/1.1
     type: string
     description: Protocol used for the request
+    optional: true
   - name: httpRequest.status
     type: string
     description: HTTP status code
+    optional: true
   - name: httpRequest.responseSize
     type: string
     description: Response size
+    optional: true
   - name: httpRequest.referer
     type: string
     description: Contents of the `Referer` header
+    optional: true
   - name: httpRequest.userAgent
     type: string
     description: Contents of the `User-Agent` header
+    optional: true
+  - name: severity
+    type: string
+    description: ''
 public_url: https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/varnish

--- a/integration_test/third_party_apps_data/applications/varnish/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/varnish/metadata.yaml
@@ -123,11 +123,13 @@ expected_logs:
   - name: jsonPayload.host
     type: string
     description: Contents of the Host header
+    optional: true
   - name: jsonPayload.user
     type: string
     description: Authenticated username for the request
+    optional: true
   - name: httpRequest.requestUrl
-    value_regex: /forbidden.html
+    value_regex: .*/forbidden.html
     type: string
     description: Request URL (typically just the path part of the URL
     optional: true

--- a/integration_test/third_party_apps_data/applications/vault/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/vault/metadata.yaml
@@ -112,116 +112,161 @@ expected_metrics:
 expected_logs:
 - log_name: vault_audit
   fields:
+  - name: jsonPayload.auth
+    type: struct
+    description: ''
+  - name: jsonPayload.request
+    type: struct
+    description: ''
+  - name: jsonPayload.response
+    type: struct
+    description: ''
+    optional: true
   - name: jsonPayload.auth.token_type
     value_regex: default
     type: string
     description: ''
+    optional: true
   - name: jsonPayload.request.namespace.id
     value_regex: root
     type: string
     description: ''
+    optional: true
   - name: jsonPayload.request.path
     value_regex: sys\/audit\/test
     type: string
     description: The requested Vault path for operation.
+    optional: true
   - name: jsonPayload.request.operation
     value_regex: update
     type: string
     description: "This is the type of operation which corresponds to path capabilities and is expected to be one of: `create`, `read`, `update`, `delete`, or `list`."
+    optional: true
   - name: jsonPayload.type
     value_regex: request
     type: string
     description: The type of audit log.
+    optional: true
   - name: jsonPayload.error
     type: string
     description: If an error occurred with the request, the error message is included in this field's value.
+    optional: true
   - name: jsonPayload.auth.client_token
     type: string
     description: This is an HMAC of the client's token ID.
+    optional: true
   - name: jsonPayload.auth.accessor
     type: string
     description: This is an HMAC of the client token accessor.
+    optional: true
   - name: jsonPayload.auth.display_name
     type: string
     description: This is the display name set by the auth method role or explicitly at secret creation time.
+    optional: true
   - name: jsonPayload.auth.policies
     type: object
     description: This will contain a list of policies associated with the client_token.
+    optional: true
   - name: jsonPayload.auth.metadata
     type: object
     description: This will contain a list of metadata key/value pairs associated with the client_token.
+    optional: true
   - name: jsonPayload.auth.entity_id
     type: string
     description: This is a token entity identifier.
+    optional: true
   - name: jsonPayload.request.id
     type: string
     description: This is the unique request identifier.
+    optional: true
   - name: jsonPayload.request.client_token
     type: string
     description: This is an HMAC of the client's token ID.
+    optional: true
   - name: jsonPayload.request.client_token_accessor
     type: string
     description: This is an HMAC of the client token accessor.
+    optional: true
   - name: jsonPayload.request.data
     type: object
     description: The data object will contain secret data in key/value pairs.
+    optional: true
   - name: jsonPayload.request.policy_override
     type: boolean
     description: This is `true` when a soft-mandatory policy override was requested.
+    optional: true
   - name: jsonPayload.request.remote_address
     type: string
     description: The IP address of the client making the request.
+    optional: true
   - name: jsonPayload.request.wrap_ttl
     type: string
     description: If the token is wrapped, this displays configured wrapped TTL value as numeric string.
+    optional: true
   - name: jsonPayload.request.headers
     type: object
     description: Additional HTTP headers specified by the client as part of the request.
+    optional: true
   - name: jsonPayload.response.data.creation_time
     type: string
     description: RFC 3339 format timestamp of the token's creation.
+    optional: true
   - name: jsonPayload.response.data.creation_ttl
     type: string
     description: Token creation TTL in seconds.
+    optional: true
   - name: jsonPayload.response.data.expire_time
     type: string
     description: RFC 3339 format timestamp representing the moment this token will expire.
+    optional: true
   - name: jsonPayload.response.data.explicit_max_ttl
     type: string
     description: Explicit token maximum TTL value as seconds ("0" when not set).
+    optional: true
   - name: jsonPayload.response.data.issue_time
     type: string
     description: RFC 3339 format timestamp.
+    optional: true
   - name: jsonPayload.response.data.num_uses
     type: number
     description: If the token is limited to a number of uses, that value will be represented here.
+    optional: true
   - name: jsonPayload.response.data.orphan
     type: boolean
     description: Boolean value representing whether the token is an orphan.
+    optional: true
   - name: jsonPayload.response.data.renewable
     type: boolean
     description: Boolean value representing whether the token is an orphan.
+    optional: true
   - name: jsonPayload.response.data.id
     type: string
     description: This is the unique response identifier.
+    optional: true
   - name: jsonPayload.response.data.path
     type: string
     description: The requested Vault path for operation.
+    optional: true
   - name: jsonPayload.response.data.policies
     type: object
     description: This will contain a list of policies associated with the client_token.
+    optional: true
   - name: jsonPayload.response.data.accessor
     type: string
     description: This is an HMAC of the client token accessor.
+    optional: true
   - name: jsonPayload.response.data.display_name
     type: string
     description: This is the display name set by the auth method role or explicitly at secret creation time.
+    optional: true
   - name: jsonPayload.response.data.display_name
     type: string
     description: This is the display name set by the auth method role or explicitly at secret creation time.
+    optional: true
   - name: jsonPayload.response.data.entity_id
     type: string
     description: This is a token entity identifier.
+    optional: true
   - name: timestamp
     type: string ([`Timestamp`](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp))
     description: Time the request was received

--- a/integration_test/third_party_apps_data/applications/vault/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/vault/metadata.yaml
@@ -225,6 +225,9 @@ expected_logs:
   - name: timestamp
     type: string ([`Timestamp`](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp))
     description: Time the request was received
+  - name: severity
+    type: string
+    description: ''
 configuration_options:
   logs:
   - type: vault_audit

--- a/integration_test/third_party_apps_data/applications/wildfly/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/wildfly/metadata.yaml
@@ -120,7 +120,7 @@ expected_logs:
     type: string
     description: Wildfly specific message code preceding the log, where applicable
   - name: jsonPayload.message
-    value_regex: (?s).*WildFly Full.* # The (?s) part will make the . match with newline as well. See https://github.com/google/re2/blob/7bab3dc83df6a838cc004cc7a7f51d5fe1a427d5/doc/syntax.txt#L65,L68
+    value_regex: (?s).*WildFly Full.* # The (?s) part will make the . match with newline as well. See https://github.com/google/re2/blob/main/doc/syntax.txt#L65,L68
     type: string
     description: Log message
   - name: jsonPayload.thread

--- a/integration_test/third_party_apps_data/applications/wildfly/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/wildfly/metadata.yaml
@@ -131,6 +131,9 @@ expected_logs:
     value_regex: org.jboss.as
     type: string
     description: Source where the log originated
+  - name: severity
+    type: string
+    description: ''
 configuration_options:
   logs:
   - type: wildfly_system

--- a/integration_test/third_party_apps_data/applications/wildfly/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/wildfly/metadata.yaml
@@ -120,7 +120,7 @@ expected_logs:
     type: string
     description: Wildfly specific message code preceding the log, where applicable
   - name: jsonPayload.message
-    value_regex: .*WildFly Full.*
+    value_regex: (?s).*WildFly Full.* # The (?s) part will make the . match with newline as well. See https://github.com/google/re2/blob/7bab3dc83df6a838cc004cc7a7f51d5fe1a427d5/doc/syntax.txt#L65,L68
     type: string
     description: Log message
   - name: jsonPayload.thread
@@ -131,6 +131,10 @@ expected_logs:
     value_regex: org.jboss.as
     type: string
     description: Source where the log originated
+  - name: jsonPayload.level
+    type: string
+    description: Log entry level
+    optional: true
   - name: severity
     type: string
     description: ''

--- a/integration_test/third_party_apps_data/applications/zookeeper/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/zookeeper/metadata.yaml
@@ -92,6 +92,9 @@ expected_logs:
   - name: jsonPayload.myid
     type: number
     description: Numeric ID of the Zookeeper instance
+  - name: severity
+    type: string
+    description: ''
 configuration_options:
   logs:
   - type: zookeeper_general

--- a/integration_test/third_party_apps_data/applications/zookeeper/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/zookeeper/metadata.yaml
@@ -75,7 +75,7 @@ expected_logs:
 - log_name: zookeeper_general
   fields:
   - name: jsonPayload.message
-    value_regex: binding to port 0.0.0.0/0.0.0.0:2181
+    value_regex: (?s)binding to port 0.0.0.0/0.0.0.0:2181.* # The (?s) part will make the . match with newline as well. See https://github.com/google/re2/blob/main/doc/syntax.txt#L65,L68 
     type: string
     description: Log message, including detailed stacktrace where provided
   - name: jsonPayload.thread
@@ -92,6 +92,7 @@ expected_logs:
   - name: jsonPayload.myid
     type: number
     description: Numeric ID of the Zookeeper instance
+    optional: true
   - name: jsonPayload.level
     type: string
     description: Log entry level

--- a/integration_test/third_party_apps_data/applications/zookeeper/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/zookeeper/metadata.yaml
@@ -92,6 +92,10 @@ expected_logs:
   - name: jsonPayload.myid
     type: number
     description: Numeric ID of the Zookeeper instance
+  - name: jsonPayload.level
+    type: string
+    description: Log entry level
+    optional: true
   - name: severity
     type: string
     description: ''

--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -241,7 +241,7 @@ func verifyLogField(fieldName, actualField string, expectedFields map[string]*me
 	expectedField, ok := expectedFields[fieldName]
 	if !ok { // Not expecting this field.
 		if actualField != "" && actualField != "0" && actualField != "false" && actualField != "0s" {
-			return fmt.Errorf("expeced no value for field %s but got %v", fieldName, actualField)
+			return fmt.Errorf("expeced no value for field %s but got %v\n", fieldName, actualField)
 		}
 		return nil
 	}
@@ -250,7 +250,7 @@ func verifyLogField(fieldName, actualField string, expectedFields map[string]*me
 		if expectedField.Optional {
 			return nil
 		} else {
-			return fmt.Errorf("expected non-empty value for log field %s", fieldName)
+			return fmt.Errorf("expected non-empty value for log field %s\n", fieldName)
 		}
 	}
 
@@ -264,7 +264,7 @@ func verifyLogField(fieldName, actualField string, expectedFields map[string]*me
 	}
 
 	if !match {
-		return fmt.Errorf("field %s of the actual log %s didn't match regex pattern: %s", fieldName, actualField, pattern)
+		return fmt.Errorf("field %s of the actual log: %s didn't match regex pattern: %s\n", fieldName, actualField, pattern)
 	}
 
 	return nil
@@ -293,7 +293,7 @@ func verifyLog(actualLog *cloudlogging.Entry, expectedLog *metadata.ExpectedLog)
 		_, fileOk := expectedFields["sourceLocation.file"]
 		_, lineOk := expectedFields["sourceLocation.line"]
 		if fileOk || lineOk {
-			multiErr = multierr.Append(multiErr, fmt.Errorf("excpected sourceLocation.file and sourceLocation.line but got nil"))
+			multiErr = multierr.Append(multiErr, fmt.Errorf("excpected sourceLocation.file and sourceLocation.line but got nil\n"))
 		}
 	} else {
 		if err := verifyLogField("sourceLocation.file", actualLog.SourceLocation.File, expectedFields); err != nil {
@@ -315,7 +315,7 @@ func verifyLog(actualLog *cloudlogging.Entry, expectedLog *metadata.ExpectedLog)
 	if actualLog.HTTPRequest == nil {
 		for _, field := range httpRequestFields {
 			if _, ok := expectedFields[field]; ok {
-				multiErr = multierr.Append(multiErr, fmt.Errorf("expected value for field %s but got nil", field))
+				multiErr = multierr.Append(multiErr, fmt.Errorf("expected value for field %s but got nil\n", field))
 			}
 		}
 	} else {
@@ -351,14 +351,14 @@ func verifyLog(actualLog *cloudlogging.Entry, expectedLog *metadata.ExpectedLog)
 	expectedPayloadFields := logFieldsMapWithPrefix(expectedLog, "jsonPayload.")
 	if actualLog.Payload == nil {
 		if len(expectedPayloadFields) > 0 {
-			multiErr = multierr.Append(multiErr, fmt.Errorf("expected values for field jsonPayload but got nil"))
+			multiErr = multierr.Append(multiErr, fmt.Errorf("expected values for field jsonPayload but got nil\n"))
 		}
 	} else {
 		actualPayloadFields := actualLog.Payload.(*structpb.Struct).GetFields()
 		for expectedKey := range expectedPayloadFields {
 			actualValue, ok := actualPayloadFields[expectedKey]
 			if !ok || actualValue == nil {
-				multiErr = multierr.Append(multiErr, fmt.Errorf("expected values for field jsonPayload.%s but got nil", expectedKey))
+				multiErr = multierr.Append(multiErr, fmt.Errorf("expected values for field jsonPayload.%s but got nil\n", expectedKey))
 			}
 
 			// Sanitize the actualValue string.
@@ -402,7 +402,7 @@ func verifyLog(actualLog *cloudlogging.Entry, expectedLog *metadata.ExpectedLog)
 
 		for actualKey, actualValue := range actualPayloadFields {
 			if _, ok := expectedPayloadFields[actualKey]; !ok {
-				multiErr = multierr.Append(multiErr, fmt.Errorf("expected no value for field jsonPayload.%s but got %s", actualKey, actualValue.String()))
+				multiErr = multierr.Append(multiErr, fmt.Errorf("expected no value for field jsonPayload.%s but got %s\n", actualKey, actualValue.String()))
 			}
 		}
 	}

--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -347,7 +347,7 @@ func verifyLog(actualLog *cloudlogging.Entry, expectedLog *metadata.ExpectedLog)
 		}
 	}
 
-	// Labels - Untested as of yet since no application sets LogEntry Labels yet.
+	// Labels - Untested as of yet, since no application sets LogEntry labels.
 
 	// JSON Payload
 	expectedPayloadFields := logFieldsMapWithPrefix(expectedLog, "jsonPayload.")
@@ -357,10 +357,14 @@ func verifyLog(actualLog *cloudlogging.Entry, expectedLog *metadata.ExpectedLog)
 		}
 	} else {
 		actualPayloadFields := actualLog.Payload.(*structpb.Struct).GetFields()
-		for expectedKey := range expectedPayloadFields {
+		for expectedKey, expectedValue := range expectedPayloadFields {
 			actualValue, ok := actualPayloadFields[expectedKey]
 			if !ok || actualValue == nil {
-				multiErr = multierr.Append(multiErr, fmt.Errorf("expected values for field jsonPayload.%s but got nil\n", expectedKey))
+				if !expectedValue.Optional {
+					multiErr = multierr.Append(multiErr, fmt.Errorf("expected values for field jsonPayload.%s but got nil\n", expectedKey))
+				}
+
+				continue
 			}
 
 			// Sanitize the actualValue string.

--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -256,7 +256,8 @@ func verifyLogField(fieldName, actualField string, expectedFields map[string]*me
 		}
 	}
 
-	pattern := ".*"
+	// The (?s) part will make the . match with newline as well. See https://github.com/google/re2/blob/main/doc/syntax.txt#L65,L68
+	pattern := "(?s).*"
 	if expectedField.ValueRegex != "" {
 		pattern = expectedField.ValueRegex
 	}

--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -239,7 +239,9 @@ func logFieldsMapWithPrefix(log *metadata.ExpectedLog, prefix string) map[string
 
 func verifyLogField(fieldName, actualField string, expectedFields map[string]*metadata.LogFields) error {
 	expectedField, ok := expectedFields[fieldName]
-	if !ok { // Not expecting this field.
+	if !ok {
+		// Not expecting this field. It could however be populated with some default zero-values when we
+		// query it back. Check for zero values basued on expectedField.type? Not ideal for sure.
 		if actualField != "" && actualField != "0" && actualField != "false" && actualField != "0s" {
 			return fmt.Errorf("expeced no value for field %s but got %v\n", fieldName, actualField)
 		}


### PR DESCRIPTION
Signed-off-by: Ridwan Sharif <ridwanmsharif@google.com>

## Description
This change makes the `expected` logs integration test more robust by asserting that the produced log entry fields strictly match the expected log formats. It also adds in logic to deal with optional fields.

## Related issue
[b/241126743](http://b/241126743) | P3 | integration_test: Make the expected logs integration test more robust

## How has this been tested?
Integration tests are being modified to run the change. Initially most tests will break and will need to be fixed as the logic is more strict now.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
