### PR TITLE
Internal: fix `git diff` command to work for release builds

### DIFF
--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -667,8 +667,8 @@ func fetchAppsAndMetadata(t *testing.T) map[string]metadata.IntegrationMetadata 
 
 func modifiedFiles(t *testing.T) []string {
 	// This command gets the files that have changed since the current branch
-	// diverged from master. See https://stackoverflow.com/a/65166745.
-	cmd := exec.Command("git", "diff", "--name-only", "master...")
+	// diverged from official master. See https://stackoverflow.com/a/65166745.
+	cmd := exec.Command("git", "diff", "--name-only", "origin/master...")
 	out, err := cmd.Output()
 	if err != nil {
 		t.Fatalf("got error calling `git diff`: %v", err)


### PR DESCRIPTION
## Description
Restores https://github.com/GoogleCloudPlatform/ops-agent/pull/926 with a hopeful fix for its issue with the release build. Reproduced locally, the error is:

```
fatal: ambiguous argument 'master...': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

My guess is that this is because kokoro clones with --depth=1, so it doesn't have the info needed to compute `git diff master...`

## Related issue
b/254325901

## How has this been tested?
I tried out the same commands that kokoro is running (see full script below) on my workstation. `git diff --name-only master...` fails, whereas adding `origin/` makes the command succeed (with empty output).

```
$ cat setup.sh 
#!/bin/bash

set -ex

function do_setup() {
tmp="$(mktemp --directory)"
cd $tmp

git init
git remote add origin https://www.github.com/GoogleCloudPlatform/ops-agent/
git fetch --tags --depth=1 origin master
git checkout FETCH_HEAD
git submodule init
git config submodule.submodules/fluent-bit.url https://www.github.com/fluent/fluent-bit.git
git config submodule.submodules/opentelemetry-java-contrib.url https://www.github.com/open-telemetry/opentelemetry-java-contrib.git
git config submodule.submodules/opentelemetry-operations-collector.url https://www.github.com/GoogleCloudPlatform/opentelemetry-operations-collector.git
git submodule update --force --depth=1
}

do_setup
git diff --name-only master... || echo continuing

do_setup
git diff --name-only origin/master...
```

Also, this PR still gives a correct diff (`integration_test/third_party_apps_test.go`) when run on itself.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
