### PR TITLE
makefile: add build target

### DIFF
--- a/tasks.mak
+++ b/tasks.mak
@@ -64,3 +64,12 @@ test_metadata_validate:
 precommit: addlicense_check yaml_lint test_confgenerator test_metadata validate_metadata
 
 precommit_update: addlicense yaml_format test_confgenerator_update test_metadata_update validate_metadata
+
+
+############
+# Build
+############
+
+build:
+	mkdir -p /tmp/google-cloud-ops-agent	
+	DOCKER_BUILDKIT=1 docker build -o /tmp/google-cloud-ops-agent . $(ARGS)


### PR DESCRIPTION
`make build` will build the ops agent. `make build ARGS=--target=buster` is an example of how to pass in arguments. It builds the Ops Agent for Debian 10 Buster.
