### PR TITLE
Testing: Workaround for b/255311117

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -627,7 +627,6 @@ var (
 		// Sometimes you can be prompted to auth with a password if OpenSSH isn't
 		// ready yet on Windows, which hangs the test. We only ever auth with keys so
 		// let's disable password auth.
-		// TODO(b/255311117): revert when we switch back to sysprep
 		"-oPreferredAuthentications=publickey",
 	}
 )


### PR DESCRIPTION
## Description
Windows tests are failing due to b/255311117. This provides a workaround using a startup script command that occurs a bit later in the VM setup.

## Related issue
b/255311117

## How has this been tested?
Tested active_directory_ds locally on windows-2019

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
