### PR TITLE
Update postgresql minimum_supported_agent_version

### DIFF
--- a/integration_test/third_party_apps_data/applications/postgresql/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/postgresql/metadata.yaml
@@ -26,7 +26,7 @@ configure_integration: |-
   The `postgresql` receiver connects by default to a local `postgresql`
   server using a Unix socket and Unix authentication as the `root` user.
 minimum_supported_agent_version:
-  metrics: 2.9.0
+  metrics: 2.20.0
   logging: 2.9.0
 supported_operating_systems: linux
 supported_app_version: ["10.18+"]


### PR DESCRIPTION
## Description
Update postgresql minimum_supported_agent_version now that we have added new metrics.

## Related issue
b/244320943

## How has this been tested?
N/A

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [x] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [x] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
