### PR TITLE
Cherry-pick collector 0.67 upgrade from public_preview/gpu

### DIFF
--- a/apps/postgresql.go
+++ b/apps/postgresql.go
@@ -79,6 +79,9 @@ func (r MetricsReceiverPostgresql) Pipelines() []otel.ReceiverPipeline {
 				otel.FlattenResourceAttribute("postgresql.index.name", "index"),
 			),
 			otel.MetricsTransform(
+				otel.UpdateMetric("postgresql.bgwriter.duration",
+					otel.ToggleScalarDataType,
+				),
 				otel.AddPrefix("workload.googleapis.com"),
 			),
 		}},

--- a/confgenerator/otel/processors.go
+++ b/confgenerator/otel/processors.go
@@ -166,11 +166,7 @@ func SummaryCountValToSum(metricName, aggregation string, isMonotonic bool) Tran
 
 // RetainResource retains the resource attributes provided, and drops all other attributes.
 func RetainResource(resourceAttributeKeys ...string) TransformQuery {
-	keyList := ""
-	for _, key := range resourceAttributeKeys {
-		keyList += fmt.Sprintf(`, "%s"`, key)
-	}
-	return TransformQuery(fmt.Sprintf(`keep_keys(resource.attributes%s)`, keyList))
+	return TransformQuery(fmt.Sprintf(`keep_keys(resource.attributes, [%s])`, strings.Join(resourceAttributeKeys[:], ",")))
 }
 
 // RenameMetric returns a config snippet that renames old to new, applying zero or more transformations.

--- a/confgenerator/otel/processors.go
+++ b/confgenerator/otel/processors.go
@@ -114,7 +114,7 @@ func TransformationMetrics(queries ...TransformQuery) Component {
 		Type: "transform",
 		Config: map[string]map[string]interface{}{
 			"metrics": {
-				"queries": queryStrings,
+				"statements": queryStrings,
 			},
 		},
 	}

--- a/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/otel.yaml
@@ -419,7 +419,7 @@ processors:
     - gcp
   transform/aerospike_2:
     metrics:
-      queries:
+      statements:
       - set(attributes["node_name"], resource.attributes["aerospike.node.name"])
       - set(attributes["namespace_name"], resource.attributes["aerospike.namespace"])
 receivers:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/otel.yaml
@@ -509,7 +509,7 @@ processors:
     - gcp
   transform/couchbase_3:
     metrics:
-      queries:
+      statements:
       - convert_gauge_to_sum("cumulative", true) where metric.name == "workload.googleapis.com/couchbase.bucket.error.oom.count"
       - set(metric.description, "Number of out of memory errors.") where metric.name == "workload.googleapis.com/couchbase.bucket.error.oom.count"
       - set(metric.unit, "{errors}") where metric.name == "workload.googleapis.com/couchbase.bucket.error.oom.count"

--- a/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/otel.yaml
@@ -443,7 +443,7 @@ processors:
     - gcp
   transform/flink_2:
     metrics:
-      queries:
+      statements:
       - set(attributes["host_name"], resource.attributes["host.name"])
       - set(attributes["taskmanager_id"], resource.attributes["flink.taskmanager.id"])
       - set(attributes["job_name"], resource.attributes["flink.job.name"])

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/otel.yaml
@@ -410,6 +410,10 @@ processors:
   metricstransform/postgresql_2:
     transforms:
     - action: update
+      include: postgresql.bgwriter.duration
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
@@ -419,7 +423,7 @@ processors:
     - gcp
   transform/postgresql_1:
     metrics:
-      queries:
+      statements:
       - set(attributes["database"], resource.attributes["postgresql.database.name"])
       - set(attributes["table"], resource.attributes["postgresql.table.name"])
       - set(attributes["index"], resource.attributes["postgresql.index.name"])

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/otel.yaml
@@ -410,6 +410,10 @@ processors:
   metricstransform/postgresql_2:
     transforms:
     - action: update
+      include: postgresql.bgwriter.duration
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
@@ -419,7 +423,7 @@ processors:
     - gcp
   transform/postgresql_1:
     metrics:
-      queries:
+      statements:
       - set(attributes["database"], resource.attributes["postgresql.database.name"])
       - set(attributes["table"], resource.attributes["postgresql.table.name"])
       - set(attributes["index"], resource.attributes["postgresql.index.name"])

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/otel.yaml
@@ -410,6 +410,10 @@ processors:
   metricstransform/postgresql_2:
     transforms:
     - action: update
