### PR TITLE
Zookeeper doc miss mentioning mntr

### DIFF
--- a/integration_test/third_party_apps_data/applications/zookeeper/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/zookeeper/metadata.yaml
@@ -22,6 +22,9 @@ description: |-
   latency, active requests, and active connections. The integration also collects
   ZooKeeper logs and parses them into a JSON payload. The result includes fields
   for node ID, source, level, and message.
+configure_integration: |-
+  The Zookeeper receiver collects metrics from a Zookeeper instance, using the `mntr` command.
+  The `mntr` 4 letter word command needs to be enabled for the receiver to be able to collect metrics.
 minimum_supported_agent_version:
   metrics: 2.10.0
   logging: 2.11.0


### PR DESCRIPTION
## Description
Zookeeper doc miss mentioning mntr

## Related issue
b/263143503

## How has this been tested?
Tested in the doc generator

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
