### PR TITLE
healthchecks: Fix `Ports Check` flake on restart (systemd)

### DIFF
--- a/cmd/google_cloud_ops_agent_engine/main.go
+++ b/cmd/google_cloud_ops_agent_engine/main.go
@@ -34,9 +34,7 @@ var (
 )
 
 func runStartupChecks(service string) {
-	switch service {
-	// Run checks in main service
-	case "":
+	if service == "" {
 		time.Sleep(time.Second)
 		gceHealthChecks := healthchecks.HealthCheckRegistryFactory()
 		logger, closer := healthchecks.CreateHealthChecksLogger(*logsDir)
@@ -47,12 +45,6 @@ func runStartupChecks(service string) {
 			log.Printf(result.Message)
 		}
 		log.Println("Startup checks finished")
-	// Adding sleep to reduce flakyness in Ports Checks
-	// when restarting ops agent service
-	case "fluentbit":
-		time.Sleep(2 * time.Second)
-	case "otel":
-		time.Sleep(2 * time.Second)
 	}
 }
 

--- a/cmd/google_cloud_ops_agent_engine/main.go
+++ b/cmd/google_cloud_ops_agent_engine/main.go
@@ -18,7 +18,6 @@ import (
 	"flag"
 	"log"
 	"os"
-	"time"
 
 	"github.com/GoogleCloudPlatform/ops-agent/apps"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
@@ -35,7 +34,6 @@ var (
 
 func runStartupChecks(service string) {
 	if service == "" {
-		time.Sleep(time.Second)
 		gceHealthChecks := healthchecks.HealthCheckRegistryFactory()
 		logger, closer := healthchecks.CreateHealthChecksLogger(*logsDir)
 		defer closer()

--- a/internal/healthchecks/healthchecks.go
+++ b/internal/healthchecks/healthchecks.go
@@ -19,7 +19,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"time"
 )
 
 var healthChecksLogFile = "health-checks.log"
@@ -67,19 +66,6 @@ func (r HealthCheckRegistry) RunAllHealthChecks(logger *log.Logger) map[string]H
 
 	for _, c := range r {
 		err = c.RunCheck(logger)
-		if c.Name() == "Ports Check" && err != nil {
-			logger.Printf("failed ports check. start retries : err %v", err)
-			for j := 0; j < 10; j++ {
-				time.Sleep(time.Second)
-				err = c.RunCheck(logger)
-				if err == nil {
-					logger.Printf("succesful retry %v : err %v", j, err)
-					break
-				}
-				logger.Printf("failed retry %v : err %v", j, err)
-			}
-		}
-
 		if err != nil {
 			if healthError, ok := err.(HealthCheckError); ok {
 				message = fmt.Sprintf("%s - Result: FAIL, Error code: %s, Failure: %s, Solution: %s, Resource: %s",

--- a/internal/healthchecks/healthchecks.go
+++ b/internal/healthchecks/healthchecks.go
@@ -61,11 +61,10 @@ func CreateHealthChecksLogger(logDir string) (logger *log.Logger, closer func())
 
 func (r HealthCheckRegistry) RunAllHealthChecks(logger *log.Logger) map[string]HealthCheckResult {
 	var message string
-	var err error
 	result := map[string]HealthCheckResult{}
 
 	for _, c := range r {
-		err = c.RunCheck(logger)
+		err := c.RunCheck(logger)
 		if err != nil {
 			if healthError, ok := err.(HealthCheckError); ok {
 				message = fmt.Sprintf("%s - Result: FAIL, Error code: %s, Failure: %s, Solution: %s, Resource: %s",

--- a/systemd/google-cloud-ops-agent-fluent-bit.service
+++ b/systemd/google-cloud-ops-agent-fluent-bit.service
@@ -16,7 +16,7 @@
 Description=Google Cloud Ops Agent - Logging Agent
 PartOf=google-cloud-ops-agent.service
 Requires=network-online.target
-After=network-online.target
+After=network-online.target google-cloud-ops-agent.service
 
 [Service]
 RuntimeDirectory=google-cloud-ops-agent-fluent-bit

--- a/systemd/google-cloud-ops-agent-opentelemetry-collector.service
+++ b/systemd/google-cloud-ops-agent-opentelemetry-collector.service
@@ -16,7 +16,7 @@
 Description=Google Cloud Ops Agent - Metrics Agent
 PartOf=google-cloud-ops-agent.service
 Requires=network-online.target
-After=network-online.target
+After=network-online.target google-cloud-ops-agent.service
 
 [Service]
 RuntimeDirectory=google-cloud-ops-agent-opentelemetry-collector


### PR DESCRIPTION
## Description
The [Ports Health Check](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/internal/healthchecks/ports_check.go) sometimes shows a false positive in Linux (systemd) since there is no restriction of execution for the subagent services (units)  so they don't overlap during startup with the `google-cloud-ops-agent.service`. This causes the port `20202` still being used by fluent-bit during the startup checks. This doesn't happen in Windows version.

This updates the `systemd` configuration so `google-cloud-ops-agent-fluent-bit.service` &`google-cloud-ops-agent-opentelemetry-collector.service` unit start after the `google-cloud-ops-agent.service` unit. This using the unit `After` systemd configuration.

The false positive error is the following :
```
Ports Check - Result: FAIL, Error code: FbMetricsPortErr, Failure: Port 20202 needed for Ops Agent self metrics is unavailable., Solution: Verify that port 20202 is open., Resource: https://cloud.google.com/logging/docs/agent/ops-agent/tr
oubleshooting
```

## Related issue
b/268046122

## How has this been tested?
- Verified that after adding the `After=` configuration, `fluent-bit` and `otelopscol` are still independent in following sense : 
  - Killing `fluent-bit` or `otelopscol` process don't restart or change the other process and viceversa (same PID).
  - Restarting a subagent service (by `sudo service * restart` ) doesn't change the other process `PID`.
- Integration and unit tests pass.
- Can't reproduce the check flake anymore with 20 repetitions of `restart` in different scenarios :
  - `fluent-bit` is busy (simulating log load)
  -  `fluent-bit` not busy (normal Ops Agent execution).

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
