### PR TITLE
Fix SetEnvironmentVariables on centos/rhel

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1130,6 +1130,8 @@ func RemoveExternalIP(ctx context.Context, logger *log.Logger, vm *VM) error {
 }
 
 // SetEnvironmentVariables sets the environment variables in the envVariables map on the given vm in a platform-dependent way.
+// On Windows platforms, variables set this way are visible to all processes.
+// On Linux platforms, variables set this way are visible to the Ops Agent services only.
 func SetEnvironmentVariables(ctx context.Context, logger *log.Logger, vm *VM, envVariables map[string]string) error {
 	if IsWindows(vm.Platform) {
 		for key, value := range envVariables {
@@ -1141,16 +1143,25 @@ func SetEnvironmentVariables(ctx context.Context, logger *log.Logger, vm *VM, en
 		}
 		return nil
 	}
-	defaultEnvironment := "DefaultEnvironment="
+	// https://serverfault.com/a/413408
+	// Escaping newlines here because we'll be using `echo -e` later
+	override := `[Service]\n`
 	for key, value := range envVariables {
-		defaultEnvironment += fmt.Sprintf(`"%s=%s" `, key, value)
+		override += fmt.Sprintf(`Environment="%s=%s"\n`, key, value)
 	}
-	cmd := fmt.Sprintf("echo '%s' | sudo tee -a /etc/systemd/system.conf", defaultEnvironment)
-	logger.Println("edit system.conf command: " + cmd)
-	if _, err := RunRemotely(ctx, logger, vm, "", cmd); err != nil {
-		return err
+	for _, service := range []string{
+		"google-cloud-ops-agent",
+		"google-cloud-ops-agent-diagnostics",
+		"google-cloud-ops-agent-fluent-bit",
+		"google-cloud-ops-agent-opentelemetry-collector",
+	} {
+		dir := fmt.Sprintf("/etc/systemd/system/%s.service.d", service)
+		cmd := fmt.Sprintf(`sudo mkdir -p %s && echo -e '%s' | sudo tee %s/override.conf`, dir, override, dir)
+		if _, err := RunRemotely(ctx, logger, vm, "", cmd); err != nil {
+			return err
+		}
 	}
-	// Reload the systemd daemon to pick up the new settings from system.conf edited in the previous command
+	// Reload the systemd daemon to pick up the new settings edited in the previous command
 	daemonReload := "sudo systemctl daemon-reload"
 	_, err := RunRemotely(ctx, logger, vm, "", daemonReload)
 	return err

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -1797,13 +1797,6 @@ func TestPrometheusMetrics(t *testing.T) {
 	t.Parallel()
 	gce.RunForEachPlatform(t, func(t *testing.T, platform string) {
 		t.Parallel()
-		// TODO: Enable this test for all distros once the prometheus receiver is GA.
-		// For some reason, the featuregate, when set in the default systemd environment
-		// file, is not being picked up on centOS distros. This is a temporary workaround.
-		if gce.IsCentOS(platform) || gce.IsRHEL(platform) {
-			t.SkipNow()
-		}
-
 		ctx, logger, vm := agents.CommonSetup(t, platform)
 
 		promConfig := `metrics:
@@ -1934,10 +1927,8 @@ func TestPrometheusMetricsWithJSONExporter(t *testing.T) {
 	t.Parallel()
 	gce.RunForEachPlatform(t, func(t *testing.T, platform string) {
 		t.Parallel()
-		// TODO: Enable this test for all distros once the prometheus receiver is GA.
-		// For some reason, the featuregate, when set in the default systemd environment
-		// file, is not being picked up on centOS distros. This is a temporary workaround.
-		if gce.IsWindows(platform) || gce.IsCentOS(platform) || gce.IsRHEL(platform) {
+		// TODO: Set up JSON exporter stuff on Windows
+		if gce.IsWindows(platform) {
 			t.SkipNow()
 		}
 		ctx, logger, vm := agents.CommonSetup(t, platform)


### PR DESCRIPTION
## Description
Centos/RHEL has a weird issue where `DefaultEnvironment` in `/etc/systemd/system.conf` is just ignored, so here's an alternative that works everywhere.

## Related issue
N/A

## How has this been tested?
Prometheus integration tests passed locally on centos-7, rhel-7 and ubuntu-2004-lts.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
