### PR TITLE
Fetch metadata from GCE VM Metadata Server

### DIFF
--- a/confgenerator/resourcedetector/detector.go
+++ b/confgenerator/resourcedetector/detector.go
@@ -4,12 +4,16 @@ import (
 	gcp_metadata "cloud.google.com/go/compute/metadata"
 )
 
+// An implementation of the Resource interface will have fields represent
+// available attributes about the current monitoring resource.
 type Resource interface {
 	GetType() string
 }
 
-// Get a resource instance for the current environment, which can be used
-// to get all the attributes
+// Get a resource instance for the current environment;
+// In order to access the attributes of a specific type of resource,
+// needs to cast the returned Resource instance to its underlying type:
+// actual, ok := resource.(GCEResource)
 func GetResource() (Resource, error) {
 	switch {
 	case gcp_metadata.OnGCE():

--- a/confgenerator/resourcedetector/detector.go
+++ b/confgenerator/resourcedetector/detector.go
@@ -4,30 +4,30 @@ import (
 	gcp_metadata "cloud.google.com/go/compute/metadata"
 )
 
-type Detector interface {
+type Resource interface {
 	GetType() string
 }
 
-// Get a Detector for the current environment, which can be used
+// Get a resource instance for the current environment, which can be used
 // to get all the attributes
-func GetDetector() (Detector, error) {
+func GetResource() (Resource, error) {
 	switch {
 	case gcp_metadata.OnGCE():
-		return GetGCEDetector()
+		return GetGCEResource()
 	default:
-		return GetUnrecognizedPlatformDetector()
+		return GetUnrecognizedPlatformResource()
 	}
 }
 
-// UnrecognizedPlatformDetector that returns an empty detector without any attributes
+// UnrecognizedPlatformResource that returns an empty resource instance without any attributes
 // for unrecognized environments
-type UnrecognizedPlatformDetector struct {
+type UnrecognizedPlatformResource struct {
 }
 
-func (UnrecognizedPlatformDetector) GetType() string {
+func (UnrecognizedPlatformResource) GetType() string {
 	return "unrecognized platform"
 }
 
-func GetUnrecognizedPlatformDetector() (Detector, error) {
-	return UnrecognizedPlatformDetector{}, nil
+func GetUnrecognizedPlatformResource() (Resource, error) {
+	return UnrecognizedPlatformResource{}, nil
 }

--- a/confgenerator/resourcedetector/detector.go
+++ b/confgenerator/resourcedetector/detector.go
@@ -1,0 +1,33 @@
+package resourcedetector
+
+import (
+	gcp_metadata "cloud.google.com/go/compute/metadata"
+)
+
+type Detector interface {
+	GetType() string
+}
+
+// Get a Detector for the current environment, which can be used
+// to get all the attributes
+func GetDetector() (Detector, error) {
+	switch {
+	case gcp_metadata.OnGCE():
+		return GetGCEDetector()
+	default:
+		return GetUnrecognizedPlatformDetector()
+	}
+}
+
+// UnrecognizedPlatformDetector that returns an empty detector without any attributes
+// for unrecognized environments
+type UnrecognizedPlatformDetector struct {
+}
+
+func (UnrecognizedPlatformDetector) GetType() string {
+	return "unrecognized platform"
+}
+
+func GetUnrecognizedPlatformDetector() (Detector, error) {
+	return UnrecognizedPlatformDetector{}, nil
+}

--- a/confgenerator/resourcedetector/gce_detector.go
+++ b/confgenerator/resourcedetector/gce_detector.go
@@ -1,0 +1,128 @@
+package resourcedetector
+
+type gceAttribute int
+
+const (
+	project gceAttribute = iota
+	zone
+	network
+	subnetwork
+	publicIP
+	privateIP
+	instanceID
+	instanceName
+	tags
+	machineType
+	metadata
+	label
+	interfaceIPv4
+)
+
+func GetGCEDetector() (Detector, error) {
+	provider := NewGCEMetadataProvider()
+	dt := GCEDetectorBuilder{provider: provider}
+	return dt.GetDetector()
+}
+
+// The data provider interface for GCE environment
+// Implementation of this provider can use either the metadata server on VM,
+// or the cloud API
+type gceDataProvider interface {
+	getProject() (string, error)
+	getZone() (string, error)
+	getNetwork() (string, error)
+	getSubnetwork() (string, error)
+	getPublicIP() (string, error)
+	getPrivateIP() (string, error)
+	getInstanceID() (string, error)
+	getInstanceName() (string, error)
+	getTags() (string, error)
+	getMachineType() (string, error)
+	getLabels() (map[string]string, error)
+	getMetadata() (map[string]string, error)
+	getInterfaceIPv4s() (map[string]string, error)
+}
+
+// List of single-valued attributes (non-nested)
+var singleAttributeSpec = map[gceAttribute]func(gceDataProvider) (string, error){
+	project:      gceDataProvider.getProject,
+	zone:         gceDataProvider.getZone,
+	network:      gceDataProvider.getNetwork,
+	subnetwork:   gceDataProvider.getSubnetwork,
+	publicIP:     gceDataProvider.getPublicIP,
+	privateIP:    gceDataProvider.getPrivateIP,
+	instanceID:   gceDataProvider.getInstanceID,
+	instanceName: gceDataProvider.getInstanceName,
+	tags:         gceDataProvider.getTags,
+	machineType:  gceDataProvider.getMachineType,
+}
+
+// List of nested attributes
+var nestedAttributeSpec = map[gceAttribute]func(gceDataProvider) (map[string]string, error){
+	metadata:      gceDataProvider.getMetadata,
+	interfaceIPv4: gceDataProvider.getInterfaceIPv4s,
+	label:         gceDataProvider.getLabels,
+}
+
+// GCEDetector implements the Detector interface and provide attributes of the VM when on GCE
+type GCEDetector struct {
+	Project       string
+	Zone          string
+	Network       string
+	Subnetwork    string
+	PublicIP      string
+	PrivateIP     string
+	InstanceID    string
+	InstanceName  string
+	Tags          string
+	MachineType   string
+	Metadata      map[string]string
+	Label         map[string]string
+	InterfaceIPv4 map[string]string
+}
+
+func (GCEDetector) GetType() string {
+	return "gce"
+}
+
+type GCEDetectorBuilder struct {
+	provider gceDataProvider
+}
+
+// Return a detector instance with all the attributes
+// based on the single and nested attributes spec
+func (gd *GCEDetectorBuilder) GetDetector() (Detector, error) {
+	singleAttributes := map[gceAttribute]string{}
+	for attrName, attrGetter := range singleAttributeSpec {
+		attr, err := attrGetter(gd.provider)
+		if err != nil {
+			return nil, err
+		}
+		singleAttributes[attrName] = attr
+	}
+	nestedAttributes := map[gceAttribute]map[string]string{}
+	for attrName, attrGetter := range nestedAttributeSpec {
+		attr, err := attrGetter(gd.provider)
+		if err != nil {
+			return nil, err
+		}
+		nestedAttributes[attrName] = attr
+	}
+
+	res := GCEDetector{
+		Project:       singleAttributes[project],
+		Zone:          singleAttributes[zone],
+		Network:       singleAttributes[network],
+		Subnetwork:    singleAttributes[subnetwork],
+		PublicIP:      singleAttributes[publicIP],
+		PrivateIP:     singleAttributes[privateIP],
+		InstanceID:    singleAttributes[instanceID],
+		InstanceName:  singleAttributes[instanceName],
+		Tags:          singleAttributes[tags],
+		MachineType:   singleAttributes[machineType],
+		Metadata:      nestedAttributes[metadata],
+		Label:         nestedAttributes[label],
+		InterfaceIPv4: nestedAttributes[interfaceIPv4],
+	}
+	return res, nil
+}

--- a/confgenerator/resourcedetector/gce_detector.go
+++ b/confgenerator/resourcedetector/gce_detector.go
@@ -18,10 +18,10 @@ const (
 	interfaceIPv4
 )
 
-func GetGCEDetector() (Detector, error) {
+func GetGCEResource() (Resource, error) {
 	provider := NewGCEMetadataProvider()
-	dt := GCEDetectorBuilder{provider: provider}
-	return dt.GetDetector()
+	dt := GCEResourceBuilder{provider: provider}
+	return dt.GetResource()
 }
 
 // The data provider interface for GCE environment
@@ -64,8 +64,8 @@ var nestedAttributeSpec = map[gceAttribute]func(gceDataProvider) (map[string]str
 	label:         gceDataProvider.getLabels,
 }
 
-// GCEDetector implements the Detector interface and provide attributes of the VM when on GCE
-type GCEDetector struct {
+// GCEResource implements the Resource interface and provide attributes of the VM when on GCE
+type GCEResource struct {
 	Project       string
 	Zone          string
 	Network       string
@@ -81,17 +81,17 @@ type GCEDetector struct {
 	InterfaceIPv4 map[string]string
 }
 
-func (GCEDetector) GetType() string {
+func (GCEResource) GetType() string {
 	return "gce"
 }
 
-type GCEDetectorBuilder struct {
+type GCEResourceBuilder struct {
 	provider gceDataProvider
 }
 
-// Return a detector instance with all the attributes
+// Return a resource instance with all the attributes
 // based on the single and nested attributes spec
-func (gd *GCEDetectorBuilder) GetDetector() (Detector, error) {
+func (gd *GCEResourceBuilder) GetResource() (Resource, error) {
 	singleAttributes := map[gceAttribute]string{}
 	for attrName, attrGetter := range singleAttributeSpec {
 		attr, err := attrGetter(gd.provider)
@@ -109,7 +109,7 @@ func (gd *GCEDetectorBuilder) GetDetector() (Detector, error) {
 		nestedAttributes[attrName] = attr
 	}
 
-	res := GCEDetector{
+	res := GCEResource{
 		Project:       singleAttributes[project],
 		Zone:          singleAttributes[zone],
 		Network:       singleAttributes[network],

--- a/confgenerator/resourcedetector/gce_detector_test.go
+++ b/confgenerator/resourcedetector/gce_detector_test.go
@@ -1,0 +1,114 @@
+package resourcedetector
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGettingDetectorWithoutError(t *testing.T) {
+	fakeProvider := FakeProvider{key: "some_key", value: "some_value"}
+	fakeBuilder := GCEDetectorBuilder{&fakeProvider}
+	actual, err := fakeBuilder.GetDetector()
+	if err != nil {
+		t.Errorf("should not have error")
+	}
+	if actual == nil {
+		t.Errorf("should not return nil detector when no error")
+	} else if d, ok := actual.(GCEDetector); ok {
+		if d.InstanceID != "some_value" {
+			t.Errorf("detector attribute InstanceID has wrong value")
+		}
+		if d.InterfaceIPv4["some_key"] != "some_value" {
+			t.Errorf("detector attribute InterfaceIPv4 has wrong value")
+		}
+	} else {
+		t.Errorf("should have created GCEDetector")
+	}
+}
+
+func TestErrorGettingDetector(t *testing.T) {
+	fakeProvider := FakeProvider{err: fmt.Errorf("some error")}
+	fakeBuilder := GCEDetectorBuilder{&fakeProvider}
+	actual, err := fakeBuilder.GetDetector()
+	if err == nil {
+		t.Errorf("should have error")
+	}
+	if err.Error() != "some error" {
+		t.Errorf("should have return the correct error message")
+	}
+	if actual != nil {
+		t.Errorf("should return nil detector when having error")
+	}
+}
+
+type FakeProvider struct {
+	err   error
+	key   string
+	value string
+}
+
+func (fp *FakeProvider) get() (string, error) {
+	if fp.err != nil {
+		return "", fp.err
+	}
+	return fp.value, nil
+}
+
+func (fp *FakeProvider) getMap() (map[string]string, error) {
+	if fp.err != nil {
+		return map[string]string{}, fp.err
+	}
+	return map[string]string{fp.key: fp.value}, nil
+}
+
+func (fp *FakeProvider) getProject() (string, error) {
+	return fp.get()
+}
+
+func (fp *FakeProvider) getZone() (string, error) {
+	return fp.get()
+}
+
+func (fp *FakeProvider) getNetwork() (string, error) {
+	return fp.get()
+}
+
+func (fp *FakeProvider) getSubnetwork() (string, error) {
+	return fp.get()
+}
+
+func (fp *FakeProvider) getPublicIP() (string, error) {
+	return fp.get()
+}
+
+func (fp *FakeProvider) getPrivateIP() (string, error) {
+	return fp.get()
+}
+
+func (fp *FakeProvider) getInstanceID() (string, error) {
+	return fp.get()
+}
+
+func (fp *FakeProvider) getInstanceName() (string, error) {
+	return fp.get()
+}
+
+func (fp *FakeProvider) getTags() (string, error) {
+	return fp.get()
+}
+
+func (fp *FakeProvider) getMachineType() (string, error) {
+	return fp.get()
+}
+
+func (fp *FakeProvider) getMetadata() (map[string]string, error) {
+	return fp.getMap()
+}
+
+func (fp *FakeProvider) getLabels() (map[string]string, error) {
+	return fp.getMap()
+}
+
+func (fp *FakeProvider) getInterfaceIPv4s() (map[string]string, error) {
+	return fp.getMap()
+}

--- a/confgenerator/resourcedetector/gce_detector_test.go
+++ b/confgenerator/resourcedetector/gce_detector_test.go
@@ -14,11 +14,11 @@ func TestGettingResourceWithoutError(t *testing.T) {
 	}
 	if actual == nil {
 		t.Errorf("should not return nil resource when no error")
-	} else if d, ok := actual.(GCEResource); ok {
-		if d.InstanceID != "some_value" {
+	} else if r, ok := actual.(GCEResource); ok {
+		if r.InstanceID != "some_value" {
 			t.Errorf("resource attribute InstanceID has wrong value")
 		}
-		if d.InterfaceIPv4["some_key"] != "some_value" {
+		if r.InterfaceIPv4["some_key"] != "some_value" {
 			t.Errorf("resource attribute InterfaceIPv4 has wrong value")
 		}
 	} else {

--- a/confgenerator/resourcedetector/gce_detector_test.go
+++ b/confgenerator/resourcedetector/gce_detector_test.go
@@ -5,31 +5,31 @@ import (
 	"testing"
 )
 
-func TestGettingDetectorWithoutError(t *testing.T) {
+func TestGettingResourceWithoutError(t *testing.T) {
 	fakeProvider := FakeProvider{key: "some_key", value: "some_value"}
-	fakeBuilder := GCEDetectorBuilder{&fakeProvider}
-	actual, err := fakeBuilder.GetDetector()
+	fakeBuilder := GCEResourceBuilder{&fakeProvider}
+	actual, err := fakeBuilder.GetResource()
 	if err != nil {
 		t.Errorf("should not have error")
 	}
 	if actual == nil {
-		t.Errorf("should not return nil detector when no error")
-	} else if d, ok := actual.(GCEDetector); ok {
+		t.Errorf("should not return nil resource when no error")
+	} else if d, ok := actual.(GCEResource); ok {
 		if d.InstanceID != "some_value" {
-			t.Errorf("detector attribute InstanceID has wrong value")
+			t.Errorf("resource attribute InstanceID has wrong value")
 		}
 		if d.InterfaceIPv4["some_key"] != "some_value" {
-			t.Errorf("detector attribute InterfaceIPv4 has wrong value")
+			t.Errorf("resource attribute InterfaceIPv4 has wrong value")
 		}
 	} else {
-		t.Errorf("should have created GCEDetector")
+		t.Errorf("should have created GCEResource")
 	}
 }
 
-func TestErrorGettingDetector(t *testing.T) {
+func TestErrorGettingResource(t *testing.T) {
 	fakeProvider := FakeProvider{err: fmt.Errorf("some error")}
-	fakeBuilder := GCEDetectorBuilder{&fakeProvider}
-	actual, err := fakeBuilder.GetDetector()
+	fakeBuilder := GCEResourceBuilder{&fakeProvider}
+	actual, err := fakeBuilder.GetResource()
 	if err == nil {
 		t.Errorf("should have error")
 	}
@@ -37,7 +37,7 @@ func TestErrorGettingDetector(t *testing.T) {
 		t.Errorf("should have return the correct error message")
 	}
 	if actual != nil {
-		t.Errorf("should return nil detector when having error")
+		t.Errorf("should return nil resource when having error")
 	}
 }
 

--- a/confgenerator/resourcedetector/gce_metadata_provider.go
+++ b/confgenerator/resourcedetector/gce_metadata_provider.go
@@ -1,0 +1,112 @@
+package resourcedetector
+
+import (
+	"fmt"
+	"strings"
+
+	gcp_metadata "cloud.google.com/go/compute/metadata"
+)
+
+const notAvailable = "NOT AVAILABLE"
+
+// Provide the GCE metadata using the on-VM metadata server
+// The following metadata are not available on the metadata server:
+// * Labels
+// * Subnet URL
+type GCEMetadataProvider struct {
+	client *gcp_metadata.Client
+}
+
+func NewGCEMetadataProvider() gceDataProvider {
+	c := gcp_metadata.NewClient(nil)
+	return &GCEMetadataProvider{c}
+}
+
+func (gmp *GCEMetadataProvider) getProject() (string, error) {
+	return gmp.client.ProjectID()
+}
+
+func (gmp *GCEMetadataProvider) getZone() (string, error) {
+	return gmp.client.Zone()
+}
+
+// We assume the current running instance has at least one network interface
+// Otherwise won't be able to connect to
+func (gmp *GCEMetadataProvider) getNetwork() (string, error) {
+	return gmp.client.Get("instance/network-interfaces/0/network")
+}
+
+func (gmp *GCEMetadataProvider) getSubnetwork() (string, error) {
+	return notAvailable, nil
+}
+
+func (gmp *GCEMetadataProvider) getPublicIP() (string, error) {
+	return gmp.client.ExternalIP()
+}
+
+func (gmp *GCEMetadataProvider) getPrivateIP() (string, error) {
+	return gmp.client.InternalIP()
+}
+
+func (gmp *GCEMetadataProvider) getInstanceID() (string, error) {
+	return gmp.client.InstanceID()
+}
+
+func (gmp *GCEMetadataProvider) getInstanceName() (string, error) {
+	return gmp.client.InstanceName()
+}
+
+func (gmp *GCEMetadataProvider) getTags() (string, error) {
+	tags, err := gmp.client.InstanceTags()
+	if err != nil {
+		return "", err
+	}
+	return strings.Join(tags, ","), nil
+}
+
+func (gmp *GCEMetadataProvider) getMachineType() (string, error) {
+	return gmp.client.Get("instance/machine-type")
+}
+
+func (gmp *GCEMetadataProvider) getMetadata() (map[string]string, error) {
+	keys, err := gmp.client.Get("instance/attributes")
+	if err != nil {
+		return map[string]string{}, err
+	}
+	metadata := map[string]string{}
+	for _, key := range strings.Fields(keys) {
+		val, err := gmp.client.Get(fmt.Sprintf("instance/attributes/%s", key))
+		if err != nil {
+			return map[string]string{}, err
+		}
+		metadata[key] = val
+	}
+	return metadata, nil
+}
+
+func (gmp *GCEMetadataProvider) getMetadataValue(key string) (string, error) {
+	return gmp.client.Get(fmt.Sprintf("instance/attributes/%s", key))
+}
+
+// GCE VM labels are currently not available in the metadata server
+func (gmp *GCEMetadataProvider) getLabels() (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
+func (gmp *GCEMetadataProvider) getInterfaceIPv4s() (map[string]string, error) {
+	names, err := gmp.client.Get("instance/network-interfaces/")
+	if err != nil {
+		return map[string]string{}, err
+	}
+	interfaces := map[string]string{}
+	for _, name := range strings.Fields(names) {
+		// The metadata server would return interfaces as "0/", needs to trim the "/"
+		name = strings.TrimRight(name, "/")
+		ip, err := gmp.client.Get(fmt.Sprintf("instance/network-interfaces/%s/ip", name))
+		if err != nil {
+			return map[string]string{}, err
+		}
+		interfaces[name] = ip
+	}
+	return interfaces, err
+}

--- a/confgenerator/resourcedetector/gce_metadata_provider.go
+++ b/confgenerator/resourcedetector/gce_metadata_provider.go
@@ -36,6 +36,8 @@ func (gmp *GCEMetadataProvider) getNetwork() (string, error) {
 	return gmp.client.Get("instance/network-interfaces/0/network")
 }
 
+// TODO: b/246995894
+// The subnetwork url is currently not available from the metadata server
 func (gmp *GCEMetadataProvider) getSubnetwork() (string, error) {
 	return notAvailable, nil
 }
@@ -84,10 +86,7 @@ func (gmp *GCEMetadataProvider) getMetadata() (map[string]string, error) {
 	return metadata, nil
 }
 
-func (gmp *GCEMetadataProvider) getMetadataValue(key string) (string, error) {
-	return gmp.client.Get(fmt.Sprintf("instance/attributes/%s", key))
-}
-
+// TODO: b/246995462
 // GCE VM labels are currently not available in the metadata server
 func (gmp *GCEMetadataProvider) getLabels() (map[string]string, error) {
 	return map[string]string{}, nil

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/GoogleCloudPlatform/ops-agent
 go 1.19
 
 require (
+	cloud.google.com/go/compute v0.1.0
 	cloud.google.com/go/logging v1.4.2
 	cloud.google.com/go/monitoring v1.2.0
 	cloud.google.com/go/storage v1.18.2
@@ -29,7 +30,6 @@ require (
 
 require (
 	cloud.google.com/go v0.100.2 // indirect
-	cloud.google.com/go/compute v0.1.0 // indirect
 	cloud.google.com/go/iam v0.1.0 // indirect
 	github.com/StackExchange/wmi v1.2.1 // indirect
 	github.com/fatih/color v1.10.0 // indirect


### PR DESCRIPTION
## Description
This change introduces a new package in confgenerator called `resourcedetector` to detect metadata of the environment Ops Agent is running in. The detected metadata can then be used by receivers/processors. Right now we only have a detector for GCE environment; the detector is not currently used by any components; this will be used by the Prometheus receivers.

## Related issue
b/244434005

## How has this been tested?
This has been tested with unit tests and manual tests on GCE. 
Integration tests for this is TBD. 

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
