### PR TITLE
Debugging docker cache misses for presubmits

### DIFF
--- a/kokoro/scripts/build/build_package.sh
+++ b/kokoro/scripts/build/build_package.sh
@@ -34,7 +34,8 @@ OPS_AGENT_REPO_HASH="$(extract_git_hash .)"
 git submodule update --init --recursive
 
 # Debugging why we are not getting Docker cache hits for presubmits.
-ls -Al submodules/opentelemetry-operations-collector/go.*
+ls -Al submodules/opentelemetry-operations-collector/go.* || echo ls failed
+stat submodules/opentelemetry-operations-collector/go.* || echo stat failed
 
 . VERSION
 export_to_sponge_config "PACKAGE_VERSION" "${PKG_VERSION}"


### PR DESCRIPTION
## Description
Add logging to see whether we see any differences run-to-run in the detailed output from `stat`. `ls -l` might not give us enough detail.

## Related issue
none filed

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
