### PR TITLE
Internal: ignore all .git files in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-.git
+**/*.git
 Dockerfile
 Dockerfile.windows
 .dockerignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-**/*.git
+**/.git
 Dockerfile
 Dockerfile.windows
 .dockerignore


### PR DESCRIPTION
## Description
The `.dockerignore` exclusion should now include all sub-directories as well as the current directory. This is important as any change to any branch in the submodules might result in a cache invalidation and re-building the sub-agents

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
