### PR TITLE
prometheus: remove feature gate for the prometheus receiver

### DIFF
--- a/confgenerator/confgenerator_test.go
+++ b/confgenerator/confgenerator_test.go
@@ -320,5 +320,5 @@ func init() {
 	confgenerator.MetadataResource = testResource
 
 	// Enable experimental features.
-	os.Setenv("EXPERIMENTAL_FEATURES", "prometheus_receiver,otlp_receiver")
+	os.Setenv("EXPERIMENTAL_FEATURES", "otlp_receiver")
 }

--- a/confgenerator/experimental.go
+++ b/confgenerator/experimental.go
@@ -23,8 +23,7 @@ import (
 )
 
 var requiredFeatureForType = map[string]string{
-	"prometheus": "prometheus_receiver",
-	"otlp":       "otlp_receiver",
+	"otlp": "otlp_receiver",
 }
 
 func IsExperimentalFeatureEnabled(feature string) bool {

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -1892,10 +1892,6 @@ func TestPrometheusMetrics(t *testing.T) {
           - prometheus
 `
 
-		// Turn on the prometheus feature gate.
-		if err := gce.SetEnvironmentVariables(ctx, logger.ToMainLog(), vm, map[string]string{"EXPERIMENTAL_FEATURES": "prometheus_receiver"}); err != nil {
-			t.Fatal(err)
-		}
 		if err := setupOpsAgent(ctx, logger, vm, promConfig); err != nil {
 			t.Fatal(err)
 		}
@@ -2060,10 +2056,6 @@ func TestPrometheusMetricsWithJSONExporter(t *testing.T) {
       prom_pipeline:
         receivers: [prom_app]
 `
-		// Turn on the prometheus feature gate.
-		if err := gce.SetEnvironmentVariables(ctx, logger.ToMainLog(), vm, map[string]string{"EXPERIMENTAL_FEATURES": "prometheus_receiver"}); err != nil {
-			t.Fatal(err)
-		}
 		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
 			t.Fatal(err)
 		}
@@ -2308,10 +2300,6 @@ func testPrometheusMetrics(t *testing.T, testFiles map[string]fileToUpload, chec
       prom_pipeline:
         receivers: [prom_app]
 `
-		// Turn on the prometheus feature gate.
-		if err := gce.SetEnvironmentVariables(ctx, logger.ToMainLog(), vm, map[string]string{"EXPERIMENTAL_FEATURES": "prometheus_receiver"}); err != nil {
-			t.Fatal(err)
-		}
 		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
## Description
Removing experimental feature gate before we go GA.

## Related issue
[b/265973579](http://b/265973579) | P1 | Remove feature gate for the prometheus receiver for GA


## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [x] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
