### PR TITLE
Internal: Update list of RHEL versions to test for releaeses

### DIFF
--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -76,7 +76,6 @@ centos = _family {
         'centos-7',
         // RHEL.
         'rhel-7',
-        'rhel-7-6-sap-ha',
         'rhel-7-7-sap-ha',
         'rhel-7-9-sap-ha',
       ]
@@ -92,6 +91,7 @@ centos = _family {
         'rhel-8-1-sap-ha',
         'rhel-8-2-sap-ha',
         'rhel-8-4-sap-ha',
+        'rhel-8-6-sap-ha',
         // Rocky.
         'rocky-linux-8',
       ]


### PR DESCRIPTION
## Description
Release tests for CentOS 7 are failing, **partly** because rhel-7-6-sap-ha is deprecated now. So this PR removes that one. But it also adds rhel-8-6-sap-ha because that one is new and we weren't testing it.

## Related issue
b/265341502

## How has this been tested?
it will be tested by release builds.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
