### PR TITLE
integration_test: Update aerospike version to 5.7.0.23.

### DIFF
--- a/integration_test/third_party_apps_data/applications/aerospike/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/aerospike/centos_rhel/install
@@ -19,9 +19,9 @@ wget -O aerospike.tgz "https://download.aerospike.com/artifacts/aerospike-server
 tar -xvf aerospike.tgz
 (cd aerospike-server-community-6.1.0.1-$centos_rhel_version/ && sudo ./asinstall)
 
-wget -O aerospike-tools.tgz "https://download.aerospike.com/artifacts/aerospike-tools/7.0.5/aerospike-tools-7.0.5-$centos_rhel_version.tgz"
+wget -O aerospike-tools.tgz "https://download.aerospike.com/artifacts/aerospike-tools/7.1.1/aerospike-tools-7.1.1-$centos_rhel_version.tgz"
 tar -xvf aerospike-tools.tgz
-(cd aerospike-tools-7.0.5-*/ && sudo ./asinstall)
+(cd aerospike-tools-7.1.1-*/ && sudo ./asinstall)
 
 # re-enable selinux
 sudo setenforce 1

--- a/integration_test/third_party_apps_data/applications/aerospike/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/aerospike/centos_rhel/install
@@ -15,9 +15,9 @@ case "$VERSION_ID" in
 esac
 
 # download, extract, install, and start aerospike community edition
-wget -O aerospike.tgz "https://download.aerospike.com/artifacts/aerospike-server-community/6.1.0.1/aerospike-server-community-6.1.0.1-$centos_rhel_version.tgz"
+wget -O aerospike.tgz "https://download.aerospike.com/artifacts/aerospike-server-community/5.7.0.23/aerospike-server-community-5.7.0.23-$centos_rhel_version.tgz"
 tar -xvf aerospike.tgz
-(cd aerospike-server-community-6.1.0.1-$centos_rhel_version/ && sudo ./asinstall)
+(cd aerospike-server-community-5.7.0.23-$centos_rhel_version/ && sudo ./asinstall)
 
 wget -O aerospike-tools.tgz "https://download.aerospike.com/artifacts/aerospike-tools/7.1.1/aerospike-tools-7.1.1-$centos_rhel_version.tgz"
 tar -xvf aerospike-tools.tgz

--- a/integration_test/third_party_apps_data/applications/aerospike/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/aerospike/centos_rhel/install
@@ -15,9 +15,9 @@ case "$VERSION_ID" in
 esac
 
 # download, extract, install, and start aerospike community edition
-wget -O aerospike.tgz "https://download.aerospike.com/artifacts/aerospike-server-community/5.7.0.17/aerospike-server-community-5.7.0.17-$centos_rhel_version.tgz"
+wget -O aerospike.tgz "https://download.aerospike.com/artifacts/aerospike-server-community/6.1.0.1/aerospike-server-community-6.1.0.1-$centos_rhel_version.tgz"
 tar -xvf aerospike.tgz
-(cd aerospike-server-community-5.7.0.17-$centos_rhel_version/ && sudo ./asinstall)
+(cd aerospike-server-community-6.1.0.1-$centos_rhel_version/ && sudo ./asinstall)
 
 wget -O aerospike-tools.tgz "https://download.aerospike.com/artifacts/aerospike-tools/7.0.5/aerospike-tools-7.0.5-$centos_rhel_version.tgz"
 tar -xvf aerospike-tools.tgz

--- a/integration_test/third_party_apps_data/applications/aerospike/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/aerospike/debian_ubuntu/install
@@ -24,13 +24,13 @@ case $ID in
 esac
 
 # download, extract, install, and start aerospike community edition
-wget -O aerospike.tgz "https://download.aerospike.com/artifacts/aerospike-server-community/c/aerospike-server-community-6.1.0.1-$os_version.tgz"
+wget -O aerospike.tgz "https://download.aerospike.com/artifacts/aerospike-server-community/6.1.0.1/aerospike-server-community-6.1.0.1-$os_version.tgz"
 tar -xvf aerospike.tgz
 (cd aerospike-server-community-6.1.0.1-*/ && sudo ./asinstall)
 
-wget -O aerospike-tools.tgz "https://download.aerospike.com/artifacts/aerospike-tools/7.0.5/aerospike-tools-7.0.5-$os_version.tgz"
+wget -O aerospike-tools.tgz "https://download.aerospike.com/artifacts/aerospike-tools/7.1.1/aerospike-tools-7.1.1-$os_version.tgz"
 tar -xzf aerospike-tools.tgz
-(cd aerospike-tools-7.0.5-*/ && sudo ./asinstall)
+(cd aerospike-tools-7.1.1-*/ && sudo ./asinstall)
 
 sudo systemctl enable aerospike
 sudo systemctl start aerospike

