### PR TITLE
Add option for Windows Event Log XML render

### DIFF
--- a/confgenerator/built-in-config-windows.yaml
+++ b/confgenerator/built-in-config-windows.yaml
@@ -3,6 +3,7 @@ logging:
     windows_event_log:
       type: windows_event_log
       channels: [System, Application, Security]
+      render_as_xml: false
   service:
     pipelines:
       default_pipeline:

--- a/confgenerator/logging_receivers.go
+++ b/confgenerator/logging_receivers.go
@@ -324,6 +324,7 @@ type LoggingReceiverWindowsEventLog struct {
 	ConfigComponent `yaml:",inline"`
 
 	Channels []string `yaml:"channels,omitempty,flow" validate:"required"`
+	RenderAsXml string `yaml:"render_as_xml,omitempty,flow"`
 }
 
 func (r LoggingReceiverWindowsEventLog) Type() string {
@@ -331,15 +332,22 @@ func (r LoggingReceiverWindowsEventLog) Type() string {
 }
 
 func (r LoggingReceiverWindowsEventLog) Components(tag string) []fluentbit.Component {
+  if r.RenderAsXml == "True" || r.RenderAsXml == "true" {
+    r.RenderAsXml = "True"
+  } else {
+    r.RenderAsXml = "False"
+  }
+
 	input := []fluentbit.Component{{
 		Kind: "INPUT",
 		Config: map[string]string{
 			// https://docs.fluentbit.io/manual/pipeline/inputs/windows-event-log
-			"Name":         "winlog",
+			"Name":         "winevtlog",
 			"Tag":          tag,
 			"Channels":     strings.Join(r.Channels, ","),
 			"Interval_Sec": "1",
 			"DB":           DBPath(tag),
+			"Render_Event_As_XML": r.RenderAsXml,
 		},
 	}}
 

--- a/confgenerator/testdata/builtin/windows/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/windows/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden_fluent_bit_main.conf
@@ -18,18 +18,20 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     Directory Service,Active Directory Web Services
-    DB           ${buffers_dir}/active_directory_ds_active_directory_ds
-    Interval_Sec 1
-    Name         winlog
-    Tag          active_directory_ds.active_directory_ds
+    Channels            Directory Service,Active Directory Web Services
+    DB                  ${buffers_dir}/active_directory_ds_active_directory_ds
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 active_directory_ds.active_directory_ds
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/logging-receiver_iis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_iis/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
@@ -18,11 +18,12 @@
     Scrape_On_Start True
 
 [INPUT]
-    Channels     System,Application,Security
-    DB           ${buffers_dir}/default_pipeline_windows_event_log
-    Interval_Sec 1
-    Name         winlog
-    Tag          default_pipeline.windows_event_log
+    Channels            System,Application,Security
+    DB                  ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec        1
+    Name                winevtlog
+    Render_Event_As_XML False
+    Tag                 default_pipeline.windows_event_log
 
 [INPUT]
     Buffer_Chunk_Size 512k


### PR DESCRIPTION
## Description
- Updated the Windows Event Log config generator to support the Rendering of Windows Event Logs as XML
- This was an added feature in Fluent Bit v1.9
- Added ability to include `render_as_xml` in the Windows Event Log configuration

## How has this been tested?
Tested in Windows VMs in Google Cloud projects.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [x] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.