### PR TITLE
Add workaround for Windows 2012 fluent-bit lockups

### DIFF
--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -89,22 +89,7 @@ func workDirForPlatform(platform string) string {
 
 func restartCommandForPlatform(platform string) string {
 	if gce.IsWindows(platform) {
-		return `
-Restart-Service google-cloud-ops-agent -Force
-# TODO(b/240564518): remove process-killing once bug is fixed
-if (!$?) {
-	Write-Output 'Could not restart services gracefully. Killing processes directly...'
-	Get-Service -Name 'google-cloud-ops-agent*' | Set-Service -StartupType Disabled
-	# TODO: use 'sc failure google-cloud-ops-agent reset= 0 actions= ""' to disable automatic recovery in case it interferes with Start-Service
-	Get-WmiObject -Class Win32_Service -Filter "Name LIKE 'google-cloud-ops-agent%'" | ForEach-Object {		
-		Stop-Process -Force $_.ProcessId -ErrorAction SilentlyContinue
-		if (!$?) {
-			Write-Output "Could not stop process $($_.ProcessId); proceeding anyway"
-		}
-	}
-	Get-Service -Name 'google-cloud-ops-agent*' | Set-Service -StartupType Automatic
-	Start-Service -Name 'google-cloud-ops-agent'
-}`
+		return "Restart-Service google-cloud-ops-agent -Force"
 	}
 	// Return a command that works for both < 2.0.0 and >= 2.0.0 agents.
 	return "sudo service google-cloud-ops-agent restart || sudo systemctl restart google-cloud-ops-agent.target"

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -262,24 +262,6 @@ func setupOpsAgentFrom(ctx context.Context, logger *logging.DirectoryLogger, vm 
 			// Sleep to avoid some flaky errors when restarting the agent because the
 			// services have not fully started up yet.
 			time.Sleep(startupDelay)
-			// TODO(b/240564518): Workaround for fluent-bit startup hang on 2012. This requires
-			// a restart of the agents, so perform this step before restartOpsAgent below.
-			if strings.Contains(vm.Platform, "2012") {
-				if _, err := gce.RunScriptRemotely(
-					ctx,
-					logger,
-					vm,
-					`$ErrorActionPreference = "Stop"
-					$key = "HKLM:\SYSTEM\CurrentControlSet\Services\google-cloud-ops-agent-fluent-bit"
-					$old_path = (Get-ItemProperty -Path $key -Name "ImagePath").ImagePath
-					$new_path = "cmd.exe /k start /AFFINITY FF /WAIT `+"`\"`\""+` $old_path"
-					Set-ItemProperty -Path $key -Name "ImagePath" $new_path`,
-					nil,
-					nil,
-				); err != nil {
-					return fmt.Errorf("setupOpsAgentFrom() windows-2012 workaround failed: %v", err)
-				}
-			}
 		}
 		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(config), util.ConfigPathForPlatform(vm.Platform)); err != nil {
 			return fmt.Errorf("setupOpsAgentFrom() failed to upload config file: %v", err)


### PR DESCRIPTION
## Description
This is the user-facing counterpart to #944 and #948. The intent is to unblock users while simultaneously simplifying the workarounds away from our test code.

While this is a user-facing change, I don't expect there to be any negative impact on users, and if something unforeseen _does_ occur then the user still has a workaround which is to manually change the service startup parameters back to where they were before.

## Related issue
b/240564518

## How has this been tested?
Tested locally + presubmits

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
