### PR TITLE
Internal: tweaks to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 .git
 Dockerfile
+Dockerfile.windows
 .dockerignore
 
 integration_test
-kokoro/config
-kokoro/scripts/test
+kokoro


### PR DESCRIPTION
## Description
two tweaks:
1. add `Dockerfile.windows` for the same reason as `Dockerfile`.
2. ignore the whole `kokoro` directory. Previously the contents of the `kokoro/scripts/build` directory were included in the build context sent to the daemon, but that doesn't make sense. `kokoro/scripts/build` isn't needed to run the `docker build`, it specifies our setup for how to invoke `docker build`. Long story short, I was getting needless cache invalidations when modifying these scripts and this PR will fix that.

## Related issue
b/232119166

## How has this been tested?
automated tests only

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.
