### PR TITLE
Update version string for experimental GPU metrics branch builds

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-PKG_VERSION="2.24.0"
+PKG_VERSION="2.23.0+pre.gpu.1"


### PR DESCRIPTION
## Description
Update the version string for testing builds based off the feature branch. The feature branch's base is newer than v2.23.0 but does not include all changes in V2.24.0 so temporarily have this as `2.23.0+pre.gpu.1`. 

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [x] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
