### PR TITLE
confgenerator: Add GetListenPorts() method to loggingReceiverMap type

### DIFF
--- a/confgenerator/config.go
+++ b/confgenerator/config.go
@@ -446,8 +446,8 @@ type LoggingNetworkReceiver interface {
 func (m *loggingReceiverMap) GetListenPorts() map[string]uint16 {
 	receiverPortMap := map[string]uint16{}
 	for rID, receiver := range *m {
-		if s, ok := receiver.(LoggingNetworkReceiver); ok {
-			receiverPortMap[rID] = s.GetListenPort()
+		if nr, ok := receiver.(LoggingNetworkReceiver); ok {
+			receiverPortMap[rID] = nr.GetListenPort()
 		}
 	}
 	return receiverPortMap

--- a/confgenerator/config.go
+++ b/confgenerator/config.go
@@ -442,6 +442,7 @@ type LoggingNetworkReceiver interface {
 	GetListenPort() uint16
 }
 
+// GetListenPorts returns a map of receiver IDs to ports for all LoggingNetworkReceivers
 func (m *loggingReceiverMap) GetListenPorts() map[string]uint16 {
 	receiverPortMap := map[string]uint16{}
 	for rID, receiver := range *m {

--- a/confgenerator/config.go
+++ b/confgenerator/config.go
@@ -813,10 +813,6 @@ var (
 		"iis":                     1,
 		"mssql":                   1,
 	}
-
-	receiverPortLimits = []string{
-		"syslog", "tcp", "fluent_forward",
-	}
 )
 
 // sortedKeys returns sorted keys from a Set if the Set has a type that can be ordered.

--- a/confgenerator/config.go
+++ b/confgenerator/config.go
@@ -442,6 +442,16 @@ type LoggingNetworkReceiver interface {
 	GetListenPort() uint16
 }
 
+func (m *loggingReceiverMap) GetListenPorts() map[string]uint16 {
+	receiverPortMap := map[string]uint16{}
+	for rID, receiver := range *m {
+		if s, ok := receiver.(LoggingNetworkReceiver); ok {
+			receiverPortMap[rID] = s.GetListenPort()
+		}
+	}
+	return receiverPortMap
+}
+
 type LoggingProcessor interface {
 	Component
 	// Components returns fluentbit components that implement this processor.
@@ -719,7 +729,7 @@ func (l *Logging) Validate(platform string) error {
 			return err
 		}
 		// portTaken will be modified/updated by the validation function
-		if _, err := validateReceiverPorts(portTaken, l.Receivers.GetReceiverListenPorts(), p.ReceiverIDs); err != nil {
+		if _, err := validateReceiverPorts(portTaken, l.Receivers.GetListenPorts(), p.ReceiverIDs); err != nil {
 			return err
 		}
 		if len(p.ExporterIDs) > 0 {
@@ -847,16 +857,6 @@ func validateComponentTypeCounts[C Component](components map[string]C, refs []st
 		}
 	}
 	return r, nil
-}
-
-func (m *loggingReceiverMap) GetReceiverListenPorts() map[string]uint16 {
-	receiverPortMap := map[string]uint16{}
-	for rID, receiver := range *m {
-		if s, ok := receiver.(LoggingNetworkReceiver); ok {
-			receiverPortMap[rID] = s.GetListenPort()
-		}
-	}
-	return receiverPortMap
 }
 
 // Validate that no two receivers are using the same port; adding new port usage to the input map `taken`


### PR DESCRIPTION
## Description
Exposing a method to retrieve all the listen ports defined by a LoggingNetworkReceiver in the Ops Agent unified configuration. This will be used later to write a Health Check to check if defined ports used in a pipeline are available.

Details : 
- Create method `GetListenPorts()` 
- Simplify the function `validateReceiverPorts`

## Related issue
b/260718203

## How has this been tested?
All the unit tests defined in the PR (https://github.com/GoogleCloudPlatform/ops-agent/pull/721) that test for repeated ports used in same pipeline or in different pipelines pass.
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests defined in PR (https://github.com/GoogleCloudPlatform/ops-agent/pull/721) pass.
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
