### PR TITLE
Updated minimum supported version of postgres to 2.20.0

### DIFF
--- a/integration_test/third_party_apps_data/applications/postgresql/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/postgresql/metadata.yaml
@@ -26,7 +26,7 @@ configure_integration: |-
   The `postgresql` receiver connects by default to a local `postgresql`
   server using a Unix socket and Unix authentication as the `root` user.
 minimum_supported_agent_version:
-  metrics: 2.9.0
+  metrics: 2.20.0
   logging: 2.9.0
 supported_operating_systems: linux
 supported_app_version: ["10.18+"]


### PR DESCRIPTION
## Description
Manually bump recommended version for Postgres to 2.20.0

## Related issue
N/A

## How has this been tested?

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [X] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

