### PR TITLE
Internal: fix condition for adding --cache-to flag

### DIFF
--- a/kokoro/scripts/build/build_package.sh
+++ b/kokoro/scripts/build/build_package.sh
@@ -78,7 +78,7 @@ BUILD_ARGS=(
 # the continuous build's cache.
 # mode=max is described here:
 # https://docs.docker.com/build/building/cache/backends/#cache-mode
-if [[ "${KOKORO_ROOT_JOB_TYPE}" == "CONTINUOUS" ]]; then
+if [[ "${KOKORO_ROOT_JOB_TYPE}" == "CONTINUOUS_INTEGRATION" ]]; then
   BUILD_ARGS+=( --cache-to="type=registry,ref=${CACHE_LOCATION},mode=max" )
 fi
 


### PR DESCRIPTION
## Description
I was wondering why our cbuild is not populating the newly-added docker cache. Turns out it's just because cbuilds have type "CONTINUOUS_INTEGRATION", not just "CONTINUOUS" like I assumed in [my prior PR](https://github.com/GoogleCloudPlatform/ops-agent/pull/922).

## Related issue
b/255600285

## How has this been tested?
automated tests only. I'll check in on our cbuild to see if it is working after this is merged.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.
