### PR TITLE
Prometheus receiver: bump build version to create new build with regex fix

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-PKG_VERSION="2.22.0+pre.prometheus.1"
+PKG_VERSION="2.22.0+pre.prometheus.2"


### PR DESCRIPTION
## Description
Bump build version to `2.22.0+pre.prometheus.2` so that new build can be created for the regex fix. 
Since RPM has issue with `-` leading the pre-release identifier, we will only have the build meta `pre.prometheus.x` here. 

## Related issue
b/249318395

## How has this been tested?
N/A

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [x] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
