### PR TITLE
Fix missing opensuse condition

### DIFF
--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -334,7 +334,7 @@ func tryInstallPackages(ctx context.Context, logger *log.Logger, vm *gce.VM, pkg
 		strings.HasPrefix(vm.Platform, "rhel-") ||
 		strings.HasPrefix(vm.Platform, "rocky-linux-") {
 		cmd = fmt.Sprintf("sudo yum -y install %s", pkgsString)
-	} else if strings.HasPrefix(vm.Platform, "sles-") {
+	} else if gce.IsSUSE(vm.Platform) {
 		cmd = fmt.Sprintf("sudo zypper --non-interactive install %s", pkgsString)
 	} else if strings.HasPrefix(vm.Platform, "debian-") ||
 		strings.HasPrefix(vm.Platform, "ubuntu-") {


### PR DESCRIPTION
## Description
Fixes `TestPrometheusMetricsWithJSONExporter/opensuse-leap*`.

## Related issue
N/A, error noticed during nightlies

## How has this been tested?
Tested `TestPrometheusMetricsWithJSONExporter/opensuse-leap` locally with `REPO_SUFFIX=20221114-1` and it passed.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
