### PR TITLE
Makefile: add integration test targets and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Makefile

--- a/.yamlfmt
+++ b/.yamlfmt
@@ -1,2 +1,7 @@
 include:
 - integration_test/**/*.yaml
+
+formatter:
+  type: basic
+  retain_line_breaks: true
+  emoji_support: true

--- a/dev-docs/makefile.md
+++ b/dev-docs/makefile.md
@@ -8,15 +8,26 @@ We are unable to use the actual `Makefile` name in this repo; because we build t
 
 ## Usage
 
+For convenience it helps to make a symlink from `tasks.mak` to `Makefile`. There is a target to do this, to run it:
+```
+make -f tasks.mak makefile_symlink
+```
+
+Now you can call the targets simply with the `make` command without needing to specify the `tasks.mak` file. The file `Makefile` is gitignored, since we don't want to push it to the repo for the reasons stated in the previous section. 
+
 To run something from the Makefile, you will need to give `make` the `-f` (file) flag with a path to `tasks.mak`. For example, to run the `test` target:
 ```
-make -f tasks.mak test
+make test
 ```
 
 If you want to run one of the tool targets (i.e. `addlicense` or `yaml_format`), you'll first need to run the `install_tools` target:
 ```
-make -f tasks.mak install_tools
+make install_tools
 ```
+
+### Precommit
+
+There are two targets, `precommit` and `precommit_update`, that are meant to be run before making commits. The `precommit` target will run specific tests and checks to make sure the changes are good to commit, and `precommit_update` will actually perform updates (i.e. yaml formatting and golden file updates) that will prepare your code for commit. Currently these targets don't run automatically as precommit hooks, to give developers the option of updating or simply checking in their precommit, however this is subject to change.
 
 ## When to add a new target
 

--- a/dev-docs/makefile.md
+++ b/dev-docs/makefile.md
@@ -8,7 +8,7 @@ We are unable to use the actual `Makefile` name in this repo; because we build t
 
 ## Usage
 
-For convenience it helps to make a symlink from `tasks.mak` to `Makefile`. There is a target to do this, to run it:
+For convenience it helps to make a symlink from `Makefile` to `tasks.mak` . There is a target to do this, to run it:
 ```
 make -f tasks.mak makefile_symlink
 ```

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -42,18 +42,15 @@ of Kokoro with some setup (see above).
 ### Testing Command
 
 When the setup steps are complete, you can run ops_agent_test (for Linux)
-like this:
-
+from the Makefile:
 ```
-PROJECT="${PROJECT}" \
-TRANSFERS_BUCKET="${TRANSFERS_BUCKET}" \
-ZONE=us-central1-b \
-PLATFORMS=debian-10 \
-go test -v ops_agent_test.go \
- -test.parallel=1000 \
- -tags=integration_test \
- -timeout=4h
+make integration_test PROJECT=${PROJECT} TRANSFERS_BUCKET=${TRANSFERS_BUCKET}
 ```
+Alternatively, you can export `PROJECT` and `TRANSFERS_BUCKET` in your 
+environment and simply call the target.  
+You can also specify the `ZONE` and `PLATFORMS` variables if you would like
+to run the tests on something other than the defaults (`us-central1-b` for 
+ZONE and `debian-11` for `PLATFORMS`).
 
 Testing on Windows is tricky because it requires a suitable value of
 WINRM_PAR_PATH, and for now only Googlers can build winrm.par to supply it at
@@ -75,6 +72,8 @@ You can obtain such a URI by:
     `gs://ops-agents-public-buckets-test-logs/prod/stackdriver_agents/testing/consumer/ops_agent/presubmit_github/debian/166/20220215-095636/logs/+build_and_test.txt`
 2.  Replace `logs/+build_and_test.txt` at the end of the URI with
     `agent_packages` and pass that as `AGENT_PACKAGES_IN_GCS`.
+
+Googlers can also provide a `REPO_SUFFIX` to test an agent built by our release scripts.
 
 ## Third Party Apps Test
 
@@ -208,22 +207,14 @@ Existing `expected_metrics` files are updated with any new metrics that are retr
 
 ### Testing Command
 
-This needs the same setup steps as the Ops Agent test (see above). The command
-is nearly the same, just replace `ops_agent_test.go` with
-`third_party_apps_test.go`:
+The make target `third_party_apps_test` similarly requires `PROJECT` and
+`TRANSFERS_BUCKET` to be specified in the environment or the command.
 
 ```
-PROJECT="${PROJECT}" \
-TRANSFERS_BUCKET="${TRANSFERS_BUCKET}" \
-ZONE=us-central1-b \
-PLATFORMS=debian-10 \
-go test -v third_party_apps_test.go \
- -test.parallel=1000 \
- -tags=integration_test \
- -timeout=4h
+make third_party_apps_test
 ```
 
-As above, you can supply `AGENT_PACKAGES_IN_GCS` to test a pre-built agent.
+As above, you can supply `AGENT_PACKAGES_IN_GCS` or `REPO_SUFFIX` to test a pre-built agent.
 
 # Test Logs
 

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -42,7 +42,7 @@ of Kokoro with some setup (see above).
 ### Testing Command
 
 When the setup steps are complete, you can run ops_agent_test (for Linux)
-from the Makefile:
+from the [Makefile](tasks.mak):
 ```
 make integration_test PROJECT=${PROJECT} TRANSFERS_BUCKET=${TRANSFERS_BUCKET}
 ```


### PR DESCRIPTION
## Description
Added integration test targets and updated the integration test instructions for running them.
Added `Makefile` to .gitignore and added `makefile_symlink` target that makes a symlinked `Makefile`.
Added some small convenience targets to reset submodules or sync the current fork.

## Related issue


## How has this been tested?


## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
