### PR TITLE
Skip failed rhel-7-6-sap-ha test TestPrometheusMetricsWithJSONExporter

### DIFF
--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -1936,7 +1936,8 @@ func TestPrometheusMetricsWithJSONExporter(t *testing.T) {
 	gce.RunForEachPlatform(t, func(t *testing.T, platform string) {
 		t.Parallel()
 		// TODO: Set up JSON exporter stuff on Windows
-		if gce.IsWindows(platform) {
+		// TODO: b/260616780 fix rhel-7-6-sap-ha failure for this test
+		if gce.IsWindows(platform) || platform == "rhel-7-6-sap-ha" {
 			t.SkipNow()
 		}
 		ctx, logger, vm := agents.CommonSetup(t, platform)


### PR DESCRIPTION
## Description
TestPrometheusMetricsWithJSONExporter would fail on rhel-7-6-sap-ha because no Python3 installation is available. Skip the test for now while working a solution. 

## Related issue
b/260616780

## How has this been tested?
Tested locally to make sure test is skipped. 

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
