### PR TITLE
remove sudo and use a different credentials helper

### DIFF
--- a/kokoro/scripts/build/build_package.sh
+++ b/kokoro/scripts/build/build_package.sh
@@ -36,25 +36,11 @@ git submodule update --init --recursive
 . VERSION
 export_to_sponge_config "PACKAGE_VERSION" "${PKG_VERSION}"
 
-# From https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired-2
-# to fix issues like b/227486796.
-curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-
-# Install Docker.
-# https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
-  | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
-  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-sudo apt-get -y update
-sudo apt-get -y install docker-ce docker-ce-cli containerd.io
-
 ARTIFACT_REGISTRY="us-docker.pkg.dev"
-sudo gcloud auth configure-docker "${ARTIFACT_REGISTRY}"
+docker-credential-gcr configure-docker --registries="${ARTIFACT_REGISTRY}"
 CACHE_LOCATION="${ARTIFACT_REGISTRY}/stackdriver-test-143416/google-cloud-ops-agent-build-cache/ops-agent-cache:${DISTRO}"
 
-sudo DOCKER_BUILDKIT=1 docker build . \
+DOCKER_BUILDKIT=1 docker build . \
   --cache-from="${CACHE_LOCATION}" \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
   --target "${DISTRO}-build" \
@@ -65,8 +51,8 @@ sudo DOCKER_BUILDKIT=1 docker build . \
 # push takes a few minutes and adds little value over just using the continuous
 # build's cache.
 if [[ "${KOKORO_ROOT_JOB_TYPE}" == "CONTINUOUS_INTEGRATION" ]]; then
-  sudo docker image tag build_image "${CACHE_LOCATION}"
-  sudo docker push "${CACHE_LOCATION}"
+  docker image tag build_image "${CACHE_LOCATION}"
+  docker push "${CACHE_LOCATION}"
 fi
 
 SIGNING_DIR="$(pwd)/kokoro/scripts/build/signing"
@@ -75,7 +61,7 @@ if [[ "${PKGFORMAT}" == "rpm" && "${SKIP_SIGNING}" != "true" ]]; then
   cp "${RPM_SIGNING_KEY}" "${SIGNING_DIR}/signing-key"
 fi
 
-sudo docker run \
+docker run \
   -i \
   -v "${RESULT_DIR}":/artifacts \
   -v "${SIGNING_DIR}":/signing \

--- a/kokoro/scripts/build/build_package.sh
+++ b/kokoro/scripts/build/build_package.sh
@@ -39,6 +39,7 @@ export_to_sponge_config "PACKAGE_VERSION" "${PKG_VERSION}"
 ARTIFACT_REGISTRY="us-docker.pkg.dev"
 docker-credential-gcr configure-docker --registries="${ARTIFACT_REGISTRY}"
 CACHE_LOCATION="${ARTIFACT_REGISTRY}/stackdriver-test-143416/google-cloud-ops-agent-build-cache/ops-agent-cache:${DISTRO}"
+time docker pull "${CACHE_LOCATION}"
 
 DOCKER_BUILDKIT=1 docker build . \
   --cache-from="${CACHE_LOCATION}" \


### PR DESCRIPTION
let's see if we can avoid the pull altogether

## Description
<!--- Describe your changes in detail. -->

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
