### PR TITLE
Always download latest OpenSSL version

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -58,18 +58,15 @@ RUN Write-Host ('Installing Visual C++ Redistributable Package'); `
 #
 # Install OpenSSL
 # This must be done after installing Visual Studio
-ARG OPENSSL_INSTALLER=Win64OpenSSL-1_1_1q.msi
-# SHA256 hash from win32_openssl_hashes.json in https://github.com/slproweb/opensslhashes.
-# DO NOT FORGET to change this hash when changing the MSI.
-ARG OPENSSL_SHA256=3668aa784017e5d03a98929829a66faa166ec704eb1752b10c38d23e7c048da6
-ADD https://slproweb.com/download/$OPENSSL_INSTALLER /local/$OPENSSL_INSTALLER
 
-RUN $ExpectedHash = $env:OPENSSL_SHA256; `
-    $ActualHash = $(Get-FileHash /local/$env:OPENSSL_INSTALLER -Algorithm SHA256).Hash.ToLower(); `
-    if ($ActualHash -ne $env:OPENSSL_SHA256) { `
-      throw \"OpenSSL hash mismatch. Expected: $env:OPENSSL_HASH, Actual: $ActualHash\" `
+RUN $files = (iwr -UseBasicParsing https://raw.githubusercontent.com/slproweb/opensslhashes/master/win32_openssl_hashes.json | ConvertFrom-Json).files.psobject.properties.value; `
+    $installer = $files | ? {$_.arch -eq \"INTEL\" -and $_.bits -eq 64 -and $_.installer -eq \"msi\" -and -not $_.light -and $_.basever -like \"1.*\" }; `
+    iwr -UseBasicParsing -Uri \"$($installer.url)\" -OutFile /local/openssl.msi; `
+    $ActualHash = $(Get-FileHash /local/openssl.msi -Algorithm SHA256).Hash.ToLower(); `
+    if ($ActualHash -ne \"$($installer.sha256)\") { `
+      throw \"OpenSSL hash mismatch. Expected: $($installer.sha256), Actual: $ActualHash\" `
     }; `
-    Start-Process msiexec.exe -Wait -ArgumentList \"/i C:\local\$env:OPENSSL_INSTALLER /quiet\";
+    Start-Process msiexec.exe -Wait -ArgumentList \"/i C:\local\openssl.msi /quiet\";
 
 #
 # Install winflexbison


### PR DESCRIPTION
## Description
OpenSSL only makes the latest release available for download. So... just always install the latest version.

## Related issue
b/237004124

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->
Manual build (will rely on CI to test all the combinations of OS)

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
