### PR TITLE
Put Windows 2012 workaround in correct spot

### DIFF
--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -247,34 +247,39 @@ func setupOpsAgentFrom(ctx context.Context, logger *logging.DirectoryLogger, vm 
 	if err := installOpsAgent(ctx, logger, vm, location); err != nil {
 		return err
 	}
+	doRestart := false
 	startupDelay := 20 * time.Second
+	// TODO(b/240564518): Workaround for fluent-bit startup hang on 2012. This requires
+	// a restart of the agents, so perform this step before restartOpsAgent below.
+	if gce.IsWindows(vm.Platform) && strings.Contains(vm.Platform, "2012") {
+		if _, err := gce.RunScriptRemotely(
+			ctx,
+			logger,
+			vm,
+			`$ErrorActionPreference = "Stop"
+			$key = "HKLM:\SYSTEM\CurrentControlSet\Services\google-cloud-ops-agent-fluent-bit"
+			$old_path = (Get-ItemProperty -Path $key -Name "ImagePath").ImagePath
+			$new_path = "cmd.exe /k start /AFFINITY FF /WAIT `+"`\"`\""+` $old_path"
+			Set-ItemProperty -Path $key -Name "ImagePath" $new_path`,
+			nil,
+			nil,
+		); err != nil {
+			return fmt.Errorf("setupOpsAgentFrom() windows-2012 workaround failed: %v", err)
+		}
+		doRestart = true
+	}
 	if len(config) > 0 {
 		if gce.IsWindows(vm.Platform) {
 			// Sleep to avoid some flaky errors when restarting the agent because the
 			// services have not fully started up yet.
 			time.Sleep(startupDelay)
-			// TODO(b/240564518): Workaround for fluent-bit startup hang on 2012. This requires
-			// a restart of the agents, so perform this step before restartOpsAgent below.
-			if strings.Contains(vm.Platform, "2012") {
-				if _, err := gce.RunScriptRemotely(
-					ctx,
-					logger,
-					vm,
-					`$ErrorActionPreference = "Stop"
-					$key = "HKLM:\SYSTEM\CurrentControlSet\Services\google-cloud-ops-agent-fluent-bit"
-					$old_path = (Get-ItemProperty -Path $key -Name "ImagePath").ImagePath
-					$new_path = "cmd.exe /k start /AFFINITY FF /WAIT `+"`\"`\""+` $old_path"
-					Set-ItemProperty -Path $key -Name "ImagePath" $new_path`,
-					nil,
-					nil,
-				); err != nil {
-					return fmt.Errorf("setupOpsAgentFrom() windows-2012 workaround failed: %v", err)
-				}
-			}
 		}
 		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(config), util.ConfigPathForPlatform(vm.Platform)); err != nil {
 			return fmt.Errorf("setupOpsAgentFrom() failed to upload config file: %v", err)
 		}
+		doRestart = true
+	}
+	if doRestart {
 		if err := restartOpsAgent(ctx, logger, vm); err != nil {
 			return err
 		}

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -249,31 +249,31 @@ func setupOpsAgentFrom(ctx context.Context, logger *logging.DirectoryLogger, vm 
 	}
 	doRestart := false
 	startupDelay := 20 * time.Second
-	// TODO(b/240564518): Workaround for fluent-bit startup hang on 2012. This requires
-	// a restart of the agents, so perform this step before restartOpsAgent below.
-	if gce.IsWindows(vm.Platform) && strings.Contains(vm.Platform, "2012") {
-		if _, err := gce.RunScriptRemotely(
-			ctx,
-			logger,
-			vm,
-			`$ErrorActionPreference = "Stop"
-			$key = "HKLM:\SYSTEM\CurrentControlSet\Services\google-cloud-ops-agent-fluent-bit"
-			$old_path = (Get-ItemProperty -Path $key -Name "ImagePath").ImagePath
-			$new_path = "cmd.exe /k start /AFFINITY FF /WAIT `+"`\"`\""+` $old_path"
-			Set-ItemProperty -Path $key -Name "ImagePath" $new_path`,
-			nil,
-			nil,
-		); err != nil {
-			return fmt.Errorf("setupOpsAgentFrom() windows-2012 workaround failed: %v", err)
+	if gce.IsWindows(vm.Platform) {
+		// Sleep to avoid some flaky errors when uploading content because the
+		// services have not fully started up yet.
+		time.Sleep(startupDelay)
+		// TODO(b/240564518): Workaround for fluent-bit startup hang on 2012. This requires
+		// a restart of the agents, so perform this step before restartOpsAgent below.
+		if strings.Contains(vm.Platform, "2012") {
+			if _, err := gce.RunScriptRemotely(
+				ctx,
+				logger,
+				vm,
+				`$ErrorActionPreference = "Stop"
+				$key = "HKLM:\SYSTEM\CurrentControlSet\Services\google-cloud-ops-agent-fluent-bit"
+				$old_path = (Get-ItemProperty -Path $key -Name "ImagePath").ImagePath
+				$new_path = "cmd.exe /k start /AFFINITY FF /WAIT `+"`\"`\""+` $old_path"
+				Set-ItemProperty -Path $key -Name "ImagePath" $new_path`,
+				nil,
+				nil,
+			); err != nil {
+				return fmt.Errorf("setupOpsAgentFrom() windows-2012 workaround failed: %v", err)
+			}
+			doRestart = true
 		}
-		doRestart = true
 	}
 	if len(config) > 0 {
-		if gce.IsWindows(vm.Platform) {
-			// Sleep to avoid some flaky errors when restarting the agent because the
-			// services have not fully started up yet.
-			time.Sleep(startupDelay)
-		}
 		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(config), util.ConfigPathForPlatform(vm.Platform)); err != nil {
 			return fmt.Errorf("setupOpsAgentFrom() failed to upload config file: %v", err)
 		}


### PR DESCRIPTION
## Description
I accidentally put the workaround from #944 in the section that only runs when there's a non-empty Ops Agent config. I want it to run unconditionally so this moves the code outside that section.

## Related issue
b/240564518

## How has this been tested?
Ran `TestSystemLogByDefault/windows-2012-r2` locally, which uses a blank config and which failed on the nightlies even after #944; it passes now.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
