### PR TITLE
Add storage buffer limit size to output plugin

### DIFF
--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -282,7 +282,7 @@ func (l *Logging) generateFluentbitComponents(userAgent string, hostInfo *host.I
 			out = append(out, s.components...)
 		}
 		if len(tags) > 0 {
-			out = append(out, stackdriverOutputComponent(strings.Join(tags, "|"), userAgent))
+			out = append(out, stackdriverOutputComponent(strings.Join(tags, "|"), userAgent, "10MB"))
 		}
 	}
 	out = append(out, LoggingReceiverFilesMixin{
@@ -292,7 +292,7 @@ func (l *Logging) generateFluentbitComponents(userAgent string, hostInfo *host.I
 		BufferInMemory: true,
 	}.Components("ops-agent-fluent-bit")...)
 
-	out = append(out, stackdriverOutputComponent("ops-agent-fluent-bit", userAgent))
+	out = append(out, stackdriverOutputComponent("ops-agent-fluent-bit", userAgent, ""))
 	out = append(out, fluentbit.MetricsOutputComponent())
 
 	return out, nil

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -282,7 +282,7 @@ func (l *Logging) generateFluentbitComponents(userAgent string, hostInfo *host.I
 			out = append(out, s.components...)
 		}
 		if len(tags) > 0 {
-			out = append(out, stackdriverOutputComponent(strings.Join(tags, "|"), userAgent, "10MB"))
+			out = append(out, stackdriverOutputComponent(strings.Join(tags, "|"), userAgent, "20MB"))
 		}
 	}
 	out = append(out, LoggingReceiverFilesMixin{

--- a/confgenerator/logging.go
+++ b/confgenerator/logging.go
@@ -44,32 +44,38 @@ func setLogNameComponents(tag, logName, receiverType string, hostName string) []
 }
 
 // stackdriverOutputComponent generates a component that outputs logs matching the regex `match` using `userAgent`.
-func stackdriverOutputComponent(match, userAgent string) fluentbit.Component {
+func stackdriverOutputComponent(match, userAgent string, storage_limit_size string) fluentbit.Component {
+	config := map[string]string{
+		// https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
+		"Name":              "stackdriver",
+		"Match_Regex":       fmt.Sprintf("^(%s)$", match),
+		"resource":          "gce_instance",
+		"stackdriver_agent": userAgent,
+
+		"http_request_key": HttpRequestKey,
+
+		// https://docs.fluentbit.io/manual/administration/scheduling-and-retries
+		// After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
+		"Retry_Limit": "3",
+
+		// https://docs.fluentbit.io/manual/administration/security
+		// Enable TLS support.
+		"tls": "On",
+		// Do not force certificate validation.
+		"tls.verify": "Off",
+
+		"workers": "8",
+
+		// Mute these errors until https://github.com/fluent/fluent-bit/issues/4473 is fixed.
+		"net.connect_timeout_log_error": "False",
+	}
+
+	if storage_limit_size != "" {
+		config["storage.total_limit_size"] = storage_limit_size
+	}
+
 	return fluentbit.Component{
-		Kind: "OUTPUT",
-		Config: map[string]string{
-			// https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
-			"Name":              "stackdriver",
-			"Match_Regex":       fmt.Sprintf("^(%s)$", match),
-			"resource":          "gce_instance",
-			"stackdriver_agent": userAgent,
-
-			"http_request_key": HttpRequestKey,
-
-			// https://docs.fluentbit.io/manual/administration/scheduling-and-retries
-			// After 3 retries, a given chunk will be discarded. So bad entries don't accidentally stay around forever.
-			"Retry_Limit": "3",
-
-			// https://docs.fluentbit.io/manual/administration/security
-			// Enable TLS support.
-			"tls": "On",
-			// Do not force certificate validation.
-			"tls.verify": "Off",
-
-			"workers": "8",
-
-			// Mute these errors until https://github.com/fluent/fluent-bit/issues/4473 is fixed.
-			"net.connect_timeout_log_error": "False",
-		},
+		Kind:   "OUTPUT",
+		Config: config,
 	}
 }

--- a/confgenerator/testdata/builtin/linux/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/linux/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/builtin/windows/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/windows/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/all-built_in_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-built_in_config/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
@@ -151,6 +151,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden_fluent_bit_main.conf
@@ -470,6 +470,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden_fluent_bit_main.conf
@@ -85,6 +85,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden_fluent_bit_main.conf
@@ -175,6 +175,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden_fluent_bit_main.conf
@@ -189,6 +189,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden_fluent_bit_main.conf
@@ -86,6 +86,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden_fluent_bit_main.conf
@@ -80,6 +80,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden_fluent_bit_main.conf
@@ -86,6 +86,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden_fluent_bit_main.conf
@@ -140,6 +140,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden_fluent_bit_main.conf
@@ -86,6 +86,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden_fluent_bit_main.conf
@@ -113,6 +113,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden_fluent_bit_main.conf
@@ -78,6 +78,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden_fluent_bit_main.conf
@@ -149,6 +149,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden_fluent_bit_main.conf
@@ -323,6 +323,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden_fluent_bit_main.conf
@@ -212,6 +212,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden_fluent_bit_main.conf
@@ -695,6 +695,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden_fluent_bit_main.conf
@@ -206,6 +206,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden_fluent_bit_main.conf
@@ -117,6 +117,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden_fluent_bit_main.conf
@@ -259,6 +259,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden_fluent_bit_main.conf
@@ -461,6 +461,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
@@ -80,6 +80,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -160,6 +160,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_flink/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_flink/golden_fluent_bit_main.conf
@@ -110,6 +110,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward/golden_fluent_bit_main.conf
@@ -79,6 +79,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden_fluent_bit_main.conf
@@ -99,6 +99,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden_fluent_bit_main.conf
@@ -99,6 +99,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden_fluent_bit_main.conf
@@ -79,6 +79,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden_fluent_bit_main.conf
@@ -110,6 +110,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden_fluent_bit_main.conf
@@ -111,6 +111,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden_fluent_bit_main.conf
@@ -110,6 +110,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden_fluent_bit_main.conf
@@ -104,6 +104,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden_fluent_bit_main.conf
@@ -110,6 +110,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden_fluent_bit_main.conf
@@ -158,6 +158,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden_fluent_bit_main.conf
@@ -194,6 +194,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden_fluent_bit_main.conf
@@ -208,6 +208,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden_fluent_bit_main.conf
@@ -675,6 +675,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden_fluent_bit_main.conf
@@ -149,6 +149,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden_fluent_bit_main.conf
@@ -323,6 +323,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden_fluent_bit_main.conf
@@ -161,6 +161,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden_fluent_bit_main.conf
@@ -357,6 +357,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden_fluent_bit_main.conf
@@ -110,6 +110,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden_fluent_bit_main.conf
@@ -208,6 +208,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden_fluent_bit_main.conf
@@ -110,6 +110,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden_fluent_bit_main.conf
@@ -104,6 +104,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden_fluent_bit_main.conf
@@ -191,6 +191,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden_fluent_bit_main.conf
@@ -111,6 +111,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden_fluent_bit_main.conf
@@ -205,6 +205,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden_fluent_bit_main.conf
@@ -110,6 +110,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -109,6 +109,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden_fluent_bit_main.conf
@@ -144,6 +144,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden_fluent_bit_main.conf
@@ -74,6 +74,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden_fluent_bit_main.conf
@@ -74,6 +74,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden_fluent_bit_main.conf
@@ -74,6 +74,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden_fluent_bit_main.conf
@@ -155,6 +155,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden_fluent_bit_main.conf
@@ -395,6 +395,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden_fluent_bit_main.conf
@@ -104,6 +104,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_vault/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_vault/golden_fluent_bit_main.conf
@@ -110,6 +110,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden_fluent_bit_main.conf
@@ -110,6 +110,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden_fluent_bit_main.conf
@@ -111,6 +111,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden_fluent_bit_main.conf
@@ -111,6 +111,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden_fluent_bit_main.conf
@@ -59,6 +59,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/all-built_in_config/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-built_in_config/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-user_config_file_deleted/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden_fluent_bit_main.conf
@@ -171,6 +171,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden_fluent_bit_main.conf
@@ -123,6 +123,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden_fluent_bit_main.conf
@@ -161,6 +161,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/logging-receiver_iis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_iis/golden_fluent_bit_main.conf
@@ -158,6 +158,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden_fluent_bit_main.conf
@@ -102,6 +102,7 @@
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      10MB
     tls                           On
     tls.verify                    Off
     workers                       8

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1574,3 +1574,77 @@ func RunForEachPlatform(t *testing.T, f func(t *testing.T, platform string)) {
 func ArbitraryPlatform() string {
 	return strings.Split(os.Getenv("PLATFORMS"), ",")[0]
 }
+
+func CreateFirewallRule(ctx context.Context, logger *log.Logger, vm *VM, name string) (CommandOutput, error) {
+	args := []string{
+		"compute", "firewall-rules", "create", name,
+		"--project=" + vm.Project,
+		"--direction=egress",
+		"--action=deny",
+		"--target-tags=" + vm.Name,
+		"--rules=tcp:443,tcp:80",
+	}
+	output, err := RunGcloud(ctx, logger, "", args)
+	if err != nil {
+		// Note: we don't try and delete the VM in this case because there is
+		// nothing to delete.
+		logger.Printf("Unable to create Firewall rule: %v", err)
+		return output, err
+	}
+	return output, nil
+}
+
+func DeleteFirewallRule(ctx context.Context, logger *log.Logger, vm *VM, name string) (CommandOutput, error) {
+	args := []string{
+		"compute", "firewall-rules", "delete", name,
+		"--project=" + vm.Project,
+		"--quiet",
+	}
+	output, err := RunGcloud(ctx, logger, "", args)
+	if err != nil {
+		// Note: we don't try and delete the VM in this case because there is
+		// nothing to delete.
+		logger.Printf("Unable to delete Firewall rule: %v", err)
+		return output, err
+	}
+	return output, nil
+}
+
+func updateFirewallRule(ctx context.Context, logger *log.Logger, vm *VM, name string, flags []string) (CommandOutput, error) {
+	args := []string{
+		"compute", "firewall-rules", "update", name,
+		"--project=" + vm.Project,
+	}
+	args = append(args, flags...)
+	output, err := RunGcloud(ctx, logger, "", args)
+	if err != nil {
+		logger.Printf("Unable to update firewall rule: %v", err)
+		return output, err
+	}
+	return output, nil
+}
+
+func EnableFirewallRule(ctx context.Context, logger *log.Logger, vm *VM, name string) (CommandOutput, error) {
+	return updateFirewallRule(ctx, logger, vm, name, []string{"--no-disabled"})
+}
+
+func DisableFirewallRule(ctx context.Context, logger *log.Logger, vm *VM, name string) (CommandOutput, error) {
+	return updateFirewallRule(ctx, logger, vm, name, []string{"--disabled"})
+}
+
+func AddTagToVm(ctx context.Context, logger *log.Logger, vm *VM, tag string) (CommandOutput, error) {
+	args := []string{
+		"compute", "instances", "add-tags", vm.Name,
+		"--zone=" + vm.Zone,
+		"--project=" + vm.Project,
+		"--tags=" + tag,
+	}
+	output, err := RunGcloud(ctx, logger, "", args)
+	if err != nil {
+		// Note: we don't try and delete the VM in this case because there is
+		// nothing to delete.
+		logger.Printf("Unable to tag vm: %v", err)
+		return output, err
+	}
+	return output, nil
+}

--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -687,6 +687,17 @@ func modifiedFiles(t *testing.T) []string {
 func determineImpactedApps(mf []string, allApps map[string]metadata.IntegrationMetadata) map[string]bool {
 	impactedApps := make(map[string]bool)
 	for _, f := range mf {
+		// File names: submodules/fluent-bit
+		if strings.HasPrefix(f, "submodules/") {
+			for app, _ := range allApps {
+				impactedApps[app] = true
+			}
+			log.Printf("impacted apps: %v", impactedApps)
+			return impactedApps
+		}
+	}
+
+	for _, f := range mf {
 		if strings.HasPrefix(f, "apps/") {
 
 			// File names: apps/<appname>.go

--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -686,13 +686,14 @@ func modifiedFiles(t *testing.T) []string {
 // Checks the extracted app names against the set of all known apps.
 func determineImpactedApps(mf []string, allApps map[string]metadata.IntegrationMetadata) map[string]bool {
 	impactedApps := make(map[string]bool)
+	defer log.Printf("impacted apps: %v", impactedApps)
+
 	for _, f := range mf {
 		// File names: submodules/fluent-bit
 		if strings.HasPrefix(f, "submodules/") {
 			for app, _ := range allApps {
 				impactedApps[app] = true
 			}
-			log.Printf("impacted apps: %v", impactedApps)
 			return impactedApps
 		}
 	}
@@ -717,7 +718,6 @@ func determineImpactedApps(mf []string, allApps map[string]metadata.IntegrationM
 
 		}
 	}
-	log.Printf("impacted apps: %v", impactedApps)
 	return impactedApps
 }
 


### PR DESCRIPTION
## Description
Added buffer_limit_size value to output plugin that has
filesystem as storage type. This prevent the size to grow out of controle.

## Related issue
b/244466293

## How has this been tested?
The tests done and benchmarking can be found on the design documentation.
Integration test is  a WIP
## Checklist:
- Unit tests
  - [] Unit tests do not apply.
  - [X] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
