### PR TITLE
Testing: Fix `git diff` command to produce cleaner diffs

### DIFF
--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -666,7 +666,9 @@ func fetchAppsAndMetadata(t *testing.T) map[string]metadata.IntegrationMetadata 
 }
 
 func modifiedFiles(t *testing.T) []string {
-	cmd := exec.Command("git", "diff", "--name-only", "origin/master")
+	// This command gets the files that have changed since the current branch
+	// diverged from master. See https://stackoverflow.com/a/65166745.
+	cmd := exec.Command("git", "diff", "--name-only", "master...")
 	out, err := cmd.Output()
 	if err != nil {
 		t.Fatalf("got error calling `git diff`: %v", err)


### PR DESCRIPTION
## Description

`git diff origin/master` will include all the diffs from all PRs merged into the remote master since your PR was forked off of master. https://stackoverflow.com/a/65166745 explains that we should be using three dots instead of two dots (which is what `git diff origin/master` is doing under the hood), and when we do that, I don't think it makes a difference whether we use local master or origin/master, so I just picked local master for no particular reason.

## Related issue
b/254325901

## How has this been tested?
I noticed that `git diff origin/master` was giving me polluted diffs. I messed around with git commands on my workstation to confirm that the new command is doing what I think it is doing. I also checked two things in the context of Kokoro:

1. I checked that the diffs look right for this PR (just `third_party_apps_test.go`)
2. I waited for a different PR to be merged into master, then reran tests without merging from master and checked that the diffs are again just `third_party_apps_test.go` and didn't include any diffs introduced by master moving ahead.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
