### PR TITLE
Use docker-credential-gcr instead of gcloud to match kokoro's prefetching logic

### DIFF
--- a/kokoro/scripts/build/build_package.ps1
+++ b/kokoro/scripts/build/build_package.ps1
@@ -49,7 +49,7 @@ PACKAGE_VERSION,$env:PKG_VERSION
 
 Invoke-Program git submodule update --init
 $artifact_registry='us-docker.pkg.dev'
-Invoke-Program gcloud auth configure-docker $artifact_registry
+Invoke-Program docker-credential-gcr configure-docker --registries="$artifact_registry"
 
 $cache_location="${artifact_registry}/stackdriver-test-143416/google-cloud-ops-agent-build-cache/ops-agent-cache:windows"
 Invoke-Program docker pull $cache_location


### PR DESCRIPTION
## Description
I'm going mad trying to figure out why docker caching on windows breaks when we turn on kokoro prefetching. Pretty much my last remaining theory is that when we set up `gcloud` as the credential helper for docker, this somehow interferes with kokoro's prefetched image, that was fetched using `docker-credential-gcr`. The theory has holes, but it's the best I've got.

Being consistent with the credential helper that kokoro is using can't be bad. I think this PR is a step in the right direction.

## Related issue
b/255601283

## How has this been tested?
automated tests should be enough.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.