### PR TITLE
Add instruction to the dev doc for using Windows custom images

### DIFF
--- a/dev-docs/create-gce-windows-build-vm.md
+++ b/dev-docs/create-gce-windows-build-vm.md
@@ -7,38 +7,94 @@ ensure the build VM has enough power/disk space to do the builds.
 
 Note: Using `ssd` speeds up the build.
 
-```shell
-# VM image family.
-export WIN_BUILD_VM_OS_IMAGE_FAMILY=windows-2019-for-containers
+## Option 1: Create VM from a Public Image
 
-# Your dev GCP project ID.
-export VM_PROJECT_ID=${USER}-sandbox
+1. Create the VM: 
+    ```shell
+    # VM image family.
+    export WIN_BUILD_VM_OS_IMAGE_FAMILY=windows-2019-for-containers
 
-# The zone to create the VM in.
-export VM_ZONE=us-central1-a
+    # Your dev GCP project ID.
+    export VM_PROJECT_ID=${USER}-sandbox
 
-# The VM name to use.
-export WIN_BUILD_VM_NAME=${USER}-win-build-vm
+    # The zone to create the VM in.
+    export VM_ZONE=us-central1-a
 
-gcloud compute instances create \
-    --project $VM_PROJECT_ID \
-    --zone $VM_ZONE \
-    --image-project windows-cloud \
-    --image-family $WIN_BUILD_VM_OS_IMAGE_FAMILY \
-    --machine-type e2-highmem-8 \
-    --boot-disk-type pd-ssd \
-    --boot-disk-size 200GB \
-    --scopes storage-rw \
-    $WIN_BUILD_VM_NAME
-```
+    # The VM name to use.
+    export WIN_BUILD_VM_NAME=${USER}-win-build-vm
 
-Once the VM is running, reset the password:
+    gcloud compute instances create \
+        --project $VM_PROJECT_ID \
+        --zone $VM_ZONE \
+        --image-project windows-cloud \
+        --image-family $WIN_BUILD_VM_OS_IMAGE_FAMILY \
+        --machine-type e2-highmem-8 \
+        --boot-disk-type pd-ssd \
+        --boot-disk-size 200GB \
+        --scopes storage-rw,logging-write,monitoring-write \
+        $WIN_BUILD_VM_NAME
+    ```
 
-```shell
-gcloud compute reset-windows-password --quiet \
-    --project $VM_PROJECT_ID \
-    --zone $VM_ZONE \
-    $WIN_BUILD_VM_NAME
-```
+1. Once the VM is running, reset the password:
 
-Record the password to use for connecting to this VM as `$WIN_BUILD_VM_PASSWORD`.
+    ```shell
+    gcloud compute reset-windows-password --quiet \
+        --project $VM_PROJECT_ID \
+        --zone $VM_ZONE \
+        $WIN_BUILD_VM_NAME
+    ```
+
+    Record the password to use for connecting to this VM as `$WIN_BUILD_VM_PASSWORD`.
+
+
+## Option 2: Create VM from a Pre-configured Custom Image
+
+We maintain pre-configured Windows custom images internally to simplify the creation of VMs. 
+
+Current available images: 
+
+| Project ID              | Image Name                                                      | Base Image                                      | Family                      |
+|-------------------------|-----------------------------------------------------------------|-------------------------------------------------|-----------------------------|
+| stackdriver-test-143416 | ops-agent-build-windows-server-2019-dc-for-containers-v20220713 | windows-server-2019-dc-for-containers-v20220713 | windows-2019-for-containers |
+
+
+1. Create the VM: 
+    ```shell
+    # Custom VM image.
+    export CUSTOM_IMAGE_NAME=ops-agent-build-windows-server-2019-dc-for-containers-v20220713
+    export CUSTOM_IMAGE_PATH=projects/stackdriver-test-143416/global/images/${CUSTOM_IMAGE_NAME}
+
+    # Your dev GCP project ID.
+    export VM_PROJECT_ID=${USER}-sandbox
+
+    # The zone to create the VM in.
+    export VM_ZONE=us-central1-a
+
+    # The VM name to use.
+    export WIN_BUILD_VM_NAME=${USER}-win-build-vm
+
+    gcloud compute instances create \
+        --project $VM_PROJECT_ID \
+        --zone $VM_ZONE \
+        --image $CUSTOM_IMAGE_PATH \
+        --machine-type e2-highmem-8 \
+        --boot-disk-type pd-ssd \
+        --boot-disk-size 200GB \
+        --scopes storage-rw,logging-write,monitoring-write \
+        $WIN_BUILD_VM_NAME
+    ```
+
+2. Once the VM is running, reset the password:
+
+    ```shell
+    gcloud compute reset-windows-password --quiet \
+        --project $VM_PROJECT_ID \
+        --zone $VM_ZONE \
+        --user=opsagentdev \
+        $WIN_BUILD_VM_NAME
+    ```
+
+    Note that the default user for the VM is `opsagentdev`. 
+    Record the password to use for connecting to this VM as `$WIN_BUILD_VM_PASSWORD`.
+
+    Skip the steps in [Set up a Windows VM](set-up-windows-vm.md); follow the steps in [Connect to a Windows VM](connect-to-windows-vm.md) to connect via RDP. 


### PR DESCRIPTION
## Description
Update the dev doc to add a section in `create-gce-windows-build-vm.md`: describe the steps on using custom images to create Windows GCE VMs. 

The custom images are pre-configured with essential software installed, so that the steps in `set-up-windows-vm.md` can be skipped. 

## Related issue
http://b/239606413

## How has this been tested?
Proofread the markdown after the changes in this PR is rendered by GitHub. 

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
