### PR TITLE
prometheus: add metadata labels to every static config

### DIFF
--- a/confgenerator/confgenerator_test.go
+++ b/confgenerator/confgenerator_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/apps"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
+	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/resourcedetector"
 	"github.com/shirou/gopsutil/host"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/golden"
@@ -165,6 +166,24 @@ func getTestsInDir(t *testing.T, testDir string) []string {
 }
 
 func testGenerateConf(t *testing.T, platform platformConfig, testDir string) error {
+	testResource := resourcedetector.GCEResource{
+		Project:       "test-project",
+		Zone:          "test-zone",
+		Network:       "test-network",
+		Subnetwork:    "test-subnetwork",
+		PublicIP:      "test-public-ip",
+		PrivateIP:     "test-private-ip",
+		InstanceID:    "test-instance-id",
+		InstanceName:  "test-instance-name",
+		Tags:          "test-tag",
+		MachineType:   "test-machine-type",
+		Metadata:      map[string]string{"test-key": "test-value"},
+		Label:         map[string]string{"test-label-key": "test-label-value"},
+		InterfaceIPv4: map[string]string{"test-interface": "test-interface-ipv4"},
+	}
+
+	confgenerator.MetadataResource = testResource
+
 	// Merge Config
 	_, confBytes, err := confgenerator.MergeConfFiles(
 		filepath.Join("testdata", testDir, inputFileName),

--- a/confgenerator/files.go
+++ b/confgenerator/files.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/resourcedetector"
 	"github.com/shirou/gopsutil/host"
 )
 
@@ -53,6 +54,13 @@ func GenerateFilesFromConfig(uc *UnifiedConfig, service, logsDir, stateDir, outD
 			}
 		}
 	case "otel":
+		// Fetch resoure metadata.
+		var err error
+		MetadataResource, err = resourcedetector.GetResource()
+		if err != nil {
+			return fmt.Errorf("can't get resource metadata: %w", err)
+		}
+
 		otelConfig, err := uc.GenerateOtelConfig(hostInfo)
 		if err != nil {
 			return fmt.Errorf("can't parse configuration: %w", err)

--- a/confgenerator/files.go
+++ b/confgenerator/files.go
@@ -54,7 +54,7 @@ func GenerateFilesFromConfig(uc *UnifiedConfig, service, logsDir, stateDir, outD
 			}
 		}
 	case "otel":
