### PR TITLE
Install varnish on centos7

### DIFF
--- a/integration_test/third_party_apps_data/applications/varnish/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/varnish/centos_rhel/install
@@ -1,8 +1,25 @@
 set -e
 
-# Centos Stream / RHEL 8: Varnish 6.0.8
+source /etc/os-release
+if [ "$ID" = centos ] && [ "$VERSION_ID" = 7 ]; then
+    sudo yum install -y epel-release
+    sudo tee /etc/yum.repos.d/varnishcache_varnish60lts.repo > /dev/null <<-EOF
+[varnishcache_varnish60lts]
+name=varnishcache_varnish60lts
+baseurl=https://packagecloud.io/varnishcache/varnish60lts/el/${VERSION_ID%%.*}/$(arch)
+repo_gpgcheck=0
+gpgcheck=0
+enabled=1
+gpgkey=https://packagecloud.io/varnishcache/varnish60lts/gpgkey
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300
+EOF
+fi
 
+# Centos Stream / RHEL 8: Varnish 6.0.8
 sudo yum install -y varnish nginx curl
+
 sudo systemctl enable --now varnish
 sudo systemctl enable --now nginx
 

--- a/integration_test/third_party_apps_data/applications/varnish/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/varnish/centos_rhel/install
@@ -17,7 +17,6 @@ metadata_expire=300
 EOF
 fi
 
-# Centos Stream / RHEL 8: Varnish 6.0.8
 sudo yum install -y varnish nginx curl
 
 sudo systemctl enable --now varnish


### PR DESCRIPTION
## Description
There's an issue installing varnish & nginx on centos7, this resolves the issue using the recommended installation instructions [here](https://www.varnish-software.com/developers/tutorials/installing-varnish-centos/).

## How has this been tested?
Tested that it successfully installed on a centos7 gcp image.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
