### PR TITLE
Fix: MinimumSupportedAgentVersion presubmit equality

### DIFF
--- a/ci/minimum_supported_agent_version_test.go
+++ b/ci/minimum_supported_agent_version_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/ops-agent/integration_test/metadata"
-	"github.com/google/go-cmp/cmp"
 )
 
 var (
@@ -103,7 +102,7 @@ func testModifiedMetadata(t *testing.T, filePaths []string) {
 
 			modifiedMinimumSupportedAgentVersion := modifiedMetadata.MinimumSupportedAgentVersion
 			originalMinimumSupportedAgentVersion := originalMetadata.MinimumSupportedAgentVersion
-			if !cmp.Equal(modifiedMinimumSupportedAgentVersion, originalMinimumSupportedAgentVersion) {
+			if *modifiedMinimumSupportedAgentVersion != *originalMinimumSupportedAgentVersion {
 				t.Fatal(fmt.Errorf("minimum_supported_agent_version has been modified for path: %s\n modified: %+v\n original: %+v", modified, modifiedMinimumSupportedAgentVersion, originalMinimumSupportedAgentVersion))
 			}
 		})

--- a/ci/minimum_supported_agent_version_test.go
+++ b/ci/minimum_supported_agent_version_test.go
@@ -100,10 +100,8 @@ func testModifiedMetadata(t *testing.T, filePaths []string) {
 				t.Fatal(err)
 			}
 
-			modifiedMinimumSupportedAgentVersion := modifiedMetadata.MinimumSupportedAgentVersion
-			originalMinimumSupportedAgentVersion := originalMetadata.MinimumSupportedAgentVersion
-			if *modifiedMinimumSupportedAgentVersion != *originalMinimumSupportedAgentVersion {
-				t.Fatal(fmt.Errorf("minimum_supported_agent_version has been modified for path: %s\n modified: %+v\n original: %+v", filePath, modifiedMinimumSupportedAgentVersion, originalMinimumSupportedAgentVersion))
+			if *modifiedMetadata.MinimumSupportedAgentVersion != *originalMetadata.MinimumSupportedAgentVersion {
+				t.Fatal(fmt.Errorf("minimum_supported_agent_version has been modified for path: %s\n modified: %+v\n original: %+v", filePath, modifiedMetadata.MinimumSupportedAgentVersion, originalMetadata.MinimumSupportedAgentVersion))
 			}
 		})
 	}

--- a/ci/minimum_supported_agent_version_test.go
+++ b/ci/minimum_supported_agent_version_test.go
@@ -103,7 +103,7 @@ func testModifiedMetadata(t *testing.T, filePaths []string) {
 			modifiedMinimumSupportedAgentVersion := modifiedMetadata.MinimumSupportedAgentVersion
 			originalMinimumSupportedAgentVersion := originalMetadata.MinimumSupportedAgentVersion
 			if *modifiedMinimumSupportedAgentVersion != *originalMinimumSupportedAgentVersion {
-				t.Fatal(fmt.Errorf("minimum_supported_agent_version has been modified for path: %s\n modified: %+v\n original: %+v", modified, modifiedMinimumSupportedAgentVersion, originalMinimumSupportedAgentVersion))
+				t.Fatal(fmt.Errorf("minimum_supported_agent_version has been modified for path: %s\n modified: %+v\n original: %+v", filePath, modifiedMinimumSupportedAgentVersion, originalMinimumSupportedAgentVersion))
 			}
 		})
 	}

--- a/ci/minimum_supported_agent_version_test.go
+++ b/ci/minimum_supported_agent_version_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/ops-agent/integration_test/metadata"
+	"github.com/google/go-cmp/cmp"
 )
 
 var (
@@ -100,8 +101,10 @@ func testModifiedMetadata(t *testing.T, filePaths []string) {
 				t.Fatal(err)
 			}
 
-			if modifiedMetadata.MinimumSupportedAgentVersion != originalMetadata.MinimumSupportedAgentVersion {
-				t.Fatal(fmt.Errorf("minimum_supported_agent_version has been modified for path: %s", filePath))
+			modifiedMinimumSupportedAgentVersion := modifiedMetadata.MinimumSupportedAgentVersion
+			originalMinimumSupportedAgentVersion := originalMetadata.MinimumSupportedAgentVersion
+			if !cmp.Equal(modifiedMinimumSupportedAgentVersion, originalMinimumSupportedAgentVersion) {
+				t.Fatal(fmt.Errorf("minimum_supported_agent_version has been modified for path: %s\n modified: %+v\n original: %+v", modified, modifiedMinimumSupportedAgentVersion, originalMinimumSupportedAgentVersion))
 			}
 		})
 	}


### PR DESCRIPTION
## Description
Fixed a bug for `MinimumSupportedAgentVersion` presubmit check where object comparison wasn't working as intended

## Related issue
b/244171329

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
