### PR TITLE
Get bison package from team vendor repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -231,8 +231,8 @@ enabled=1
 autorefresh=0
 repo_gpgcheck=0
 gpgcheck=0
-EOF && \
-    zypper addrepo agent-vendor.repo && \
+EOF
+RUN set -x; zypper addrepo agent-vendor.repo && \
     zypper -n --gpg-auto-import-keys refresh && \
     zypper -n update && \
     zypper -n install bison>3.4 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -223,7 +223,16 @@ FROM opensuse/leap:15.1 AS sles15-build
 
 RUN set -x; zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros java-11-openjdk-devel unzip zip && \
     # Add home:d4vid:co22 repo to install >3.4 bison
-    zypper addrepo https://packages.cloud.google.com/yum/repos/google-cloud-monitoring-sles15-x86_64-test-20221109-1 && \
+    cat > agent-vendor.repo << EOF
+[google-cloud-monitoring-sles15-x86_64-test]
+name=google-cloud-monitoring-sles15-x86_64-test
+baseurl=https://packages.cloud.google.com/yum/repos/google-cloud-monitoring-sles15-x86_64-test-20221109-1
+enabled=1
+autorefresh=0
+repo_gpgcheck=0
+gpgcheck=0
+EOF && \
+    zypper addrepo agent-vendor.repo && \
     zypper -n --gpg-auto-import-keys refresh && \
     zypper -n update && \
     zypper -n install bison>3.4 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -223,15 +223,13 @@ FROM opensuse/leap:15.1 AS sles15-build
 
 RUN set -x; zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros java-11-openjdk-devel unzip zip && \
     # Add home:d4vid:co22 repo to install >3.4 bison
-    cat > agent-vendor.repo << EOF
-[google-cloud-monitoring-sles15-x86_64-test]
-name=google-cloud-monitoring-sles15-x86_64-test
-baseurl=https://packages.cloud.google.com/yum/repos/google-cloud-monitoring-sles15-x86_64-test-20221109-1
-enabled=1
-autorefresh=0
-repo_gpgcheck=0
-gpgcheck=0
-EOF
+    RUN echo $'[google-cloud-monitoring-sles15-x86_64-test] \n\
+    name=google-cloud-monitoring-sles15-x86_64-test \n\
+    baseurl=https://packages.cloud.google.com/yum/repos/google-cloud-monitoring-sles15-x86_64-test-20221109-1 \n\
+    enabled         = 1 \n\
+    autorefresh     = 0 \n\
+    repo_gpgcheck   = 0 \n\
+    gpgcheck        = 0' > agent-vendor.repo
 RUN set -x; zypper addrepo agent-vendor.repo && \
     zypper -n --gpg-auto-import-keys refresh && \
     zypper -n update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -221,15 +221,15 @@ RUN ./pkg/rpm/build.sh
 
 FROM opensuse/leap:15.1 AS sles15-build
 SHELL ["/bin/bash", "-c"]
-RUN set -x; zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros java-11-openjdk-devel unzip zip && \
-    # Add home:d4vid:co22 repo to install >3.4 bison
-    RUN echo $'[google-cloud-monitoring-sles15-x86_64-test] \n\
-    name=google-cloud-monitoring-sles15-x86_64-test \n\
-    baseurl=https://packages.cloud.google.com/yum/repos/google-cloud-monitoring-sles15-x86_64-test-20221109-1 \n\
-    enabled         = 1 \n\
-    autorefresh     = 0 \n\
-    repo_gpgcheck   = 0 \n\
-    gpgcheck        = 0' > agent-vendor.repo
+RUN set -x; zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros java-11-openjdk-devel unzip zip
+# Add agent-vendor.repo to install >3.4 bison
+RUN echo $'[google-cloud-monitoring-sles15-x86_64-test] \n\
+name=google-cloud-monitoring-sles15-x86_64-test \n\
+baseurl=https://packages.cloud.google.com/yum/repos/google-cloud-monitoring-sles15-x86_64-test-20221109-1 \n\
+enabled         = 1 \n\
+autorefresh     = 0 \n\
+repo_gpgcheck   = 0 \n\
+gpgcheck        = 0' > agent-vendor.repo
 RUN set -x; zypper addrepo agent-vendor.repo && \
     zypper -n --gpg-auto-import-keys refresh && \
     zypper -n update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -220,7 +220,6 @@ WORKDIR /work
 RUN ./pkg/rpm/build.sh
 
 FROM opensuse/leap:15.1 AS sles15-build
-SHELL ["/bin/bash", "-c"]
 RUN set -x; zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros java-11-openjdk-devel unzip zip
 # Add agent-vendor.repo to install >3.4 bison
 RUN echo $'[google-cloud-monitoring-sles15-x86_64-test] \n\

--- a/Dockerfile
+++ b/Dockerfile
@@ -220,7 +220,7 @@ WORKDIR /work
 RUN ./pkg/rpm/build.sh
 
 FROM opensuse/leap:15.1 AS sles15-build
-
+SHELL ["/bin/bash", "-c"]
 RUN set -x; zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros java-11-openjdk-devel unzip zip && \
     # Add home:d4vid:co22 repo to install >3.4 bison
     RUN echo $'[google-cloud-monitoring-sles15-x86_64-test] \n\

--- a/Dockerfile
+++ b/Dockerfile
@@ -219,11 +219,11 @@ COPY . /work
 WORKDIR /work
 RUN ./pkg/rpm/build.sh
 
-FROM opensuse/leap:15.3 AS sles15-build
+FROM opensuse/leap:15.1 AS sles15-build
 
 RUN set -x; zypper -n install git systemd autoconf automake flex libtool libcurl-devel libopenssl-devel libyajl-devel gcc gcc-c++ zlib-devel rpm-build expect cmake systemd-devel systemd-rpm-macros java-11-openjdk-devel unzip zip && \
     # Add home:d4vid:co22 repo to install >3.4 bison
-    zypper addrepo https://download.opensuse.org/repositories/home:/d4vid:/co22/15.3/home:d4vid:co22.repo && \
+    zypper addrepo https://packages.cloud.google.com/yum/repos/google-cloud-monitoring-sles15-x86_64-test-20221109-1 && \
     zypper -n --gpg-auto-import-keys refresh && \
     zypper -n update && \
     zypper -n install bison>3.4 && \


### PR DESCRIPTION
## Description
15.1 and 15.2 needs bison > 3.4 < 3.8. The public suse repo kept getting wiped out. Thus we will hold the pkg ourselves.

## Related issue
b/256835289

## How has this been tested?
Create a new sles 15.1 then add repo then install bison(b/256835289#comment8)

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
