### PR TITLE
integration_test: skip prometheus tests on rhel

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1061,6 +1061,10 @@ func IsCentOS(platform string) bool {
 	return strings.HasPrefix(platform, "centos-")
 }
 
+func IsRHEL(platform string) bool {
+	return strings.HasPrefix(platform, "rhel-")
+}
+
 // CreateInstance launches a new VM instance based on the given options.
 // Also waits for the instance to be reachable over ssh.
 // Returns a VM object or an error (never both). The caller is responsible for

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -1799,7 +1799,7 @@ func TestPrometheusMetrics(t *testing.T) {
 		// TODO: Enable this test for all distros once the prometheus receiver is GA.
 		// For some reason, the featuregate, when set in the default systemd environment
 		// file, is not being picked up on centOS distros. This is a temporary workaround.
-		if gce.IsCentOS(platform) {
+		if gce.IsCentOS(platform) || gce.IsRHEL(platform) {
 			t.SkipNow()
 		}
 
@@ -1936,7 +1936,7 @@ func TestPrometheusMetricsWithJSONExporter(t *testing.T) {
 		// TODO: Enable this test for all distros once the prometheus receiver is GA.
 		// For some reason, the featuregate, when set in the default systemd environment
 		// file, is not being picked up on centOS distros. This is a temporary workaround.
-		if gce.IsWindows(platform) || gce.IsCentOS(platform) {
+		if gce.IsWindows(platform) || gce.IsCentOS(platform) || gce.IsRHEL(platform) {
 			t.SkipNow()
 		}
 		ctx, logger, vm := agents.CommonSetup(t, platform)


### PR DESCRIPTION
## Description
Skip prometheus tests on RHEL since we can't set the environment variables for the feature gate on that distro using the current way of doing it.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
