### PR TITLE
Revert "Testing: Fix `git diff` command to produce cleaner diffs"

### DIFF
--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -666,9 +666,7 @@ func fetchAppsAndMetadata(t *testing.T) map[string]metadata.IntegrationMetadata 
 }
 
 func modifiedFiles(t *testing.T) []string {
-	// This command gets the files that have changed since the current branch
-	// diverged from master. See https://stackoverflow.com/a/65166745.
-	cmd := exec.Command("git", "diff", "--name-only", "master...")
+	cmd := exec.Command("git", "diff", "--name-only", "origin/master")
 	out, err := cmd.Output()
 	if err != nil {
 		t.Fatalf("got error calling `git diff`: %v", err)


### PR DESCRIPTION
Reverts GoogleCloudPlatform/ops-agent#926 due to issues with the release build. Reproduced locally, the error is:

```
fatal: ambiguous argument 'master...': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

My guess is that this is because kokoro clones with --depth=1, so it doesn't have the info needed to compute `git diff master...`