### PR TITLE
Testing: try to repro restart fails on windows-2012-r2

### DIFF
--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -195,6 +195,7 @@ func RunOpsAgentDiagnostics(ctx context.Context, logger *logging.DirectoryLogger
 
 func runOpsAgentDiagnosticsWindows(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.VM) {
 	gce.RunRemotely(ctx, logger.ToFile("windows_System_log.txt"), vm, "", "Get-WinEvent -LogName System | Format-Table -AutoSize -Wrap")
+	gce.RunRemotely(ctx, logger.ToFile("netstat.txt"), vm, "", "netstat -aon")
 
 	gce.RunRemotely(ctx, logger.ToFile("Get-Service_output.txt"), vm, "", "Get-Service google-cloud-ops-agent* | Format-Table -AutoSize -Wrap")
 

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1478,6 +1478,9 @@ func waitForStartWindows(ctx context.Context, logger *log.Logger, vm *VM) error 
 	if err := backoff.Retry(printFoo, backoffPolicy); err != nil {
 		return fmt.Errorf("%v, even after %v of attempts. err=%v", winRMDummyCommandMessage, gracePeriod, err)
 	}
+
+	time.Sleep(60 * time.Second)
+
 	return nil
 }
 


### PR DESCRIPTION
not to be merged.

Run it like this (needs winrm.par to exist in ~, to get that please run the commands in [this doc](https://docs.google.com/document/d/1XWW9gCiof9tKDz5lNvhS5crUfP6-YuLRerTnw3qoedM/edit?usp=sharing&resourcekey=0-qCPDai977uIclPf257mXCw) first):

```
WINRM_PAR_PATH=~/winrm.par \
PROJECT=stackdriver-kubernetes-1337 \
TRANSFERS_BUCKET=stackdriver-test-143416-untrusted-file-transfers \
AGENT_PACKAGES_IN_GCS=gs://artifacts.stackdriver-kubernetes-1337.appspot.com/martijnvs-debug-fluent-hang \
ZONE=us-central1-b \
PLATFORMS=windows-2012-r2 \
go test -v ops_agent_test.go \
 -test.parallel=1000 \
 -tags=integration_test \
 -timeout=2h \
 -test.run=TestXYZ 2>&1 | tee test_output.txt
```