### PR TITLE
Bump recommended version for mongodb to 2.19.0

### DIFF
--- a/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
@@ -9,7 +9,7 @@ description: |-
   collects logs and parses them into a JSON payload. The result includes fields
   for context, component, level, and message.
 minimum_supported_agent_version:
-  metrics: 2.11.0
+  metrics: 2.19.0
   logging: 2.10.0
 supported_operating_systems: linux
 supported_app_version: ["4.0+"]

--- a/integration_test/third_party_apps_data/applications/vault/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/vault/metadata.yaml
@@ -2,7 +2,7 @@ app_url: "https://www.vaultproject.io/"
 short_name: Vault
 long_name: Hashicorp Vault
 description: |-
-  Vault is an identity-based secrets and encryption management system. This integration Collects Vault's audit logs. The integration also collects token, memory, and storage metrics.
+  Vault is an identity-based secrets and encryption management system. This integration collects Vault's audit logs. The integration also collects token, memory, and storage metrics.
 supported_operating_systems: linux
 supported_app_version: ["1.6+"]
 expected_metrics:


### PR DESCRIPTION
## Description
Manually bump recommended version for mongodb to 2.19.0
## Related issue
b/239727588#comment13

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [x ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
