### PR TITLE
Remove deprecated and no longer available opensuse-leap-15-2.

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -852,7 +852,6 @@ func prepareSLES(ctx context.Context, logger *log.Logger, vm *VM) error {
 
 var (
 	overriddenImages = map[string]string{
-		"opensuse-leap-15-2": "opensuse-leap-15-2-v20200702",
 		"opensuse-leap-15-3": "opensuse-leap-15-3-v20220429-x86-64",
 		"opensuse-leap-15-4": "opensuse-leap-15-4-v20220624-x86-64",
 	}

--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -117,7 +117,6 @@ sles = _family {
         'sles-15-sp1-sap',
         'sles-15-sp2-sap',
         'opensuse-leap',
-        'opensuse-leap-15-2',
         'opensuse-leap-15-3',
         'opensuse-leap-15-4',
       ]


### PR DESCRIPTION
## Description
Fixes tests by removing the deprecated image.

## Related issue
[b/244614874](http://b/244614874)

## How has this been tested?
N/A, pure removal.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
