### PR TITLE
Makefile: Add `go vet` support

### DIFF
--- a/tasks.mak
+++ b/tasks.mak
@@ -96,9 +96,9 @@ third_party_apps_test:
 # Precommit
 ############
 
-precommit: addlicense_check yaml_lint test_confgenerator test_metadata test_metadata_validate
+precommit: addlicense_check yaml_lint test_confgenerator test_metadata test_metadata_validate go_vet
 
-precommit_update: addlicense yaml_format test_confgenerator_update test_metadata_update test_metadata_validate
+precommit_update: addlicense yaml_format test_confgenerator_update test_metadata_update test_metadata_validate go_vet
 
 ############
 # Convenience
@@ -116,3 +116,6 @@ sync_fork:
 
 update_go_modules:
 	go get -t -u ./...
+
+go_vet:
+	go list ./... | grep -v "generated" | grep -v "/vendor/" | xargs go vet


### PR DESCRIPTION
## Description
Added go vet support to the makefile. It ignores the package `confgenerator/filter/internal/generated` because there's nothing we can do about that. This PR also fixes a vet issue in
`generate_expected_metrics.go` where a sync.Mutex was being copied by value.

Signed-off-by: braydonk <braydonk@google.com>

## Related issue


## How has this been tested?
Ran the new `go_vet` target and fixed the errors it found.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