--- a/integration_test/third_party_apps_data/applications/aerospike/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/aerospike/debian_ubuntu/install
@@ -24,9 +24,9 @@ case $ID in
 esac
 
 # download, extract, install, and start aerospike community edition
-wget -O aerospike.tgz "https://download.aerospike.com/artifacts/aerospike-server-community/5.7.0.17/aerospike-server-community-5.7.0.17-$os_version.tgz"
+wget -O aerospike.tgz "https://download.aerospike.com/artifacts/aerospike-server-community/c/aerospike-server-community-6.1.0.1-$os_version.tgz"
 tar -xvf aerospike.tgz
-(cd aerospike-server-community-5.7.0.17-*/ && sudo ./asinstall)
+(cd aerospike-server-community-6.1.0.1-*/ && sudo ./asinstall)
 
 wget -O aerospike-tools.tgz "https://download.aerospike.com/artifacts/aerospike-tools/7.0.5/aerospike-tools-7.0.5-$os_version.tgz"
 tar -xzf aerospike-tools.tgz

--- a/integration_test/third_party_apps_data/applications/aerospike/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/aerospike/debian_ubuntu/install
@@ -24,9 +24,9 @@ case $ID in
 esac
 
 # download, extract, install, and start aerospike community edition
-wget -O aerospike.tgz "https://download.aerospike.com/artifacts/aerospike-server-community/6.1.0.1/aerospike-server-community-6.1.0.1-$os_version.tgz"
+wget -O aerospike.tgz "https://download.aerospike.com/artifacts/aerospike-server-community/5.7.0.23/aerospike-server-community-5.7.0.23-$os_version.tgz"
 tar -xvf aerospike.tgz
-(cd aerospike-server-community-6.1.0.1-*/ && sudo ./asinstall)
+(cd aerospike-server-community-5.7.0.23-*/ && sudo ./asinstall)
 
 wget -O aerospike-tools.tgz "https://download.aerospike.com/artifacts/aerospike-tools/7.1.1/aerospike-tools-7.1.1-$os_version.tgz"
 tar -xzf aerospike-tools.tgz

--- a/integration_test/third_party_apps_data/applications/aerospike/sles/install
+++ b/integration_test/third_party_apps_data/applications/aerospike/sles/install
@@ -3,7 +3,7 @@ set -e
 # aerospike-init requires `python` in $PATH
 sudo ln -s /usr/bin/python3 /usr/bin/python
 
-curl -L -o aerospike.tar.gz https://github.com/aerospike/aerospike-server/releases/download/5.7.0.17/aerospike-server-community-5.7.0.17.tar.gz
+curl -L -o aerospike.tar.gz https://github.com/aerospike/aerospike-server/releases/download/6.1.0.1/aerospike-server-community-6.1.0.1.tar.gz
 tar -xzf aerospike.tar.gz
 cd aerospike-server
 ./bin/aerospike init

--- a/integration_test/third_party_apps_data/applications/aerospike/sles/install
+++ b/integration_test/third_party_apps_data/applications/aerospike/sles/install
@@ -16,6 +16,6 @@ sudo ./bin/aerospike start
 
 cd -
 
-wget -O aerospike-tools.tgz "https://download.aerospike.com/artifacts/aerospike-tools/7.0.5/aerospike-tools-7.0.5-el8.tgz"
+wget -O aerospike-tools.tgz "https://download.aerospike.com/artifacts/aerospike-tools/7.1.1/aerospike-tools-7.1.1-el8.tgz"
 tar -xzf aerospike-tools.tgz
-(cd aerospike-tools-7.0.5-el8 && sudo ./asinstall)
+(cd aerospike-tools-7.1.1-el8 && sudo ./asinstall)

--- a/integration_test/third_party_apps_data/applications/aerospike/sles/install
+++ b/integration_test/third_party_apps_data/applications/aerospike/sles/install
@@ -3,7 +3,7 @@ set -e
 # aerospike-init requires `python` in $PATH
 sudo ln -s /usr/bin/python3 /usr/bin/python
 
-curl -L -o aerospike.tar.gz https://github.com/aerospike/aerospike-server/releases/download/6.1.0.1/aerospike-server-community-6.1.0.1.tar.gz
+curl -L -o aerospike.tar.gz https://github.com/aerospike/aerospike-server/releases/download/5.7.0.23/aerospike-server-community-5.7.0.23.tar.gz
 tar -xzf aerospike.tar.gz
 cd aerospike-server
 ./bin/aerospike init


### PR DESCRIPTION
## Description
Update aerospike version from `5.7.0.17` to `5.7.0.23` to address third party app test errors due to incorrect URL in aerospike site when trying to download `5.7.0.17`.

## Related issue
b/257047270

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
