### PR TITLE
Internal: manually `docker push` instead for better pullability

### DIFF
--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -1,7 +1,5 @@
 # Integration Testing
 
-# Foo
-
 Integration tests are implemented as Kokoro builds that run on each PR. The
 builds first build the Ops Agent and then run tests on that agent. The Kokoro
 builds are split up by distro.

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -1,5 +1,7 @@
 # Integration Testing
 
+# Foo
+
 Integration tests are implemented as Kokoro builds that run on each PR. The
 builds first build the Ops Agent and then run tests on that agent. The Kokoro
 builds are split up by distro.

--- a/kokoro/scripts/build/build_package.sh
+++ b/kokoro/scripts/build/build_package.sh
@@ -60,12 +60,6 @@ sudo DOCKER_BUILDKIT=1 docker build . \
   --target "${DISTRO}-build" \
   -t build_image
 
-
-# DO NOT MERGE THIS PART
-sudo docker image tag build_image "${CACHE_LOCATION}"
-sudo docker push "${CACHE_LOCATION}"
-
-
 # Tell our continuous build to update the cache. Our other builds do not
 # write to any kind of cache, for example a per-PR cache, because the
 # push takes a few minutes and adds little value over just using the continuous

--- a/kokoro/scripts/build/build_package.sh
+++ b/kokoro/scripts/build/build_package.sh
@@ -89,4 +89,4 @@ sudo docker run \
     fi
 EOF
 
-docker push 
+asdf


### PR DESCRIPTION
## Description
Instead of using the `--cache-to` flag, which requires some gymnastics and doesn't seem to be `git pull`-able, let's just do a `git push` and use that for our cached image. It seems to work great in my testing, even getting cache hits for some of the layers but not all when appropriate. This should enable us to use kokoro's prefetching feature too. 

Dropping `--cache-to` also means we don't need to use `docker-container` or `buildx`.

## Related issue
b/255601283

## How has this been tested?
I ran a few similar builds, and got partial cache hits on https://source.cloud.google.com/results/invocations/91180c6c-d031-4ff2-ad09-1df2a731e8f9/targets, and full cache hits on https://source.cloud.google.com/results/invocations/38e87531-adde-46c6-ba2d-a19f4c9dfe3a/targets.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
