### PR TITLE
Internal: add support for testing oracledb

### DIFF
--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -697,6 +697,9 @@ var defaultPlatforms = map[string]bool{
 const (
 	SAPHANAPlatform = "sles-15-sp3-sap-saphana"
 	SAPHANAApp      = "saphana"
+
+	OracleDBPlatform = "rhel-7-oracledb"
+	OracleDBApp      = "oracledb"
 )
 
 // incompatibleOperatingSystem looks at the supported_operating_systems field
@@ -718,7 +721,8 @@ func incompatibleOperatingSystem(testCase test) string {
 // platforms for those apps.
 // `platforms_to_skip` overrides the above.
 // Also, restrict `SAPHANAPlatform` to only test `SAPHANAApp` and skip that
-// app on all other platforms too.
+// app on all other platforms too. Same for `OracleDBPlatform` and
+// `OracleDBApp`.
 func determineTestsToSkip(tests []test, impactedApps map[string]bool, testConfig testConfig) {
 	for i, test := range tests {
 		if testing.Short() {
@@ -741,6 +745,11 @@ func determineTestsToSkip(tests []test, impactedApps map[string]bool, testConfig
 		isSAPHANAApp := test.app == SAPHANAApp
 		if isSAPHANAPlatform != isSAPHANAApp {
 			tests[i].skipReason = fmt.Sprintf("Skipping %v because we only want to test %v on %v", test.app, SAPHANAApp, SAPHANAPlatform)
+		}
+		isOracleDBPlatform := test.platform == OracleDBPlatform
+		isOracleDBApp := test.app == OracleDBApp
+		if isOracleDBPlatform != isOracleDBApp {
+			tests[i].skipReason = fmt.Sprintf("Skipping %v because we only want to test %v on %v", test.app, OracleDBApp, OracleDBPlatform)
 		}
 	}
 }
@@ -791,6 +800,9 @@ func TestThirdPartyApps(t *testing.T) {
 				if tc.platform == SAPHANAPlatform {
 					// This image needs an SSD in order to be performant enough.
 					options.ExtraCreateArguments = append(options.ExtraCreateArguments, "--boot-disk-type=pd-ssd")
+					options.ImageProject = "stackdriver-test-143416"
+				}
+				if tc.platform == OracleDBPlatform {
 					options.ImageProject = "stackdriver-test-143416"
 				}
 

--- a/kokoro/config/build/presubmit/oracledb.gcl
+++ b/kokoro/config/build/presubmit/oracledb.gcl
@@ -1,0 +1,11 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      // The testing image is based on RHEL 7, see b/245339285.
+      DISTRO = 'centos7'
+      PKGFORMAT = 'rpm'
+    }
+  }
+}

--- a/kokoro/config/test/third_party_apps/oracledb.gcl
+++ b/kokoro/config/test/third_party_apps/oracledb.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    // Created in b/245339285.
+    platforms = ['rhel-7-oracledb']
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/oracledb.gcl
+++ b/kokoro/config/test/third_party_apps/release/oracledb.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    // Created in b/245339285.
+    platforms = ['rhel-7-oracledb']
+  }
+}


### PR DESCRIPTION
## Description
Some changes necessary to start testing an as-yet-unimplemented app called oracledb using a prebaked image.
This change is very similar to #623.

## Related issue
b/245339285

## How has this been tested?
This is not ready to be actually run yet. We still need job configs to be checked into Piper first.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.