### PR TITLE
Kill service processes if Restart-Service fails

### DIFF
--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -82,7 +82,7 @@ func restartCommandForPlatform(platform string) string {
 	if gce.IsWindows(platform) {
 		return `
 Restart-Service google-cloud-ops-agent -Force
-#TODO(b/240564518): remove process-killing once bug is fixed
+# TODO(b/240564518): remove process-killing once bug is fixed
 if (!$?) {
 	Write-Output 'Could not restart services gracefully. Killing processes directly...'
 	Get-Service -Name 'google-cloud-ops-agent*' | Set-Service -StartupType Disabled

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -88,7 +88,7 @@ if (!$?) {
 	Get-Service -Name 'google-cloud-ops-agent*' | Set-Service -StartupType Disabled
 	# TODO: use 'sc failure google-cloud-ops-agent reset= 0 actions= ""' to disable automatic recovery in case it interferes with Start-Service
 	Get-WmiObject -Class Win32_Service -Filter "Name LIKE 'google-cloud-ops-agent%'" | ForEach-Object {		
-		Stop-Process -Force $_.ProcessId
+		Stop-Process -Force $_.ProcessId -ErrorAction SilentlyContinue
 		if (!$?) {
 			Write-Output "Could not stop process $($_.ProcessId); proceeding anyway"
 		}


### PR DESCRIPTION
Lots of flakes lately on Windows 2012 due to timeouts on Restart-Service

## Description
The `Restart-Service` command can timeout and fail the test if the sub-agents don't respond. We're trying to find a root cause for such situations, but for now we'd like to work around test flakes which depend on service restarts.

## Related issue
b/240564518

## How has this been tested?
Will let the PR presubmits run the tests

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
