### PR TITLE
Removed Time_Offset from Fluent-bit self logs

### DIFF
--- a/apps/mongodb.go
+++ b/apps/mongodb.go
@@ -284,7 +284,7 @@ func (p *LoggingProcessorMongodb) promoteWiredTiger(tag, uid string) []fluentbit
 func (p *LoggingProcessorMongodb) RegexLogComponents(tag, uid string) []fluentbit.Component {
 	c := []fluentbit.Component{}
 	parseKey := "message"
-	parser, parserName := fluentbit.ParserComponentBase("%Y-%m-%dT%H:%M:%S.%L%z", "timestamp", "", map[string]string{
+	parser, parserName := fluentbit.ParserComponentBase("%Y-%m-%dT%H:%M:%S.%L%z", "timestamp", map[string]string{
 		"message":   "string",
 		"id":        "integer",
 		"s":         "string",

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -383,7 +383,7 @@ func (l *Logging) generateFluentbitComponents(userAgent string, hostInfo *host.I
 		//Following: b/226668416 temporarily set storage.type to "memory"
 		//to prevent chunk corruption errors
 		BufferInMemory: true,
-	}.Components("ops-agent-fluent-bit")...)
+	}.Components(fluentBitSelfLogTag)...)
 
 	out = append(out, generateSeveritySelfLogsParser()...)
 

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -396,7 +396,6 @@ func (l *Logging) generateFluentbitComponents(userAgent string, hostInfo *host.I
 func generateSeveritySelfLogsParser() []fluentbit.Component {
 	out := make([]fluentbit.Component, 0)
 
-	// TODO(b/268046702) Time_Offset does not work for windows will be patched in Fluent-bit 2.x upgrade
 	parser := LoggingProcessorParseRegex{
 		Regex:       `(?<message>\[[ ]*(?<time>\d+\/\d+\/\d+ \d+:\d+:\d+)] \[[ ]*(?<severity>[a-z]+)\].*)`,
 		PreserveKey: true,

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -25,7 +25,6 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
-	"time"
 
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
@@ -398,15 +397,12 @@ func generateSeveritySelfLogsParser() []fluentbit.Component {
 	out := make([]fluentbit.Component, 0)
 
 	// TODO(b/268046702) Time_Offset does not work for windows will be patched in Fluent-bit 2.x upgrade
-	timeOffset := time.Now().Format("-0700")
-
 	parser := LoggingProcessorParseRegex{
 		Regex:       `(?<message>\[[ ]*(?<time>\d+\/\d+\/\d+ \d+:\d+:\d+)] \[[ ]*(?<severity>[a-z]+)\].*)`,
 		PreserveKey: true,
 		ParserShared: ParserShared{
 			TimeKey:    "time",
 			TimeFormat: "%Y/%m/%d %H:%M:%S",
-			TimeOffset: timeOffset,
 			Types: map[string]string{
 				"severity": "string",
 			},

--- a/confgenerator/fluentbit/processors.go
+++ b/confgenerator/fluentbit/processors.go
@@ -96,7 +96,7 @@ func LuaFilterComponents(tag, function, src string) []Component {
 }
 
 // The parser component is incomplete and needs (at a minimum) the "Format" key to be set.
-func ParserComponentBase(TimeFormat string, TimeKey string, TimeOffset string, Types map[string]string, tag string, uid string) (Component, string) {
+func ParserComponentBase(TimeFormat string, TimeKey string, Types map[string]string, tag string, uid string) (Component, string) {
 	parserName := fmt.Sprintf("%s.%s", tag, uid)
 	parser := Component{
 		Kind: "PARSER",
@@ -110,9 +110,6 @@ func ParserComponentBase(TimeFormat string, TimeKey string, TimeOffset string, T
 	}
 	if TimeKey != "" {
 		parser.Config["Time_Key"] = TimeKey
-	}
-	if TimeOffset != "" && TimeOffset != "+0000" && TimeOffset != "-0000" {
-		parser.Config["Time_Offset"] = TimeOffset
 	}
 	if len(Types) > 0 {
 		var types []string

--- a/confgenerator/logging_processors.go
+++ b/confgenerator/logging_processors.go
@@ -93,7 +93,6 @@ func init() {
 type ParserShared struct {
 	TimeKey    string `yaml:"time_key,omitempty" validate:"required_with=TimeFormat"` // by default does not parse timestamp
 	TimeFormat string `yaml:"time_format,omitempty" validate:"required_with=TimeKey"` // must be provided if time_key is present
-	TimeOffset string `yaml:"-"`                                                      // timezone offset
 	// Types allows parsing the extracted fields.
 	// Not exposed to users for now, but can be used by app receivers.
 	// Documented at https://docs.fluentbit.io/manual/v/1.3/parser
@@ -102,7 +101,7 @@ type ParserShared struct {
 }
 
 func (p ParserShared) Component(tag, uid string) (fluentbit.Component, string) {
-	return fluentbit.ParserComponentBase(p.TimeFormat, p.TimeKey, p.TimeOffset, p.Types, tag, uid)
+	return fluentbit.ParserComponentBase(p.TimeFormat, p.TimeKey, p.Types, tag, uid)
 }
 
 // A LoggingProcessorParseJson parses the specified field as JSON.

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -2694,13 +2694,6 @@ func TestLoggingFluentbitSelfLogs(t *testing.T) {
 		t.Parallel()
 		ctx, logger, vm := agents.CommonSetup(t, platform)
 
-		if !gce.IsWindows(platform) {
-			cmd := `sudo timedatectl set-timezone America/Toronto`
-			if _, err := gce.RunRemotely(ctx, logger.ToMainLog(), vm, "", cmd); err != nil {
-				t.Fatal(err)
-			}
-		}
-
 		if err := setupOpsAgent(ctx, logger, vm, ""); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Reverting Time_Offset from Fluent-bit self logs.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
