### PR TITLE
files: use DB.locking config option to improve input performance

### DIFF
--- a/confgenerator/logging_receivers.go
+++ b/confgenerator/logging_receivers.go
@@ -73,8 +73,12 @@ func (r LoggingReceiverFilesMixin) Components(tag string) []fluentbit.Component 
 		"Name": "tail",
 		"Tag":  tag,
 		// TODO: Escaping?
-		"Path":           strings.Join(r.IncludePaths, ","),
-		"DB":             DBPath(tag),
+		"Path": strings.Join(r.IncludePaths, ","),
+		"DB":   DBPath(tag),
+		// DB.locking specifies that the database will be accessed only by Fluent Bit.
+		// Enabling this feature helps to increase performance when accessing the database
+		// but it restrict any external tool to query the content.
+		"DB.locking":     "true",
 		"Read_from_Head": "True",
 		// Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
 		"Buffer_Chunk_Size": "512k",

--- a/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/all-built_in_config/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/pipeline1_log_source_id1
+    DB.locking        true
     Exclude_Path      /path/to/log/1/a/exclude_a,/path/to/log/1/b/exclude_b
     Key               message
     Mem_Buf_Limit     10M
@@ -36,6 +37,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/pipeline2_log_source_id2
+    DB.locking        true
     Exclude_Path      /path/to/log/2/a/exclude_a,/path/to/log/2/b/exclude_b
     Key               message
     Mem_Buf_Limit     10M
@@ -71,6 +73,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/p1_sample_logs
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/p1_sample_logs
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/pipeline1_sample_logs
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/pipeline2_sample_logs
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -63,6 +66,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/pipeline1_log_source_id1
+    DB.locking        true
     Exclude_Path      /path/to/log/1/a/exclude_a,/path/to/log/1/b/exclude_b
     Key               message
     Mem_Buf_Limit     10M
@@ -36,6 +37,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/pipeline2_log_source_id2
+    DB.locking        true
     Exclude_Path      /path/to/log/2/a/exclude_a,/path/to/log/2/b/exclude_b
     Key               message
     Mem_Buf_Limit     10M
@@ -71,6 +73,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/p1_files_1
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -51,6 +53,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/p1_files_1
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -50,6 +52,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/p1_files_1
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -51,6 +53,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/p1_files_1
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -51,6 +53,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/p2_files_2
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/p3_files_3
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -83,6 +87,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/p1_files_1
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -51,6 +53,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/p1_files_1
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -51,6 +53,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/p2_files_1
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/apache_apache_access
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/apache_apache_error
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -63,6 +66,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/apache_custom_apache_custom_access
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -36,6 +37,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/apache_custom_apache_custom_error
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -51,6 +53,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/apache_default_apache_default_access
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -65,6 +68,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/apache_default_apache_default_error
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -99,6 +103,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -113,6 +118,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/cassandra_cassandra_debug
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/cassandra_cassandra_gc
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/cassandra_cassandra_system
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -63,6 +66,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -77,6 +81,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/cassandra_custom_cassandra_custom_debug
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -36,6 +37,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/cassandra_custom_cassandra_custom_gc
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -51,6 +53,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/cassandra_custom_cassandra_custom_system
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -66,6 +69,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/cassandra_default_cassandra_default_debug
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -80,6 +84,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/cassandra_default_cassandra_default_gc
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -94,6 +99,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/cassandra_default_cassandra_default_system
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -138,6 +144,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -152,6 +159,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/couchbase_couchbase_general
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/couchbase_couchbase_goxdcr
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/couchbase_couchbase_http_access
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -63,6 +66,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -77,6 +81,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/couchdb_couchdb
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -36,6 +37,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -50,6 +52,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/elasticsearch_elasticsearch_gc
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/elasticsearch_elasticsearch_json
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -64,6 +67,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/elasticsearch_custom_elasticsearch_gc_custom
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -50,6 +52,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/elasticsearch_custom_elasticsearch_json_custom
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -66,6 +69,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/elasticsearch_default_elasticsearch_gc_default
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -80,6 +84,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/elasticsearch_default_elasticsearch_json_default
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -95,6 +100,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/pipeline1_log_source_id1
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -50,6 +52,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/pipeline1_log_source_id1
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/pipeline2_log_source_id2
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/pipeline3_log_source_id3
+    DB.locking        true
     Exclude_Path      /path/to/log/3/exclude
     Key               message
     Mem_Buf_Limit     10M
