### PR TITLE
Re-enable aerospike logging tests

### DIFF
--- a/integration_test/third_party_apps_data/applications/aerospike/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/aerospike/metadata.yaml
@@ -86,14 +86,13 @@ expected_metrics:
     monitored_resource: gce_instance
     type: workload.googleapis.com/aerospike.node.memory.free
     value_type: INT64
-# TODO (b/239240173#comment5): Re-enable once we get SLES 15 logs to go to syslog instead of a local file during tests.
-# expected_logs:
-#   - log_name: syslog
-#     fields:
-#       - name: jsonPayload.message
-#         value_regex: ' asd(\[[0-9]+\])*:'
-#         type: string
-#         description: Aerospike application logs written to Journald.
+expected_logs:
+  - log_name: syslog
+    fields:
+      - name: jsonPayload.message
+        value_regex: ' asd(\[[0-9]+\])*:'
+        type: string
+        description: Aerospike application logs written to Journald.
 configuration_options:
   metrics:
     - type: aerospike

--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -592,7 +592,10 @@ func runSingleTest(ctx context.Context, logger *logging.DirectoryLogger, vm *gce
 
 	if metadata.ExpectedLogs != nil {
 		logger.ToMainLog().Println("found expectedLogs, running logging test cases...")
-		if err = runLoggingTestCases(ctx, logger, vm, metadata.ExpectedLogs); err != nil {
+		// TODO(b/239240173): bad bad bad, remove this horrible hack once we fix Aerospike on SLES
+		if app == AerospikeApp && folder == "sles" {
+			logger.ToMainLog().Printf("skipping aerospike logging tests (b/239240173)")
+		} else if err = runLoggingTestCases(ctx, logger, vm, metadata.ExpectedLogs); err != nil {
 			return nonRetryable, err
 		}
 	}
@@ -699,6 +702,8 @@ const (
 	SAPHANAApp      = "saphana"
 
 	OracleDBApp = "oracledb"
+
+	AerospikeApp = "aerospike"
 )
 
 // incompatibleOperatingSystem looks at the supported_operating_systems field


### PR DESCRIPTION
## Description
Re-enable the tests that we disabled in #882, but keep disabling the tests on SLES because logs are still broken there.

## Related issue
b/239240173

## How has this been tested?
Ran integration tests locally for SLES-15 and Debian-10. Confirmed that the tests are skpped on SLES and run on Debian.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
