### PR TITLE
Internal: improve `git diff` error messages

### DIFF
--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -640,10 +640,14 @@ func fetchAppsAndMetadata(t *testing.T) map[string]metadata.IntegrationMetadata 
 func modifiedFiles(t *testing.T) []string {
 	cmd := exec.Command("git", "diff", "--name-only", "origin/master")
 	out, err := cmd.Output()
-	if err != nil {
-		t.Fatalf("got error calling `git diff`: %v", err)
-	}
 	stdout := string(out)
+	if err != nil {
+		stderr := ""
+        	if exitError := err.(*exec.ExitError); exitError != nil {
+			stderr = string(exitError.Stderr)
+		}
+		t.Fatalf("got error calling `git diff`: %v,stderr=%v,stdout=%v", err, stderr, stdout)
+	}
 	log.Printf("git diff output:\n\tstdout:%v", stdout)
 
 	return strings.Split(stdout, "\n")

--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -646,7 +646,7 @@ func modifiedFiles(t *testing.T) []string {
         	if exitError := err.(*exec.ExitError); exitError != nil {
 			stderr = string(exitError.Stderr)
 		}
-		t.Fatalf("got error calling `git diff`: %v,stderr=%v,stdout=%v", err, stderr, stdout)
+		t.Fatalf("got error calling `git diff`: %v\nstderr=%v\nstdout=%v", err, stderr, stdout)
 	}
 	log.Printf("git diff output:\n\tstdout:%v", stdout)
 


### PR DESCRIPTION
## Description
Adds the stderr for `git diff` to the error message in case of errors.

## Related issue
igor hit a debuggability issue with the previous code.

## How has this been tested?
I ran this  similar code on the go playground (https://go.dev/play/p/MlcbVo4H8Q1):

```
package main

import (
	"fmt"
	"log"
	"os/exec"
)

func main() {
	out, err := exec.Command("grep").Output()
	stdout := string(out)
	if err != nil {
		stderr := ""
		if exitError := err.(*exec.ExitError); exitError != nil {
			stderr = string(exitError.Stderr)
		}
		log.Fatalf("%v,stderr=%v,stdout=%v", err, stderr, stdout)
	}
	fmt.Printf("grep finished! stdout=%v\n", stdout)
}
```

The output is:
```
2009/11/10 23:00:00 exit status 2,stderr=BusyBox v1.32.1 (2021-02-18 00:55:45 UTC) multi-call binary.

Usage: grep [-HhnlLoqvsrRiwFE] [-m N] [-A/B/C N] PATTERN/-e PATTERN.../-f FILE [FILE]...

Search for PATTERN in FILEs (or stdin)

	-H	Add 'filename:' prefix
	-h	Do not add 'filename:' prefix
	-n	Add 'line_no:' prefix
	-l	Show only names of files that match
	-L	Show only names of files that don't match
	-c	Show only count of matching lines
	-o	Show only the matching part of line
	-q	Quiet. Return 0 if PATTERN is found, 1 otherwise
	-v	Select non-matching lines
	-s	Suppress open and read errors
	-r	Recurse
	-R	Recurse and dereference symlinks
	-i	Ignore case
	-w	Match whole words only
	-x	Match whole lines only
	-F	PATTERN is a literal (not regexp)
	-E	PATTERN is an extended regexp
	-m N	Match up to N times per file
	-A N	Print N lines of trailing context
	-B N	Print N lines of leading context
	-C N	Same as '-A N -B N'
	-e PTRN	Pattern to match
	-f FILE	Read pattern from file
,stdout=

Program exited.
```

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