+      include: postgresql.bgwriter.duration
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
@@ -419,7 +423,7 @@ processors:
     - gcp
   transform/postgresql_1:
     metrics:
-      queries:
+      statements:
       - set(attributes["database"], resource.attributes["postgresql.database.name"])
       - set(attributes["table"], resource.attributes["postgresql.table.name"])
       - set(attributes["index"], resource.attributes["postgresql.index.name"])

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/otel.yaml
@@ -410,6 +410,10 @@ processors:
   metricstransform/postgresql_2:
     transforms:
     - action: update
+      include: postgresql.bgwriter.duration
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
@@ -419,7 +423,7 @@ processors:
     - gcp
   transform/postgresql_1:
     metrics:
-      queries:
+      statements:
       - set(attributes["database"], resource.attributes["postgresql.database.name"])
       - set(attributes["table"], resource.attributes["postgresql.table.name"])
       - set(attributes["index"], resource.attributes["postgresql.index.name"])

--- a/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/otel.yaml
@@ -425,7 +425,7 @@ processors:
     - gcp
   transform/saphana_3:
     metrics:
-      queries:
+      statements:
       - set(attributes["host"], resource.attributes["saphana.host"])
 receivers:
   hostmetrics/hostmetrics:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/otel.yaml
@@ -463,7 +463,7 @@ processors:
     - gcp
   transform/vault_0:
     metrics:
-      queries:
+      statements:
       - convert_summary_count_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"
       - convert_summary_sum_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"
       - set(attributes["storage"], "azure") where metric.name == "vault_azure_delete_count"

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/otel.yaml
@@ -463,7 +463,7 @@ processors:
     - gcp
   transform/vault_0:
     metrics:
-      queries:
+      statements:
       - convert_summary_count_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"
       - convert_summary_sum_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"
       - set(attributes["storage"], "azure") where metric.name == "vault_azure_delete_count"

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/otel.yaml
@@ -463,7 +463,7 @@ processors:
     - gcp
   transform/vault_0:
     metrics:
-      queries:
+      statements:
       - convert_summary_count_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"
       - convert_summary_sum_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"
       - set(attributes["storage"], "azure") where metric.name == "vault_azure_delete_count"

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/otel.yaml
@@ -494,7 +494,7 @@ processors:
   transform/iis__v2_1:
     metrics:
       statements:
-      - keep_keys(resource.attributes)
+      - keep_keys(resource.attributes, [])
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/otel.yaml
@@ -488,12 +488,12 @@ processors:
     - gcp
   transform/iis__v2_0:
     metrics:
-      queries:
+      statements:
       - set(attributes["site"], resource.attributes["iis.site"])
       - set(attributes["app_pool"], resource.attributes["iis.application_pool"])
   transform/iis__v2_1:
     metrics:
-      queries:
+      statements:
       - keep_keys(resource.attributes)
 receivers:
   hostmetrics/hostmetrics:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/otel.yaml
@@ -454,12 +454,12 @@ processors:
     - gcp
   transform/iis_0:
     metrics:
-      queries:
+      statements:
       - set(attributes["site"], resource.attributes["iis.site"])
       - set(attributes["app_pool"], resource.attributes["iis.application_pool"])
   transform/iis_1:
     metrics:
-      queries:
+      statements:
       - keep_keys(resource.attributes)
 receivers:
   hostmetrics/hostmetrics:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/otel.yaml
@@ -460,7 +460,7 @@ processors:
   transform/iis_1:
     metrics:
       statements:
-      - keep_keys(resource.attributes)
+      - keep_keys(resource.attributes, [])
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/otel.yaml
@@ -481,7 +481,7 @@ processors:
     - gcp
   transform/mssql__v2_1:
     metrics:
-      queries:
+      statements:
       - set(attributes["database"], resource.attributes["sqlserver.database.name"])
 receivers:
   hostmetrics/hostmetrics:

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/otel.yaml
@@ -466,7 +466,7 @@ processors:
     - gcp
   transform/mssql_1:
     metrics:
-      queries:
+      statements:
       - set(attributes["database"], resource.attributes["sqlserver.database.name"])
 receivers:
   hostmetrics/hostmetrics:


### PR DESCRIPTION
## Description
Cherry-picking #1016 and #1024 to help separate the changes needed for the mongodb fork, since the fork is based on 0.67 but master is still on a much older version of the collector.

## Related issue
b/258440096

## How has this been tested?
Letting kokoro run in PR

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
