### PR TITLE
Update validate_metadata_test.go

### DIFF
--- a/integration_test/validate_metadata_test.go
+++ b/integration_test/validate_metadata_test.go
@@ -64,9 +64,8 @@ func TestThirdPartyPublicUrls(t *testing.T) {
 	err := walkThirdPartyApps(func(contents []byte) error {
 		integrationMetadata := &metadata.IntegrationMetadata{}
 		err := metadata.UnmarshalAndValidate(contents, integrationMetadata)
-		if integrationMetadata.MinimumSupportedAgentVersion == nil {
-			// If the application support has not been released, it will not
-			// have a public URL to validate
+		if integrationMetadata.PublicUrl == nil {
+			// The public doc isn't available yet. 
 			return nil
 		}
 		if err != nil {

--- a/integration_test/validate_metadata_test.go
+++ b/integration_test/validate_metadata_test.go
@@ -64,7 +64,7 @@ func TestThirdPartyPublicUrls(t *testing.T) {
 	err := walkThirdPartyApps(func(contents []byte) error {
 		integrationMetadata := &metadata.IntegrationMetadata{}
 		err := metadata.UnmarshalAndValidate(contents, integrationMetadata)
-		if integrationMetadata.PublicUrl == nil {
+		if integrationMetadata.PublicUrl == "" {
 			// The public doc isn't available yet. 
 			return nil
 		}


### PR DESCRIPTION
## Description
public_url isn't assigned when it's a new app and google technical writer hasn't triggered the doc generation to update the corresponding apps's public_urls

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
Doesn't apply

## Checklist:
- Unit tests
  - [x ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
