### PR TITLE
tomcat: add description back for user field

### DIFF
--- a/integration_test/third_party_apps_data/applications/tomcat/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/tomcat/metadata.yaml
@@ -154,6 +154,7 @@ expected_logs:
       - name: jsonPayload.user
         type: string
         optional: true
+        description: Authenticated username for the request
       - name: severity
         type: string
         description: ''


### PR DESCRIPTION
## Description
This change adds in the description field back as it was accidentally removed in https://github.com/GoogleCloudPlatform/ops-agent/pull/797.

## Related issue
[b/245738338](http://b/245738338) | P3 | Fix tomcat metadata description

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