@@ -64,6 +67,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/pipeline4_log_source_id4
+    DB.locking        true
     Exclude_Path      /path/to/log/4/exclude_a,/path/to/log/4/exclude_b
     Key               message
     Mem_Buf_Limit     10M
@@ -79,6 +83,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/pipeline5_log_source_id5
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -93,6 +98,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/flink_flink
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -43,6 +44,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -51,6 +52,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -51,6 +52,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -43,6 +44,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/hadoop_hadoop
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -50,6 +52,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/hadoop_hadoop
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -51,6 +53,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/hbase_hbase_system
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/jetty_jetty_access
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/kafka_kafka
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/kafka_custom_kafka_custom
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/mongodb_mongodb
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/mysql_mysql_error
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/mysql_mysql_general
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -63,6 +66,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/mysql_mysql_slow
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -77,6 +81,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/mysql_custom_mysql_custom_error
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -50,6 +52,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/mysql_custom_mysql_custom_general
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -65,6 +68,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/mysql_custom_mysql_custom_slow
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -80,6 +84,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/mysql_default_mysql_default_error
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -94,6 +99,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/mysql_default_mysql_default_general
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -108,6 +114,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/mysql_default_mysql_default_slow
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -152,6 +159,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/nginx_nginx_access
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/nginx_nginx_error
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -63,6 +66,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/nginx_custom_nginx_custom_access
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -50,6 +52,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/nginx_custom_nginx_custom_error
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -65,6 +68,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/nginx_default_nginx_default_access
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -79,6 +83,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/nginx_default_nginx_default_error
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -113,6 +118,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/oracledb_oracledb_alert
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/oracledb_oracledb_audit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -63,6 +66,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/oracledb_custom_oracledb_alert_custom
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/oracledb_custom_oracledb_audit_custom
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -63,6 +66,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/oracledb_default_oracledb_alert
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -77,6 +81,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/oracledb_default_oracledb_audit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -111,6 +116,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/postgresql_postgresql_general
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/postgresql_custom_postgresql_custom_general
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/postgresql_default_postgresql_default_general
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -73,6 +76,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/rabbitmq_rabbitmq
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -50,6 +52,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/redis_redis
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/redis_custom_redis_custom
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -50,6 +52,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/redis_default_redis_default
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +77,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/saphana_saphana
+    DB.locking        true
     Exclude_Path      /usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver_history*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*loads*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*executed_statements*.trc
     Key               message
     Mem_Buf_Limit     10M
@@ -51,6 +53,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/saphana_custom_saphana_custom
+    DB.locking        true
     Exclude_Path      /usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver_history*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*loads*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*executed_statements*.trc
     Key               message
     Mem_Buf_Limit     10M
@@ -52,6 +54,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/saphana_default_saphana
+    DB.locking        true
     Exclude_Path      /usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver_history*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*loads*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*executed_statements*.trc
     Key               message
     Mem_Buf_Limit     10M
@@ -78,6 +81,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/solr_solr_system
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -41,6 +41,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -40,6 +41,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/tomcat_tomcat_access
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/tomcat_tomcat_system
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -63,6 +66,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/tomcat_custom_tomcat_custom_access
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/tomcat_custom_tomcat_custom_system
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -63,6 +66,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/tomcat_default_tomcat_default_access
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -77,6 +81,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/tomcat_default_tomcat_default_system
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -111,6 +116,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/varnish_varnish
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -49,6 +51,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/vault_vault_audit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -50,6 +52,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/wildfly_system_wildfly_system
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -50,6 +52,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/zookeeper_general_zookeeper_general
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -50,6 +52,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/zookeeper_zookeeper_general
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -50,6 +52,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -35,6 +36,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -21,6 +21,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_main.conf
@@ -35,6 +35,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/pipeline1_log_source_id1
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -43,6 +44,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/pipeline1_log_source_id1
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -42,6 +43,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/pipeline2_log_source_id2
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -56,6 +58,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/iis_iis_access
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -42,6 +43,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_main.conf
@@ -28,6 +28,7 @@
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   5M
     DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
     Name              tail


### PR DESCRIPTION
Fluent Bit has this option available in the `tail` input plugin. From looking at the upstream code, it looks like should help to reduce the number of syscalls on every commit to the DB but at the price of locking the access to the database file to third party programs. But for us, that trade-off seems okay?

We should soak test/performance test this to see if we get any visible benefit.