### PR TITLE
Fix otel keep_keys to use list

### DIFF
--- a/confgenerator/otel/processors.go
+++ b/confgenerator/otel/processors.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"path"
 	"sort"
+	"strings"
 )
 
 // Helper functions to easily build up processor configs.
@@ -159,11 +160,7 @@ func SummaryCountValToSum(metricName, aggregation string, isMonotonic bool) Tran
 
 // RetainResource retains the resource attributes provided, and drops all other attributes.
 func RetainResource(resourceAttributeKeys ...string) TransformQuery {
-	keyList := ""
-	for _, key := range resourceAttributeKeys {
-		keyList += fmt.Sprintf(`, "%s"`, key)
-	}
-	return TransformQuery(fmt.Sprintf(`keep_keys(resource.attributes%s)`, keyList))
+	return TransformQuery(fmt.Sprintf(`keep_keys(resource.attributes, [%s])`, strings.Join(resourceAttributeKeys[:], ",")))
 }
 
 // RenameMetric returns a config snippet that renames old to new, applying zero or more transformations.

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/otel.yaml
@@ -494,7 +494,7 @@ processors:
   transform/iispipeline_iis__v2_1:
     metrics:
       statements:
-      - keep_keys(resource.attributes)
+      - keep_keys(resource.attributes, [])
 receivers:
   hostmetrics/default__pipeline_hostmetrics:
     collection_interval: 60s

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/otel.yaml
@@ -477,7 +477,7 @@ processors:
   transform/default__pipeline_iis_1:
     metrics:
       statements:
-      - keep_keys(resource.attributes)
+      - keep_keys(resource.attributes, [])
   transform/iispipeline_iis_0:
     metrics:
       statements:
@@ -486,7 +486,7 @@ processors:
   transform/iispipeline_iis_1:
     metrics:
       statements:
-      - keep_keys(resource.attributes)
+      - keep_keys(resource.attributes, [])
 receivers:
   hostmetrics/default__pipeline_hostmetrics:
     collection_interval: 60s


### PR DESCRIPTION
## Description
Address the grammar change introduced by otel 0.67.0. 

## Related issue
b/262879179

## How has this been tested?
Previously failed IIS integration test can pass now.  

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
