### PR TITLE
postgres: fix flattening of metric atrributes

### DIFF
--- a/apps/postgresql.go
+++ b/apps/postgresql.go
@@ -73,6 +73,11 @@ func (r MetricsReceiverPostgresql) Pipelines() []otel.Pipeline {
 		},
 		Processors: []otel.Component{
 			otel.NormalizeSums(),
+			otel.TransformationMetrics(
+				otel.FlattenResourceAttribute("postgresql.database.name", "database"),
+				otel.FlattenResourceAttribute("postgresql.table.name", "table"),
+				otel.FlattenResourceAttribute("postgresql.index.name", "index"),
+			),
 			otel.MetricsTransform(
 				otel.AddPrefix("workload.googleapis.com"),
 			),

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden_otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden_otel.yaml
@@ -407,7 +407,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  metricstransform/postgresql_postgresql_1:
+  metricstransform/postgresql_postgresql_2:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -417,6 +417,12 @@ processors:
   resourcedetection/_global_0:
     detectors:
     - gce
+  transform/postgresql_postgresql_1:
+    metrics:
+      queries:
+      - set(attributes["database"], resource.attributes["postgresql.database.name"])
+      - set(attributes["table"], resource.attributes["postgresql.table.name"])
+      - set(attributes["index"], resource.attributes["postgresql.index.name"])
 receivers:
   hostmetrics/default__pipeline_hostmetrics:
     collection_interval: 60s
@@ -490,7 +496,8 @@ service:
       - googlecloud
       processors:
       - normalizesums/postgresql_postgresql_0
-      - metricstransform/postgresql_postgresql_1
+      - transform/postgresql_postgresql_1
+      - metricstransform/postgresql_postgresql_2
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql_postgresql

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden_otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden_otel.yaml
@@ -407,7 +407,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  metricstransform/postgresql_postgresql_1:
+  metricstransform/postgresql_postgresql_2:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -417,6 +417,12 @@ processors:
   resourcedetection/_global_0:
     detectors:
     - gce
+  transform/postgresql_postgresql_1:
+    metrics:
+      queries:
+      - set(attributes["database"], resource.attributes["postgresql.database.name"])
+      - set(attributes["table"], resource.attributes["postgresql.table.name"])
+      - set(attributes["index"], resource.attributes["postgresql.index.name"])
 receivers:
   hostmetrics/default__pipeline_hostmetrics:
     collection_interval: 60s
@@ -492,7 +498,8 @@ service:
       - googlecloud
       processors:
       - normalizesums/postgresql_postgresql_0
-      - metricstransform/postgresql_postgresql_1
+      - transform/postgresql_postgresql_1
+      - metricstransform/postgresql_postgresql_2
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql_postgresql

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden_otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden_otel.yaml
@@ -407,7 +407,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  metricstransform/postgresql_postgresql_1:
+  metricstransform/postgresql_postgresql_2:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -417,6 +417,12 @@ processors:
   resourcedetection/_global_0:
     detectors:
     - gce
+  transform/postgresql_postgresql_1:
+    metrics:
+      queries:
+      - set(attributes["database"], resource.attributes["postgresql.database.name"])
+      - set(attributes["table"], resource.attributes["postgresql.table.name"])
+      - set(attributes["index"], resource.attributes["postgresql.index.name"])
 receivers:
   hostmetrics/default__pipeline_hostmetrics:
     collection_interval: 60s
@@ -493,7 +499,8 @@ service:
       - googlecloud
       processors:
       - normalizesums/postgresql_postgresql_0
-      - metricstransform/postgresql_postgresql_1
+      - transform/postgresql_postgresql_1
+      - metricstransform/postgresql_postgresql_2
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql_postgresql

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden_otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden_otel.yaml
@@ -407,7 +407,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  metricstransform/postgresql_postgresql_1:
+  metricstransform/postgresql_postgresql_2:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -417,6 +417,12 @@ processors:
   resourcedetection/_global_0:
     detectors:
     - gce
+  transform/postgresql_postgresql_1:
+    metrics:
+      queries:
+      - set(attributes["database"], resource.attributes["postgresql.database.name"])
+      - set(attributes["table"], resource.attributes["postgresql.table.name"])
+      - set(attributes["index"], resource.attributes["postgresql.index.name"])
 receivers:
   hostmetrics/default__pipeline_hostmetrics:
     collection_interval: 60s
@@ -496,7 +502,8 @@ service:
       - googlecloud
       processors:
       - normalizesums/postgresql_postgresql_0
-      - metricstransform/postgresql_postgresql_1
+      - transform/postgresql_postgresql_1
+      - metricstransform/postgresql_postgresql_2
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql_postgresql


### PR DESCRIPTION
## Description
postgres: fix flattening of metric atrributes that broke the tests on master

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
