### PR TITLE
kokoro: install go 1.19 for tests

### DIFF
--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -81,8 +81,10 @@ sudo rm -rf /usr/local/go
 # GOPATH is semi-deprecated nowadays too.
 unset GOPATH
 
+GO_VERSION="1.19"
+
 # Download and install a newer version of go.
-wget --no-verbose --output-document=/dev/stdout https://golang.org/dl/go1.17.linux-amd64.tar.gz | \
+wget --no-verbose --output-document=/dev/stdout https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz | \
   sudo tar --directory /usr/local -xzf /dev/stdin
 
 PATH=$PATH:/usr/local/go/bin
@@ -101,7 +103,7 @@ if [[ -n "${TEST_SOURCE_PIPER_LOCATION-}" ]]; then
   # Make a module containing the latest dependencies from GitHub.
   go mod init "${TEST_SUITE_NAME}"
   go get github.com/GoogleCloudPlatform/ops-agent@master
-  go mod tidy -compat=1.17
+  go mod tidy -compat=${GO_VERSION}
 else
   cd integration_test
 fi


### PR DESCRIPTION
## Description
The Go version update missed that Go is running on 1.17 still in the integration tests. This PR updates that, introducing a variable for the next time this occurs.

## Related issue
b/245751121

## How has this been tested?
I'm using GitHub Actions to test it.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
