### PR TITLE
Update sles12 repo in Dockerfile to get bison

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -194,7 +194,7 @@ RUN set -x; \
     # Remove expired root certificate.
     mv /var/lib/ca-certificates/pem/DST_Root_CA_X3.pem /etc/pki/trust/blacklist/ && \
     update-ca-certificates && \
-    # Add home:Ledest:devel repo to install >3.4 bison
+    # Add home:odassau repo to install >3.4 bison
     zypper addrepo https://download.opensuse.org/repositories/home:/odassau/SLE_12_SP4/home:odassau.repo && \
     zypper -n --gpg-auto-import-keys refresh && \
     zypper -n update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -195,7 +195,7 @@ RUN set -x; \
     mv /var/lib/ca-certificates/pem/DST_Root_CA_X3.pem /etc/pki/trust/blacklist/ && \
     update-ca-certificates && \
     # Add home:Ledest:devel repo to install >3.4 bison
-    zypper addrepo https://download.opensuse.org/repositories/home:Ledest:devel/openSUSE_Leap_42.3/home:Ledest:devel.repo && \
+    zypper addrepo https://download.opensuse.org/repositories/home:/odassau/SLE_12_SP4/home:odassau.repo && \
     zypper -n --gpg-auto-import-keys refresh && \
     zypper -n update && \
     # zypper/libcurl has a use-after-free bug that causes segfaults for particular download sequences.


### PR DESCRIPTION
## Description
sles 12 nightly job failed on building stage due to:
```
#5 185.4 + zypper addrepo https://download.opensuse.org/repositories/home:Ledest:devel/openSUSE_Leap_42.3/home:Ledest:devel.repo
#5 186.3 File '/repositories/home:Ledest:devel/openSUSE_Leap_42.3/home:Ledest:devel.repo' not found on medium 'https://download.opensuse.org/'
```
## Related issue
b/254552994

## How has this been tested?
The Build(sles12) passed in the github test
![image](https://user-images.githubusercontent.com/8354694/197067973-683d7e89-2cb0-4b01-9596-f2cf5eb4dab9.png)

## Checklist:
- Unit tests
  - [x ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
