### PR TITLE
Add Windows 2022 to nightly tests

### DIFF
--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -151,6 +151,7 @@ windows = _family {
         // TODO(martijnvs): Switch this to windows-20h2-core.
         'windows-2019',
         'windows-2022',
+        'windows-2022-core',
       ]
     }
   }

--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -150,8 +150,6 @@ windows = _family {
         'windows-2012-r2',
         // TODO(martijnvs): Switch this to windows-20h2-core.
         'windows-2019',
-        'windows-2022',
-        'windows-2022-core',
       ]
     }
   }

--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -143,11 +143,14 @@ windows = _family {
         'windows-2016-core',
         'windows-2019',
         'windows-2019-core',
+        'windows-2022',
+        'windows-2022-core',
       ]
       presubmit = [
         'windows-2012-r2',
         // TODO(martijnvs): Switch this to windows-20h2-core.
         'windows-2019',
+        'windows-2022',
       ]
     }
   }

--- a/kokoro/config/test/third_party_apps/release/windows.gcl
+++ b/kokoro/config/test/third_party_apps/release/windows.gcl
@@ -6,6 +6,7 @@ config build = common.third_party_apps_test {
       'windows-2012-r2',
       'windows-2019',
       'sql-std-2019-win-2019',
+      'windows-2022', 
     ]
   }
 }

--- a/kokoro/config/test/third_party_apps/windows.gcl
+++ b/kokoro/config/test/third_party_apps/windows.gcl
@@ -5,8 +5,6 @@ config build = common.third_party_apps_test {
     platforms = [
       'windows-2012-r2',
       'sql-std-2019-win-2019',
-      'windows-2022',
-      'windows-2022-core',
     ]
   }
 }

--- a/kokoro/config/test/third_party_apps/windows.gcl
+++ b/kokoro/config/test/third_party_apps/windows.gcl
@@ -6,6 +6,7 @@ config build = common.third_party_apps_test {
       'windows-2012-r2',
       'sql-std-2019-win-2019',
       'windows-2022',
+      'windows-2022-core',
     ]
   }
 }

--- a/kokoro/config/test/third_party_apps/windows.gcl
+++ b/kokoro/config/test/third_party_apps/windows.gcl
@@ -5,6 +5,7 @@ config build = common.third_party_apps_test {
     platforms = [
       'windows-2012-r2',
       'sql-std-2019-win-2019',
+      'windows-2022',
     ]
   }
 }


### PR DESCRIPTION
## Description
Add Windows 2022 to nightly builds. 
- Add `windows-2022` and `windows-2022-core` to regular e2e in the nightly;
- Add `windows-2022` to 3P app tests in nightly;
- Do not run on any 2022 images in the presubmit yet.  

## Related issue
b/269650726

## How has this been tested?
Tested with both images to run the integration tests and 3P app tests in this PR, all passed: 
1. https://source.cloud.google.com/results/invocations/c4f55b93-54e6-4c6b-9627-b41cbf9f9285/targets/logs/tests;query=2022;passed=true 
2. https://source.cloud.google.com/results/invocations/34aa25a0-9543-41e4-ab01-fc0e7374d08e/targets/logs/tests


## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
