### PR TITLE
Add Elasticsearch metric enhancements

### DIFF
--- a/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
@@ -216,10 +216,6 @@ expected_metrics:
   value_type: INT64
   kind: CUMULATIVE
   monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.node.open_files
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
 - type: workload.googleapis.com/elasticsearch.node.pipeline.ingest.documents.current
   value_type: INT64
   kind: GAUGE

--- a/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
@@ -34,103 +34,264 @@ minimum_supported_agent_version:
 supported_operating_systems: linux
 supported_app_version: ["7.9+"]
 expected_metrics:
-  - type: workload.googleapis.com/elasticsearch.cluster.data_nodes
-    value_type: INT64
-    kind: GAUGE
-    monitored_resource: gce_instance
-  - type: workload.googleapis.com/elasticsearch.cluster.health
-    value_type: INT64
-    kind: GAUGE
-    monitored_resource: gce_instance
-    labels:
-      status: .*
-  - type: workload.googleapis.com/elasticsearch.cluster.nodes
-    value_type: INT64
-    kind: GAUGE
-    monitored_resource: gce_instance
-  - type: workload.googleapis.com/elasticsearch.cluster.shards
-    value_type: INT64
-    kind: GAUGE
-    monitored_resource: gce_instance
-    labels:
-      state: .*
-  - type: workload.googleapis.com/elasticsearch.node.cache.evictions
-    value_type: INT64
-    kind: CUMULATIVE
-    monitored_resource: gce_instance
-    labels:
-      cache_name: .*
-  - type: workload.googleapis.com/elasticsearch.node.cache.memory.usage
-    value_type: INT64
-    kind: GAUGE
-    monitored_resource: gce_instance
-    labels:
-      cache_name: .*
-  - type: workload.googleapis.com/elasticsearch.node.cluster.connections
-    value_type: INT64
-    kind: GAUGE
-    monitored_resource: gce_instance
-  - type: workload.googleapis.com/elasticsearch.node.cluster.io
-    value_type: INT64
-    kind: CUMULATIVE
-    monitored_resource: gce_instance
-    labels:
-      direction: .*
-  - type: workload.googleapis.com/elasticsearch.node.documents
-    value_type: INT64
-    kind: GAUGE
-    monitored_resource: gce_instance
-    labels:
-      state: .*
-  - type: workload.googleapis.com/elasticsearch.node.fs.disk.available
-    value_type: INT64
-    kind: GAUGE
-    monitored_resource: gce_instance
-  - type: workload.googleapis.com/elasticsearch.node.http.connections
-    value_type: INT64
-    kind: GAUGE
-    monitored_resource: gce_instance
-  - type: workload.googleapis.com/elasticsearch.node.open_files
-    value_type: INT64
-    kind: GAUGE
-    monitored_resource: gce_instance
-    representative: true
-  - type: workload.googleapis.com/elasticsearch.node.operations.completed
-    value_type: INT64
-    kind: CUMULATIVE
-    monitored_resource: gce_instance
-    labels:
-      operation: .*
-  - type: workload.googleapis.com/elasticsearch.node.operations.time
-    value_type: INT64
-    kind: CUMULATIVE
-    monitored_resource: gce_instance
-    labels:
-      operation: .*
-  - type: workload.googleapis.com/elasticsearch.node.shards.size
-    value_type: INT64
-    kind: GAUGE
-    monitored_resource: gce_instance
-  - type: workload.googleapis.com/elasticsearch.node.thread_pool.tasks.finished
-    value_type: INT64
-    kind: CUMULATIVE
-    monitored_resource: gce_instance
-    labels:
-      state: .*
-      thread_pool_name: .*
-  - type: workload.googleapis.com/elasticsearch.node.thread_pool.tasks.queued
-    value_type: INT64
-    kind: GAUGE
-    monitored_resource: gce_instance
-    labels:
-      thread_pool_name: .*
-  - type: workload.googleapis.com/elasticsearch.node.thread_pool.threads
-    value_type: INT64
-    kind: GAUGE
-    monitored_resource: gce_instance
-    labels:
-      state: .*
-      thread_pool_name: .*
+- type: workload.googleapis.com/elasticsearch.cluster.data_nodes
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.cluster.health
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+  labels:
+    status: .*
+- type: workload.googleapis.com/elasticsearch.cluster.nodes
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.cluster.shards
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+  labels:
+    state: .*
+- type: workload.googleapis.com/elasticsearch.node.cache.evictions
+  value_type: INT64
+  kind: CUMULATIVE
+  monitored_resource: gce_instance
+  labels:
+    cache_name: .*
+- type: workload.googleapis.com/elasticsearch.node.cache.memory.usage
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+  labels:
+    cache_name: .*
+- type: workload.googleapis.com/elasticsearch.node.cluster.connections
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.node.cluster.io
+  value_type: INT64
+  kind: CUMULATIVE
+  monitored_resource: gce_instance
+  labels:
+    direction: .*
+- type: workload.googleapis.com/elasticsearch.node.documents
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+  labels:
+    state: .*
+- type: workload.googleapis.com/elasticsearch.node.fs.disk.available
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.node.http.connections
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.node.open_files
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+  representative: true
+- type: workload.googleapis.com/elasticsearch.node.operations.completed
+  value_type: INT64
+  kind: CUMULATIVE
+  monitored_resource: gce_instance
+  labels:
+    operation: .*
+- type: workload.googleapis.com/elasticsearch.node.operations.time
+  value_type: INT64
+  kind: CUMULATIVE
+  monitored_resource: gce_instance
+  labels:
+    operation: .*
+- type: workload.googleapis.com/elasticsearch.node.shards.size
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.node.thread_pool.tasks.finished
+  value_type: INT64
+  kind: CUMULATIVE
+  monitored_resource: gce_instance
+  labels:
+    state: .*
+    thread_pool_name: .*
+- type: workload.googleapis.com/elasticsearch.node.thread_pool.tasks.queued
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+  labels:
+    thread_pool_name: .*
+- type: workload.googleapis.com/elasticsearch.node.thread_pool.threads
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+  labels:
+    state: .*
+    thread_pool_name: .*
+- type: workload.googleapis.com/elasticsearch.breaker.memory.estimated
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+  labels:
+    name: .*
+- type: workload.googleapis.com/elasticsearch.breaker.memory.limit
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+  labels:
+    name: .*
+- type: workload.googleapis.com/elasticsearch.breaker.tripped
+  value_type: INT64
+  kind: CUMULATIVE
+  monitored_resource: gce_instance
+  labels:
+    name: .*
+- type: workload.googleapis.com/elasticsearch.cluster.published_states.differences
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+  labels:
+    state: incompatible|compatible
+- type: workload.googleapis.com/elasticsearch.cluster.published_states.full
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.cluster.state_queue
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+  labels:
+    state: pending|committed
+- type: workload.googleapis.com/elasticsearch.cluster.state_update.count
+  value_type: INT64
+  kind: CUMULATIVE
+  monitored_resource: gce_instance
+  labels:
+    state: .*
+- type: workload.googleapis.com/elasticsearch.cluster.state_update.time
+  value_type: INT64
+  kind: CUMULATIVE
+  monitored_resource: gce_instance
+  labels:
+    state: .*
+    type: computation|context_construction|commit|completion|master_apply|notification
+- type: workload.googleapis.com/elasticsearch.indexing_pressure.memory.limit
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.indexing_pressure.memory.total.primary_rejections
+  value_type: INT64
+  kind: CUMULATIVE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.indexing_pressure.memory.total.replica_rejections
+  value_type: INT64
+  kind: CUMULATIVE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.memory.indexing_pressure
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+  labels:
+    stage: coordinating|primary|replica
+- type: workload.googleapis.com/elasticsearch.node.disk.io.read
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.node.disk.io.write
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.node.ingest.documents
+  value_type: INT64
+  kind: CUMULATIVE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.node.ingest.documents.current
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.node.ingest.operations.failed
+  value_type: INT64
+  kind: CUMULATIVE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.node.open_files
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.node.pipeline.ingest.documents.current
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+  labels:
+    name: .*
+- type: workload.googleapis.com/elasticsearch.node.pipeline.ingest.documents.preprocessed
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+  labels:
+    name: .*
+- type: workload.googleapis.com/elasticsearch.node.pipeline.ingest.operations.failed
+  value_type: INT64
+  kind: CUMULATIVE
+  monitored_resource: gce_instance
+  labels:
+    name: .*
+- type: workload.googleapis.com/elasticsearch.node.script.cache_evictions
+  value_type: INT64
+  kind: CUMULATIVE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.node.script.compilation_limit_triggered
+  value_type: INT64
+  kind: CUMULATIVE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.node.script.compilations
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.node.shards.data_set.size
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.node.shards.reserved.size
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.node.translog.operations
+  value_type: INT64
+  kind: CUMULATIVE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.node.translog.size
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.node.translog.uncommitted.size
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.os.cpu.load_avg.15m
+  value_type: DOUBLE
+  kind: GAUGE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.os.cpu.load_avg.1m
+  value_type: DOUBLE
+  kind: GAUGE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.os.cpu.load_avg.5m
+  value_type: DOUBLE
+  kind: GAUGE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.os.cpu.usage
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+- type: workload.googleapis.com/elasticsearch.os.memory
+  value_type: INT64
+  kind: GAUGE
+  monitored_resource: gce_instance
+  labels:
+    state: free|used
 expected_logs:
   - log_name: elasticsearch_json
     fields:

