### PR TITLE
Update MongoDB supported_app_version

### DIFF
--- a/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
@@ -12,7 +12,7 @@ minimum_supported_agent_version:
   metrics: 2.19.0
   logging: 2.10.0
 supported_operating_systems: linux
-supported_app_version: ["4.0+"]
+supported_app_version: ["2.6", "3.0+", "4.0+", "5.0"]
 expected_metrics:
 - type: workload.googleapis.com/mongodb.cache.operations
   value_type: INT64


### PR DESCRIPTION
## Description
MongoDB metadata.yaml file field `supported_app_version` should be updated from `4.0` since we agreed to support an earlier versions(`2.6, 3.0+, 4.0+, 5.0`) based on the scope doc in [this thread](https://docs.google.com/document/d/1NGIRf6giORsQebIOTKfIrHfnMAj3xgcMsfVb05BmM00/edit\?disco\=AAAATiSoN10) 

## Related issue

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
