### PR TITLE
Remove deprecated and no longer available sles-12-sp4-sap.

### DIFF
--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -105,7 +105,6 @@ sles = _family {
       name = 'SLES 12'
       release = [
         'sles-12',
-        'sles-12-sp4-sap',
         'sles-12-sp5-sap',
       ]
       presubmit = ['sles-12']


### PR DESCRIPTION
## Description
Fixes tests by removing the deprecated image.

## Related issue
[b/264292467](http://b/264292467)

## How has this been tested?
N/A, pure removal.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
