### PR TITLE
Internal: tests install `go` from a GCS bucket

### DIFF
--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -75,7 +75,7 @@ unset GOPATH
 GO_VERSION="1.19"
 
 # Download and install a newer version of go.
-wget --no-verbose --output-document=/dev/stdout https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz | \
+gsutil cp "gs://stackdriver-test-143416-go-install/go${GO_VERSION}.linux-amd64.tar.gz" - | \
   sudo tar --directory /usr/local -xzf /dev/stdin
 
 PATH=$PATH:/usr/local/go/bin

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -75,6 +75,7 @@ unset GOPATH
 GO_VERSION="1.19"
 
 # Download and install a newer version of go.
+# Install from a GCS bucket to avoid being throttled by go.dev.
 gsutil cp "gs://stackdriver-test-143416-go-install/go${GO_VERSION}.linux-amd64.tar.gz" - | \
   sudo tar --directory /usr/local -xzf /dev/stdin
 


### PR DESCRIPTION
This is to prevent flakes due to `golang.org` throttling us. :)

## Description
I manually set up a new bucket to hold the golang install tar and copied the tar there. This PR points the tests at the new location. That should prevent us from being throttled (and it might download faster too, who knows).

## Related issue
Nightly flake.

## How has this been tested?
automated tests should be enough.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.