### PR TITLE
secret: added secret string type, use for vault

### DIFF
--- a/apps/vault.go
+++ b/apps/vault.go
@@ -20,6 +20,7 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/secret"
 )
 
 type MetricsReceiverVault struct {
@@ -27,10 +28,10 @@ type MetricsReceiverVault struct {
 	confgenerator.MetricsReceiverShared    `yaml:",inline"`
 	confgenerator.MetricsReceiverSharedTLS `yaml:",inline"`
 
-	Token       string `yaml:"token"`
-	Endpoint    string `yaml:"endpoint" validate:"omitempty,hostname_port"`
-	MetricsPath string `yaml:"metrics_path" validate:"omitempty,startswith=/"`
-	Scheme      string `yaml:"scheme" validate:"omitempty"`
+	Token       secret.String `yaml:"token"`
+	Endpoint    string        `yaml:"endpoint" validate:"omitempty,hostname_port"`
+	MetricsPath string        `yaml:"metrics_path" validate:"omitempty,startswith=/"`
+	Scheme      string        `yaml:"scheme" validate:"omitempty"`
 }
 
 const (
@@ -99,7 +100,7 @@ func (r MetricsReceiverVault) Pipelines() []otel.ReceiverPipeline {
 
 	if r.Token != "" {
 		scrapeConfig["authorization"] = map[string]interface{}{
-			"credentials": r.Token,
+			"credentials": r.Token.SecretValue(),
 			"type":        "Bearer",
 		}
 	}

--- a/internal/secret/string.go
+++ b/internal/secret/string.go
@@ -20,6 +20,8 @@ import (
 	"github.com/goccy/go-yaml"
 )
 
+var RedactedValue string = "__redacted__"
+
 type Secret[T any] interface {
 	fmt.Stringer
 	yaml.BytesMarshaler
@@ -30,7 +32,7 @@ type String string
 
 // fmt.Stringer
 func (s String) String() string {
-	return "xxxxx"
+	return RedactedValue
 }
 
 // yaml.BytesMarshaler

--- a/internal/secret/string.go
+++ b/internal/secret/string.go
@@ -28,12 +28,12 @@ type Secret[T any] interface {
 
 type String string
 
+// fmt.Stringer
 func (s String) String() string {
 	return "xxxxx"
 }
 
-// From github.com/goccy/go-yaml. See:
-// https://github.com/goccy/go-yaml/blob/master/yaml.go
+// yaml.BytesMarshaler
 func (s String) MarshalYAML() ([]byte, error) {
 	return []byte(s.String()), nil
 }

--- a/internal/secret/string.go
+++ b/internal/secret/string.go
@@ -1,0 +1,43 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secret
+
+import (
+	"fmt"
+
+	"github.com/goccy/go-yaml"
+)
+
+type Secret[T any] interface {
+	fmt.Stringer
+	yaml.BytesMarshaler
+	SecretValue() T
+}
+
+type String string
+
+func (s String) String() string {
+	return "xxxxx"
+}
+
+// From github.com/goccy/go-yaml. See:
+// https://github.com/goccy/go-yaml/blob/master/yaml.go
+func (s String) MarshalYAML() ([]byte, error) {
+	return []byte(s.String()), nil
+}
+
+func (s String) SecretValue() string {
+	return string(s)
+}

--- a/internal/secret/string_test.go
+++ b/internal/secret/string_test.go
@@ -1,0 +1,32 @@
+package secret_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/ops-agent/internal/secret"
+	"github.com/goccy/go-yaml"
+)
+
+func TestSecretStringStringer(t *testing.T) {
+	var s secret.String = "My credit card number!"
+	result := s.String()
+	if !strings.Contains(result, "x") {
+		t.Fatalf("expected result to be redacted, instead was \"%s\"", result)
+	}
+}
+
+func TestSecretStringMarshalYAML(t *testing.T) {
+	type x struct {
+		S secret.String `yaml:"s"`
+	}
+
+	testX := x{S: "My credit card number!"}
+	result, err := yaml.Marshal(testX)
+	if err != nil {
+		t.Fatalf("expected marshal not to error, got: %s", result)
+	}
+	if string(result) != "s: xxxxx\n" {
+		t.Fatalf("expected secret field to be redacted, got: %s", string(result))
+	}
+}

--- a/internal/secret/string_test.go
+++ b/internal/secret/string_test.go
@@ -27,6 +27,22 @@ func TestSecretStringMarshalYAML(t *testing.T) {
 		t.Fatalf("expected marshal not to error, got: %s", result)
 	}
 	if string(result) != "s: xxxxx\n" {
-		t.Fatalf("expected secret field to be redacted, got: %s", string(result))
+		t.Fatalf("expected Marshal to redact secret field, got: %s", string(result))
+	}
+}
+
+func TestSecretStringUnmarshalYAML(t *testing.T) {
+	type x struct {
+		S secret.String `yaml:"s"`
+	}
+
+	yml := "s: My credit card number!"
+	var result x
+	err := yaml.Unmarshal([]byte(yml), &result)
+	if err != nil {
+		t.Fatalf("expected marshal not to error, got: %s", result)
+	}
+	if result.S != "My credit card number!" {
+		t.Fatalf("expected Unmarshal to retain secret field value, got: %s", result.S)
 	}
 }

--- a/internal/secret/string_test.go
+++ b/internal/secret/string_test.go
@@ -11,7 +11,7 @@ import (
 func TestSecretStringStringer(t *testing.T) {
 	var s secret.String = "My credit card number!"
 	result := s.String()
-	if !strings.Contains(result, "x") {
+	if !strings.Contains(result, secret.RedactedValue) {
 		t.Fatalf("expected result to be redacted, instead was \"%s\"", result)
 	}
 }
@@ -22,12 +22,13 @@ func TestSecretStringMarshalYAML(t *testing.T) {
 	}
 
 	testX := x{S: "My credit card number!"}
-	result, err := yaml.Marshal(testX)
+	resultBytes, err := yaml.Marshal(testX)
+	result := string(resultBytes)
 	if err != nil {
 		t.Fatalf("expected marshal not to error, got: %s", result)
 	}
-	if string(result) != "s: xxxxx\n" {
-		t.Fatalf("expected Marshal to redact secret field, got: %s", string(result))
+	if !strings.Contains(result, secret.RedactedValue) {
+		t.Fatalf("expected Marshal to redact secret field, got: %s", result)
 	}
 }
 

--- a/tasks.mak
+++ b/tasks.mak
@@ -45,6 +45,11 @@ addlicense:
 addlicense_check:
 	addlicense -check -ignore "submodules/**" -ignore "**/testdata/**" -ignore "**/built-in-config*" -c "Google LLC" -l apache . 
 
+# Originally I made the argument to this "PATH" but of course that messes with
+# the PATH environment variable. :D
+addlicense_to:
+	addlicense -c "Google LLC" -l apache $(P)
+
 yaml_format:
 	yamlfmt
 


### PR DESCRIPTION
## Description
Added a secret.Data interface and a secret.String type that will allow for custom secret data which will be redacted on output (yaml or print).

Showing example usage on vault Token, future PRs should address other sensitive data.

## Related issue
#1035
b/266204153

## How has this been tested?
Unit tests and manual runs in ops agent engine.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [x] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
