### PR TITLE
Upgrade sles-15 build from 15.1 -> 15.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -219,11 +219,11 @@ COPY . /work
 WORKDIR /work
 RUN ./pkg/rpm/build.sh
 
-FROM opensuse/leap:15.1 AS sles15-build
+FROM opensuse/leap:15.3 AS sles15-build
 
 RUN set -x; zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros java-11-openjdk-devel unzip zip && \
-    # Add home:ptrommler:formal repo to install >3.4 bison
-    zypper addrepo https://download.opensuse.org/repositories/home:ptrommler:formal/openSUSE_Leap_15.1/home:ptrommler:formal.repo && \
+    # Add home:d4vid:co22 repo to install >3.4 bison
+    zypper addrepo https://download.opensuse.org/repositories/home:/d4vid:/co22/15.3/home:d4vid:co22.repo && \
     zypper -n --gpg-auto-import-keys refresh && \
     zypper -n update && \
     zypper -n install bison>3.4 && \


### PR DESCRIPTION
## Description
This should fix the sles-15 build/test errors. 15.1 and 15.2 are EOL (and 15.3 goes EOL soon as well).

## Related issue
b/255956977

## How has this been tested?
Tested all 3p apps locally for sles15.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
