### PR TITLE
healthchecks: Refactor logging and results.

### DIFF
--- a/cmd/google_cloud_ops_agent_engine/main.go
+++ b/cmd/google_cloud_ops_agent_engine/main.go
@@ -39,9 +39,12 @@ func runStartupChecks(service string) {
 	case "":
 		time.Sleep(time.Second)
 		gceHealthChecks := healthchecks.HealthCheckRegistryFactory()
-		healthCheckResults := gceHealthChecks.RunAllHealthChecks(*logsDir)
-		for _, message := range healthCheckResults {
-			log.Printf(message)
+		logger, closer := healthchecks.CreateHealthChecksLogger(*logsDir)
+		defer closer()
+
+		healthCheckResults := gceHealthChecks.RunAllHealthChecks(logger)
+		for _, result := range healthCheckResults {
+			log.Printf(result.Message)
 		}
 		log.Println("Startup checks finished")
 	// Adding sleep to reduce flakyness in Ports Checks

--- a/internal/healthchecks/healthchecks_test.go
+++ b/internal/healthchecks/healthchecks_test.go
@@ -94,9 +94,9 @@ func TestRunAllHealthChecks(t *testing.T) {
 	eCheck := ErrorCheck{}
 	AllHealthChecks := healthchecks.HealthCheckRegistry{fCheck, sCheck, eCheck}
 
-	result := AllHealthChecks.RunAllHealthChecks("log")
+	result := AllHealthChecks.RunAllHealthChecks(testLogger)
 
-	assert.Check(t, strings.Contains(result[fCheck.Name()], "Result: FAIL"))
-	assert.Check(t, strings.Contains(result[sCheck.Name()], "Result: PASS"))
-	assert.Check(t, strings.Contains(result[eCheck.Name()], "Result: ERROR"))
+	assert.Check(t, strings.Contains(result[fCheck.Name()].Message, "Result: FAIL"))
+	assert.Check(t, strings.Contains(result[sCheck.Name()].Message, "Result: PASS"))
+	assert.Check(t, strings.Contains(result[eCheck.Name()].Message, "Result: ERROR"))
 }

--- a/internal/healthchecks/healthchecks_test.go
+++ b/internal/healthchecks/healthchecks_test.go
@@ -92,9 +92,9 @@ func TestRunAllHealthChecks(t *testing.T) {
 	fCheck := FailureCheck{}
 	sCheck := SuccessCheck{}
 	eCheck := ErrorCheck{}
-	AllHealthChecks := healthchecks.HealthCheckRegistry{fCheck, sCheck, eCheck}
+	allHealthChecks := healthchecks.HealthCheckRegistry{fCheck, sCheck, eCheck}
 
-	result := AllHealthChecks.RunAllHealthChecks(testLogger)
+	result := allHealthChecks.RunAllHealthChecks(testLogger)
 
 	assert.Check(t, strings.Contains(result[fCheck.Name()].Message, "Result: FAIL"))
 	assert.Check(t, strings.Contains(result[sCheck.Name()].Message, "Result: PASS"))


### PR DESCRIPTION
## Description
- Refactor how the `health-checks.log` file is created so unit tests don't generate any file.
- Use windows event log levels to report `ERROR` or `FAIL` result from Health Checks.

## Related issue
b/261476417

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
