### PR TITLE
Internal: fix links not rendering as links

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1669,7 +1669,7 @@ func SetupLogger(t *testing.T) *logging.DirectoryLogger {
 		}
 	})
 	logger.ToMainLog().Printf("Starting test %s", name)
-	t.Logf("Test logs: %s", logLocation(logRootDir, name))
+	t.Logf("Test logs: %s ", logLocation(logRootDir, name))
 	return logger
 }
 


### PR DESCRIPTION
Jefferbrecht said:

a caveat of the JSON change: links appearing at the end of the line scoop up the trailing \n and won't work when clicked, you need to manually remove the \n

example:
```
{"Time":"2023-01-24T12:58:56.418993823Z","Action":"output","Package":"command-line-arguments","Test":"TestThirdPartyApps/debian-10/memcached","Output":"    third_party_apps_test.go:908: Test logs: https://console.cloud.google.com/storage/browser/ops-agents-public-buckets-test-logs/prod/stackdriver_agents/testing/consumer/third_party_apps/ops_agent_release/buster/418/20230124-045727/logs/TestThirdPartyApps_debian-10_memcached\n"}
```

This should fix that

## Description
<!--- Describe your changes in detail. -->

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
