### PR TITLE
Update otel ops collector to v0.71.0

### DIFF
--- a/apps/hostmetrics.go
+++ b/apps/hostmetrics.go
@@ -284,14 +284,14 @@ func (r MetricsReceiverHostmetrics) Pipelines() []otel.ReceiverPipeline {
 					otel.AddLabel("process", "all"),
 				),
 				otel.RenameMetric(
-					"process.memory.physical_usage",
+					"process.memory.usage",
 					"processes/rss_usage",
 					// change data type from int64 -> double
 					otel.ToggleScalarDataType,
 					otel.AddLabel("process", "all"),
 				),
 				otel.RenameMetric(
-					"process.memory.virtual_usage",
+					"process.memory.virtual",
 					"processes/vm_usage",
 					// change data type from int64 -> double
 					otel.ToggleScalarDataType,

--- a/confgenerator/testdata/builtin/linux/builtin/golden/otel.yaml
+++ b/confgenerator/testdata/builtin/linux/builtin/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/builtin/windows/builtin/golden/otel.yaml
+++ b/confgenerator/testdata/builtin/windows/builtin/golden/otel.yaml
@@ -357,7 +357,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -365,7 +365,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/otel.yaml
@@ -337,7 +337,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -345,7 +345,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/otel.yaml
@@ -343,7 +343,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -351,7 +351,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/otel.yaml
@@ -344,7 +344,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/otel.yaml
@@ -344,7 +344,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/otel.yaml
@@ -343,7 +343,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -351,7 +351,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/otel.yaml
@@ -337,7 +337,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -345,7 +345,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/otel.yaml
@@ -358,7 +358,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -366,7 +366,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/otel.yaml
@@ -358,7 +358,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -366,7 +366,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/otel.yaml
@@ -358,7 +358,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -366,7 +366,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/otel.yaml
@@ -364,7 +364,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -372,7 +372,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/otel.yaml
@@ -364,7 +364,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -372,7 +372,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/otel.yaml
@@ -358,7 +358,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -366,7 +366,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/otel.yaml
@@ -358,7 +358,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -366,7 +366,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/otel.yaml
@@ -448,7 +448,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -456,7 +456,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/otel.yaml
@@ -358,7 +358,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -366,7 +366,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/otel.yaml
@@ -358,7 +358,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -366,7 +366,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/otel.yaml
@@ -358,7 +358,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -366,7 +366,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/otel.yaml
@@ -358,7 +358,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -366,7 +366,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/otel.yaml
@@ -358,7 +358,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -366,7 +366,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/otel.yaml
@@ -358,7 +358,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -366,7 +366,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/otel.yaml
@@ -358,7 +358,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -366,7 +366,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/otel.yaml
@@ -382,7 +382,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -390,7 +390,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/otel.yaml
@@ -358,7 +358,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -366,7 +366,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/otel.yaml
@@ -358,7 +358,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -366,7 +366,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/otel.yaml
@@ -365,7 +365,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -373,7 +373,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/otel.yaml
@@ -365,7 +365,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -373,7 +373,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/otel.yaml
@@ -367,7 +367,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -375,7 +375,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/otel.yaml
@@ -367,7 +367,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -375,7 +375,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/otel.yaml
@@ -358,7 +358,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -366,7 +366,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/otel.yaml
@@ -351,7 +351,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -359,7 +359,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/otel.yaml
@@ -351,7 +351,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -359,7 +359,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/otel.yaml
@@ -351,7 +351,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -359,7 +359,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/otel.yaml
@@ -351,7 +351,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -359,7 +359,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/otel.yaml
@@ -351,7 +351,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -359,7 +359,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/otel.yaml
@@ -351,7 +351,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -359,7 +359,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/otel.yaml
@@ -351,7 +351,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -359,7 +359,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/otel.yaml
@@ -359,7 +359,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -367,7 +367,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/otel.yaml
@@ -359,7 +359,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -367,7 +367,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/otel.yaml
@@ -358,7 +358,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -366,7 +366,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/otel.yaml
@@ -374,7 +374,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -382,7 +382,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/otel.yaml
@@ -374,7 +374,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -382,7 +382,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/otel.yaml
@@ -374,7 +374,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -382,7 +382,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/otel.yaml
@@ -352,7 +352,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/otel.yaml
@@ -357,7 +357,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -365,7 +365,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/otel.yaml
@@ -357,7 +357,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -365,7 +365,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/otel.yaml
@@ -357,7 +357,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -365,7 +365,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/otel.yaml
@@ -357,7 +357,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -365,7 +365,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/otel.yaml
@@ -357,7 +357,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -365,7 +365,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/otel.yaml
@@ -357,7 +357,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -365,7 +365,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/otel.yaml
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -368,7 +368,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/otel.yaml
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -368,7 +368,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/otel.yaml
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -368,7 +368,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/otel.yaml
@@ -342,7 +342,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -350,7 +350,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/otel.yaml
@@ -363,7 +363,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -371,7 +371,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/otel.yaml
@@ -363,7 +363,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -371,7 +371,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/otel.yaml
@@ -360,7 +360,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -368,7 +368,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/otel.yaml
@@ -373,7 +373,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -381,7 +381,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/otel.yaml
@@ -379,7 +379,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -387,7 +387,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/otel.yaml
@@ -379,7 +379,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -387,7 +387,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/otel.yaml
@@ -357,7 +357,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -365,7 +365,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/otel.yaml
@@ -368,7 +368,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -376,7 +376,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/otel.yaml
@@ -363,7 +363,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -371,7 +371,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/otel.yaml
@@ -367,7 +367,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -375,7 +375,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/otel.yaml
@@ -367,7 +367,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -375,7 +375,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/otel.yaml
@@ -367,7 +367,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -375,7 +375,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/otel.yaml
@@ -367,7 +367,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -375,7 +375,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/otel.yaml
@@ -367,7 +367,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -375,7 +375,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/otel.yaml
@@ -367,7 +367,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -375,7 +375,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/otel.yaml
@@ -367,7 +367,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -375,7 +375,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/otel.yaml
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/otel.yaml
@@ -367,7 +367,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.physical_usage
+      include: process.memory.usage
       new_name: processes/rss_usage
       operations:
       - action: toggle_scalar_data_type
@@ -375,7 +375,7 @@ processors:
         new_label: process
         new_value: all
     - action: update
-      include: process.memory.virtual_usage
+      include: process.memory.virtual
       new_name: processes/vm_usage
       operations:
       - action: toggle_scalar_data_type


### PR DESCRIPTION
## Description
Update the ops agent with the new version of the operations-collector updated to otel release v0.71.0

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
