### PR TITLE
Internal: cache dependencies for faster unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{matrix.os}}
     steps:
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: 1.x
         cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: 1.x
+        cache: true
     - run: |
         go install golang.org/x/tools/cmd/goimports@latest
         go install github.com/mattn/goveralls@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{matrix.os}}
     steps:
+    - run: |
+        git config --global core.symlinks true
+        git config --global core.autocrlf false
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
     - uses: actions/setup-go@v3
       with:
         go-version: 1.x
@@ -29,12 +35,6 @@ jobs:
     - run: |
         go install golang.org/x/tools/cmd/goimports@latest
         go install github.com/mattn/goveralls@latest
-    - run: |
-        git config --global core.symlinks true
-        git config --global core.autocrlf false
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
     - if: ${{ runner.os == 'Linux' }}
       run: if [ $(goimports -l .) ]; then goimports -d .; echo 'Failed the goimports format check. Please format the code using "goimports -w ."'; exit 1; fi
     - run: go test -mod=mod -coverpkg="./..." -coverprofile=covprofile ./...

--- a/.github/workflows/pr_presubmit.yaml
+++ b/.github/workflows/pr_presubmit.yaml
@@ -22,7 +22,7 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{matrix.os}}
     steps:
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: 1.x
         cache: true

--- a/.github/workflows/pr_presubmit.yaml
+++ b/.github/workflows/pr_presubmit.yaml
@@ -22,11 +22,11 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{matrix.os}}
     steps:
+    - uses: actions/checkout@v2
     - uses: actions/setup-go@v3
       with:
         go-version: 1.x
         cache: true
-    - uses: actions/checkout@v2
     - id: files
       uses: jitterbit/get-changed-files@v1
     - uses: actions/checkout@v2

--- a/.github/workflows/pr_presubmit.yaml
+++ b/.github/workflows/pr_presubmit.yaml
@@ -25,6 +25,7 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: 1.x
+        cache: true
     - uses: actions/checkout@v2
     - id: files
       uses: jitterbit/get-changed-files@v1


### PR DESCRIPTION
## Description
`setup-go` has a caching feature, described here: https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs

To use it, i needed to upgrade to `v3` of `setup-go` and reorder the steps so that `setup-go` could see our `go.sum` file and use that as its cache key.

## Results
Total workflow time:

linux 1m 42s    -> 1m 15s (-26%)
windows 4m 51s -> 2m 36s (-46%)

## Related issue
none

## How has this been tested?
automated tests, also manual inspection of unit tests times.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [X] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.