### PR TITLE
resourcedetector: Get default service account scopes.

### DIFF
--- a/confgenerator/resourcedetector/gce_detector_test.go
+++ b/confgenerator/resourcedetector/gce_detector_test.go
@@ -115,6 +115,10 @@ func (fp *FakeProvider) getMachineType() (string, error) {
 	return fp.get()
 }
 
+func (fp *FakeProvider) getDefaultScopes() ([]string, error) {
+	return fp.getMap()
+}
+
 func (fp *FakeProvider) getMetadata() (map[string]string, error) {
 	return fp.getMap()
 }

--- a/confgenerator/resourcedetector/gce_detector_test.go
+++ b/confgenerator/resourcedetector/gce_detector_test.go
@@ -68,6 +68,13 @@ func (fp *FakeProvider) get() (string, error) {
 	return fp.value, nil
 }
 
+func (fp *FakeProvider) getSlice() ([]string, error) {
+	if fp.err != nil {
+		return []string{}, fp.err
+	}
+	return []string{fp.value}, nil
+}
+
 func (fp *FakeProvider) getMap() (map[string]string, error) {
 	if fp.err != nil {
 		return map[string]string{}, fp.err
@@ -116,7 +123,7 @@ func (fp *FakeProvider) getMachineType() (string, error) {
 }
 
 func (fp *FakeProvider) getDefaultScopes() ([]string, error) {
-	return fp.getMap()
+	return fp.getSlice()
 }
 
 func (fp *FakeProvider) getMetadata() (map[string]string, error) {

--- a/confgenerator/resourcedetector/gce_detector_test.go
+++ b/confgenerator/resourcedetector/gce_detector_test.go
@@ -35,6 +35,9 @@ func TestGettingResourceWithoutError(t *testing.T) {
 		if r.InterfaceIPv4["some_key"] != "some_value" {
 			t.Errorf("resource attribute InterfaceIPv4 has wrong value")
 		}
+		if r.DefaultScopes[0] != "some_value" {
+			t.Errorf("resource attribute DefaultScopes has wrong value")
+		}
 	} else {
 		t.Errorf("should have created GCEResource")
 	}

--- a/confgenerator/resourcedetector/gce_metadata_provider.go
+++ b/confgenerator/resourcedetector/gce_metadata_provider.go
@@ -84,6 +84,10 @@ func (gmp *GCEMetadataProvider) getMachineType() (string, error) {
 	return gmp.client.Get("instance/machine-type")
 }
 
+func (gmp *GCEMetadataProvider) getDefaultScopes() ([]string, error) {
+	return gmp.client.Scopes("default")
+}
+
 func (gmp *GCEMetadataProvider) getMetadata() (map[string]string, error) {
 	keys, err := gmp.client.Get("instance/attributes")
 	if err != nil {


### PR DESCRIPTION
## Description
Obtain the default service account scopes from the metadata server within the `resourcedetector`.

## Related issue
b/259443373

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
  - [x] Current Integration tests pass.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
