### PR TITLE
Testing: Conserve external IPv4 addresses on Kokoro

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -64,7 +64,7 @@ triggered from GitHub.
 USE_INTERNAL_IP: If set to "true", pass --no-address to gcloud when creating
 VMs. This will not create an external IP address for that VM (because those are
 expensive), and instead the VM will use cloud NAT to get to the external
-interet. ssh-ing to the VM is done via its internal IP address.
+internet. ssh-ing to the VM is done via its internal IP address.
 Only useful on Kokoro.
 
 SERVICE_EMAIL: If provided, which service account to use for spawned VMs. The

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -995,6 +995,13 @@ func attemptCreateInstance(ctx context.Context, logger *log.Logger, options VMOp
 	if email := os.Getenv("SERVICE_EMAIL"); email != "" {
 		args = append(args, "--service-account="+email)
 	}
+	if internalIP := os.Getenv("USE_INTERNAL_IP"); internalIP == "true" {
+		// Don't assign an external IP address. This is to avoid using up
+		// a very limited budget of external IPv4 addresses. The instances
+		// will talk to the external internet by routing through a Cloud NAT
+		// gateway that is configured in our testing project.
+		args = append(args, "--no-address")
+	}
 	args = append(args, options.ExtraCreateArguments...)
 
 	output, err := RunGcloud(ctx, logger, "", args)

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -61,8 +61,10 @@ logs will be uploaded. If unset, this will point to
 ops-agents-public-buckets-test-logs, which should work for all tests
 triggered from GitHub.
 
-USE_INTERNAL_IP: Whether to try to connect to the VMs' internal IP addresses
-(if set to "true"), or external IP addresses (in all other cases).
+USE_INTERNAL_IP: If set to "true", pass --no-address to gcloud when creating
+VMs. This will not create an external IP address for that VM (because those are
+expensive), and instead the VM will use cloud NAT to get to the external
+interet. ssh-ing to the VM is done via its internal IP address.
 Only useful on Kokoro.
 
 SERVICE_EMAIL: If provided, which service account to use for spawned VMs. The

--- a/kokoro/config/test/common.gcl
+++ b/kokoro/config/test/common.gcl
@@ -12,6 +12,9 @@ template config common = {
       // Note: if we ever need to change regions, we will need to set up a new
       // Cloud Router and Cloud NAT gateway for that region. This is because
       // we use --no-address on Kokoro, because of b/169084857.
+      // The new Cloud NAT gateway must have "Minimum ports per VM instance"
+      // set to something >160 as per this article:
+      // https://www.suse.com/support/kb/doc/?id=000019662
       ZONE = 'us-central1-b'
 
       PLATFORMS = join(platforms, ',')

--- a/kokoro/config/test/common.gcl
+++ b/kokoro/config/test/common.gcl
@@ -9,6 +9,9 @@ template config common = {
 
     environment = {
       PROJECT = 'stackdriver-test-143416'
+      // Note: if we ever need to change regions, we will need to set up a new
+      // Cloud Router and Cloud NAT gateway for that region. This is because
+      // we use --no-address on Kokoro, because of b/169084857.
       ZONE = 'us-central1-b'
 
       PLATFORMS = join(platforms, ',')

--- a/kokoro/config/test/common.gcl
+++ b/kokoro/config/test/common.gcl
@@ -36,11 +36,12 @@ template config go_test = common {
     environment {
       TEST_SUITE_NAME = test_suite
 
-      // The firewall rules for our test project don't allow us to ssh/RDP
-      // from the Kokoro worker into the VM under test via the external IP
-      // address. Using the internal IP address gets around this issue though
-      // (but only because the Kokoro worker is in the same project as the VM
-      // under test).
+      // Use a codepath that conserves external IPv4 addresses for quota
+      // reasons. The VMs will not be assigned external IPv4 addresses.
+      // Outgoing connections will use Cloud NAT, and incoming connections
+      // use the VM's internal IP address, which only works because the
+      // Kokoro worker is running in the same network as the spawned VM.
+      // Using the internal IP address also avoids issues with the firewall.
       USE_INTERNAL_IP = 'true'
 
       // TRANSFERS_BUCKET and SERVICE_EMAIL are always modified as a pair.


### PR DESCRIPTION
## Description

Solves our issues with running out of IP addresses quota. This is done by passing --no-address to gcloud when creating
VMs. This will not create an external IP address for that VM, and instead the VM will use cloud NAT to get to the external
internet. This took a lot of research to figure out how to do this.

A last minute gotcha was that I needed to set the "Minimum ports per VM instance" to >160, according to https://www.suse.com/support/kb/doc/?id=000019662.

## Related issue
b/169084857

## How has this been tested?
integration tests

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.