### PR TITLE
Testing: fix issues with test XML

### DIFF
--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -81,7 +81,7 @@ gsutil cp "gs://stackdriver-test-143416-go-install/go${GO_VERSION}.linux-amd64.t
 PATH=$PATH:/usr/local/go/bin
 
 # Install a utility for producing XML test results.
-go install github.com/jstemmer/go-junit-report@latest
+go install github.com/jstemmer/go-junit-report/v2@latest
 
 if [[ -n "${TEST_SOURCE_PIPER_LOCATION-}" ]]; then
   if [[ -n "${SCRIPTS_DIR-}" ]]; then
@@ -106,7 +106,7 @@ fi
 
 STDERR_STDOUT_FILE="${KOKORO_ARTIFACTS_DIR}/test_stderr_stdout.txt"
 function produce_xml() {
-  cat "${STDERR_STDOUT_FILE}" | "$(go env GOPATH)/bin/go-junit-report" > "${LOGS_DIR}/sponge_log.xml"
+  cat "${STDERR_STDOUT_FILE}" | "$(go env GOPATH)/bin/go-junit-report" -parser gojson > "${LOGS_DIR}/sponge_log.xml"
 }
 # Always run produce_xml on exit, whether the test passes or fails.
 trap produce_xml EXIT
@@ -116,6 +116,7 @@ ulimit -n 1000000
 
 # Set up some command line flags for "go test".
 args=(
+  -json
   -test.parallel=1000
   -tags=integration_test
   -timeout=3h


### PR DESCRIPTION
## Description
Occasionally (or more than that) logs would end up in the wrong expando in the test XML [Example](https://source.cloud.google.com/results/invocations/cf2961d6-9e2c-48bf-a98c-a0cfe32178e8/targets/logs/tests;group=command-line-arguments;test=TestThirdPartyApps%2Frocky-linux-9%2Felasticsearch;row=2). Using the -json flag fixes those issues. The only downside is that "plain stderr" logs on Kokoro are less readable since they have JSON fluff. [Before](https://source.cloud.google.com/results/invocations/cf2961d6-9e2c-48bf-a98c-a0cfe32178e8/targets/stackdriver_agents%2Ftesting%2Fconsumer%2Fthird_party_apps%2Ftest%2Fbullseye/log) vs [After](https://source.cloud.google.com/results/invocations/a980a7d8-d894-4526-bc89-6a88aea9d2c2/targets/stackdriver_agents%2Ftesting%2Fconsumer%2Fthird_party_apps%2Ftest%2Fbuster/log)

But the XML looks much more correct now.

Bad (the more you look the worse it gets):
    https://source.cloud.google.com/results/invocations/cf2961d6-9e2c-48bf-a98c-a0cfe32178e8/targets/logs/tests
Better:
    https://source.cloud.google.com/results/invocations/a980a7d8-d894-4526-bc89-6a88aea9d2c2/targets/logs/tests

## Related issue
no issue

## How has this been tested?
Automated tests, some limited manual inspection of the logs.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

