### PR TITLE
Only prefix metrics with unknown domain

### DIFF
--- a/apps/otlp.go
+++ b/apps/otlp.go
@@ -15,12 +15,20 @@
 package apps
 
 import (
+	"fmt"
+	"regexp"
+	"strings"
+
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
 )
 
 // TODO: The collector defaults to this, but should we default to 127.0.0.1 or ::1 instead?
 const defaultGRPCEndpoint = "0.0.0.0:4317"
+
+// Keep these in sync:
+// https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/main/exporter/collector/config.go#L158
+var knownDomains = []string{"googleapis.com", "kubernetes.io", "istio.io", "knative.dev"}
 
 type ReceiverOTLP struct {
 	confgenerator.ConfigComponent `yaml:",inline"`
@@ -37,6 +45,10 @@ func (r ReceiverOTLP) Pipelines() []otel.ReceiverPipeline {
 	if endpoint == "" {
 		endpoint = defaultGRPCEndpoint
 	}
+	var knownDomainsRegexEscaped []string
+	for _, knownDomain := range knownDomains {
+		knownDomainsRegexEscaped = append(knownDomainsRegexEscaped, regexp.QuoteMeta(knownDomain))
+	}
 	return []otel.ReceiverPipeline{{
 		Receiver: otel.Component{
 			Type: "otlp",
@@ -49,9 +61,35 @@ func (r ReceiverOTLP) Pipelines() []otel.ReceiverPipeline {
 			},
 		},
 		Processors: map[string][]otel.Component{
+			// The intent here is to add the workload.googleapis.com prefix to any metrics
+			// that do not match the list of known domains in the exporter [1].
+			//
+			// This would ordinarily be accomplished using a metricstransform processor
+			// with a negative-lookahead regexp, but Go regexp (the regexp engine used by
+			// metricstransform) does not support such a thing. Emulating a negative-lookahead
+			// pattern in Go regexp might be possible but I tried it and it melted my brain.
+			//
+			// The metricstransform processor does not support negative matching either.
+			//
+			// So instead we apply a sequence of transformations:
+			// 1) Prefix all metrics with 'A'.
+			// 2) Replace 'A' with 'B' if the metric name matches a known domain.
+			// 3) All metrics that still have 'A' are the ones that don't match any known domain.
+			//    For these, replace 'A' with 'Aworkload.googleapis.com/' (we keep the 'A').
+			// 4) All metrics have either 'A' or 'B' at the start; remove it.
+			//    At this point, we have prefixed all metrics with 'workload.googleapis.com/'
+			//    if they did not match any known domains.
+			//
+			// TODO: get OTEL to split the prefixing behaviour of the googlecloud exporter out as
+			// a processor and replace all of this stuff with that processor.
+			//
+			// [1] https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/main/exporter/collector/config.go#L158
 			"metrics": {
 				otel.MetricsTransform(
-					otel.AddPrefix("workload.googleapis.com"),
+					otel.RegexpRename(`^(.*)$`, `A${1}`),
+					otel.RegexpRename(fmt.Sprintf(`^A((?:[a-z]+\.)*(?:%s)/.+)$`, strings.Join(knownDomainsRegexEscaped, "|")), `B${1}`),
+					otel.RegexpRename(`^A(.*)$`, `Aworkload.googleapis.com/${1}`),
+					otel.RegexpRename(`^[AB](.*)$`, `${1}`),
 				),
 				// TODO: Set instrumentation_source labels, etc.
 			},

--- a/confgenerator/otel/processors.go
+++ b/confgenerator/otel/processors.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"path"
 	"sort"
+	"strings"
 )
 
 // Helper functions to easily build up processor configs.
@@ -67,15 +68,33 @@ func CastToSum(metrics ...string) Component {
 	}
 }
 
-// AddPrefix returns a config snippet that adds a prefix to all metrics.
+// AddPrefix returns a config snippet that adds a domain prefix to all metrics.
 func AddPrefix(prefix string, operations ...map[string]interface{}) map[string]interface{} {
+	return RegexpRename(
+		`^(.*)$`,
+		path.Join(prefix, `${1}`),
+		operations...,
+	)
+}
+
+// ChangePrefix returns a config snippet that updates a prefix on all metrics.
+func ChangePrefix(oldPrefix, newPrefix string) map[string]interface{} {
+	return RegexpRename(
+		fmt.Sprintf(`^%s(.*)$`, oldPrefix),
+		fmt.Sprintf("%s%s", newPrefix, `${1}`),
+	)
+}
+
+// RegexpRename returns a config snippet that renames metrics matching the given regexp.
+// The `rename` argument supports capture groups as `${1}`, `${2}`, and so on.
+func RegexpRename(regexp string, rename string, operations ...map[string]interface{}) map[string]interface{} {
 	// $ needs to be escaped because reasons.
 	// https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor#rename-multiple-metrics-using-substitution
 	out := map[string]interface{}{
-		"include":    `^(.*)$$`,
+		"include":    strings.ReplaceAll(regexp, "$", "$$"),
 		"match_type": "regexp",
 		"action":     "update",
-		"new_name":   path.Join(prefix, `$${1}`),
+		"new_name":   strings.ReplaceAll(rename, "$", "$$"),
 	}
 
 	if len(operations) > 0 {
@@ -83,18 +102,6 @@ func AddPrefix(prefix string, operations ...map[string]interface{}) map[string]i
 	}
 
 	return out
-}
-
-// ChangePrefix returns a config snippet that updates a prefix on all metrics.
-func ChangePrefix(oldPrefix, newPrefix string) map[string]interface{} {
-	// $ needs to be escaped because reasons.
-	// https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor#rename-multiple-metrics-using-substitution
-	return map[string]interface{}{
-		"include":    fmt.Sprintf(`^%s(.*)$$`, oldPrefix),
-		"match_type": "regexp",
-		"action":     "update",
-		"new_name":   fmt.Sprintf("%s%s", newPrefix, `$${1}`),
-	}
 }
 
 // TransformationMetrics returns a transform processor object that contains all the queries passed into it.

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/otel.yaml
@@ -412,7 +412,19 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: A$${1}
+    - action: update
+      include: "^A((?:[a-z]+\\.)*(?:googleapis\\.com|kubernetes\\.io|istio\\.io|knative\\.dev)/.+)$$"
+      match_type: regexp
+      new_name: B$${1}
+    - action: update
+      include: ^A(.*)$$
+      match_type: regexp
+      new_name: Aworkload.googleapis.com/$${1}
+    - action: update
+      include: ^[AB](.*)$$
+      match_type: regexp
+      new_name: $${1}
   resourcedetection/_global_0:
     detectors:
     - gce

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/otel.yaml
@@ -412,7 +412,19 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: A$${1}
+    - action: update
+      include: "^A((?:[a-z]+\\.)*(?:googleapis\\.com|kubernetes\\.io|istio\\.io|knative\\.dev)/.+)$$"
+      match_type: regexp
+      new_name: B$${1}
+    - action: update
+      include: ^A(.*)$$
+      match_type: regexp
+      new_name: Aworkload.googleapis.com/$${1}
+    - action: update
+      include: ^[AB](.*)$$
+      match_type: regexp
+      new_name: $${1}
   resourcedetection/_global_0:
     detectors:
     - gce

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/otel.yaml
@@ -412,7 +412,19 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: A$${1}
+    - action: update
+      include: "^A((?:[a-z]+\\.)*(?:googleapis\\.com|kubernetes\\.io|istio\\.io|knative\\.dev)/.+)$$"
+      match_type: regexp
+      new_name: B$${1}
+    - action: update
+      include: ^A(.*)$$
+      match_type: regexp
+      new_name: Aworkload.googleapis.com/$${1}
+    - action: update
+      include: ^[AB](.*)$$
+      match_type: regexp
+      new_name: $${1}
   resourcedetection/_global_0:
     detectors:
     - gce

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -2624,11 +2624,19 @@ traces:
 			t.Fatal(err)
 		}
 
-		if _, err = gce.WaitForMetric(ctx, logger.ToMainLog(), vm, "workload.googleapis.com/otlp.test.gauge", time.Hour, nil, false); err != nil {
-			t.Error(err)
-		}
-		if _, err = gce.WaitForMetric(ctx, logger.ToMainLog(), vm, "workload.googleapis.com/otlp.test.cumulative", time.Hour, nil, false); err != nil {
-			t.Error(err)
+		// See testdata/otlp/metrics.go for the metrics we're sending
+		for _, name := range []string{
+			"workload.googleapis.com/otlp.test.gauge",
+			"workload.googleapis.com/otlp.test.cumulative",
+			"workload.googleapis.com/otlp.test.prefix1",
+			"workload.googleapis.com/.invalid.googleapis.com/otlp.test.prefix2",
+			"workload.googleapis.com/otlp.test.prefix3/workload.googleapis.com/abc",
+			"workload.googleapis.com/WORKLOAD.GOOGLEAPIS.COM/otlp.test.prefix4",
+			"workload.googleapis.com/WORKLOAD.googleapis.com/otlp.test.prefix5",
+		} {
+			if _, err = gce.WaitForMetric(ctx, logger.ToMainLog(), vm, name, time.Hour, nil, false); err != nil {
+				t.Error(err)
+			}
 		}
 	})
 }


### PR DESCRIPTION
## Description
Existing behaviour was to prefix all metrics with `workload.googleapis.com`. It would be better to match the behaviour of the `googlecloudexporter` which only prefixes metrics that don't match a [list of known domains](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/main/exporter/collector/config.go#L158).

## Related issue
b/259696576

## How has this been tested?
Will run tests in PR.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [x] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
