### PR TITLE
Add startup delay on SUES platforms

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -153,6 +153,7 @@ const (
 	vmInitBackoffDuration             = 10 * time.Second
 	vmWinPasswordResetBackoffDuration = 30 * time.Second
 
+	slesStartupDelay        = 60 * time.Second
 	slesInitMaxAttempts     = 5
 	slesInitBackoffDuration = 5 * time.Second
 
@@ -1487,6 +1488,13 @@ func waitForStartLinux(ctx context.Context, logger *log.Logger, vm *VM) error {
 	if err := backoff.Retry(isStartupDone, backoffPolicy); err != nil {
 		return fmt.Errorf("%v. Last err=%v", startupFailedMessage, err)
 	}
+
+	// TODO(b/259122953): SUSE needs additional startup time. Remove once we have more
+	// sensible/deterministic workarounds for each of the individual problems.
+	if IsSUSE(vm.Platform) {
+		time.Sleep(slesStartupDelay)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Description
This is a temporary, general effort to unblock the nightlies, since it seems that many of the issues we're seeing are related to incomplete startup.

## Related issue
b/259122953

## How has this been tested?
Local integration tests passed.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
