### PR TITLE
oracle_audit works for single-digit dates or hours

### DIFF
--- a/apps/oracledb.go
+++ b/apps/oracledb.go
@@ -945,12 +945,12 @@ func (lr LoggingProcessorOracleDBAudit) Components(tag string, uid string) []flu
 			{
 				StateName: "start_state",
 				NextState: "cont",
-				Regex:     `^\w+ \w+ \d+ \d+:\d+:\d+ \d+ (?:[-+]\d+:\d+|Z)`,
+				Regex:     `^\w+ \w+ {1,2}\d+ {1,2}\d+:\d+:\d+ \d+ (?:[-+]\d+:\d+|Z)`,
 			},
 			{
 				StateName: "cont",
 				NextState: "cont",
-				Regex:     `^(?!\w+ \w+ \d+ \d+:\d+:\d+ \d+ (?:[-+]\d+:\d+|Z)).*$`,
+				Regex:     `^(?!\w+ \w+ {1,2}\d+ {1,2}\d+:\d+:\d+ \d+ (?:[-+]\d+:\d+|Z)).*$`,
 			},
 		},
 	}.Components(tag, uid)

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_parser.conf
@@ -22,5 +22,5 @@
 [MULTILINE_PARSER]
     Name oracledb.oracledb_audit.oracledb_audit.multiline
     Type regex
-    rule "start_state"    "^\w+ \w+ \d+ \d+:\d+:\d+ \d+ (?:[-+]\d+:\d+|Z)"    "cont"
-    rule "cont"    "^(?!\w+ \w+ \d+ \d+:\d+:\d+ \d+ (?:[-+]\d+:\d+|Z)).*$"    "cont"
+    rule "start_state"    "^\w+ \w+ {1,2}\d+ {1,2}\d+:\d+:\d+ \d+ (?:[-+]\d+:\d+|Z)"    "cont"
+    rule "cont"    "^(?!\w+ \w+ {1,2}\d+ {1,2}\d+:\d+:\d+ \d+ (?:[-+]\d+:\d+|Z)).*$"    "cont"

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_parser.conf
@@ -62,8 +62,8 @@
 [MULTILINE_PARSER]
     Name oracledb_custom.oracledb_audit_custom.oracledb_audit.multiline
     Type regex
-    rule "start_state"    "^\w+ \w+ \d+ \d+:\d+:\d+ \d+ (?:[-+]\d+:\d+|Z)"    "cont"
-    rule "cont"    "^(?!\w+ \w+ \d+ \d+:\d+:\d+ \d+ (?:[-+]\d+:\d+|Z)).*$"    "cont"
+    rule "start_state"    "^\w+ \w+ {1,2}\d+ {1,2}\d+:\d+:\d+ \d+ (?:[-+]\d+:\d+|Z)"    "cont"
+    rule "cont"    "^(?!\w+ \w+ {1,2}\d+ {1,2}\d+:\d+:\d+ \d+ (?:[-+]\d+:\d+|Z)).*$"    "cont"
 
 [MULTILINE_PARSER]
     Name oracledb_default.oracledb_alert.oracledb_alert.multiline
@@ -74,8 +74,8 @@
 [MULTILINE_PARSER]
     Name oracledb_default.oracledb_audit.oracledb_audit.multiline
     Type regex
-    rule "start_state"    "^\w+ \w+ \d+ \d+:\d+:\d+ \d+ (?:[-+]\d+:\d+|Z)"    "cont"
-    rule "cont"    "^(?!\w+ \w+ \d+ \d+:\d+:\d+ \d+ (?:[-+]\d+:\d+|Z)).*$"    "cont"
+    rule "start_state"    "^\w+ \w+ {1,2}\d+ {1,2}\d+:\d+:\d+ \d+ (?:[-+]\d+:\d+|Z)"    "cont"
+    rule "cont"    "^(?!\w+ \w+ {1,2}\d+ {1,2}\d+:\d+:\d+ \d+ (?:[-+]\d+:\d+|Z)).*$"    "cont"
 
 [MULTILINE_PARSER]
     Name oracledb_syslog_alert.oracledb_syslog_alert.0.multiline
@@ -86,5 +86,5 @@
 [MULTILINE_PARSER]
     Name oracledb_syslog_audit.oracledb_syslog_audit.0.multiline
     Type regex
-    rule "start_state"    "^\w+ \w+ \d+ \d+:\d+:\d+ \d+ (?:[-+]\d+:\d+|Z)"    "cont"
-    rule "cont"    "^(?!\w+ \w+ \d+ \d+:\d+:\d+ \d+ (?:[-+]\d+:\d+|Z)).*$"    "cont"
+    rule "start_state"    "^\w+ \w+ {1,2}\d+ {1,2}\d+:\d+:\d+ \d+ (?:[-+]\d+:\d+|Z)"    "cont"
+    rule "cont"    "^(?!\w+ \w+ {1,2}\d+ {1,2}\d+:\d+:\d+ \d+ (?:[-+]\d+:\d+|Z)).*$"    "cont"

--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -248,7 +248,7 @@ func verifyLogField(fieldName, actualField string, expectedFields map[string]*me
 	if expectedField.ValueRegex != "" {
 		pattern = expectedField.ValueRegex
 	}
-	match, err := regexp.MatchString(fmt.Sprintf("^(?:%s)$", pattern), actualField)
+	match, err := regexp.MatchString(pattern, actualField)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
`oracle_audit` logs would previously fail to parse multilines for dates with single digits because the regex only has one space between month and date. Also added a similar change for hours just in case those are also single-digits early in the morning.

## Related issue
N/A nightly failure

## How has this been tested?
Will let the PR run the tests

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
