### PR TITLE
Internal: Make go_vet also vet windows files

### DIFF
--- a/cmd/ops_agent_windows/run_windows.go
+++ b/cmd/ops_agent_windows/run_windows.go
@@ -88,7 +88,6 @@ func (s *service) Execute(args []string, r <-chan svc.ChangeRequest, changes cha
 			}
 		}
 	}
-	return
 }
 
 func (s *service) parseFlags(args []string) error {

--- a/tasks.mak
+++ b/tasks.mak
@@ -127,3 +127,4 @@ update_go_modules:
 
 go_vet:
 	go list ./... | grep -v "generated" | grep -v "/vendor/" | xargs go vet
+	GOOS=windows go list ./... | grep -v "generated" | grep -v "/vendor/" | GOOS=windows xargs go vet


### PR DESCRIPTION
## Description
Currently, `make go_vet` does not vet windows files. Add another `go vet` command to fix that

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
