### PR TITLE
Add temporary workaround for breakage caused by systemd update.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,6 +113,8 @@ RUN set -x; apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
     autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
     build-essential cmake bison flex file libsystemd-dev \
+    # Temporary workaround for breakage caused by systemd update.
+    libsystemd0=237-3ubuntu10.53 \
     devscripts cdbs pkg-config openjdk-11-jdk zip
 
 ADD https://golang.org/dl/go1.19.linux-amd64.tar.gz /tmp/go1.19.linux-amd64.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,14 +107,12 @@ COPY . /work
 WORKDIR /work
 RUN ./pkg/deb/build.sh
 
-FROM ubuntu:bionic AS bionic-build
+FROM ubuntu:bionic-20220801 AS bionic-build
 
 RUN set -x; apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
     autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
     build-essential cmake bison flex file libsystemd-dev \
-    # Temporary workaround for breakage caused by systemd update.
-    libsystemd0=237-3ubuntu10.53 \
     devscripts cdbs pkg-config openjdk-11-jdk zip
 
 ADD https://golang.org/dl/go1.19.linux-amd64.tar.gz /tmp/go1.19.linux-amd64.tar.gz


### PR DESCRIPTION
https://bugs.launchpad.net/ubuntu/+source/systemd/237-3ubuntu10.54

## Description
Works around the build issue caused by the above update.

## How has this been tested?
Manual build succeeded.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