-		// Fetch resoure metadata.
+		// Fetch resource information from the metadata server.
 		var err error
 		MetadataResource, err = resourcedetector.GetResource()
 		if err != nil {

--- a/confgenerator/otel/modular.go
+++ b/confgenerator/otel/modular.go
@@ -112,6 +112,9 @@ func (c ModularConfig) Generate() (string, error) {
 	// If so, add the googlemanagedprometheus exporter.
 	if len(c.GoogleManagedPrometheusPipelines) > 0 {
 		exporters[googleManagedPrometheusExporter] = c.GoogleManagedPrometheusExporter.Config
+
+		// Add the groupbyattrs processor so prometheus pipelines can use it.
+		processors["groupbyattrs/custom_prometheus"] = gceGroupByAttrs().Config
 	}
 
 	var globalProcessorNames []string
@@ -134,6 +137,7 @@ func (c ModularConfig) Generate() (string, error) {
 
 		if contains(c.GoogleManagedPrometheusPipelines, prefix) {
 			exporter = googleManagedPrometheusExporter
+			processorNames = append(processorNames, "groupbyattrs/custom_prometheus")
 		} else {
 			processorNames = append(processorNames, globalProcessorNames...)
 		}
@@ -162,4 +166,13 @@ func contains(s []string, str string) bool {
 	}
 
 	return false
+}
+
+func gceGroupByAttrs() Component {
+	return Component{
+		Type: "groupbyattrs",
+		Config: map[string]interface{}{
+			"keys": []string{"namespace", "cluster", "location"},
+		},
+	}
 }

--- a/confgenerator/prometheus.go
+++ b/confgenerator/prometheus.go
@@ -23,11 +23,19 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
+	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/resourcedetector"
 	"github.com/go-playground/validator/v10"
 	commonconfig "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
 	promconfig "github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
 	_ "github.com/prometheus/prometheus/discovery/install" // init() of this package registers service discovery impl.
+)
+
+var (
+	// MetadataResource is the resource metadata for the instance we're running on.
+	// Note: This is a global variable so that it can be set in tests.
+	MetadataResource resourcedetector.Resource
 )
 
 type PrometheusMetrics struct {
@@ -49,6 +57,32 @@ func (r PrometheusMetrics) Type() string {
 }
 
 func (r PrometheusMetrics) Pipelines() []otel.Pipeline {
+	// Get the resource metadata for the instance we're running on.
+	if gceMetadata, ok := MetadataResource.(resourcedetector.GCEResource); ok {
+		// Create a prometheus style mapping for the GCE metadata.
+		gceMetadataMap := createPrometheusStyleGCEMetadata(gceMetadata)
+
+		// Add the GCE metadata to the prometheus config.
+		for i := range r.PromConfig.ScrapeConfigs {
+			// Iterate over the static configs.
+			for j := range r.PromConfig.ScrapeConfigs[i].ServiceDiscoveryConfigs {
+				staticConfigs := r.PromConfig.ScrapeConfigs[i].ServiceDiscoveryConfigs[j].(discovery.StaticConfig)
+				for k := range staticConfigs {
+					labels := staticConfigs[k].Labels
+					if labels == nil {
+						labels = model.LabelSet{}
+					}
+					for k, v := range gceMetadataMap {
+						// If there are conflicts, the GCE metadata should take precedence.
+						labels[model.LabelName(k)] = model.LabelValue(v)
+					}
+
+					staticConfigs[k].Labels = labels
+				}
+			}
+		}
+	}
+
 	// TODO(b/248268653): Fix the issue we have with the regex capture group syntax.
 	return []otel.Pipeline{{
 		Receiver: otel.Component{
@@ -56,6 +90,43 @@ func (r PrometheusMetrics) Pipelines() []otel.Pipeline {
 			Config: map[string]interface{}{"config": r.PromConfig},
 		},
 	}}
+}
+
+func createPrometheusStyleGCEMetadata(gceMetadata resourcedetector.GCEResource) map[string]string {
+	metaLabels := map[string]string{
+		"__meta_gce_instance_id":   gceMetadata.InstanceID,
+		"__meta_gce_instance_name": gceMetadata.InstanceName,
+		"__meta_gce_project_id":    gceMetadata.Project,
+		"__meta_gce_zone":          gceMetadata.Zone,
+		"__meta_gce_network":       gceMetadata.Network,
+		"__meta_gce_subnetwork":    gceMetadata.Subnetwork,
+		"__meta_gce_public_ip":     gceMetadata.PublicIP,
+		"__meta_gce_private_ip":    gceMetadata.PrivateIP,
+		"__meta_gce_tags":          gceMetadata.Tags,
+		"__meta_gce_machine_type":  gceMetadata.MachineType,
+	}
+	prefix := "__meta_gce_"
+	for k, v := range gceMetadata.Metadata {
+		metaLabels[prefix+"metadata_"+k] = v
+	}
+
+	// Labels are not available using the GCE metadata API.
+	// TODO(b/246995462): Add support for labels.
+	//
+	// for k, v := range gceMetadata.Label {
+	// 	metaLabels[prefix+"label_"+k] = v
+	// }
+
+	for k, v := range gceMetadata.InterfaceIPv4 {
+		metaLabels[prefix+"interface_ipv4_nic"+k] = v
+	}
+
+	// Set the location, namespace and cluster labels.
+	metaLabels["location"] = gceMetadata.Zone
+	metaLabels["namespace"] = gceMetadata.InstanceID
+	metaLabels["cluster"] = "gce"
+
+	return metaLabels
 }
 
 func validatePrometheusConfig(sl validator.StructLevel) {
@@ -134,10 +205,18 @@ func validatePrometheus(promConfig promconfig.Config) (string, error) {
 	}
 
 	for _, sc := range promConfig.ScrapeConfigs {
+		for _, rc := range sc.RelabelConfigs {
+			if rc.TargetLabel == "location" || rc.TargetLabel == "namespace" || rc.TargetLabel == "cluster" {
+				return "relabel_config", fmt.Errorf("error validating scrapeconfig for job %v: %v", sc.JobName, "relabel_configs cannot rename location, namespace or cluster")
+			}
+		}
 		for _, rc := range sc.MetricRelabelConfigs {
 			if rc.TargetLabel == "__name__" {
 				// TODO(#2297): Remove validation after renaming is fixed
 				return "metric_relabel_config", fmt.Errorf("error validating scrapeconfig for job %v: %v", sc.JobName, "metric_relabel_configs cannot rename __name__")
+			}
+			if rc.TargetLabel == "location" || rc.TargetLabel == "namespace" || rc.TargetLabel == "cluster" {
+				return "metric_relabel_config", fmt.Errorf("error validating scrapeconfig for job %v: %v", sc.JobName, "metric_relabel_configs cannot rename location, namespace or cluster")
 			}
 		}
 

--- a/confgenerator/resourcedetector/gce_detector.go
+++ b/confgenerator/resourcedetector/gce_detector.go
@@ -85,6 +85,10 @@ func (GCEResource) GetType() string {
 	return "gce"
 }
 
+type GCEResourceBuilderInterface interface {
+	GetResource() (Resource, error)
+}
+
 type GCEResourceBuilder struct {
 	provider gceDataProvider
 }

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_prometheus_invalid_metric_relabel/golden_error
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_prometheus_invalid_metric_relabel/golden_error
@@ -1,0 +1,1 @@
+Key: 'PrometheusMetrics.config.config' Error:Field validation for 'config' failed on the 'error validating scrapeconfig for job prometheus: metric_relabel_configs cannot rename location, namespace or cluster' tag

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_prometheus_invalid_metric_relabel/input.yaml
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_prometheus_invalid_metric_relabel/input.yaml
@@ -1,0 +1,39 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+metrics:
+  receivers:
+    prometheus:
+        type: prometheus
+        config:
+          scrape_configs:
+          - job_name: prometheus
+            static_configs:
+            - targets:
+              - localhost:1234
+            relabel_configs:
+            - source_labels: [__meta_gce_zone]
+              regex: '(.+)'
+              replacement: '$${1}'
+              target_label: new_location
+            metric_relabel_configs:
+            - source_labels: [new_location]
+              regex: '(.+)'
+              replacement: '$${1}'
+              target_label: location
+  service:
+    pipelines:
+      prometheus_pipeline:
+        receivers:
+          - prometheus

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_prometheus_invalid_relabel/golden_error
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_prometheus_invalid_relabel/golden_error
@@ -1,0 +1,1 @@
+Key: 'PrometheusMetrics.config.config' Error:Field validation for 'config' failed on the 'error validating scrapeconfig for job prometheus: relabel_configs cannot rename location, namespace or cluster' tag

--- a/confgenerator/testdata/invalid/linux/metrics-receiver_prometheus_invalid_relabel/input.yaml
+++ b/confgenerator/testdata/invalid/linux/metrics-receiver_prometheus_invalid_relabel/input.yaml
@@ -1,0 +1,34 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+metrics:
+  receivers:
+    prometheus:
+        type: prometheus
+        config:
+          scrape_configs:
+          - job_name: prometheus
+            static_configs:
+            - targets:
+              - localhost:1234
+            relabel_configs:
+            - source_labels: [__meta_gce_zone]
+              regex: '(.+)'
+              replacement: '$${1}'
+              target_label: location
+  service:
+    pipelines:
+      prometheus_pipeline:
+        receivers:
+          - prometheus

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden_otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden_otel.yaml
@@ -47,6 +47,11 @@ processors:
         - otelcol_process_memory_rss
         - otelcol_grpc_io_client_completed_rpcs
         - otelcol_googlecloudmonitoring_point_count
+  groupbyattrs/custom_prometheus:
+    keys:
+    - namespace
+    - cluster
+    - location
   metricstransform/default__pipeline_hostmetrics_2:
     transforms:
     - action: update
@@ -471,14 +476,13 @@ receivers:
           labels:
             __meta_gce_instance_id: test-instance-id
             __meta_gce_instance_name: test-instance-name
-            __meta_gce_interface_ipv4_nictest-interface: test-interface-ipv4
+            __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test-key: test-value
+            __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip
-            __meta_gce_project_id: test-project
+            __meta_gce_project: test-project
             __meta_gce_public_ip: test-public-ip
-            __meta_gce_subnetwork: test-subnetwork
             __meta_gce_tags: test-tag
             __meta_gce_zone: test-zone
             cluster: gce
@@ -518,7 +522,8 @@ service:
     metrics/prometheus__pipeline_prometheus:
       exporters:
       - googlemanagedprometheus
-      processors: []
+      processors:
+      - groupbyattrs/custom_prometheus
       receivers:
       - prometheus/prometheus__pipeline_prometheus
   telemetry:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden_otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden_otel.yaml
@@ -468,6 +468,22 @@ receivers:
         static_configs:
         - targets:
           - localhost:1234
+          labels:
+            __meta_gce_instance_id: test-instance-id
+            __meta_gce_instance_name: test-instance-name
+            __meta_gce_interface_ipv4_nictest-interface: test-interface-ipv4
+            __meta_gce_machine_type: test-machine-type
+            __meta_gce_metadata_test-key: test-value
+            __meta_gce_network: test-network
+            __meta_gce_private_ip: test-private-ip
+            __meta_gce_project_id: test-project
+            __meta_gce_public_ip: test-public-ip
+            __meta_gce_subnetwork: test-subnetwork
+            __meta_gce_tags: test-tag
+            __meta_gce_zone: test-zone
+            cluster: gce
+            location: test-zone
+            namespace: test-instance-id
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden_otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden_otel.yaml
@@ -47,6 +47,11 @@ processors:
         - otelcol_process_memory_rss
         - otelcol_grpc_io_client_completed_rpcs
         - otelcol_googlecloudmonitoring_point_count
+  groupbyattrs/custom_prometheus:
+    keys:
+    - namespace
+    - cluster
+    - location
   metricstransform/default__pipeline_hostmetrics_2:
     transforms:
     - action: update
@@ -464,14 +469,13 @@ receivers:
           labels:
             __meta_gce_instance_id: test-instance-id
             __meta_gce_instance_name: test-instance-name
-            __meta_gce_interface_ipv4_nictest-interface: test-interface-ipv4
+            __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test-key: test-value
+            __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip
-            __meta_gce_project_id: test-project
+            __meta_gce_project: test-project
             __meta_gce_public_ip: test-public-ip
-            __meta_gce_subnetwork: test-subnetwork
             __meta_gce_tags: test-tag
             __meta_gce_zone: test-zone
             cluster: gce
@@ -521,14 +525,13 @@ receivers:
           labels:
             __meta_gce_instance_id: test-instance-id
             __meta_gce_instance_name: test-instance-name
-            __meta_gce_interface_ipv4_nictest-interface: test-interface-ipv4
+            __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test-key: test-value
+            __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip
-            __meta_gce_project_id: test-project
+            __meta_gce_project: test-project
             __meta_gce_public_ip: test-public-ip
-            __meta_gce_subnetwork: test-subnetwork
             __meta_gce_tags: test-tag
             __meta_gce_zone: test-zone
             cluster: gce
@@ -568,7 +571,8 @@ service:
     metrics/prometheus__pipeline_prometheus:
       exporters:
       - googlemanagedprometheus
-      processors: []
+      processors:
+      - groupbyattrs/custom_prometheus
       receivers:
       - prometheus/prometheus__pipeline_prometheus
   telemetry:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/input.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/input.yaml
@@ -30,11 +30,11 @@ metrics:
                 - source_labels: [ __address__ ]
                   action: replace
                   replacement: 'new_location'
-                  target_label: location
+                  target_label: exported_location
                 - source_labels: [ __address__ ]
                   action: replace
                   replacement: 'new_cluster'
-                  target_label: cluster
+                  target_label: exported_cluster
                 - source_labels: [__meta_gce_machine_type]
                   regex: '(.+)'
                   replacement: '$${1}'

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden_otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden_otel.yaml
@@ -47,6 +47,11 @@ processors:
         - otelcol_process_memory_rss
         - otelcol_grpc_io_client_completed_rpcs
         - otelcol_googlecloudmonitoring_point_count
+  groupbyattrs/custom_prometheus:
+    keys:
+    - namespace
+    - cluster
+    - location
   metricstransform/default__pipeline_hostmetrics_2:
     transforms:
     - action: update
@@ -464,14 +469,13 @@ receivers:
           labels:
             __meta_gce_instance_id: test-instance-id
             __meta_gce_instance_name: test-instance-name
-            __meta_gce_interface_ipv4_nictest-interface: test-interface-ipv4
+            __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test-key: test-value
+            __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip
-            __meta_gce_project_id: test-project
+            __meta_gce_project: test-project
             __meta_gce_public_ip: test-public-ip
-            __meta_gce_subnetwork: test-subnetwork
             __meta_gce_tags: test-tag
             __meta_gce_zone: test-zone
             cluster: gce
@@ -511,7 +515,8 @@ service:
     metrics/prometheus__pipeline_prometheus:
       exporters:
       - googlemanagedprometheus
-      processors: []
+      processors:
+      - groupbyattrs/custom_prometheus
       receivers:
       - prometheus/prometheus__pipeline_prometheus
   telemetry:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden_otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden_otel.yaml
@@ -461,6 +461,22 @@ receivers:
         static_configs:
         - targets:
           - localhost:1234
+          labels:
+            __meta_gce_instance_id: test-instance-id
+            __meta_gce_instance_name: test-instance-name
+            __meta_gce_interface_ipv4_nictest-interface: test-interface-ipv4
+            __meta_gce_machine_type: test-machine-type
+            __meta_gce_metadata_test-key: test-value
+            __meta_gce_network: test-network
+            __meta_gce_private_ip: test-private-ip
+            __meta_gce_project_id: test-project
+            __meta_gce_public_ip: test-public-ip
+            __meta_gce_subnetwork: test-subnetwork
+            __meta_gce_tags: test-tag
+            __meta_gce_zone: test-zone
+            cluster: gce
+            location: test-zone
+            namespace: test-instance-id
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/f120d4527bd717cab023dbbe5fbdc332.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/f120d4527bd717cab023dbbe5fbdc332.lua
@@ -1,0 +1,42 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["agent.googleapis.com/log_file_path"]
+end)();
+local __field_1 = (function()
+if record["logging.googleapis.com/labels"] == nil
+then
+return nil
+end
+return record["logging.googleapis.com/labels"]["compute.googleapis.com/resource_name"]
+end)();
+local __field_2 = (function()
+return record["logging.googleapis.com/logName"]
+end)();
+(function(value)
+record["agent.googleapis.com/log_file_path"] = value
+end)(nil);
+local v = __field_0;
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/log_file_path"] = value
+end)(v)
+local v = __field_1;
+if v == nil then v = "" end;
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["compute.googleapis.com/resource_name"] = value
+end)(v)
+local v = __field_2;
+if v == nil then v = "syslog" end;
+(function(value)
+record["logging.googleapis.com/logName"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden_fluent_bit_main.conf
@@ -1,0 +1,82 @@
+@SET buffers_dir=/var/lib/google-cloud-ops-agent/fluent-bit/buffers
+@SET logs_dir=/var/log/google-cloud-ops-agent/subagents
+
+[SERVICE]
+    Daemon                    off
+    Flush                     1
+    Log_Level                 info
+    dns.resolver              legacy
+    storage.backlog.mem_limit 50M
+    storage.checksum          off
+    storage.max_chunks_up     128
+    storage.metrics           on
+    storage.sync              normal
+
+[INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 60
+    Scrape_On_Start True
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   5M
+    DB                ${buffers_dir}/default_pipeline_syslog
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              /var/log/messages,/var/log/syslog
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               default_pipeline.syslog
+    storage.type      filesystem
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   5M
+    DB                ${buffers_dir}/ops-agent-fluent-bit
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/logging-module.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-fluent-bit
+    storage.type      memory
+
+[FILTER]
+    Match  default_pipeline.syslog
+    Name   lua
+    call   process
+    script f120d4527bd717cab023dbbe5fbdc332.lua
+
+[OUTPUT]
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  20202

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden_otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden_otel.yaml
@@ -477,55 +477,51 @@ receivers:
           target_label: machine_type
           replacement: $${1}
           action: replace
-        static_configs:
-        - targets:
-          - localhost:1234
-          labels:
-            __meta_gce_instance_id: test-instance-id
-            __meta_gce_instance_name: test-instance-name
-            __meta_gce_interface_ipv4_nictest-interface: test-interface-ipv4
-            __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test-key: test-value
-            __meta_gce_network: test-network
-            __meta_gce_private_ip: test-private-ip
-            __meta_gce_project_id: test-project
-            __meta_gce_public_ip: test-public-ip
-            __meta_gce_subnetwork: test-subnetwork
-            __meta_gce_tags: test-tag
-            __meta_gce_zone: test-zone
-            cluster: gce
-            location: test-zone
-            namespace: test-instance-id
-      - job_name: job_2
-        honor_timestamps: true
-        scrape_interval: 10s
-        scrape_timeout: 10s
-        metrics_path: /metrics
-        scheme: http
-        follow_redirects: true
-        enable_http2: true
-        relabel_configs:
-        - source_labels: [__meta_gce_instance_name]
+        - source_labels: [__meta_gce_project_id]
           separator: ;
           regex: (.+)
-          target_label: instance_name
+          target_label: instance_project_id
           replacement: $${1}
           action: replace
-        - source_labels: [__meta_gce_instance_id]
+        - source_labels: [__meta_gce_zone]
           separator: ;
           regex: (.+)
-          target_label: instance_id
+          target_label: zone
           replacement: $${1}
           action: replace
-        - source_labels: [__meta_gce_machine_type]
+        - source_labels: [__meta_gce_tags]
           separator: ;
           regex: (.+)
-          target_label: machine_type
+          target_label: tags
+          replacement: $${1}
+          action: replace
+        - source_labels: [__meta_gce_network]
+          separator: ;
+          regex: (.+)
+          target_label: network
+          replacement: $${1}
+          action: replace
+        - source_labels: [__meta_gce_subnetwork]
+          separator: ;
+          regex: (.+)
+          target_label: subnetwork
+          replacement: $${1}
+          action: replace
+        - source_labels: [__meta_gce_public_ip]
+          separator: ;
+          regex: (.+)
+          target_label: public_ip
+          replacement: $${1}
+          action: replace
+        - source_labels: [__meta_gce_private_ip]
+          separator: ;
+          regex: (.+)
+          target_label: private_ip
           replacement: $${1}
           action: replace
         static_configs:
         - targets:
-          - localhost:1235
+          - 0.0.0.0:9100
           labels:
             __meta_gce_instance_id: test-instance-id
             __meta_gce_instance_name: test-instance-name

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden_otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden_otel.yaml
@@ -450,7 +450,7 @@ receivers:
         scrape_timeout: 10s
         evaluation_interval: 1m
       scrape_configs:
-      - job_name: prometheus
+      - job_name: Job_1
         honor_timestamps: true
         scrape_interval: 10s
         scrape_timeout: 10s
@@ -458,6 +458,25 @@ receivers:
         scheme: http
         follow_redirects: true
         enable_http2: true
+        relabel_configs:
+        - source_labels: [__meta_gce_instance_name]
+          separator: ;
+          regex: (.+)
+          target_label: instance_name
+          replacement: $${1}
+          action: replace
+        - source_labels: [__meta_gce_instance_id]
+          separator: ;
+          regex: (.+)
+          target_label: instance_id
+          replacement: $${1}
+          action: replace
+        - source_labels: [__meta_gce_machine_type]
+          separator: ;
+          regex: (.+)
+          target_label: machine_type
+          replacement: $${1}
+          action: replace
         static_configs:
         - targets:
           - localhost:1234
@@ -477,7 +496,7 @@ receivers:
             cluster: gce
             location: test-zone
             namespace: test-instance-id
-      - job_name: drop
+      - job_name: job_2
         honor_timestamps: true
         scrape_interval: 10s
         scrape_timeout: 10s
@@ -486,17 +505,17 @@ receivers:
         follow_redirects: true
         enable_http2: true
         relabel_configs:
-        - source_labels: [__address__]
+        - source_labels: [__meta_gce_instance_name]
           separator: ;
-          regex: (.*)
-          target_label: exported_location
-          replacement: new_location
+          regex: (.+)
+          target_label: instance_name
+          replacement: $${1}
           action: replace
-        - source_labels: [__address__]
+        - source_labels: [__meta_gce_instance_id]
           separator: ;
-          regex: (.*)
-          target_label: exported_cluster
-          replacement: new_cluster
+          regex: (.+)
+          target_label: instance_id
+          replacement: $${1}
           action: replace
         - source_labels: [__meta_gce_machine_type]
           separator: ;
@@ -504,20 +523,9 @@ receivers:
           target_label: machine_type
           replacement: $${1}
           action: replace
-        metric_relabel_configs:
-        - source_labels: [__name__]
-          separator: ;
-          regex: <dropped_metric_regex_1>
-          replacement: $1
-          action: drop
-        - source_labels: [__name__]
-          separator: ;
-          regex: <dropped_metric_regex_2>
-          replacement: $1
-          action: drop
         static_configs:
         - targets:
-          - 0.0.0.0:9100
+          - localhost:1235
           labels:
             __meta_gce_instance_id: test-instance-id
             __meta_gce_instance_name: test-instance-name

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden_otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden_otel.yaml
@@ -47,6 +47,11 @@ processors:
         - otelcol_process_memory_rss
         - otelcol_grpc_io_client_completed_rpcs
         - otelcol_googlecloudmonitoring_point_count
+  groupbyattrs/custom_prometheus:
+    keys:
+    - namespace
+    - cluster
+    - location
   metricstransform/default__pipeline_hostmetrics_2:
     transforms:
     - action: update
@@ -525,14 +530,13 @@ receivers:
           labels:
             __meta_gce_instance_id: test-instance-id
             __meta_gce_instance_name: test-instance-name
-            __meta_gce_interface_ipv4_nictest-interface: test-interface-ipv4
+            __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test-key: test-value
+            __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip
-            __meta_gce_project_id: test-project
+            __meta_gce_project: test-project
             __meta_gce_public_ip: test-public-ip
-            __meta_gce_subnetwork: test-subnetwork
             __meta_gce_tags: test-tag
             __meta_gce_zone: test-zone
             cluster: gce
@@ -572,7 +576,8 @@ service:
     metrics/prometheus__pipeline_prometheus:
       exporters:
       - googlemanagedprometheus
-      processors: []
+      processors:
+      - groupbyattrs/custom_prometheus
       receivers:
       - prometheus/prometheus__pipeline_prometheus
   telemetry:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/input.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/input.yaml
@@ -15,14 +15,14 @@
 metrics:
   receivers:
     prometheus:
-        type: prometheus
-        config:
-          scrape_configs:
-            - job_name: 'Job_1'
-              scrape_interval: 10s
-              static_configs:
-                - targets: ['localhost:1234']
-              relabel_configs:
+      type: prometheus
+      config:
+        scrape_configs:
+          - job_name: 'Job_1'
+            scrape_interval: 10s
+            static_configs:
+              - targets: ['0.0.0.0:9100']
+            relabel_configs:
               - source_labels: [__meta_gce_instance_name]
                 regex: '(.+)'
                 replacement: '$${1}'
@@ -35,25 +35,35 @@ metrics:
                 regex: '(.+)'
                 replacement: '$${1}'
                 target_label: machine_type
-            - job_name: 'job_2'
-              scrape_interval: 10s
-              static_configs:
-                - targets: ['localhost:1235']
-              relabel_configs:
-              - source_labels: [__meta_gce_instance_name]
+              - source_labels: [__meta_gce_project_id]
                 regex: '(.+)'
                 replacement: '$${1}'
-                target_label: instance_name
-              - source_labels: [__meta_gce_instance_id]
+                target_label: instance_project_id
+              - source_labels: [__meta_gce_zone]
                 regex: '(.+)'
                 replacement: '$${1}'
-                target_label: instance_id
-              - source_labels: [__meta_gce_machine_type]
+                target_label: zone
+              - source_labels: [__meta_gce_tags]
                 regex: '(.+)'
                 replacement: '$${1}'
-                target_label: machine_type
+                target_label: tags
+              - source_labels: [__meta_gce_network]
+                regex: '(.+)'
+                replacement: '$${1}'
+                target_label: network
+              - source_labels: [__meta_gce_subnetwork]
+                regex: '(.+)'
+                replacement: '$${1}'
+                target_label: subnetwork
+              - source_labels: [__meta_gce_public_ip]
+                regex: '(.+)'
+                replacement: '$${1}'
+                target_label: public_ip
+              - source_labels: [__meta_gce_private_ip]
+                regex: '(.+)'
+                replacement: '$${1}'
+                target_label: private_ip
   service:
     pipelines:
       prometheus_pipeline:
-        receivers:
-          - prometheus
+        receivers: [prometheus]

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/input.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/input.yaml
@@ -1,0 +1,59 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+metrics:
+  receivers:
+    prometheus:
+        type: prometheus
+        config:
+          scrape_configs:
+            - job_name: 'Job_1'
+              scrape_interval: 10s
+              static_configs:
+                - targets: ['localhost:1234']
+              relabel_configs:
+              - source_labels: [__meta_gce_instance_name]
+                regex: '(.+)'
+                replacement: '$${1}'
+                target_label: instance_name
+              - source_labels: [__meta_gce_instance_id]
+                regex: '(.+)'
+                replacement: '$${1}'
+                target_label: instance_id
+              - source_labels: [__meta_gce_machine_type]
+                regex: '(.+)'
+                replacement: '$${1}'
+                target_label: machine_type
+            - job_name: 'job_2'
+              scrape_interval: 10s
+              static_configs:
+                - targets: ['localhost:1235']
+              relabel_configs:
+              - source_labels: [__meta_gce_instance_name]
+                regex: '(.+)'
+                replacement: '$${1}'
+                target_label: instance_name
+              - source_labels: [__meta_gce_instance_id]
+                regex: '(.+)'
+                replacement: '$${1}'
+                target_label: instance_id
+              - source_labels: [__meta_gce_machine_type]
+                regex: '(.+)'
+                replacement: '$${1}'
+                target_label: machine_type
+  service:
+    pipelines:
+      prometheus_pipeline:
+        receivers:
+          - prometheus

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden_otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden_otel.yaml
@@ -466,6 +466,22 @@ receivers:
         static_configs:
         - targets:
           - localhost:1234
+          labels:
+            __meta_gce_instance_id: test-instance-id
+            __meta_gce_instance_name: test-instance-name
+            __meta_gce_interface_ipv4_nictest-interface: test-interface-ipv4
+            __meta_gce_machine_type: test-machine-type
+            __meta_gce_metadata_test-key: test-value
+            __meta_gce_network: test-network
+            __meta_gce_private_ip: test-private-ip
+            __meta_gce_project_id: test-project
+            __meta_gce_public_ip: test-public-ip
+            __meta_gce_subnetwork: test-subnetwork
+            __meta_gce_tags: test-tag
+            __meta_gce_zone: test-zone
+            cluster: gce
+            location: test-zone
+            namespace: test-instance-id
 service:
   pipelines:
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden_otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden_otel.yaml
@@ -47,6 +47,11 @@ processors:
         - otelcol_process_memory_rss
         - otelcol_grpc_io_client_completed_rpcs
         - otelcol_googlecloudmonitoring_point_count
+  groupbyattrs/custom_prometheus:
+    keys:
+    - namespace
+    - cluster
+    - location
   metricstransform/default__pipeline_hostmetrics_2:
     transforms:
     - action: update
@@ -469,14 +474,13 @@ receivers:
           labels:
             __meta_gce_instance_id: test-instance-id
             __meta_gce_instance_name: test-instance-name
-            __meta_gce_interface_ipv4_nictest-interface: test-interface-ipv4
+            __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test-key: test-value
+            __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip
-            __meta_gce_project_id: test-project
+            __meta_gce_project: test-project
             __meta_gce_public_ip: test-public-ip
-            __meta_gce_subnetwork: test-subnetwork
             __meta_gce_tags: test-tag
             __meta_gce_zone: test-zone
             cluster: gce
@@ -516,7 +520,8 @@ service:
     metrics/prometheus__pipeline_prometheus:
       exporters:
       - googlemanagedprometheus
-      processors: []
+      processors:
+      - groupbyattrs/custom_prometheus
       receivers:
       - prometheus/prometheus__pipeline_prometheus
   telemetry:

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	cloud.google.com/go/storage v1.22.1
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.1.3
+	github.com/davecgh/go-spew v1.1.1
 	github.com/go-playground/validator/v10 v10.9.0
 	github.com/goccy/go-yaml v1.9.4
 	github.com/google/go-cmp v0.5.8
@@ -53,7 +54,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cncf/xds/go v0.0.0-20220314180256-7f1daf1720fc // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/digitalocean/godo v1.82.0 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v20.10.17+incompatible // indirect

--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -232,7 +232,7 @@ func WaitForUptimeMetrics(ctx context.Context, logger *log.Logger, vm *gce.VM, s
 			}
 			_, err := gce.WaitForMetric(
 				ctx, logger, vm, "agent.googleapis.com/agent/uptime", TrailingQueryWindow,
-				[]string{fmt.Sprintf("metric.labels.version = starts_with(%q)", service.UptimeMetricName)})
+				[]string{fmt.Sprintf("metric.labels.version = starts_with(%q)", service.UptimeMetricName)}, false)
 			c <- err
 		}()
 	}

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -384,7 +384,7 @@ func lookupMetric(ctx context.Context, logger *log.Logger, vm *VM, metric string
 	end := timestamppb.New(now)
 	filters := []string{
 		fmt.Sprintf("metric.type = %q", metric),
-		fmt.Sprintf(`resource.labels.instance_id = "%d"`, vm.ID),
+		// fmt.Sprintf(`resource.labels.instance_id = "%d"`, vm.ID),
 	}
 
 	req := &monitoringpb.ListTimeSeriesRequest{

--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -491,7 +491,7 @@ func runMetricsTestCases(ctx context.Context, logger *logging.DirectoryLogger, v
 }
 
 func assertMetric(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.VM, metric *metadata.ExpectedMetric) error {
-	series, err := gce.WaitForMetric(ctx, logger.ToMainLog(), vm, metric.Type, 1*time.Hour, nil)
+	series, err := gce.WaitForMetric(ctx, logger.ToMainLog(), vm, metric.Type, 1*time.Hour, nil, false)
 	if err != nil {
 		// Optional metrics can be missing
 		if metric.Optional && gce.IsExhaustedRetriesMetricError(err) {


### PR DESCRIPTION
This change adds the following:
- [x] Hooks up the receiver to the metadata detector
- [x] Adds labels to every static config
- [x] Adds unit tests
- [x] Adds integration tests
- [x] Disallows updating namespace, location and cluster labels

## Description
<!--- Describe your changes in detail. -->

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [x] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
