### PR TITLE
resourcedetector: Return empty DefaultScopes if default service account is not set.

### DIFF
--- a/confgenerator/resourcedetector/gce_detector.go
+++ b/confgenerator/resourcedetector/gce_detector.go
@@ -127,7 +127,7 @@ func (gd *GCEResourceBuilder) GetResource() (Resource, error) {
 		singleAttributes[attrName] = attr
 	}
 	multiAttributes := map[gceAttribute][]string{}
-	for attrName, attrGetter := range	multiAttributeSpec {
+	for attrName, attrGetter := range multiAttributeSpec {
 		attr, err := attrGetter(gd.provider)
 		if err != nil {
 			return nil, err

--- a/confgenerator/resourcedetector/gce_metadata_provider.go
+++ b/confgenerator/resourcedetector/gce_metadata_provider.go
@@ -85,7 +85,12 @@ func (gmp *GCEMetadataProvider) getMachineType() (string, error) {
 }
 
 func (gmp *GCEMetadataProvider) getDefaultScopes() ([]string, error) {
-	return gmp.client.Scopes("default")
+	scopes, err := gmp.client.Scopes("default")
+	// If default service account is not defined return empty scopes
+	if _, ok := err.(gcp_metadata.NotDefinedError); ok {
+		return []string{}, nil
+	}
+	return scopes, err
 }
 
 func (gmp *GCEMetadataProvider) getMetadata() (map[string]string, error) {


### PR DESCRIPTION
## Description
Return empty `DefaultScopes` if default service account is not set in the metadata server.

## Related issue
When the confgenerator runs the `resourcedetector` in a VM without any default service account the following error will show :
```
2022/11/30 21:58:46 The agent config file is not valid. Detailed error: can't get resource metadata: metadata: GCE metadata "instance/service-accounts/default/scopes" not defined
```

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
