### PR TITLE
Testing: Install erlang differently for rabbitmq

### DIFF
--- a/integration_test/third_party_apps_data/applications/rabbitmq/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/rabbitmq/centos_rhel/install
@@ -2,12 +2,7 @@ set -e
 
 sudo yum install -y curl epel-release
 
-curl -s \
-    -o erlang.rpm \
-    https://packages.erlang-solutions.com/erlang-solutions-2.0-1.noarch.rpm
-sudo rpm -Uvh erlang.rpm
-
-sudo yum install -y erlang
+curl -s https://packagecloud.io/install/repositories/rabbitmq/erlang/script.rpm.sh | sudo bash
 
 curl -s \
     https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | \


### PR DESCRIPTION
## Description
This technique was taken from https://www.rabbitmq.com/install-rpm.html#package-cloud.

This fixes issues we're seeing at head that look like:

```
+ sudo yum -y install rabbitmq-server
        Last metadata expiration check: 0:00:01 ago on Wed Nov 16 18:39:45 2022.
        Error:
         Problem: cannot install the best candidate for the job
          - nothing provides erlang >= 25.0 needed by rabbitmq-server-3.11.3-1.el8.noarch
```

(https://source.cloud.google.com/results/invocations/2ecf0d78-49f1-4ed1-aa09-62182f7a770f/targets)

## Related issue
b/259553369

## How has this been tested?
rocky-linux-8 tests fail before ths PR and pass after this PR.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
