### PR TITLE
Document Aerospike logs being unsupported on SLES

### DIFF
--- a/integration_test/third_party_apps_data/applications/aerospike/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/aerospike/metadata.yaml
@@ -21,7 +21,13 @@ description: |-
   and connections. The integration collects these metrics using the official
   client API provided by Aerospike.
 supported_app_version: ["4.9", "5.x", "6.x"]
-configure_integration: ""
+configure_integration: |-
+  Aerospike logs are not supported on systems such as SLES where Aerospike
+  does not normally run as a `systemd` service. Instead, you can manually
+  configure a
+  [`files`](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/configuration#logging-receivers)
+  receiver which points to Aerospike's log file, which is usually located at
+  `/home/<user>/aerospike-server/var/log/aerospike.log`.
 expected_metrics:
   - kind: CUMULATIVE
     labels:

--- a/integration_test/third_party_apps_data/applications/aerospike/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/aerospike/metadata.yaml
@@ -25,7 +25,7 @@ configure_integration: |-
   Aerospike logs are not automatically ingested on systems such as SLES where Aerospike
   does not normally run as a `systemd` service. Instead, you can manually
   configure a
-  [`files`](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/configuration#logging-receivers)
+  [`files`](/stackdriver/docs/solutions/agents/ops-agent/configuration#logging-receivers)
   receiver which points to Aerospike's log file, which is usually located at
   `$HOME/aerospike-server/var/log/aerospike.log`.
 expected_metrics:

--- a/integration_test/third_party_apps_data/applications/aerospike/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/aerospike/metadata.yaml
@@ -22,7 +22,7 @@ description: |-
   client API provided by Aerospike.
 supported_app_version: ["4.9", "5.x", "6.x"]
 configure_integration: |-
-  Aerospike logs are not supported on systems such as SLES where Aerospike
+  Aerospike logs are not automatically ingested on systems such as SLES where Aerospike
   does not normally run as a `systemd` service. Instead, you can manually
   configure a
   [`files`](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/configuration#logging-receivers)

--- a/integration_test/third_party_apps_data/applications/aerospike/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/aerospike/metadata.yaml
@@ -22,8 +22,8 @@ description: |-
   client API provided by Aerospike.
 supported_app_version: ["4.9", "5.x", "6.x"]
 configure_integration: |-
-  Aerospike logs are not automatically ingested on systems such as SLES where Aerospike
-  does not normally run as a `systemd` service. Instead, you can manually
+  Aerospike logs are automatically ingested on systems where Aerospike runs as
+  a `systemd` service. On other systems such as SLES, you can manually
   configure a
   [`files`](/stackdriver/docs/solutions/agents/ops-agent/configuration#logging-receivers)
   receiver which points to Aerospike's log file, which is usually located at

--- a/integration_test/third_party_apps_data/applications/aerospike/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/aerospike/metadata.yaml
@@ -27,7 +27,7 @@ configure_integration: |-
   configure a
   [`files`](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/configuration#logging-receivers)
   receiver which points to Aerospike's log file, which is usually located at
-  `/home/<user>/aerospike-server/var/log/aerospike.log`.
+  `$HOME/aerospike-server/var/log/aerospike.log`.
 expected_metrics:
   - kind: CUMULATIVE
     labels:


### PR DESCRIPTION
## Description
Document Aerospike logs being unsupported on SLES

## Related issue
http://b/254325217
http://b/239240173

## How has this been tested?
N/A

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [x] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
