### PR TITLE
prometheus: add instance_name and machine_type as metric labels

### DIFF
--- a/confgenerator/prometheus.go
+++ b/confgenerator/prometheus.go
@@ -169,7 +169,11 @@ func createPrometheusStyleGCEMetadata(gceMetadata resourcedetector.GCEResource) 
 	// Set the location, namespace and cluster labels.
 	metaLabels["location"] = gceMetadata.Zone
 	metaLabels["namespace"] = gceMetadata.InstanceID
-	metaLabels["cluster"] = "gce"
+	metaLabels["cluster"] = "__gce__"
+
+	// Set some curated labels.
+	metaLabels["instance_name"] = gceMetadata.InstanceName
+	metaLabels["machine_type"] = gceMetadata.MachineType
 
 	return metaLabels
 }

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/otel.yaml
@@ -487,8 +487,10 @@ receivers:
             __meta_gce_public_ip: test-public-ip
             __meta_gce_tags: test-tag
             __meta_gce_zone: test-zone
-            cluster: gce
+            cluster: __gce__
+            instance_name: test-instance-name
             location: test-zone
+            machine_type: test-machine-type
             namespace: test-instance-id
 service:
   pipelines:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/otel.yaml
@@ -480,8 +480,10 @@ receivers:
             __meta_gce_public_ip: test-public-ip
             __meta_gce_tags: test-tag
             __meta_gce_zone: test-zone
-            cluster: gce
+            cluster: __gce__
+            instance_name: test-instance-name
             location: test-zone
+            machine_type: test-machine-type
             namespace: test-instance-id
       - job_name: drop
         honor_timestamps: true
@@ -536,8 +538,10 @@ receivers:
             __meta_gce_public_ip: test-public-ip
             __meta_gce_tags: test-tag
             __meta_gce_zone: test-zone
-            cluster: gce
+            cluster: __gce__
+            instance_name: test-instance-name
             location: test-zone
+            machine_type: test-machine-type
             namespace: test-instance-id
 service:
   pipelines:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/otel.yaml
@@ -487,8 +487,10 @@ receivers:
             __meta_gce_public_ip: test-public-ip
             __meta_gce_tags: test-tag
             __meta_gce_zone: test-zone
-            cluster: gce
+            cluster: __gce__
+            instance_name: test-instance-name
             location: test-zone
+            machine_type: test-machine-type
             namespace: test-instance-id
 service:
   pipelines:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/otel.yaml
@@ -487,8 +487,10 @@ receivers:
             __meta_gce_public_ip: test-public-ip
             __meta_gce_tags: test-tag
             __meta_gce_zone: test-zone
-            cluster: gce
+            cluster: __gce__
+            instance_name: test-instance-name
             location: test-zone
+            machine_type: test-machine-type
             namespace: test-instance-id
 service:
   pipelines:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/otel.yaml
@@ -480,8 +480,10 @@ receivers:
             __meta_gce_public_ip: test-public-ip
             __meta_gce_tags: test-tag
             __meta_gce_zone: test-zone
-            cluster: gce
+            cluster: __gce__
+            instance_name: test-instance-name
             location: test-zone
+            machine_type: test-machine-type
             namespace: test-instance-id
 service:
   pipelines:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/otel.yaml
@@ -541,8 +541,10 @@ receivers:
             __meta_gce_public_ip: test-public-ip
             __meta_gce_tags: test-tag
             __meta_gce_zone: test-zone
-            cluster: gce
+            cluster: __gce__
+            instance_name: test-instance-name
             location: test-zone
+            machine_type: test-machine-type
             namespace: test-instance-id
 service:
   pipelines:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/otel.yaml
@@ -485,8 +485,10 @@ receivers:
             __meta_gce_public_ip: test-public-ip
             __meta_gce_tags: test-tag
             __meta_gce_zone: test-zone
-            cluster: gce
+            cluster: __gce__
+            instance_name: test-instance-name
             location: test-zone
+            machine_type: test-machine-type
             namespace: test-instance-id
 service:
   pipelines:

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -1826,18 +1826,10 @@ func TestPrometheusMetrics(t *testing.T) {
             static_configs:
               - targets: ['localhost:20202']
             relabel_configs:
-              - source_labels: [__meta_gce_instance_name]
-                regex: '(.+)'
-                replacement: '${1}'
-                target_label: instance_name
               - source_labels: [__meta_gce_instance_id]
                 regex: '(.+)'
                 replacement: '${1}'
                 target_label: instance_id
-              - source_labels: [__meta_gce_machine_type]
-                regex: '(.+)'
-                replacement: '${1}'
-                target_label: machine_type
               - source_labels: [__meta_gce_project]
                 regex: '(.+)'
                 replacement: '${1}'


### PR DESCRIPTION
This change adds some useful metadata to the metric labels to annotate the prometheus metrics with.

## Related issue
[b/259256003](http://b/259256003) | P2 | Add instance_name and machine_type to the metric labels for prometheus metrics

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
