### PR TITLE
dummy change to trigger builds and flush windows workers

### DIFF
--- a/kokoro/scripts/build/build_package.ps1
+++ b/kokoro/scripts/build/build_package.ps1
@@ -12,45 +12,4 @@ function Invoke-Program() {
     throw "failed: $Args"
   }
 }
-
-$tag = 'build'
-$name = 'build-result'
-
-# Try to disable Windows Defender antivirus for improved build speed.
-# Sometimes it seems that Defender is already disabled and it fails with
-# an error like "Set-MpPreference : Operation failed with the following error: 0x800106ba"
-Set-MpPreference -Force -DisableRealtimeMonitoring $true -ErrorAction Continue
-# Try to disable Windows Defender firewall for improved build speed.
-Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False -ErrorAction Continue
-
-$gitOnBorgLocation = "$env:KOKORO_ARTIFACTS_DIR/git/unified_agents"
-if (Test-Path -Path $gitOnBorgLocation) {
-  Set-Location $gitOnBorgLocation
-}
-else {
-  Set-Location "$env:KOKORO_ARTIFACTS_DIR/github/unified_agents"
-}
-
-# Record OPS_AGENT_REPO_HASH so that we can later run tests from the
-# same commit that the agent was built from. This only applies to the
-# build+test flow for release builds, not the GitHub presubmits.
-$hash = Invoke-Program git -C . rev-parse HEAD
-
-# Set variables from the VERSION file. Currently this is only PKG_VERSION.
-Get-Content VERSION | Where-Object length | ForEach-Object { Invoke-Expression "`$env:$_" };
-
-# Write OPS_AGENT_REPO_HASH and PACKAGE_VERSION into Sponge custom config variables file.
-Write-Output @"
-OPS_AGENT_REPO_HASH,$hash
-PACKAGE_VERSION,$env:PKG_VERSION
-"@ |
-  Out-File -FilePath "$env:KOKORO_ARTIFACTS_DIR/custom_sponge_config.csv" -Encoding ascii
-
-Invoke-Program git submodule update --init
-Invoke-Program docker build -t $tag -f './Dockerfile.windows' .
-Invoke-Program docker create --name $name $tag
-Invoke-Program docker cp "${name}:/work/out" $env:KOKORO_ARTIFACTS_DIR
-
-# Copy the .goo file from $env:KOKORO_ARTIFACTS_DIR/out to $env:KOKORO_ARTIFACTS_DIR/result.
-New-Item -Path $env:KOKORO_ARTIFACTS_DIR -Name 'result' -ItemType 'directory'
-Move-Item -Path "$env:KOKORO_ARTIFACTS_DIR/out/*.goo" -Destination "$env:KOKORO_ARTIFACTS_DIR/result"
+Asdf

--- a/kokoro/scripts/build/build_package.sh
+++ b/kokoro/scripts/build/build_package.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-asdf
+exit 1
 
 # cd to the root of the git repo containing this script.
 cd "$(readlink -f "$(dirname "$0")")"
@@ -25,6 +25,8 @@ source "kokoro/scripts/utils/common.sh"
 set -e
 set -x
 set -o pipefail
+
+asdf
 
 RESULT_DIR=${RESULT_DIR:-"${KOKORO_ARTIFACTS_DIR}/result"}
 export RESULT_DIR

--- a/kokoro/scripts/build/build_package.sh
+++ b/kokoro/scripts/build/build_package.sh
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+asdf
 
 # cd to the root of the git repo containing this script.
 cd "$(readlink -f "$(dirname "$0")")"


### PR DESCRIPTION
## Description
there's a kokoro issue. this PR is just to cycle the windows workers a bit to see if the fix works.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
