### PR TITLE
confgenerator: add metric for retried log entries

### DIFF
--- a/confgenerator/agentmetrics.go
+++ b/confgenerator/agentmetrics.go
@@ -117,6 +117,7 @@ func (r AgentSelfMetrics) LoggingSubmodulePipeline() otel.ReceiverPipeline {
 				"fluentbit_uptime",
 				"fluentbit_stackdriver_requests_total",
 				"fluentbit_stackdriver_proc_records_total",
+				"fluentbit_stackdriver_retried_records_total",
 			),
 			otel.MetricsTransform(
 				otel.RenameMetric("fluentbit_uptime", "agent/uptime",
@@ -133,6 +134,12 @@ func (r AgentSelfMetrics) LoggingSubmodulePipeline() otel.ReceiverPipeline {
 					otel.AggregateLabels("sum", "response_code"),
 				),
 				otel.RenameMetric("fluentbit_stackdriver_proc_records_total", "agent/log_entry_count",
+					// change data type from double -> int64
+					otel.ToggleScalarDataType,
+					otel.RenameLabel("status", "response_code"),
+					otel.AggregateLabels("sum", "response_code"),
+				),
+				otel.RenameMetric("fluentbit_stackdriver_retried_records_total", "agent/log_entry_retry_count",
 					// change data type from double -> int64
 					otel.ToggleScalarDataType,
 					otel.RenameLabel("status", "response_code"),

--- a/confgenerator/testdata/builtin/linux/builtin/golden/otel.yaml
+++ b/confgenerator/testdata/builtin/linux/builtin/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/builtin/windows/builtin/golden/otel.yaml
+++ b/confgenerator/testdata/builtin/windows/builtin/golden/otel.yaml
@@ -41,6 +41,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -89,6 +90,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/otel.yaml
@@ -21,6 +21,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -69,6 +70,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/otel.yaml
@@ -27,6 +27,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,6 +76,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/otel.yaml
@@ -28,6 +28,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -76,6 +77,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/otel.yaml
@@ -28,6 +28,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -76,6 +77,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/otel.yaml
@@ -27,6 +27,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,6 +76,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/otel.yaml
@@ -21,6 +21,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -69,6 +70,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -90,6 +91,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -90,6 +91,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -90,6 +91,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/otel.yaml
@@ -42,6 +42,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -96,6 +97,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/otel.yaml
@@ -42,6 +42,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -96,6 +97,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -90,6 +91,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -90,6 +91,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/otel.yaml
@@ -46,6 +46,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -180,6 +181,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -90,6 +91,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -90,6 +91,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -90,6 +91,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -90,6 +91,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -90,6 +91,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -90,6 +91,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -90,6 +91,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -114,6 +115,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -99,6 +100,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -99,6 +100,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -90,6 +91,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/otel.yaml
@@ -30,6 +30,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,6 +84,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/otel.yaml
@@ -30,6 +30,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,6 +84,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/otel.yaml
@@ -30,6 +30,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,6 +84,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/otel.yaml
@@ -30,6 +30,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,6 +84,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/otel.yaml
@@ -30,6 +30,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,6 +84,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/otel.yaml
@@ -30,6 +30,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,6 +84,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/otel.yaml
@@ -30,6 +30,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,6 +84,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -91,6 +92,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -91,6 +92,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -90,6 +91,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -106,6 +107,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -106,6 +107,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -106,6 +107,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/otel.yaml
@@ -36,6 +36,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,6 +85,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/otel.yaml
@@ -41,6 +41,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -89,6 +90,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/otel.yaml
@@ -41,6 +41,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -89,6 +90,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/otel.yaml
@@ -41,6 +41,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -89,6 +90,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/otel.yaml
@@ -41,6 +41,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -89,6 +90,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/otel.yaml
@@ -41,6 +41,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -89,6 +90,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/otel.yaml
@@ -41,6 +41,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -89,6 +90,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/otel.yaml
@@ -41,6 +41,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -89,6 +90,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/otel.yaml
@@ -41,6 +41,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -89,6 +90,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/otel.yaml
@@ -41,6 +41,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -89,6 +90,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/otel.yaml
@@ -41,6 +41,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -89,6 +90,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/otel.yaml
@@ -44,6 +44,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -92,6 +93,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/otel.yaml
@@ -44,6 +44,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -92,6 +93,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/otel.yaml
@@ -44,6 +44,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -92,6 +93,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/otel.yaml
@@ -26,6 +26,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,6 +75,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/otel.yaml
@@ -47,6 +47,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -95,6 +96,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/otel.yaml
@@ -47,6 +47,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -95,6 +96,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/otel.yaml
@@ -44,6 +44,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -92,6 +93,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/otel.yaml
@@ -51,6 +51,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -105,6 +106,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/otel.yaml
@@ -57,6 +57,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -111,6 +112,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/otel.yaml
@@ -57,6 +57,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -111,6 +112,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/otel.yaml
@@ -41,6 +41,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -89,6 +90,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/otel.yaml
@@ -51,6 +51,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -100,6 +101,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/otel.yaml
@@ -46,6 +46,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -95,6 +96,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/otel.yaml
@@ -51,6 +51,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -99,6 +100,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/otel.yaml
@@ -51,6 +51,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -99,6 +100,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/otel.yaml
@@ -51,6 +51,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -99,6 +100,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/otel.yaml
@@ -51,6 +51,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -99,6 +100,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/otel.yaml
@@ -51,6 +51,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -99,6 +100,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/otel.yaml
@@ -51,6 +51,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -99,6 +100,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/otel.yaml
@@ -51,6 +51,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -99,6 +100,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/otel.yaml
@@ -51,6 +51,7 @@ processors:
         - fluentbit_uptime
         - fluentbit_stackdriver_requests_total
         - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -99,6 +100,18 @@ processors:
     - action: update
       include: fluentbit_stackdriver_proc_records_total
       new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: update_label

--- a/integration_test/agent_metrics/metadata.yaml
+++ b/integration_test/agent_metrics/metadata.yaml
@@ -26,12 +26,12 @@ expected_metrics:
     labels:
       response_code: \d+
   - type: agent.googleapis.com/agent/log_entry_retry_count
-   value_type: INT64
-   kind: CUMULATIVE
-   monitored_resource: gce_instance
-   labels:
-     response_code: .*
-   optional: true
+    value_type: INT64
+    kind: CUMULATIVE
+    monitored_resource: gce_instance
+    labels:
+     response_code: \d+
+    optional: true
   - type: agent.googleapis.com/agent/memory_usage
     value_type: DOUBLE
     kind: GAUGE

--- a/integration_test/agent_metrics/metadata.yaml
+++ b/integration_test/agent_metrics/metadata.yaml
@@ -25,14 +25,13 @@ expected_metrics:
     monitored_resource: gce_instance
     labels:
       response_code: \d+
-  #  TODO(b/170138116): Enable this metric once it is being collected.
-  #- type: agent.googleapis.com/agent/log_entry_retry_count
-  #  value_type: INT64
-  #  kind: CUMULATIVE
-  #  monitored_resource: gce_instance
-  #  labels:
-  #    response_code: .*
-  #  optional: true
+  - type: agent.googleapis.com/agent/log_entry_retry_count
+   value_type: INT64
+   kind: CUMULATIVE
+   monitored_resource: gce_instance
+   labels:
+     response_code: .*
+   optional: true
   - type: agent.googleapis.com/agent/memory_usage
     value_type: DOUBLE
     kind: GAUGE


### PR DESCRIPTION


## Description
This change tests out https://github.com/fluent/fluent-bit/pull/6537 and should only be merged after the submodule has been updated to use that change. This PR exists to soak test and integration test the fluent bit commit.

## Related issue
[b/232158052](http://b/232158052) | P2 | Add log_entry_retry_count self metrics to Ops Agent

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
