### PR TITLE
Update nvml metrics namespace

### DIFF
--- a/apps/nvml.go
+++ b/apps/nvml.go
@@ -57,7 +57,7 @@ func (r MetricsReceiverNvml) Pipelines() []otel.ReceiverPipeline {
 					"nvml.gpu.processes.max_bytes_used",
 					"gpu/processes/max_bytes_used",
 				),
-				otel.AddPrefix("workload.googleapis.com"),
+				otel.AddPrefix("agent.googleapis.com"),
 			),
 		}},
 	}}

--- a/confgenerator/testdata/builtin/linux/builtin/golden/otel.yaml
+++ b/confgenerator/testdata/builtin/linux/builtin/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/otel.yaml
@@ -18,6 +18,11 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
+  filter/default__pipeline_nvml_0:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names: []
   filter/fluentbit_0:
     metrics:
       include:
@@ -361,6 +366,30 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  metricstransform/nvml_1:
+    transforms:
+    - action: update
+      include: nvml.gpu.utilization
+      new_name: gpu/utilization
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 100.0
+    - action: update
+      include: nvml.gpu.memory.bytes_used
+      new_name: gpu/memory/bytes_used
+    - action: update
+      include: nvml.gpu.processes.utilization
+      new_name: gpu/processes/utilization
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 100.0
+    - action: update
+      include: nvml.gpu.processes.max_bytes_used
+      new_name: gpu/processes/max_bytes_used
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update
@@ -407,6 +436,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  normalizesums/nvml_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -424,6 +454,8 @@ receivers:
       process:
         mute_process_name_error: true
       processes: {}
+  nvml/nvml:
+    collection_interval: 60s
   prometheus/fluentbit:
     config:
       scrape_configs:
@@ -454,6 +486,16 @@ service:
       - resourcedetection/_global_0
       receivers:
       - hostmetrics/hostmetrics
+    metrics/default__pipeline_nvml:
+      exporters:
+      - googlecloud
+      processors:
+      - normalizesums/nvml_0
+      - metricstransform/nvml_1
+      - filter/default__pipeline_nvml_0
+      - resourcedetection/_global_0
+      receivers:
+      - nvml/nvml
     metrics/fluentbit:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/otel.yaml
@@ -391,7 +391,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/otel.yaml
@@ -393,7 +393,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/otel.yaml
@@ -393,7 +393,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/otel.yaml
@@ -391,7 +391,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/otel.yaml
@@ -401,7 +401,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/otel.yaml
@@ -401,7 +401,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/otel.yaml
@@ -485,7 +485,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_dcgm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_dcgm/golden/otel.yaml
@@ -399,7 +399,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/otel.yaml
@@ -419,7 +419,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/otel.yaml
@@ -402,7 +402,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/otel.yaml
@@ -402,7 +402,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/otel.yaml
@@ -410,7 +410,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/otel.yaml
@@ -410,7 +410,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/otel.yaml
@@ -401,7 +401,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/otel.yaml
@@ -415,7 +415,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/oracledb_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/oracledb_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/oracledb_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/otel.yaml
@@ -398,7 +398,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/otel.yaml
@@ -398,7 +398,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/otel.yaml
@@ -398,7 +398,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/otel.yaml
@@ -398,7 +398,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/otel.yaml
@@ -398,7 +398,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/otel.yaml
@@ -398,7 +398,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/otel.yaml
@@ -398,7 +398,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/otel.yaml
@@ -396,7 +396,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/otel.yaml
@@ -396,7 +396,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/otel.yaml
@@ -395,7 +395,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/otel.yaml
@@ -411,7 +411,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/otel.yaml
@@ -411,7 +411,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/otel.yaml
@@ -411,7 +411,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/otel.yaml
@@ -389,7 +389,7 @@ processors:
     - action: update
       include: ^(.*)$$
       match_type: regexp
-      new_name: workload.googleapis.com/$${1}
+      new_name: agent.googleapis.com/$${1}
   metricstransform/otel_1:
     transforms:
     - action: update

--- a/integration_test/third_party_apps_data/applications/nvml/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/nvml/metadata.yaml
@@ -24,7 +24,7 @@ configure_integration: |-
 supported_operating_systems: linux
 supported_app_version: ["515.65.01"]
 expected_metrics:
-  - type: workload.googleapis.com/gpu/utilization
+  - type: agent.googleapis.com/gpu/utilization
     value_type: DOUBLE
     kind: GAUGE
     monitored_resource: gce_instance
@@ -33,7 +33,7 @@ expected_metrics:
       uuid: .*
       gpu_number: "[0-9]*"
     representative: true
-  - type: workload.googleapis.com/gpu/memory/bytes_used
+  - type: agent.googleapis.com/gpu/memory/bytes_used
     value_type: INT64
     kind: GAUGE
     monitored_resource: gce_instance
@@ -42,7 +42,7 @@ expected_metrics:
       uuid: .*
       gpu_number: "[0-9]*"
       memory_state: free|used
-  - type: workload.googleapis.com/gpu/processes/utilization
+  - type: agent.googleapis.com/gpu/processes/utilization
     value_type: DOUBLE
     kind: GAUGE
     monitored_resource: gce_instance
@@ -55,7 +55,7 @@ expected_metrics:
       command: .*
       command_line: .*
       owner: .* 
-  - type: workload.googleapis.com/gpu/processes/max_bytes_used
+  - type: agent.googleapis.com/gpu/processes/max_bytes_used
     value_type: INT64
     kind: GAUGE
     monitored_resource: gce_instance


### PR DESCRIPTION
## Description
Update the namespace from workload to agent for the NVML receiver. 

The feature branch has been rebased on 2.25.1. Fixed an unit tests introduced in 2.25.1.  

## Related issue
b/268619021

## How has this been tested?
Make sure integration tests pass. 

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
