### PR TITLE
Revert aerospike expected_logs

### DIFF
--- a/integration_test/third_party_apps_data/applications/aerospike/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/aerospike/metadata.yaml
@@ -86,13 +86,14 @@ expected_metrics:
     monitored_resource: gce_instance
     type: workload.googleapis.com/aerospike.node.memory.free
     value_type: INT64
-expected_logs:
-  - log_name: syslog
-    fields:
-      - name: jsonPayload.message
-        value_regex: ' asd(\[[0-9]+\])*:'
-        type: string
-        description: Aerospike application logs written to Journald.
+# TODO (b/239240173#comment5): Re-enable once we get SLES 15 logs to go to syslog instead of a local file during tests.
+# expected_logs:
+#   - log_name: syslog
+#     fields:
+#       - name: jsonPayload.message
+#         value_regex: ' asd(\[[0-9]+\])*:'
+#         type: string
+#         description: Aerospike application logs written to Journald.
 configuration_options:
   metrics:
     - type: aerospike


### PR DESCRIPTION
## Description
Discovered an issue affecting logs tests on SLES 15. Revert for now until we resolve the issue.

## Related issue
b/239240173#comment5

## How has this been tested?
Ran unit tests locally, will run integration tests in PR.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [x] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
