### PR TITLE
Testing: update tests to go v1.20.

### DIFF
--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -71,7 +71,7 @@ sudo rm -rf /usr/local/go
 # GOPATH is semi-deprecated nowadays too.
 unset GOPATH
 
-GO_VERSION="1.19"
+GO_VERSION="1.20"
 
 # Download and install a newer version of go.
 # Install from a GCS bucket to avoid being throttled by go.dev.


### PR DESCRIPTION
## Description
This doesn't do much, I was just reading the release notes and figured I should probably upgrade us to the new version while I was at it.

## Related issue
<none>

## How has this been tested?
automated tests

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.
