### PR TITLE
Restore "Testing: use ssh to connect to Windows instances"

### DIFF
--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -10,17 +10,16 @@ You will need a GCP project to run VMs in. This is referred to as `${PROJECT}` i
 the following instructions.
 
 The project needs sufficient quota to run many tests in parallel. It also needs
-(when testing Windows) a firewall that allows connections over port 5986. In the
-case of Google-owned projects, such a firewall is difficult to obtain, so for this
-reason and quota reasons it is recommended for Googlers to use our prebuilt testing
-project. Ask a teammate (e.g. martijnvs@) for the project ID.
+a firewall that allows connections over port 22 for ssh. It is recommended for
+Googlers to use our prebuilt testing project. Ask a teammate (e.g. martijnvs@)
+for the project ID.
 
 You will also need a GCS bucket that is used to transfer files onto the 
 testing VMs. This is referred to as `${TRANSFERS_BUCKET}`. For Googlers,
 `stackdriver-test-143416-untrusted-file-transfers` is recommended.
 
 You will need `gcloud` to be installed. Run `gcloud auth login` to set up `gcloud`
-    authentication (if you haven't done that already).
+authentication (if you haven't done that already).
 
 To give the tests credentials to be able to access Google APIs as you,
 run the following command and do what it says (it may ask you to run
@@ -41,8 +40,9 @@ of Kokoro with some setup (see above).
 
 ### Testing Command
 
-When the setup steps are complete, you can run ops_agent_test (for Linux)
-from the [Makefile](tasks.mak):
+When the setup steps are complete, you can run ops_agent_test from the
+[Makefile](tasks.mak):
+
 ```
 make integration_test PROJECT=${PROJECT} TRANSFERS_BUCKET=${TRANSFERS_BUCKET}
 ```
@@ -51,10 +51,6 @@ environment and simply call the target.
 You can also specify the `ZONE` and `PLATFORMS` variables if you would like
 to run the tests on something other than the defaults (`us-central1-b` for 
 ZONE and `debian-11` for `PLATFORMS`).
-
-Testing on Windows is tricky because it requires a suitable value of
-WINRM_PAR_PATH, and for now only Googlers can build winrm.par to supply it at
-runtime.
 
 The above command will run the tests against the stable Ops Agent. To test
 against a pre-built but unreleased agent, you can use add the

--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -642,8 +642,9 @@ func RunInstallFuncWithRetry(ctx context.Context, logger *log.Logger, vm *gce.VM
 // on a Windows VM.
 func InstallStandaloneWindowsLoggingAgent(ctx context.Context, logger *log.Logger, vm *gce.VM) error {
 	// https://cloud.google.com/logging/docs/agent/installation#joint-install
+	// The command needed to be adjusted to work in a non-GUI context.
 	cmd := `(New-Object Net.WebClient).DownloadFile("https://dl.google.com/cloudagents/windows/StackdriverLogging-v1-16.exe", "${env:UserProfile}\StackdriverLogging-v1-16.exe")
-		& "${env:UserProfile}\StackdriverLogging-v1-16.exe" /S`
+		Start-Process -FilePath "${env:UserProfile}\StackdriverLogging-v1-16.exe" -ArgumentList "/S" -Wait -NoNewWindow`
 	_, err := gce.RunRemotely(ctx, logger, vm, "", cmd)
 	return err
 }
@@ -652,8 +653,9 @@ func InstallStandaloneWindowsLoggingAgent(ctx context.Context, logger *log.Logge
 // agent on a Windows VM.
 func InstallStandaloneWindowsMonitoringAgent(ctx context.Context, logger *log.Logger, vm *gce.VM) error {
 	// https://cloud.google.com/monitoring/agent/installation#joint-install
+	// The command needed to be adjusted to work in a non-GUI context.
 	cmd := `(New-Object Net.WebClient).DownloadFile("https://repo.stackdriver.com/windows/StackdriverMonitoring-GCM-46.exe", "${env:UserProfile}\StackdriverMonitoring-GCM-46.exe")
-		& "${env:UserProfile}\StackdriverMonitoring-GCM-46.exe" /S`
+		Start-Process -FilePath "${env:UserProfile}\StackdriverMonitoring-GCM-46.exe" -ArgumentList "/S" -Wait -NoNewWindow`
 	_, err := gce.RunRemotely(ctx, logger, vm, "", cmd)
 	return err
 }

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -23,8 +23,8 @@ To run a test based on this library, you can either:
 in README.md.
 
 NOTE: When testing Windows VMs without using Kokoro, PROJECT needs to be
-a project whose firewall allows WinRM connections.
-[Kokoro can use stackdriver-test-143416, which does not allow WinRM
+a project whose firewall allows ssh connections.
+[Kokoro can use stackdriver-test-143416, which does not allow ssh
 connections, because our Kokoro workers are also running in that project.]
 
 NOTE: This command does not actually build the Ops Agent. To test the latest
@@ -45,8 +45,6 @@ AGENT_PACKAGES_IN_GCS, for details see README.md.
 This library needs the following environment variables to be defined:
 PROJECT: What GCP project to use.
 ZONE: What GCP zone to run in.
-WINRM_PAR_PATH: (required for Windows) Path to winrm.par, used to connect to
-Windows VMs.
 
 The following variables are optional:
 
@@ -163,11 +161,6 @@ const (
 func init() {
 	ctx := context.Background()
 	var err error
-
-	if strings.Contains(os.Getenv("PLATFORMS"), "windows") && os.Getenv("WINRM_PAR_PATH") == "" {
-		log.Fatal("WINRM_PAR_PATH must be nonempty when testing Windows VMs")
-	}
-
 	storageClient, err = storage.NewClient(ctx)
 	if err != nil {
 		log.Fatalf("storage.NewClient() failed: %v:", err)
@@ -258,13 +251,6 @@ func (f *logClientFactory) new(project string) (*logadmin.Client, error) {
 	return logClient, nil
 }
 
-// WindowsCredentials is a low-security way to hold login credentials for
-// a Windows VM.
-type WindowsCredentials struct {
-	Username string
-	Password string
-}
-
 // VM represents an individual virtual machine.
 type VM struct {
 	Name        string
@@ -274,13 +260,11 @@ type VM struct {
 	Zone        string
 	MachineType string
 	ID          int64
-	// The IP address to ssh/WinRM to. This is the external IP address, unless
+	// The IP address to ssh to. This is the external IP address, unless
 	// USE_INTERNAL_IP is set to 'true'. See comment on extractIPAddress() for
 	// rationale.
-	IPAddress string
-	// WindowsCredentials is only populated for Windows VMs.
-	WindowsCredentials *WindowsCredentials
-	AlreadyDeleted     bool
+	IPAddress      string
+	AlreadyDeleted bool
 }
 
 // imageProject returns the image project providing the given image family.
@@ -348,12 +332,6 @@ var (
 // instead of the default gcloud installed on the system.
 func SetGcloudPath(path string) {
 	gcloudPath = path
-}
-
-// winRM() returns the path to the winrm.par binary to use to connect to
-// Windows VMs.
-func winRM() string {
-	return os.Getenv("WINRM_PAR_PATH")
 }
 
 // IsWindows returns whether the given platform is a version of Windows (including Microsoft SQL Server).
@@ -580,12 +558,6 @@ func runCommand(ctx context.Context, logger *log.Logger, stdin string, args []st
 	if len(args) < 1 {
 		return output, fmt.Errorf("runCommand() needs a nonempty argument slice, got %v", args)
 	}
-	if !strings.HasSuffix(args[0], "winrm.par") {
-		// Print out the command we're running. Skip this for winrm.par commands
-		// because they are base64 encoded and the real command is already printed
-		// inside runRemotelyWindows() anyway.
-		logger.Printf("Running command: %v", args)
-	}
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 
 	stdinPipe, err := cmd.StdinPipe()
@@ -631,29 +603,8 @@ func runCommand(ctx context.Context, logger *log.Logger, stdin string, args []st
 // Various pros/cons of shelling out to gcloud vs using the Compute API are discussed here:
 // http://go/sdi-gcloud-vs-api
 func RunGcloud(ctx context.Context, logger *log.Logger, stdin string, args []string) (CommandOutput, error) {
+	logger.Printf("Running command: gcloud %v", args)
 	return runCommand(ctx, logger, stdin, append([]string{gcloudPath}, args...))
-}
-
-// runRemotelyWindows runs the provided powershell command on the provided Windows VM.
-// The command is base64 encoded in transit because that is an effective way to run
-// complex commands, such as commands with nested quoting.
-func runRemotelyWindows(ctx context.Context, logger *log.Logger, vm *VM, command string) (CommandOutput, error) {
-	logger.Printf("Running command %q", command)
-
-	uni := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)
-	encoded, err := uni.NewEncoder().String(command)
-	if err != nil {
-		return CommandOutput{}, err
-	}
-	return runCommand(ctx, logger, "",
-		[]string{winRM(),
-			"--host=" + vm.IPAddress,
-			"--username=" + vm.WindowsCredentials.Username,
-			"--password=" + vm.WindowsCredentials.Password,
-			fmt.Sprintf("--command=powershell -NonInteractive -encodedcommand %q", base64.StdEncoding.EncodeToString([]byte(encoded))),
-			"--stderrthreshold=fatal",
-			"--verbosity=-2",
-		})
 }
 
 var (
@@ -676,6 +627,15 @@ var (
 	}
 )
 
+func wrapPowershellCommand(command string) (string, error) {
+	uni := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)
+	encoded, err := uni.NewEncoder().String(command)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("powershell -NonInteractive -EncodedCommand %q", base64.StdEncoding.EncodeToString([]byte(encoded))), nil
+}
+
 // RunRemotely runs a command on the provided VM.
 // The command should be a shell command if the VM is Linux, or powershell if the VM is Windows.
 // Returns the combined stdout+stderr as a string, plus an error if there was
@@ -683,22 +643,21 @@ var (
 //
 // 'command' is what to run on the machine. Example: "cat /tmp/foo; echo hello"
 // 'stdin' is what to supply to the command on stdin. It is usually "".
-// TODO: Remove the stdin parameter, because it is hardly used and doesn't work
-// on Windows.
+// TODO: Remove the stdin parameter, because it is hardly used.
 func RunRemotely(ctx context.Context, logger *log.Logger, vm *VM, stdin string, command string) (_ CommandOutput, err error) {
+	logger.Printf("Running command remotely: %v", command)
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("Command failed: %v\n%v", command, err)
 		}
 	}()
+	wrappedCommand := command
 	if IsWindows(vm.Platform) {
-		if stdin != "" {
-			// TODO(martijnvs): Support stdin on Windows, if we see a need for it.
-			return CommandOutput{}, errors.New("RunRemotely() does not support stdin when run on Windows")
+		wrappedCommand, err = wrapPowershellCommand(command)
+		if err != nil {
+			return CommandOutput{}, err
 		}
-		return runRemotelyWindows(ctx, logger, vm, command)
 	}
-
 	// Raw ssh is used instead of "gcloud compute ssh" with OS Login because:
 	// 1. OS Login will generate new ssh keys for each kokoro run and they don't carry over.
 	//    This means that they pile up and need to be deleted periodically.
@@ -708,7 +667,7 @@ func RunRemotely(ctx context.Context, logger *log.Logger, vm *VM, stdin string, 
 	args = append(args, sshUserName+"@"+vm.IPAddress)
 	args = append(args, "-oIdentityFile="+privateKeyFile)
 	args = append(args, sshOptions...)
-	args = append(args, command)
+	args = append(args, wrappedCommand)
 	return runCommand(ctx, logger, stdin, args)
 }
 
@@ -872,36 +831,38 @@ func addFrameworkMetadata(platform string, inputMetadata map[string]string) (map
 		metadataCopy[k] = v
 	}
 
+	if _, ok := metadataCopy["enable-oslogin"]; ok {
+		return nil, errors.New("the 'enable-oslogin' metadata key is reserved for framework use")
+	}
+	// We manage our own ssh keys, so we don't need OS Login. For a while, it
+	// worked to leave it enabled anyway, but one day that broke (b/181867249).
+	// Disabling OS Login fixed the issue.
+	metadataCopy["enable-oslogin"] = "false"
+
+	if _, ok := metadataCopy["ssh-keys"]; ok {
+		return nil, errors.New("the 'ssh-keys' metadata key is reserved for framework use")
+	}
+	publicKey, err := os.ReadFile(publicKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("could not read local public key file %v: %v", publicKeyFile, err)
+	}
+	metadataCopy["ssh-keys"] = fmt.Sprintf("%s:%s", sshUserName, string(publicKey))
+
 	if IsWindows(platform) {
-		if _, ok := metadataCopy["windows-startup-script-ps1"]; ok {
-			return nil, errors.New("you cannot pass a startup script for Windows instances because the startup script is used to detect that the instance is running. Instead, wait for the instance to be ready and then run things with RunRemotely() or RunScriptRemotely()")
+		if _, ok := metadataCopy["sysprep-specialize-script-cmd"]; ok {
+			return nil, errors.New("you cannot pass a sysprep script for Windows instances because the sysprep script is needed to enable ssh-ing. Instead, wait for the instance to be ready and then run things with RunRemotely() or RunScriptRemotely()")
 		}
-		metadataCopy["windows-startup-script-ps1"] = `
-$port = new-Object System.IO.Ports.SerialPort 'COM3'
-$port.Open()
-$port.WriteLine("STARTUP_SCRIPT_DONE")
-$port.Close()
-`
+		// From https://cloud.google.com/compute/docs/connect/windows-ssh#create_vm
+		metadataCopy["sysprep-specialize-script-cmd"] = "googet -noconfirm=true update && googet -noconfirm=true install google-compute-engine-ssh"
+
+		if _, ok := metadataCopy["enable-windows-ssh"]; ok {
+			return nil, errors.New("the 'enable-windows-ssh' metadata key is reserved for framework use")
+		}
+		metadataCopy["enable-windows-ssh"] = "TRUE"
 	} else {
 		if _, ok := metadataCopy["startup-script"]; ok {
 			return nil, errors.New("the 'startup-script' metadata key is reserved for future use. Instead, wait for the instance to be ready and then run things with RunRemotely() or RunScriptRemotely()")
 		}
-		if _, ok := metadataCopy["enable-oslogin"]; ok {
-			return nil, errors.New("the 'enable-oslogin' metadata key is reserved for framework use")
-		}
-		// We manage our own ssh keys, so we don't need OS Login. For a while, it
-		// worked to leave it enabled anyway, but one day that broke (b/181867249).
-		// Disabling OS Login fixed the issue.
-		metadataCopy["enable-oslogin"] = "false"
-
-		if _, ok := metadataCopy["ssh-keys"]; ok {
-			return nil, errors.New("the 'ssh-keys' metadata key is reserved for framework use")
-		}
-		publicKey, err := os.ReadFile(publicKeyFile)
-		if err != nil {
-			return nil, fmt.Errorf("could not read local public key file %v: %v", publicKeyFile, err)
-		}
-		metadataCopy["ssh-keys"] = fmt.Sprintf("%s:%s", sshUserName, string(publicKey))
 	}
 	return metadataCopy, nil
 }
@@ -1100,8 +1061,6 @@ func CreateInstance(origCtx context.Context, logger *log.Logger, options VMOptio
 			strings.Contains(err.Error(), "Internal error") ||
 			// Instance creation can also fail due to service unavailability.
 			strings.Contains(err.Error(), "currently unavailable") ||
-			// Windows instances sometimes fail to initialize WinRM: b/185923886.
-			strings.Contains(err.Error(), winRMDummyCommandMessage) ||
 			// SLES instances sometimes fail to be ssh-able: b/186426190
 			(isSUSE(options.Platform) && strings.Contains(err.Error(), startupFailedMessage)) ||
 			strings.Contains(err.Error(), prepareSLESMessage)
@@ -1404,74 +1363,13 @@ func extractID(stdout string) (int64, error) {
 	return strconv.ParseInt(instance.ID, 10, 64)
 }
 
-func resetAndFetchWindowsCredentials(ctx context.Context, logger *log.Logger, vm *VM) (*WindowsCredentials, error) {
-	output, err := RunGcloud(ctx, logger, "",
-		[]string{"compute", "reset-windows-password", vm.Name,
-			// The username can be anything; it just has to comply with the requirements here:
-			// https://docs.microsoft.com/en-us/windows/win32/api/lmaccess/nf-lmaccess-netuseradd
-			"--user=windows_user",
-			"--project=" + vm.Project,
-			"--zone=" + vm.Zone,
-			"--format=json",
-		})
-	if err != nil {
-		return nil, fmt.Errorf("failed to reset Windows password: %v", err)
-	}
-	var creds WindowsCredentials
-	if err := json.Unmarshal([]byte(output.Stdout), &creds); err != nil {
-		return nil, fmt.Errorf("could not parse JSON for %q: %v", output.Stdout, err)
-	}
-	if creds.Username == "" || creds.Password == "" {
-		return nil, fmt.Errorf("username or password was empty when parsing %q. Parsed result: %#v", output.Stdout, creds)
-	}
-	return &creds, nil
-}
-
 const (
-	// Retry errors that look like b/185923886.
-	winRMDummyCommandMessage = "waitForStartWindows() failed: dummy command could not run over WinRM"
-
 	// Retry errors that look like b/186426190.
 	startupFailedMessage = "waitForStartLinux() failed: waiting for startup timed out"
 )
 
 func waitForStartWindows(ctx context.Context, logger *log.Logger, vm *VM) error {
-	lookForReadyMessages := func() error {
-		output, err := RunGcloud(ctx, logger, "", []string{
-			"compute", "instances", "get-serial-port-output",
-			"--port=3",
-			"--project=" + vm.Project,
-			"--zone=" + vm.Zone,
-			vm.Name})
-		if err != nil {
-			return fmt.Errorf("error getting COM3 serial port output: %v", err)
-		}
-		if strings.Contains(output.Stdout, "STARTUP_SCRIPT_DONE") {
-			// Success.
-			return nil
-		}
-		return fmt.Errorf("STARTUP_SCRIPT_DONE not found in serial port output: %v", output)
-	}
-	backoffPolicy := backoff.WithContext(backoff.NewConstantBackOff(vmInitBackoffDuration), ctx)
-	if err := backoff.Retry(lookForReadyMessages, backoffPolicy); err != nil {
-		return fmt.Errorf("ran out of attempts waiting for VM to initialize: %v", err)
-	}
-
-	resetCredentials := func() error {
-		creds, err := resetAndFetchWindowsCredentials(ctx, logger, vm)
-		if err != nil {
-			return fmt.Errorf("resetAndFetchWindowsCredentials() failed: %v", err)
-		}
-		vm.WindowsCredentials = creds
-		return nil
-	}
-
-	backoffPolicy = backoff.WithContext(backoff.NewConstantBackOff(vmWinPasswordResetBackoffDuration), ctx)
-	if err := backoff.Retry(resetCredentials, backoffPolicy); err != nil {
-		return fmt.Errorf("ran out of attempts resetting credentials: %v", err)
-	}
-
-	// Now, make sure the server is really ready to run remote commands by
+	// Make sure the server is really ready to run remote commands by
 	// sending it a dummy command repeatedly until it works.
 	attempt := 0
 	printFoo := func() error {
@@ -1482,11 +1380,9 @@ func waitForStartWindows(ctx context.Context, logger *log.Logger, vm *VM) error 
 		return err
 	}
 
-	gracePeriod := 3 * time.Minute // I'm not sure what's a good value here.
-	maxAttempts := uint64(gracePeriod / vmInitBackoffDuration)
-	backoffPolicy = backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(vmInitBackoffDuration), maxAttempts), ctx)
+	backoffPolicy := backoff.WithContext(backoff.NewConstantBackOff(vmInitBackoffDuration), ctx)
 	if err := backoff.Retry(printFoo, backoffPolicy); err != nil {
-		return fmt.Errorf("%v, even after %v of attempts. err=%v", winRMDummyCommandMessage, gracePeriod, err)
+		return fmt.Errorf("waitForStartWindows() failed: ran out of attempts waiting for dummy command to run. err=%v", err)
 	}
 	return nil
 }

--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -166,6 +166,24 @@ func installAgent(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.
 	return nonRetryable, agents.InstallPackageFromGCS(ctx, logger, vm, packagesInGCS)
 }
 
+// updateSSHKeysForActiveDirectory alters the ssh-keys metadata value for the
+// given VM by prepending the given domain and a backslash onto the username.
+func updateSSHKeysForActiveDirectory(ctx context.Context, logger *log.Logger, vm *gce.VM, domain string) error {
+	metadata, err := gce.FetchMetadata(ctx, logger, vm)
+	if err != nil {
+		return err
+	}
+	if _, err = gce.RunGcloud(ctx, logger, "", []string{
+		"compute", "instances", "add-metadata", vm.Name,
+		"--project=" + vm.Project,
+		"--zone=" + vm.Zone,
+		"--metadata=ssh-keys=" + domain + `\` + metadata["ssh-keys"],
+	}); err != nil {
+		return fmt.Errorf("error setting new ssh keys metadata for vm %v: %w", vm.Name, err)
+	}
+	return nil
+}
+
 // constructQuery converts the given struct of:
 //
 //	field name => field value regex
@@ -242,7 +260,7 @@ func verifyLogField(fieldName, actualField string, expectedFields map[string]*me
 	return nil
 }
 
-// verifyJsonPayload verifies that the jsonPayload component of th LogEntry is as expected.
+// verifyJsonPayload verifies that the jsonPayload component of the LogEntry is as expected.
 // TODO: We don't unpack the jsonPayload and assert that the nested substructure is as expected.
 //
 //	The way we could do this is flatten the nested payload into a single layer (using something like https://github.com/jeremywohl/flatten)
@@ -557,6 +575,13 @@ func runSingleTest(ctx context.Context, logger *logging.DirectoryLogger, vm *gce
 	if _, err = runScriptFromScriptsDir(
 		ctx, logger, vm, path.Join("applications", app, folder, "install"), installEnv); err != nil {
 		return retryable, fmt.Errorf("error installing %s: %v", app, err)
+	}
+
+	if app == "active_directory_ds" {
+		// This will allow us to be able to access the machine over ssh after it restarts.
+		if err = updateSSHKeysForActiveDirectory(ctx, logger.ToMainLog(), vm, "test"); err != nil {
+			return nonRetryable, err
+		}
 	}
 
 	if metadata.RestartAfterInstall {


### PR DESCRIPTION
Reverts GoogleCloudPlatform/ops-agent#915, restoring GoogleCloudPlatform/ops-agent#873, with additional fixes for active directory.

Tested locally with all applications, on the following non-comprehensive list of platforms: debian-10,rocky-linux-8,sql-std-2019-win-2019,windows-2019,windows-2016,windows-2012-r2