### PR TITLE
confgenerator: omit semantic validation on user config

### DIFF
--- a/confgenerator/confmerger.go
+++ b/confgenerator/confmerger.go
@@ -20,7 +20,7 @@ func MergeConfFiles(userConfPath, platform string, builtInConfStructs map[string
 	builtInStruct := builtInConfStructs[platform]
 
 	// Start with the built-in config.
-	template, err := builtInStruct.DeepCopy(platform)
+	result, err := builtInStruct.DeepCopy(platform)
 	if err != nil {
 		return nil, err
 	}
@@ -32,19 +32,19 @@ func MergeConfFiles(userConfPath, platform string, builtInConfStructs map[string
 
 	// Optionally merge the user config file.
 	if overrides != nil {
-		mergeConfigs(template, overrides)
+		mergeConfigs(result, overrides)
 	}
 
-	if err := template.Validate(); err != nil {
+	if err := result.Validate(); err != nil {
 		return nil, err
 	}
 
 	// Ensure the merged config struct fields are valid.
 	v := newValidator()
-	if err := v.Struct(template); err != nil {
+	if err := v.Struct(result); err != nil {
 		panic(err)
 	}
-	return template, nil
+	return result, nil
 }
 
 func mergeConfigs(original, overrides *UnifiedConfig) {

--- a/confgenerator/confmerger.go
+++ b/confgenerator/confmerger.go
@@ -19,7 +19,7 @@ package confgenerator
 func MergeConfFiles(userConfPath, platform string, builtInConfStructs map[string]*UnifiedConfig) (*UnifiedConfig, error) {
 	builtInStruct := builtInConfStructs[platform]
 
-	// Read the built-in config file.
+	// Start with the built-in config.
 	template, err := builtInStruct.DeepCopy(platform)
 	if err != nil {
 		return nil, err

--- a/confgenerator/confmerger.go
+++ b/confgenerator/confmerger.go
@@ -20,7 +20,7 @@ func MergeConfFiles(userConfPath, platform string, builtInConfStructs map[string
 	builtInStruct := builtInConfStructs[platform]
 
 	// Read the built-in config file.
-	original, err := builtInStruct.DeepCopy(platform)
+	template, err := builtInStruct.DeepCopy(platform)
 	if err != nil {
 		return nil, err
 	}
@@ -32,19 +32,19 @@ func MergeConfFiles(userConfPath, platform string, builtInConfStructs map[string
 
 	// Optionally merge the user config file.
 	if overrides != nil {
-		mergeConfigs(original, overrides)
+		mergeConfigs(template, overrides)
 	}
 
-	if err := original.Validate(); err != nil {
+	if err := template.Validate(); err != nil {
 		return nil, err
 	}
 
 	// Ensure the merged config struct fields are valid.
 	v := newValidator()
-	if err := v.Struct(original); err != nil {
+	if err := v.Struct(template); err != nil {
 		panic(err)
 	}
-	return original, nil
+	return template, nil
 }
 
 func mergeConfigs(original, overrides *UnifiedConfig) {

--- a/confgenerator/files.go
+++ b/confgenerator/files.go
@@ -43,9 +43,6 @@ func ReadUnifiedConfigFromFile(path, platform string) (*UnifiedConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := uc.Validate(); err != nil {
-		return nil, err
-	}
 
 	return uc, nil
 }

--- a/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/f120d4527bd717cab023dbbe5fbdc332.lua
+++ b/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/f120d4527bd717cab023dbbe5fbdc332.lua
@@ -1,0 +1,42 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["agent.googleapis.com/log_file_path"]
+end)();
+local __field_1 = (function()
+if record["logging.googleapis.com/labels"] == nil
+then
+return nil
+end
+return record["logging.googleapis.com/labels"]["compute.googleapis.com/resource_name"]
+end)();
+local __field_2 = (function()
+return record["logging.googleapis.com/logName"]
+end)();
+(function(value)
+record["agent.googleapis.com/log_file_path"] = value
+end)(nil);
+local v = __field_0;
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/log_file_path"] = value
+end)(v)
+local v = __field_1;
+if v == nil then v = "" end;
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["compute.googleapis.com/resource_name"] = value
+end)(v)
+local v = __field_2;
+if v == nil then v = "syslog" end;
+(function(value)
+record["logging.googleapis.com/logName"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/features.yaml
+++ b/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/features.yaml
@@ -1,0 +1,8 @@
+- module: logging
+  feature: service:pipelines
+  key: default_pipeline_overridden
+  value: "false"
+- module: metrics
+  feature: service:pipelines
+  key: default_pipeline_overridden
+  value: "false"

--- a/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
@@ -1,0 +1,105 @@
+@SET buffers_dir=/var/lib/google-cloud-ops-agent/fluent-bit/buffers
+@SET logs_dir=/var/log/google-cloud-ops-agent/subagents
+
+[SERVICE]
+    Daemon                    off
+    Flush                     1
+    Log_Level                 info
+    dns.resolver              legacy
+    storage.backlog.mem_limit 50M
+    storage.checksum          off
+    storage.max_chunks_up     128
+    storage.metrics           on
+    storage.sync              normal
+
+[INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 60
+    Scrape_On_Start True
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              /var/log/messages,/var/log/syslog
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               default_pipeline.syslog
+    storage.type      filesystem
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/host_syslog
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              /var/log/messages,/var/log/syslog
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               host.syslog
+    storage.type      filesystem
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/logging-module.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-fluent-bit
+    storage.type      memory
+
+[FILTER]
+    Match  default_pipeline.syslog
+    Name   lua
+    call   process
+    script f120d4527bd717cab023dbbe5fbdc332.lua
+
+[FILTER]
+    Match  host.syslog
+    Name   lua
+    call   process
+    script f120d4527bd717cab023dbbe5fbdc332.lua
+
+[OUTPUT]
+    Match_Regex                   ^(default_pipeline\.syslog|host\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  20202

--- a/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/otel.yaml
@@ -1,0 +1,487 @@
+exporters:
+  googlecloud:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    retry_on_failure:
+      enabled: false
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+processors:
+  agentmetrics/hostmetrics_0:
+    blank_label_metrics:
+    - system.cpu.utilization
+  filter/default__pipeline_hostmetrics_0:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names: []
+  filter/fluentbit_0:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+        - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
+        - fluentbit_stackdriver_proc_records_total
+  filter/hostmetrics_1:
+    metrics:
+      exclude:
+        match_type: strict
+        metric_names:
+        - system.cpu.time
+        - system.network.dropped
+        - system.filesystem.inodes.usage
+        - system.paging.faults
+        - system.disk.operation_time
+  filter/otel_0:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+        - otelcol_process_uptime
+        - otelcol_process_memory_rss
+        - otelcol_grpc_io_client_completed_rpcs
+        - otelcol_googlecloudmonitoring_point_count
+  metricstransform/fluentbit_1:
+    transforms:
+    - action: update
+      include: fluentbit_uptime
+      new_name: agent/uptime
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: version
+        new_value: google-cloud-ops-agent-logging/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_proc_records_total
+      new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/hostmetrics_2:
+    transforms:
+    - action: update
+      include: system.cpu.time
+      new_name: cpu/usage_time
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: cpu
+        new_label: cpu_number
+      - action: update_label
+        label: state
+        new_label: cpu_state
+    - action: update
+      include: system.cpu.utilization
+      new_name: cpu/utilization
+      operations:
+      - action: aggregate_labels
+        aggregation_type: mean
+        label_set:
+        - state
+        - blank
+      - action: update_label
+        label: blank
+        new_label: cpu_number
+      - action: update_label
+        label: state
+        new_label: cpu_state
+    - action: update
+      include: system.cpu.load_average.1m
+      new_name: cpu/load_1m
+    - action: update
+      include: system.cpu.load_average.5m
+      new_name: cpu/load_5m
+    - action: update
+      include: system.cpu.load_average.15m
+      new_name: cpu/load_15m
+    - action: update
+      include: system.disk.read_io
+      new_name: disk/read_bytes_count
+    - action: update
+      include: system.disk.write_io
+      new_name: disk/write_bytes_count
+    - action: update
+      include: system.disk.operations
+      new_name: disk/operation_count
+    - action: update
+      include: system.disk.io_time
+      new_name: disk/io_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.weighted_io_time
+      new_name: disk/weighted_io_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.average_operation_time
+      new_name: disk/operation_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.pending_operations
+      new_name: disk/pending_operations
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.merged
+      new_name: disk/merged_operations
+    - action: update
+      include: system.filesystem.usage
+      new_name: disk/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: max
+        label_set:
+        - device
+        - state
+    - action: update
+      include: system.filesystem.utilization
+      new_name: disk/percent_used
+      operations:
+      - action: aggregate_labels
+        aggregation_type: max
+        label_set:
+        - device
+        - state
+    - action: update
+      include: system.memory.usage
+      new_name: memory/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_label_values
+        aggregated_values:
+        - slab_reclaimable
+        - slab_unreclaimable
+        aggregation_type: sum
+        label: state
+        new_value: slab
+    - action: update
+      include: system.memory.utilization
+      new_name: memory/percent_used
+      operations:
+      - action: aggregate_label_values
+        aggregated_values:
+        - slab_reclaimable
+        - slab_unreclaimable
+        aggregation_type: sum
+        label: state
+        new_value: slab
+    - action: update
+      include: system.network.io
+      new_name: interface/traffic
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.errors
+      new_name: interface/errors
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.packets
+      new_name: interface/packets
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.connections
+      new_name: network/tcp_connections
+      operations:
+      - action: toggle_scalar_data_type
+      - action: delete_label_value
+        label: protocol
+        label_value: udp
+      - action: update_label
+        label: state
+        new_label: tcp_state
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - tcp_state
+      - action: add_label
+        new_label: port
+        new_value: all
+    - action: update
+      include: system.processes.created
+      new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
+    - action: update
+      include: system.paging.usage
+      new_name: swap/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.paging.utilization
+      new_name: swap/percent_used
+    - action: insert
+      include: swap/percent_used
+      new_name: pagefile/percent_used
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - state
+    - action: update
+      include: system.paging.operations
+      new_name: swap/io
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - direction
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: in
+          value: page_in
+        - new_value: out
+          value: page_out
+    - action: update
+      include: process.cpu.time
+      new_name: processes/cpu_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1e+06
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+      - action: delete_label_value
+        label: state
+        label_value: wait
+      - action: update_label
+        label: state
+        new_label: user_or_syst
+      - action: update_label
+        label: user_or_syst
+        value_actions:
+        - new_value: syst
+          value: system
+    - action: update
+      include: process.disk.read_io
+      new_name: processes/disk/read_bytes_count
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.disk.write_io
+      new_name: processes/disk/write_bytes_count
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.memory.physical_usage
+      new_name: processes/rss_usage
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.memory.virtual_usage
+      new_name: processes/vm_usage
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/otel_1:
+    transforms:
+    - action: update
+      include: otelcol_process_uptime
+      new_name: agent/uptime
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: version
+        new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
+    - action: update
+      include: otelcol_process_memory_rss
+      new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
+    - action: update
+      include: otelcol_grpc_io_client_completed_rpcs
+      new_name: agent/api_request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: grpc_client_status
+        new_label: state
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - state
+    - action: update
+      include: otelcol_googlecloudmonitoring_point_count
+      new_name: agent/monitoring/point_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  resourcedetection/_global_0:
+    detectors:
+    - gcp
+receivers:
+  hostmetrics/hostmetrics:
+    collection_interval: 60s
+    scrapers:
+      cpu: {}
+      disk: {}
+      filesystem: {}
+      load: {}
+      memory: {}
+      network: {}
+      paging: {}
+      process:
+        mute_process_name_error: true
+      processes: {}
+  prometheus/fluentbit:
+    config:
+      scrape_configs:
+      - job_name: logging-collector
+        metrics_path: /metrics
+        scrape_interval: 1m
+        static_configs:
+        - targets:
+          - 0.0.0.0:20202
+  prometheus/otel:
+    config:
+      scrape_configs:
+      - job_name: otel-collector
+        scrape_interval: 1m
+        static_configs:
+        - targets:
+          - 0.0.0.0:20201
+service:
+  pipelines:
+    metrics/default__pipeline_hostmetrics:
+      exporters:
+      - googlecloud
+      processors:
+      - agentmetrics/hostmetrics_0
+      - filter/hostmetrics_1
+      - metricstransform/hostmetrics_2
+      - filter/default__pipeline_hostmetrics_0
+      - resourcedetection/_global_0
+      receivers:
+      - hostmetrics/hostmetrics
+    metrics/fluentbit:
+      exporters:
+      - googlecloud
+      processors:
+      - filter/fluentbit_0
+      - metricstransform/fluentbit_1
+      - resourcedetection/_global_0
+      receivers:
+      - prometheus/fluentbit
+    metrics/host_hostmetrics:
+      exporters:
+      - googlecloud
+      processors:
+      - agentmetrics/hostmetrics_0
+      - filter/hostmetrics_1
+      - metricstransform/hostmetrics_2
+      - resourcedetection/_global_0
+      receivers:
+      - hostmetrics/hostmetrics
+    metrics/otel:
+      exporters:
+      - googlecloud
+      processors:
+      - filter/otel_0
+      - metricstransform/otel_1
+      - resourcedetection/_global_0
+      receivers:
+      - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/input.yaml
+++ b/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/input.yaml
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+logging:
+  service:
+    pipelines:
+      host:
+        receivers: [syslog]
+metrics:
+  service:
+    pipelines:
+      host:
+        receivers: [hostmetrics]

--- a/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/5fc5f42c16c9e1ab8292e3d42f74f3be.lua
+++ b/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/5fc5f42c16c9e1ab8292e3d42f74f3be.lua
@@ -1,0 +1,49 @@
+
+  function shallow_merge(record, parsedRecord)
+    -- If no exiting record exists
+    if (record == nil) then 
+        return parsedRecord
+    end
+    
+    for k, v in pairs(parsedRecord) do
+        record[k] = v
+    end
+
+    return record
+end
+
+function merge(record, parsedRecord)
+    -- If no exiting record exists
+    if record == nil then 
+        return parsedRecord
+    end
+    
+    -- Potentially overwrite or merge the original records.
+    for k, v in pairs(parsedRecord) do
+        -- If there is no conflict
+        if k == "logging.googleapis.com/logName" then 
+            -- Ignore the parsed payload since the logName is controlled
+            -- by the OpsAgent.
+        elseif k == "logging.googleapis.com/labels" then 
+            -- LogEntry.labels are basically a map[string]string and so only require a
+            -- shallow merge (one level deep merge).
+            record[k] = shallow_merge(record[k], v)
+        else
+            record[k] = v
+        end
+    end
+
+    return record
+end
+
+function parser_merge_record(tag, timestamp, record)
+    originalPayload = record["logging.googleapis.com/__tmp"]
+    if originalPayload == nil then
+        return 0, timestamp, record
+    end
+    
+    -- Remove original payload
+    record["logging.googleapis.com/__tmp"] = nil
+    record = merge(originalPayload, record)
+    return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/98b52408a7bd746aaf24acc193569c95.lua
+++ b/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/98b52408a7bd746aaf24acc193569c95.lua
@@ -1,0 +1,17 @@
+
+function parser_nest(tag, timestamp, record)
+  local nestedRecord = {}
+  local parseKey = "TimeGenerated"
+  for k, v in pairs(record) do
+      if k ~= parseKey then
+          nestedRecord[k] = v
+      end
+  end
+
+  local result = {}
+  result[parseKey] = record[parseKey]
+  result["logging.googleapis.com/__tmp"] = nestedRecord
+
+  return 2, timestamp, result
+end
+

--- a/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/f261516bf0c22cc61bb3f5f741e83a3a.lua
+++ b/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/f261516bf0c22cc61bb3f5f741e83a3a.lua
@@ -1,0 +1,42 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["agent.googleapis.com/log_file_path"]
+end)();
+local __field_1 = (function()
+if record["logging.googleapis.com/labels"] == nil
+then
+return nil
+end
+return record["logging.googleapis.com/labels"]["compute.googleapis.com/resource_name"]
+end)();
+local __field_2 = (function()
+return record["logging.googleapis.com/logName"]
+end)();
+(function(value)
+record["agent.googleapis.com/log_file_path"] = value
+end)(nil);
+local v = __field_0;
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/log_file_path"] = value
+end)(v)
+local v = __field_1;
+if v == nil then v = "" end;
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["compute.googleapis.com/resource_name"] = value
+end)(v)
+local v = __field_2;
+if v == nil then v = "windows_event_log" end;
+(function(value)
+record["logging.googleapis.com/logName"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/features.yaml
+++ b/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/features.yaml
@@ -1,0 +1,8 @@
+- module: logging
+  feature: service:pipelines
+  key: default_pipeline_overridden
+  value: "false"
+- module: metrics
+  feature: service:pipelines
+  key: default_pipeline_overridden
+  value: "false"

--- a/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
@@ -1,0 +1,189 @@
+@SET buffers_dir=C:\ProgramData\Google\Cloud Operations\Ops Agent\run/buffers
+@SET logs_dir=C:\ProgramData\Google\Cloud Operations\Ops Agent\log
+
+[SERVICE]
+    Daemon                    off
+    Flush                     1
+    Log_Level                 info
+    dns.resolver              legacy
+    storage.backlog.mem_limit 50M
+    storage.checksum          off
+    storage.max_chunks_up     128
+    storage.metrics           on
+    storage.sync              normal
+
+[INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 60
+    Scrape_On_Start True
+
+[INPUT]
+    Channels     System,Application,Security
+    DB           ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec 1
+    Name         winlog
+    Tag          default_pipeline.windows_event_log
+
+[INPUT]
+    Channels     System,Application,Security
+    DB           ${buffers_dir}/host_windows_event_log
+    Interval_Sec 1
+    Name         winlog
+    Tag          host.windows_event_log
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/logging-module.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-fluent-bit
+    storage.type      memory
+
+[FILTER]
+    Match  default_pipeline.windows_event_log
+    Name   lua
+    call   parser_nest
+    script 98b52408a7bd746aaf24acc193569c95.lua
+
+[FILTER]
+    Key_Name     TimeGenerated
+    Match        default_pipeline.windows_event_log
+    Name         parser
+    Preserve_Key True
+    Reserve_Data True
+    Parser       default_pipeline.windows_event_log.timestamp_parser
+
+[FILTER]
+    Match  default_pipeline.windows_event_log
+    Name   lua
+    call   parser_merge_record
+    script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
+
+[FILTER]
+    Add       logging.googleapis.com/severity ERROR
+    Condition Key_Value_Equals EventType Error
+    Match     default_pipeline.windows_event_log
+    Name      modify
+
+[FILTER]
+    Add       logging.googleapis.com/severity INFO
+    Condition Key_Value_Equals EventType Information
+    Match     default_pipeline.windows_event_log
+    Name      modify
+
+[FILTER]
+    Add       logging.googleapis.com/severity WARNING
+    Condition Key_Value_Equals EventType Warning
+    Match     default_pipeline.windows_event_log
+    Name      modify
+
+[FILTER]
+    Add       logging.googleapis.com/severity NOTICE
+    Condition Key_Value_Equals EventType SuccessAudit
+    Match     default_pipeline.windows_event_log
+    Name      modify
+
+[FILTER]
+    Add       logging.googleapis.com/severity NOTICE
+    Condition Key_Value_Equals EventType FailureAudit
+    Match     default_pipeline.windows_event_log
+    Name      modify
+
+[FILTER]
+    Match  default_pipeline.windows_event_log
+    Name   lua
+    call   process
+    script f261516bf0c22cc61bb3f5f741e83a3a.lua
+
+[FILTER]
+    Match  host.windows_event_log
+    Name   lua
+    call   parser_nest
+    script 98b52408a7bd746aaf24acc193569c95.lua
+
+[FILTER]
+    Key_Name     TimeGenerated
+    Match        host.windows_event_log
+    Name         parser
+    Preserve_Key True
+    Reserve_Data True
+    Parser       host.windows_event_log.timestamp_parser
+
+[FILTER]
+    Match  host.windows_event_log
+    Name   lua
+    call   parser_merge_record
+    script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
+
+[FILTER]
+    Add       logging.googleapis.com/severity ERROR
+    Condition Key_Value_Equals EventType Error
+    Match     host.windows_event_log
+    Name      modify
+
+[FILTER]
+    Add       logging.googleapis.com/severity INFO
+    Condition Key_Value_Equals EventType Information
+    Match     host.windows_event_log
+    Name      modify
+
+[FILTER]
+    Add       logging.googleapis.com/severity WARNING
+    Condition Key_Value_Equals EventType Warning
+    Match     host.windows_event_log
+    Name      modify
+
+[FILTER]
+    Add       logging.googleapis.com/severity NOTICE
+    Condition Key_Value_Equals EventType SuccessAudit
+    Match     host.windows_event_log
+    Name      modify
+
+[FILTER]
+    Add       logging.googleapis.com/severity NOTICE
+    Condition Key_Value_Equals EventType FailureAudit
+    Match     host.windows_event_log
+    Name      modify
+
+[FILTER]
+    Match  host.windows_event_log
+    Name   lua
+    call   process
+    script f261516bf0c22cc61bb3f5f741e83a3a.lua
+
+[OUTPUT]
+    Match_Regex                   ^(default_pipeline\.windows_event_log|host\.windows_event_log)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  20202

--- a/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_parser.conf
@@ -1,0 +1,13 @@
+[PARSER]
+    Format      regex
+    Name        default_pipeline.windows_event_log.timestamp_parser
+    Regex       (?<timestamp>\d+-\d+-\d+ \d+:\d+:\d+ [+-]\d{4})
+    Time_Format %Y-%m-%d %H:%M:%S %z
+    Time_Key    timestamp
+
+[PARSER]
+    Format      regex
+    Name        host.windows_event_log.timestamp_parser
+    Regex       (?<timestamp>\d+-\d+-\d+ \d+:\d+:\d+ [+-]\d{4})
+    Time_Format %Y-%m-%d %H:%M:%S %z
+    Time_Key    timestamp

--- a/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/otel.yaml
@@ -1,0 +1,598 @@
+exporters:
+  googlecloud:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    retry_on_failure:
+      enabled: false
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+processors:
+  agentmetrics/hostmetrics_0:
+    blank_label_metrics:
+    - system.cpu.utilization
+  casttosum/iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
+  filter/default__pipeline_hostmetrics_0:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names: []
+  filter/default__pipeline_iis_0:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names: []
+  filter/default__pipeline_mssql_0:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names: []
+  filter/fluentbit_0:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+        - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
+        - fluentbit_stackdriver_proc_records_total
+  filter/hostmetrics_1:
+    metrics:
+      exclude:
+        match_type: strict
+        metric_names:
+        - system.cpu.time
+        - system.network.dropped
+        - system.filesystem.inodes.usage
+        - system.paging.faults
+        - system.disk.operation_time
+  filter/otel_0:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+        - otelcol_process_uptime
+        - otelcol_process_memory_rss
+        - otelcol_grpc_io_client_completed_rpcs
+        - otelcol_googlecloudmonitoring_point_count
+  metricstransform/fluentbit_1:
+    transforms:
+    - action: update
+      include: fluentbit_uptime
+      new_name: agent/uptime
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: version
+        new_value: google-cloud-ops-agent-logging/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_proc_records_total
+      new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/hostmetrics_2:
+    transforms:
+    - action: update
+      include: system.cpu.time
+      new_name: cpu/usage_time
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: cpu
+        new_label: cpu_number
+      - action: update_label
+        label: state
+        new_label: cpu_state
+    - action: update
+      include: system.cpu.utilization
+      new_name: cpu/utilization
+      operations:
+      - action: aggregate_labels
+        aggregation_type: mean
+        label_set:
+        - state
+        - blank
+      - action: update_label
+        label: blank
+        new_label: cpu_number
+      - action: update_label
+        label: state
+        new_label: cpu_state
+    - action: update
+      include: system.cpu.load_average.1m
+      new_name: cpu/load_1m
+    - action: update
+      include: system.cpu.load_average.5m
+      new_name: cpu/load_5m
+    - action: update
+      include: system.cpu.load_average.15m
+      new_name: cpu/load_15m
+    - action: update
+      include: system.disk.read_io
+      new_name: disk/read_bytes_count
+    - action: update
+      include: system.disk.write_io
+      new_name: disk/write_bytes_count
+    - action: update
+      include: system.disk.operations
+      new_name: disk/operation_count
+    - action: update
+      include: system.disk.io_time
+      new_name: disk/io_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.weighted_io_time
+      new_name: disk/weighted_io_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.average_operation_time
+      new_name: disk/operation_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.pending_operations
+      new_name: disk/pending_operations
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.merged
+      new_name: disk/merged_operations
+    - action: update
+      include: system.filesystem.usage
+      new_name: disk/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: max
+        label_set:
+        - device
+        - state
+    - action: update
+      include: system.filesystem.utilization
+      new_name: disk/percent_used
+      operations:
+      - action: aggregate_labels
+        aggregation_type: max
+        label_set:
+        - device
+        - state
+    - action: update
+      include: system.memory.usage
+      new_name: memory/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_label_values
+        aggregated_values:
+        - slab_reclaimable
+        - slab_unreclaimable
+        aggregation_type: sum
+        label: state
+        new_value: slab
+    - action: update
+      include: system.memory.utilization
+      new_name: memory/percent_used
+      operations:
+      - action: aggregate_label_values
+        aggregated_values:
+        - slab_reclaimable
+        - slab_unreclaimable
+        aggregation_type: sum
+        label: state
+        new_value: slab
+    - action: update
+      include: system.network.io
+      new_name: interface/traffic
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.errors
+      new_name: interface/errors
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.packets
+      new_name: interface/packets
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.connections
+      new_name: network/tcp_connections
+      operations:
+      - action: toggle_scalar_data_type
+      - action: delete_label_value
+        label: protocol
+        label_value: udp
+      - action: update_label
+        label: state
+        new_label: tcp_state
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - tcp_state
+      - action: add_label
+        new_label: port
+        new_value: all
+    - action: update
+      include: system.processes.created
+      new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
+    - action: update
+      include: system.paging.usage
+      new_name: swap/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.paging.utilization
+      new_name: swap/percent_used
+    - action: insert
+      include: swap/percent_used
+      new_name: pagefile/percent_used
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - state
+    - action: update
+      include: system.paging.operations
+      new_name: swap/io
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - direction
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: in
+          value: page_in
+        - new_value: out
+          value: page_out
+    - action: update
+      include: process.cpu.time
+      new_name: processes/cpu_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1e+06
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+      - action: delete_label_value
+        label: state
+        label_value: wait
+      - action: update_label
+        label: state
+        new_label: user_or_syst
+      - action: update_label
+        label: user_or_syst
+        value_actions:
+        - new_value: syst
+          value: system
+    - action: update
+      include: process.disk.read_io
+      new_name: processes/disk/read_bytes_count
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.disk.write_io
+      new_name: processes/disk/write_bytes_count
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.memory.physical_usage
+      new_name: processes/rss_usage
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.memory.virtual_usage
+      new_name: processes/vm_usage
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/iis_0:
+    transforms:
+    - action: update
+      include: "\\Web Service(_Total)\\Current Connections"
+      new_name: iis/current_connections
+    - action: combine
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
+      match_type: regexp
+      new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
+      submatch_case: lower
+    - action: update
+      include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
+      new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
+    - action: combine
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
+      match_type: regexp
+      new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      submatch_case: lower
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/mssql_0:
+    transforms:
+    - action: update
+      include: "\\SQLServer:General Statistics(_Total)\\User Connections"
+      new_name: mssql/connections/user
+    - action: update
+      include: "\\SQLServer:Databases(_Total)\\Transactions/sec"
+      new_name: mssql/transaction_rate
+    - action: update
+      include: "\\SQLServer:Databases(_Total)\\Write Transactions/sec"
+      new_name: mssql/write_transaction_rate
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/otel_1:
+    transforms:
+    - action: update
+      include: otelcol_process_uptime
+      new_name: agent/uptime
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: version
+        new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
+    - action: update
+      include: otelcol_process_memory_rss
+      new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
+    - action: update
+      include: otelcol_grpc_io_client_completed_rpcs
+      new_name: agent/api_request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: grpc_client_status
+        new_label: state
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - state
+    - action: update
+      include: otelcol_googlecloudmonitoring_point_count
+      new_name: agent/monitoring/point_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  normalizesums/iis_2: {}
+  resourcedetection/_global_0:
+    detectors:
+    - gcp
+receivers:
+  hostmetrics/hostmetrics:
+    collection_interval: 60s
+    scrapers:
+      cpu: {}
+      disk: {}
+      filesystem: {}
+      load: {}
+      memory: {}
+      network: {}
+      paging: {}
+      process:
+        mute_process_name_error: true
+      processes: {}
+  prometheus/fluentbit:
+    config:
+      scrape_configs:
+      - job_name: logging-collector
+        metrics_path: /metrics
+        scrape_interval: 1m
+        static_configs:
+        - targets:
+          - 0.0.0.0:20202
+  prometheus/otel:
+    config:
+      scrape_configs:
+      - job_name: otel-collector
+        scrape_interval: 1m
+        static_configs:
+        - targets:
+          - 0.0.0.0:20201
+  windowsperfcounters/iis:
+    collection_interval: 60s
+    perfcounters:
+    - counters:
+      - name: Current Connections
+      - name: Total Bytes Received
+      - name: Total Bytes Sent
+      - name: Total Connection Attempts (all instances)
+      - name: Total Delete Requests
+      - name: Total Get Requests
+      - name: Total Head Requests
+      - name: Total Options Requests
+      - name: Total Post Requests
+      - name: Total Put Requests
+      - name: Total Trace Requests
+      instances:
+      - _Total
+      object: Web Service
+  windowsperfcounters/mssql:
+    collection_interval: 60s
+    perfcounters:
+    - counters:
+      - name: User Connections
+      instances:
+      - _Total
+      object: SQLServer:General Statistics
+    - counters:
+      - name: Transactions/sec
+      - name: Write Transactions/sec
+      instances:
+      - _Total
+      object: SQLServer:Databases
+service:
+  pipelines:
+    metrics/default__pipeline_hostmetrics:
+      exporters:
+      - googlecloud
+      processors:
+      - agentmetrics/hostmetrics_0
+      - filter/hostmetrics_1
+      - metricstransform/hostmetrics_2
+      - filter/default__pipeline_hostmetrics_0
+      - resourcedetection/_global_0
+      receivers:
+      - hostmetrics/hostmetrics
+    metrics/default__pipeline_iis:
+      exporters:
+      - googlecloud
+      processors:
+      - metricstransform/iis_0
+      - casttosum/iis_1
+      - normalizesums/iis_2
+      - filter/default__pipeline_iis_0
+      - resourcedetection/_global_0
+      receivers:
+      - windowsperfcounters/iis
+    metrics/default__pipeline_mssql:
+      exporters:
+      - googlecloud
+      processors:
+      - metricstransform/mssql_0
+      - filter/default__pipeline_mssql_0
+      - resourcedetection/_global_0
+      receivers:
+      - windowsperfcounters/mssql
+    metrics/fluentbit:
+      exporters:
+      - googlecloud
+      processors:
+      - filter/fluentbit_0
+      - metricstransform/fluentbit_1
+      - resourcedetection/_global_0
+      receivers:
+      - prometheus/fluentbit
+    metrics/host_hostmetrics:
+      exporters:
+      - googlecloud
+      processors:
+      - agentmetrics/hostmetrics_0
+      - filter/hostmetrics_1
+      - metricstransform/hostmetrics_2
+      - resourcedetection/_global_0
+      receivers:
+      - hostmetrics/hostmetrics
+    metrics/otel:
+      exporters:
+      - googlecloud
+      processors:
+      - filter/otel_0
+      - metricstransform/otel_1
+      - resourcedetection/_global_0
+      receivers:
+      - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/input.yaml
+++ b/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/input.yaml
@@ -1,0 +1,23 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+logging:
+  service:
+    pipelines:
+      host:
+        receivers: [windows_event_log]
+metrics:
+  service:
+    pipelines:
+      host:
+        receivers: [hostmetrics]


### PR DESCRIPTION
## Description
The semantic validation should only happen on the merged config.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->
http://b/267762522

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