--- a/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
@@ -34,260 +34,260 @@ minimum_supported_agent_version:
 supported_operating_systems: linux
 supported_app_version: ["7.9+"]
 expected_metrics:
-- type: workload.googleapis.com/elasticsearch.cluster.data_nodes
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.cluster.health
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-  labels:
-    status: .*
-- type: workload.googleapis.com/elasticsearch.cluster.nodes
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.cluster.shards
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-  labels:
-    state: .*
-- type: workload.googleapis.com/elasticsearch.node.cache.evictions
-  value_type: INT64
-  kind: CUMULATIVE
-  monitored_resource: gce_instance
-  labels:
-    cache_name: .*
-- type: workload.googleapis.com/elasticsearch.node.cache.memory.usage
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-  labels:
-    cache_name: .*
-- type: workload.googleapis.com/elasticsearch.node.cluster.connections
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.node.cluster.io
-  value_type: INT64
-  kind: CUMULATIVE
-  monitored_resource: gce_instance
-  labels:
-    direction: .*
-- type: workload.googleapis.com/elasticsearch.node.documents
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-  labels:
-    state: .*
-- type: workload.googleapis.com/elasticsearch.node.fs.disk.available
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.node.http.connections
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.node.open_files
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-  representative: true
-- type: workload.googleapis.com/elasticsearch.node.operations.completed
-  value_type: INT64
-  kind: CUMULATIVE
-  monitored_resource: gce_instance
-  labels:
-    operation: .*
-- type: workload.googleapis.com/elasticsearch.node.operations.time
-  value_type: INT64
-  kind: CUMULATIVE
-  monitored_resource: gce_instance
-  labels:
-    operation: .*
-- type: workload.googleapis.com/elasticsearch.node.shards.size
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.node.thread_pool.tasks.finished
-  value_type: INT64
-  kind: CUMULATIVE
-  monitored_resource: gce_instance
-  labels:
-    state: .*
-    thread_pool_name: .*
-- type: workload.googleapis.com/elasticsearch.node.thread_pool.tasks.queued
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-  labels:
-    thread_pool_name: .*
-- type: workload.googleapis.com/elasticsearch.node.thread_pool.threads
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-  labels:
-    state: .*
-    thread_pool_name: .*
-- type: workload.googleapis.com/elasticsearch.breaker.memory.estimated
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-  labels:
-    name: .*
-- type: workload.googleapis.com/elasticsearch.breaker.memory.limit
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-  labels:
-    name: .*
-- type: workload.googleapis.com/elasticsearch.breaker.tripped
-  value_type: INT64
-  kind: CUMULATIVE
-  monitored_resource: gce_instance
-  labels:
-    name: .*
-- type: workload.googleapis.com/elasticsearch.cluster.published_states.differences
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-  labels:
-    state: incompatible|compatible
-- type: workload.googleapis.com/elasticsearch.cluster.published_states.full
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.cluster.state_queue
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-  labels:
-    state: pending|committed
-- type: workload.googleapis.com/elasticsearch.cluster.state_update.count
-  value_type: INT64
-  kind: CUMULATIVE
-  monitored_resource: gce_instance
-  labels:
-    state: .*
-- type: workload.googleapis.com/elasticsearch.cluster.state_update.time
-  value_type: INT64
-  kind: CUMULATIVE
-  monitored_resource: gce_instance
-  labels:
-    state: .*
-    type: computation|context_construction|commit|completion|master_apply|notification
-- type: workload.googleapis.com/elasticsearch.indexing_pressure.memory.limit
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.indexing_pressure.memory.total.primary_rejections
-  value_type: INT64
-  kind: CUMULATIVE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.indexing_pressure.memory.total.replica_rejections
-  value_type: INT64
-  kind: CUMULATIVE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.memory.indexing_pressure
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-  labels:
-    stage: coordinating|primary|replica
-- type: workload.googleapis.com/elasticsearch.node.disk.io.read
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.node.disk.io.write
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.node.ingest.documents
-  value_type: INT64
-  kind: CUMULATIVE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.node.ingest.documents.current
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.node.ingest.operations.failed
-  value_type: INT64
-  kind: CUMULATIVE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.node.pipeline.ingest.documents.current
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-  labels:
-    name: .*
-- type: workload.googleapis.com/elasticsearch.node.pipeline.ingest.documents.preprocessed
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-  labels:
-    name: .*
-- type: workload.googleapis.com/elasticsearch.node.pipeline.ingest.operations.failed
-  value_type: INT64
-  kind: CUMULATIVE
-  monitored_resource: gce_instance
-  labels:
-    name: .*
-- type: workload.googleapis.com/elasticsearch.node.script.cache_evictions
-  value_type: INT64
-  kind: CUMULATIVE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.node.script.compilation_limit_triggered
-  value_type: INT64
-  kind: CUMULATIVE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.node.script.compilations
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.node.shards.data_set.size
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.node.shards.reserved.size
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.node.translog.operations
-  value_type: INT64
-  kind: CUMULATIVE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.node.translog.size
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.node.translog.uncommitted.size
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.os.cpu.load_avg.15m
-  value_type: DOUBLE
-  kind: GAUGE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.os.cpu.load_avg.1m
-  value_type: DOUBLE
-  kind: GAUGE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.os.cpu.load_avg.5m
-  value_type: DOUBLE
-  kind: GAUGE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.os.cpu.usage
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-- type: workload.googleapis.com/elasticsearch.os.memory
-  value_type: INT64
-  kind: GAUGE
-  monitored_resource: gce_instance
-  labels:
-    state: free|used
+  - type: workload.googleapis.com/elasticsearch.cluster.data_nodes
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.cluster.health
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+    labels:
+      status: .*
+  - type: workload.googleapis.com/elasticsearch.cluster.nodes
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.cluster.shards
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+    labels:
+      state: .*
+  - type: workload.googleapis.com/elasticsearch.node.cache.evictions
+    value_type: INT64
+    kind: CUMULATIVE
+    monitored_resource: gce_instance
+    labels:
+      cache_name: .*
+  - type: workload.googleapis.com/elasticsearch.node.cache.memory.usage
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+    labels:
+      cache_name: .*
+  - type: workload.googleapis.com/elasticsearch.node.cluster.connections
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.node.cluster.io
+    value_type: INT64
+    kind: CUMULATIVE
+    monitored_resource: gce_instance
+    labels:
+      direction: .*
+  - type: workload.googleapis.com/elasticsearch.node.documents
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+    labels:
+      state: .*
+  - type: workload.googleapis.com/elasticsearch.node.fs.disk.available
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.node.http.connections
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.node.open_files
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+    representative: true
+  - type: workload.googleapis.com/elasticsearch.node.operations.completed
+    value_type: INT64
+    kind: CUMULATIVE
+    monitored_resource: gce_instance
+    labels:
+      operation: .*
+  - type: workload.googleapis.com/elasticsearch.node.operations.time
+    value_type: INT64
+    kind: CUMULATIVE
+    monitored_resource: gce_instance
+    labels:
+      operation: .*
+  - type: workload.googleapis.com/elasticsearch.node.shards.size
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.node.thread_pool.tasks.finished
+    value_type: INT64
+    kind: CUMULATIVE
+    monitored_resource: gce_instance
+    labels:
+      state: .*
+      thread_pool_name: .*
+  - type: workload.googleapis.com/elasticsearch.node.thread_pool.tasks.queued
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+    labels:
+      thread_pool_name: .*
+  - type: workload.googleapis.com/elasticsearch.node.thread_pool.threads
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+    labels:
+      state: .*
+      thread_pool_name: .*
+  - type: workload.googleapis.com/elasticsearch.breaker.memory.estimated
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+    labels:
+      name: .*
+  - type: workload.googleapis.com/elasticsearch.breaker.memory.limit
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+    labels:
+      name: .*
+  - type: workload.googleapis.com/elasticsearch.breaker.tripped
+    value_type: INT64
+    kind: CUMULATIVE
+    monitored_resource: gce_instance
+    labels:
+      name: .*
+  - type: workload.googleapis.com/elasticsearch.cluster.published_states.differences
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+    labels:
+      state: incompatible|compatible
+  - type: workload.googleapis.com/elasticsearch.cluster.published_states.full
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.cluster.state_queue
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+    labels:
+      state: pending|committed
+  - type: workload.googleapis.com/elasticsearch.cluster.state_update.count
+    value_type: INT64
+    kind: CUMULATIVE
+    monitored_resource: gce_instance
+    labels:
+      state: .*
+  - type: workload.googleapis.com/elasticsearch.cluster.state_update.time
+    value_type: INT64
+    kind: CUMULATIVE
+    monitored_resource: gce_instance
+    labels:
+      state: .*
+      type: computation|context_construction|commit|completion|master_apply|notification
+  - type: workload.googleapis.com/elasticsearch.indexing_pressure.memory.limit
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.indexing_pressure.memory.total.primary_rejections
+    value_type: INT64
+    kind: CUMULATIVE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.indexing_pressure.memory.total.replica_rejections
+    value_type: INT64
+    kind: CUMULATIVE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.memory.indexing_pressure
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+    labels:
+      stage: coordinating|primary|replica
+  - type: workload.googleapis.com/elasticsearch.node.disk.io.read
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.node.disk.io.write
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.node.ingest.documents
+    value_type: INT64
+    kind: CUMULATIVE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.node.ingest.documents.current
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.node.ingest.operations.failed
+    value_type: INT64
+    kind: CUMULATIVE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.node.pipeline.ingest.documents.current
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+    labels:
+      name: .*
+  - type: workload.googleapis.com/elasticsearch.node.pipeline.ingest.documents.preprocessed
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+    labels:
+      name: .*
+  - type: workload.googleapis.com/elasticsearch.node.pipeline.ingest.operations.failed
+    value_type: INT64
+    kind: CUMULATIVE
+    monitored_resource: gce_instance
+    labels:
+      name: .*
+  - type: workload.googleapis.com/elasticsearch.node.script.cache_evictions
+    value_type: INT64
+    kind: CUMULATIVE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.node.script.compilation_limit_triggered
+    value_type: INT64
+    kind: CUMULATIVE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.node.script.compilations
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.node.shards.data_set.size
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.node.shards.reserved.size
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.node.translog.operations
+    value_type: INT64
+    kind: CUMULATIVE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.node.translog.size
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.node.translog.uncommitted.size
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.os.cpu.load_avg.15m
+    value_type: DOUBLE
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.os.cpu.load_avg.1m
+    value_type: DOUBLE
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.os.cpu.load_avg.5m
+    value_type: DOUBLE
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.os.cpu.usage
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.os.memory
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+    labels:
+      state: free|used
 expected_logs:
   - log_name: elasticsearch_json
     fields:


### PR DESCRIPTION
## Description
Updates Elastic Search with additional metrics outlined in the metadata.yaml.

This PR is dependent on 
- https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/pull/122

## Related issue
Reflects the [scope doc](https://docs.google.com/document/d/1ByUTgrwwbL5ihuqb7QTE_XZMRE7aAfHS6KBsD8_n_l0/edit)
Recent metrics added:
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13115
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/12176
Recent Bug fixes:
- [1](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14012), [2](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13984), [3](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13983), [4](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13930), [5](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13815)

## How has this been tested?

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
