### PR TITLE
Running all 3rd party integration tests when a submodule is changed

### DIFF
--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -658,13 +658,14 @@ func modifiedFiles(t *testing.T) []string {
 // Checks the extracted app names against the set of all known apps.
 func determineImpactedApps(mf []string, allApps map[string]metadata.IntegrationMetadata) map[string]bool {
 	impactedApps := make(map[string]bool)
+	defer log.Printf("impacted apps: %v", impactedApps)
+
 	for _, f := range mf {
 		// File names: submodules/fluent-bit
 		if strings.HasPrefix(f, "submodules/") {
 			for app, _ := range allApps {
 				impactedApps[app] = true
 			}
-			log.Printf("impacted apps: %v", impactedApps)
 			return impactedApps
 		}
 	}
@@ -689,7 +690,6 @@ func determineImpactedApps(mf []string, allApps map[string]metadata.IntegrationM
 
 		}
 	}
-	log.Printf("impacted apps: %v", impactedApps)
 	return impactedApps
 }
 

--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -659,6 +659,17 @@ func modifiedFiles(t *testing.T) []string {
 func determineImpactedApps(mf []string, allApps map[string]metadata.IntegrationMetadata) map[string]bool {
 	impactedApps := make(map[string]bool)
 	for _, f := range mf {
+		// File names: submodules/fluent-bit
+		if strings.HasPrefix(f, "submodules/") {
+			for app, _ := range allApps {
+				impactedApps[app] = true
+			}
+			log.Printf("impacted apps: %v", impactedApps)
+			return impactedApps
+		}
+	}
+
+	for _, f := range mf {
 		if strings.HasPrefix(f, "apps/") {
 
 			// File names: apps/<appname>.go


### PR DESCRIPTION
## Description
Integration tests should not be skipped when a submodule is upgraded. Enforcing that any changes to submodule/* folder will trigger the integration tests.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
I added a submodule change and verified that the tests were scheduled. Then i reverted the change.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
