### PR TITLE
Update opentelemetry-operations-collector

### DIFF
--- a/apps/iis.go
+++ b/apps/iis.go
@@ -55,10 +55,12 @@ func (r MetricsReceiverIis) Pipelines() []otel.Pipeline {
 				),
 				otel.CondenseResourceMetrics(),
 				otel.MetricsTransform(
-					otel.AggregateLabels(
-						"sum",
-						"direction",
-						"request",
+					otel.UpdateMetricRegexp("^iis",
+						otel.AggregateLabels(
+							"sum",
+							"direction",
+							"request",
+						),
 					),
 					otel.AddPrefix("workload.googleapis.com"),
 				),

--- a/confgenerator/otel/processors.go
+++ b/confgenerator/otel/processors.go
@@ -191,6 +191,19 @@ func UpdateMetric(metric string, operations ...map[string]interface{}) map[strin
 	return out
 }
 
+// UpdateMetricRegexp returns a config snippet applies transformations to the given metric name regex
+func UpdateMetricRegexp(metricRegex string, operations ...map[string]interface{}) map[string]interface{} {
+	out := map[string]interface{}{
+		"include":    metricRegex,
+		"match_type": "regexp",
+		"action":     "update",
+	}
+	if len(operations) > 0 {
+		out["operations"] = operations
+	}
+	return out
+}
+
 // DuplicateMetric returns a config snippet that copies old to new, applying zero or more transformations.
 func DuplicateMetric(old, new string, operations ...map[string]interface{}) map[string]interface{} {
 	out := map[string]interface{}{

--- a/confgenerator/otel/processors.go
+++ b/confgenerator/otel/processors.go
@@ -157,6 +157,15 @@ func SummaryCountValToSum(metricName, aggregation string, isMonotonic bool) Tran
 	return TransformQuery(fmt.Sprintf(`convert_summary_count_val_to_sum("%s",  %t) where metric.name == "%s"`, aggregation, isMonotonic, metricName))
 }
 
+// RetainResource retains the resource attributes provided, and drops all other attributes.
+func RetainResource(resourceAttributeKeys ...string) TransformQuery {
+	keyList := ""
+	for _, key := range resourceAttributeKeys {
+		keyList += fmt.Sprintf(`, "%s"`, key)
+	}
+	return TransformQuery(fmt.Sprintf(`keep_keys(resource.attributes%s)`, keyList))
+}
+
 // RenameMetric returns a config snippet that renames old to new, applying zero or more transformations.
 func RenameMetric(old, new string, operations ...map[string]interface{}) map[string]interface{} {
 	out := map[string]interface{}{
@@ -284,5 +293,15 @@ func AggregateLabelValues(aggregationType string, label string, new string, old 
 		"label":             label,
 		"new_value":         new,
 		"aggregated_values": old,
+	}
+}
+
+// CondenseResourceMetrics merges multiple resource metrics on
+// a slice of metrics to a single resource metrics payload, if they have the same
+// resource.
+func CondenseResourceMetrics() Component {
+	return Component{
+		Type:   "groupbyattrs",
+		Config: map[string]any{},
 	}
 }

--- a/confgenerator/otel/processors.go
+++ b/confgenerator/otel/processors.go
@@ -191,7 +191,8 @@ func UpdateMetric(metric string, operations ...map[string]interface{}) map[strin
 	return out
 }
 
-// UpdateMetricRegexp returns a config snippet applies transformations to the given metric name regex
+// UpdateMetricRegexp returns a config snippet that applies transformations to metrics matching
+// the input regex
 func UpdateMetricRegexp(metricRegex string, operations ...map[string]interface{}) map[string]interface{} {
 	out := map[string]interface{}{
 		"include":    metricRegex,

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden_otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden_otel.yaml
@@ -422,11 +422,15 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/iispipeline_iis__v2_3:
     transforms:
-    - action: aggregate_labels
-      aggregation_type: sum
-      label_set:
-      - direction
-      - request
+    - action: update
+      include: ^iis
+      match_type: regexp
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - direction
+        - request
     - action: update
       include: ^(.*)$$
       match_type: regexp

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden_otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden_otel.yaml
@@ -60,6 +60,7 @@ processors:
         - otelcol_process_memory_rss
         - otelcol_grpc_io_client_completed_rpcs
         - otelcol_googlecloudmonitoring_point_count
+  groupbyattrs/iispipeline_iis__v2_2: {}
   metricstransform/default__pipeline_hostmetrics_2:
     transforms:
     - action: update
@@ -419,8 +420,13 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  metricstransform/iispipeline_iis__v2_1:
+  metricstransform/iispipeline_iis__v2_3:
     transforms:
+    - action: aggregate_labels
+      aggregation_type: sum
+      label_set:
+      - direction
+      - request
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -472,10 +478,19 @@ processors:
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
   normalizesums/default__pipeline_iis_2: {}
-  normalizesums/iispipeline_iis__v2_0: {}
+  normalizesums/iispipeline_iis__v2_4: {}
   resourcedetection/_global_0:
     detectors:
     - gce
+  transform/iispipeline_iis__v2_0:
+    metrics:
+      queries:
+      - set(attributes["site"], resource.attributes["iis.site"])
+      - set(attributes["app_pool"], resource.attributes["iis.application_pool"])
+  transform/iispipeline_iis__v2_1:
+    metrics:
+      queries:
+      - keep_keys(resource.attributes)
 receivers:
   hostmetrics/default__pipeline_hostmetrics:
     collection_interval: 60s
@@ -587,8 +602,11 @@ service:
       exporters:
       - googlecloud
       processors:
-      - normalizesums/iispipeline_iis__v2_0
-      - metricstransform/iispipeline_iis__v2_1
+      - transform/iispipeline_iis__v2_0
+      - transform/iispipeline_iis__v2_1
+      - groupbyattrs/iispipeline_iis__v2_2
+      - metricstransform/iispipeline_iis__v2_3
+      - normalizesums/iispipeline_iis__v2_4
       - resourcedetection/_global_0
       receivers:
       - iis/iispipeline_iis__v2

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden_otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden_otel.yaml
@@ -28,7 +28,7 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/default__pipeline_iis_2:
+  filter/default__pipeline_iis_5:
     metrics:
       exclude:
         match_type: regexp
@@ -55,6 +55,8 @@ processors:
         - otelcol_process_memory_rss
         - otelcol_grpc_io_client_completed_rpcs
         - otelcol_googlecloudmonitoring_point_count
+  groupbyattrs/default__pipeline_iis_2: {}
+  groupbyattrs/iispipeline_iis_2: {}
   metricstransform/default__pipeline_hostmetrics_2:
     transforms:
     - action: update
@@ -329,8 +331,13 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  metricstransform/default__pipeline_iis_1:
+  metricstransform/default__pipeline_iis_3:
     transforms:
+    - action: aggregate_labels
+      aggregation_type: sum
+      label_set:
+      - direction
+      - request
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -392,8 +399,13 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  metricstransform/iispipeline_iis_1:
+  metricstransform/iispipeline_iis_3:
     transforms:
+    - action: aggregate_labels
+      aggregation_type: sum
+      label_set:
+      - direction
+      - request
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -444,11 +456,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  normalizesums/default__pipeline_iis_0: {}
-  normalizesums/iispipeline_iis_0: {}
+  normalizesums/default__pipeline_iis_4: {}
+  normalizesums/iispipeline_iis_4: {}
   resourcedetection/_global_0:
     detectors:
     - gce
+  transform/default__pipeline_iis_0:
+    metrics:
+      queries:
+      - set(attributes["site"], resource.attributes["iis.site"])
+      - set(attributes["app_pool"], resource.attributes["iis.application_pool"])
+  transform/default__pipeline_iis_1:
+    metrics:
+      queries:
+      - keep_keys(resource.attributes)
+  transform/iispipeline_iis_0:
+    metrics:
+      queries:
+      - set(attributes["site"], resource.attributes["iis.site"])
+      - set(attributes["app_pool"], resource.attributes["iis.application_pool"])
+  transform/iispipeline_iis_1:
+    metrics:
+      queries:
+      - keep_keys(resource.attributes)
 receivers:
   hostmetrics/default__pipeline_hostmetrics:
     collection_interval: 60s
@@ -515,9 +545,12 @@ service:
       exporters:
       - googlecloud
       processors:
-      - normalizesums/default__pipeline_iis_0
-      - metricstransform/default__pipeline_iis_1
-      - filter/default__pipeline_iis_2
+      - transform/default__pipeline_iis_0
+      - transform/default__pipeline_iis_1
+      - groupbyattrs/default__pipeline_iis_2
+      - metricstransform/default__pipeline_iis_3
+      - normalizesums/default__pipeline_iis_4
+      - filter/default__pipeline_iis_5
       - resourcedetection/_global_0
       receivers:
       - iis/default__pipeline_iis
@@ -543,8 +576,11 @@ service:
       exporters:
       - googlecloud
       processors:
-      - normalizesums/iispipeline_iis_0
-      - metricstransform/iispipeline_iis_1
+      - transform/iispipeline_iis_0
+      - transform/iispipeline_iis_1
+      - groupbyattrs/iispipeline_iis_2
+      - metricstransform/iispipeline_iis_3
+      - normalizesums/iispipeline_iis_4
       - resourcedetection/_global_0
       receivers:
       - iis/iispipeline_iis

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden_otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden_otel.yaml
@@ -333,11 +333,15 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/default__pipeline_iis_3:
     transforms:
-    - action: aggregate_labels
-      aggregation_type: sum
-      label_set:
-      - direction
-      - request
+    - action: update
+      include: ^iis
+      match_type: regexp
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - direction
+        - request
     - action: update
       include: ^(.*)$$
       match_type: regexp
@@ -401,11 +405,15 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/iispipeline_iis_3:
     transforms:
-    - action: aggregate_labels
-      aggregation_type: sum
-      label_set:
-      - direction
-      - request
+    - action: update
+      include: ^iis
+      match_type: regexp
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - direction
+        - request
     - action: update
       include: ^(.*)$$
       match_type: regexp


### PR DESCRIPTION
## Description
- Update opentelemetry-operations-collector to latest to take in OTel v0.61.0.
- In v0.61.0 of opentelemetry-collector-contrib, the IIS receiver now emits metrics per-site. This PR adds in extra configuration to retain the old behavior, where metrics are sums of all sites.

## How has this been tested?
Update goldens, test build to make sure metrics still show up
<img width="1701" alt="Screen Shot 2022-09-29 at 2 06 21 PM" src="https://user-images.githubusercontent.com/10042942/193109565-cb01fb21-c467-4038-b8e6-95bfd071beca.png">

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.
