### PR TITLE
Reverting changes made in #1091

### DIFF
--- a/kokoro/scripts/build/build_package.sh
+++ b/kokoro/scripts/build/build_package.sh
@@ -34,7 +34,6 @@ OPS_AGENT_REPO_HASH="$(extract_git_hash .)"
 git submodule update --init --recursive
 
 # Debugging why we are not getting Docker cache hits for presubmits.
-git diff --name-only HEAD master
 ls -Al submodules/opentelemetry-operations-collector/go.*
 
 . VERSION


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Reverting https://github.com/GoogleCloudPlatform/ops-agent/pull/1091, all nightly builds failed.
## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
