### PR TITLE
Fall back to absolute mkswap

### DIFF
--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -1655,8 +1655,8 @@ func testDefaultMetrics(ctx context.Context, t *testing.T, logger *logging.Direc
 		_, err := gce.RunRemotely(ctx, logger.ToMainLog(), vm, "", strings.Join([]string{
 			"sudo dd if=/dev/zero of=/swapfile bs=1024 count=102400",
 			"sudo chmod 600 /swapfile",
-			"sudo /usr/sbin/mkswap /swapfile",
-			"sudo /usr/sbin/swapon /swapfile",
+			"(sudo mkswap /swapfile || sudo /usr/sbin/mkswap /swapfile)",
+			"(sudo swapon /swapfile || sudo /usr/sbin/swapon /swapfile)",
 		}, " && "))
 		if err != nil {
 			t.Fatalf("Failed to enable swap file: %v", err)


### PR DESCRIPTION
## Description
I broke this with #978. Some platforms, e.g. bionic, have mkswap under a different folder. We haven't had any problems running mkswap unqualified on bionic, or anywhere outside of SLES really, so do unqualified mkswap first and then fall back to the absolute path if it fails.

## Related issue
b/259122953

## How has this been tested?
Tested `TestDefaultMetricsNoProxy` locally on these platforms, which passed: `ubuntu-minimal-1804-lts`, `ubuntu-1804-lts`, `sles-15-sp1-sap`, `sles-15-sp2-sap`

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
