### PR TITLE
Remove obsolete opensuse-leap-15-3 and update opensuse-leap-15-4

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -928,8 +928,7 @@ func prepareSLES(ctx context.Context, logger *log.Logger, vm *VM) error {
 
 var (
 	overriddenImages = map[string]string{
-		"opensuse-leap-15-3": "opensuse-leap-15-3-v20220429-x86-64",
-		"opensuse-leap-15-4": "opensuse-leap-15-4-v20220624-x86-64",
+		"opensuse-leap-15-4": "opensuse-leap-15-4-v20221201-x86-64",
 	}
 )
 

--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -126,7 +126,6 @@ sles = _family {
         'sles-15-sp1-sap',
         'sles-15-sp2-sap',
         'opensuse-leap',
-        'opensuse-leap-15-3',
         'opensuse-leap-15-4',
       ]
       presubmit = ['sles-15']


### PR DESCRIPTION
## Description
```
- Invalid value for field 'resource.disks[0].initializeParams.sourceImage': '[https://compute.googleapis.com/compute/v1/projects/opensuse-cloud/global/images/opensuse-leap-15-3-v20220429-x86-64](https://www.google.com/url?q=https://compute.googleapis.com/compute/v1/projects/opensuse-cloud/global/images/opensuse-leap-15-3-v20220429-x86-64&sa=D)'. The referenced image resource cannot be found.
- Invalid value for field 'resource.disks[0].initializeParams.sourceImage': '[https://compute.googleapis.com/compute/v1/projects/opensuse-cloud/global/images/opensuse-leap-15-4-v20220624-x86-64](https://www.google.com/url?q=https://compute.googleapis.com/compute/v1/projects/opensuse-cloud/global/images/opensuse-leap-15-4-v20220624-x86-64&sa=D)'. The referenced image resource cannot be found.
```

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
