### PR TITLE
Add centos 9 to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -162,6 +162,27 @@ COPY . /work
 WORKDIR /work
 RUN ./pkg/rpm/build.sh
 
+FROM rockylinux:9 AS centos9-build
+
+RUN set -x; yum -y update && \
+    dnf -y install 'dnf-command(config-manager)' && \
+    dnf config-manager --set-enabled crb && \
+    dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+    dnf -y install git systemd \
+    autoconf libtool libcurl-devel libtool-ltdl-devel openssl-devel yajl-devel \
+    gcc gcc-c++ make cmake bison flex file systemd-devel zlib-devel gtest-devel rpm-build systemd-rpm-macros java-11-openjdk-devel \
+    expect rpm-sign zip
+
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk/
+
+ADD https://golang.org/dl/go1.17.linux-amd64.tar.gz /tmp/go1.17.linux-amd64.tar.gz
+RUN set -xe; \
+    tar -xf /tmp/go1.17.linux-amd64.tar.gz -C /usr/local
+
+COPY . /work
+WORKDIR /work
+RUN ./pkg/rpm/build.sh
+
 # Use OpenSUSE Leap 42.3 to emulate SLES 12: https://en.opensuse.org/openSUSE:Build_Service_cross_distribution_howto#Detect_a_distribution_flavor_for_special_code
 FROM opensuse/archive:42.3 AS sles12-build
 
@@ -249,6 +270,10 @@ FROM scratch AS centos8
 COPY --from=centos8-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-centos-8.tgz
 COPY --from=centos8-build /google-cloud-ops-agent*.rpm /
 
+FROM scratch AS centos9
+COPY --from=centos9-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-centos-9.tgz
+COPY --from=centos9-build /google-cloud-ops-agent*.rpm /
+
 FROM scratch AS sles12
 COPY --from=sles12-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-sles-12.tgz
 COPY --from=sles12-build /google-cloud-ops-agent*.rpm /
@@ -265,5 +290,6 @@ COPY --from=focal /* /
 COPY --from=bionic /* /
 COPY --from=centos7 /* /
 COPY --from=centos8 /* /
+COPY --from=centos9 /* /
 COPY --from=sles12 /* /
 COPY --from=sles15 /* /

--- a/Dockerfile
+++ b/Dockerfile
@@ -164,7 +164,7 @@ RUN ./pkg/rpm/build.sh
 
 FROM rockylinux:9 AS centos9-build
 
-RUN set -x; yum -y update && \
+RUN set -x; dnf -y update && \
     dnf -y install 'dnf-command(config-manager)' && \
     dnf config-manager --set-enabled crb && \
     dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \


### PR DESCRIPTION
## Description
Adding CentOS 9 support into Dockerfile.

## Related issue
b/242854267

## How has this been tested?
Built locally with no errors.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
  **_NOTE:_** This is the first step of the integration test. Follow up PRs will close the full loop
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
