### PR TITLE
Fix expectedmetrics formatting

### DIFF
--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -673,7 +673,7 @@ func modifiedFiles(t *testing.T) []string {
 	stdout := string(out)
 	if err != nil {
 		stderr := ""
-		if exitError := err.(*exec.ExitError); exitError != nil {
+        	if exitError := err.(*exec.ExitError); exitError != nil {
 			stderr = string(exitError.Stderr)
 		}
 		t.Fatalf("got error calling `git diff`: %v\nstderr=%v\nstdout=%v", err, stderr, stdout)
@@ -753,7 +753,7 @@ const (
 	SAPHANAApp      = "saphana"
 
 	OracleDBPlatform = "rhel-7"
-	OracleDBApp      = "oracledb"
+	OracleDBApp = "oracledb"
 
 	AerospikeApp = "aerospike"
 )
@@ -773,11 +773,10 @@ func incompatibleOperatingSystem(testCase test) string {
 
 // When in `-short` test mode, mark some tests for skipping, based on
 // test_config and impacted apps.
-//   - For all impacted apps, test on all platforms.
-//   - Always test all apps against the default platform.
-//   - Always test the default app (postgres/active_directory_ds for now)
+//   * For all impacted apps, test on all platforms.
+//   * Always test all apps against the default platform.
+//   * Always test the default app (postgres/active_directory_ds for now)
 //     on all platforms.
-//
 // `platforms_to_skip` overrides the above.
 // Also, restrict `SAPHANAPlatform` to only test `SAPHANAApp` and skip that
 // app on all other platforms too. Same for `OracleDBPlatform` and

--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -462,7 +462,7 @@ func runLoggingTestCases(ctx context.Context, logger *logging.DirectoryLogger, v
 
 func runMetricsTestCases(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.VM, metrics []*metadata.ExpectedMetric) error {
 	var err error
-	logger.ToMainLog().Printf("Parsed expectedMetrics: %+v", metrics)
+	logger.ToMainLog().Printf("Parsed expectedMetrics: %s", util.DumpPointerArray(metrics, "%+v"))
 	// Wait for the representative metric first, which is intended to *always*
 	// be sent. If it doesn't exist, we fail fast and skip running the other metrics;
 	// if it does exist, we go on to the other metrics in parallel, by which point they
@@ -673,7 +673,7 @@ func modifiedFiles(t *testing.T) []string {
 	stdout := string(out)
 	if err != nil {
 		stderr := ""
-        	if exitError := err.(*exec.ExitError); exitError != nil {
+		if exitError := err.(*exec.ExitError); exitError != nil {
 			stderr = string(exitError.Stderr)
 		}
 		t.Fatalf("got error calling `git diff`: %v\nstderr=%v\nstdout=%v", err, stderr, stdout)
@@ -753,7 +753,7 @@ const (
 	SAPHANAApp      = "saphana"
 
 	OracleDBPlatform = "rhel-7"
-	OracleDBApp = "oracledb"
+	OracleDBApp      = "oracledb"
 
 	AerospikeApp = "aerospike"
 )
@@ -773,10 +773,11 @@ func incompatibleOperatingSystem(testCase test) string {
 
 // When in `-short` test mode, mark some tests for skipping, based on
 // test_config and impacted apps.
-//   * For all impacted apps, test on all platforms.
-//   * Always test all apps against the default platform.
-//   * Always test the default app (postgres/active_directory_ds for now)
+//   - For all impacted apps, test on all platforms.
+//   - Always test all apps against the default platform.
+//   - Always test the default app (postgres/active_directory_ds for now)
 //     on all platforms.
+//
 // `platforms_to_skip` overrides the above.
 // Also, restrict `SAPHANAPlatform` to only test `SAPHANAApp` and skip that
 // app on all other platforms too. Same for `OracleDBPlatform` and

--- a/integration_test/util/util.go
+++ b/integration_test/util/util.go
@@ -17,6 +17,8 @@
 package util
 
 import (
+	"fmt"
+
 	"github.com/GoogleCloudPlatform/ops-agent/integration_test/gce"
 )
 
@@ -25,4 +27,19 @@ func ConfigPathForPlatform(platform string) string {
 		return `C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml`
 	}
 	return "/etc/google-cloud-ops-agent/config.yaml"
+}
+
+// DumpPointerArray formats the given array of pointers-to-structs as a strings
+// using the given format, rather than just formatting them as addresses.
+// format is usually either "%v" or "%+v".
+func DumpPointerArray[T any](array []*T, format string) string {
+	s := "["
+	for i, element := range array {
+		if i > 0 {
+			s += ", "
+		}
+		s += fmt.Sprintf(format, element)
+	}
+	s += "]"
+	return s
 }


### PR DESCRIPTION
## Description

The tests currently show something like this:

```
2022/11/07 09:36:30 Parsed expectedMetrics: [0xc000114de0 0xc000115440 0xc000115500 0xc0001155c0 0xc000115680 0xc000115740 0xc000115800 0xc0001158c0 0xc000115980 0xc000115a40 0xc000115b00 0xc000115bc0 0xc000115c80 0xc000115d40 0xc000115e00 0xc000115ec0 0xc000115f80 0xc0000bab40]
```

which is not super useful. This change formats pointers according to their underlying structure instead, for example:

```
2022/11/07 10:04:11 Parsed expectedMetrics: [&{Type:workload.googleapis.com/nginx.connections_accepted ValueType:INT64 Kind:CUMULATIVE MonitoredResource:gce_instance Labels:map[] Optional:false Representative:false Platform:}, &{Type:workload.googleapis.com/nginx.connections_current ValueType:INT64 Kind:GAUGE MonitoredResource:gce_instance Labels:map[state:.*] Optional:false Representative:false Platform:}, &{Type:workload.googleapis.com/nginx.connections_handled ValueType:INT64 Kind:CUMULATIVE MonitoredResource:gce_instance Labels:map[] Optional:false Representative:false Platform:}, &{Type:workload.googleapis.com/nginx.requests ValueType:INT64 Kind:CUMULATIVE MonitoredResource:gce_instance Labels:map[] Optional:false Representative:true Platform:}]
```

## Related issue
N/A

## How has this been tested?
Tested a single 3p app.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
