### PR TITLE
Update mongodb on centos-7

### DIFF
--- a/integration_test/third_party_apps_data/applications/mongodb/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/mongodb/centos_rhel/install
@@ -14,12 +14,12 @@ sudo chown root:root /etc/yum.repos.d/mongodb-org-5.0.repo
 sudo chmod 0644 /etc/yum.repos.d/mongodb-org-5.0.repo
 
 sudo yum install -y \
-    mongodb-org-5.0.5 \
-    mongodb-org-database-5.0.5 \
-    mongodb-org-server-5.0.5 \
-    mongodb-org-shell-5.0.5 \
-    mongodb-org-mongos-5.0.5 \
-    mongodb-org-tools-5.0.5
+    mongodb-org-5.0.14 \
+    mongodb-org-database-5.0.14 \
+    mongodb-org-server-5.0.14 \
+    mongodb-org-shell-5.0.14 \
+    mongodb-org-mongos-5.0.14 \
+    mongodb-org-tools-5.0.14
 
 sudo systemctl enable mongod 
 sudo systemctl restart mongod 

--- a/integration_test/third_party_apps_data/applications/mongodb/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/mongodb/debian_ubuntu/install
@@ -26,12 +26,12 @@ esac
 
 sudo apt-get update
 sudo apt-get install -y \
-    mongodb-org=5.0.5 \
-    mongodb-org-database=5.0.5 \
-    mongodb-org-server=5.0.5 \
-    mongodb-org-shell=5.0.5 \
-    mongodb-org-mongos=5.0.5 \
-    mongodb-org-tools=5.0.5
+    mongodb-org=5.0.14 \
+    mongodb-org-database=5.0.14 \
+    mongodb-org-server=5.0.14 \
+    mongodb-org-shell=5.0.14 \
+    mongodb-org-mongos=5.0.14 \
+    mongodb-org-tools=5.0.14
 
 systemctl enable mongod
 

--- a/integration_test/third_party_apps_data/applications/mongodb/sles/install
+++ b/integration_test/third_party_apps_data/applications/mongodb/sles/install
@@ -18,12 +18,12 @@ case $SUSE_VERSION in
 esac
 
 sudo zypper install -y \
-    mongodb-org-5.0.5 \
-    mongodb-org-database-5.0.5 \
-    mongodb-org-server-5.0.5 \
-    mongodb-org-shell-5.0.5 \
-    mongodb-org-mongos-5.0.5 \
-    mongodb-org-tools-5.0.5
+    mongodb-org-5.0.14 \
+    mongodb-org-database-5.0.14 \
+    mongodb-org-server-5.0.14 \
+    mongodb-org-shell-5.0.14 \
+    mongodb-org-mongos-5.0.14 \
+    mongodb-org-tools-5.0.14
 
 sudo systemctl enable mongod
 sudo systemctl restart mongod


### PR DESCRIPTION
## Description
5.0.5 isn't available anymore; 5.0.14 is the latest.

## Related issue
N/A, was a nightly failure

## How has this been tested?
Tested on fresh centos-7 VM

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
