### PR TITLE
Cleanup centos8

### DIFF
--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -84,8 +84,6 @@ centos = _family {
     centos8 = _distro {
       name = 'CentOS 8'
       release = [
-        // CentOS.
-        'centos-8',
         // RHEL.
         'rhel-8',
         'rhel-8-1-sap-ha',

--- a/kokoro/config/test/ops_agent/release/centos8.gcl
+++ b/kokoro/config/test/ops_agent/release/centos8.gcl
@@ -3,14 +3,6 @@ import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    // TODO(b/217189970): Change back to 
-    // image_lists.centos.distros.centos8.release once centos-8 is gone.
-    platforms = [
-      'rhel-8',
-      'rhel-8-1-sap-ha',
-      'rhel-8-2-sap-ha',
-      'rhel-8-4-sap-ha',
-      'rocky-linux-8',
-    ]
+    platforms = image_lists.centos.distros.centos8.release
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
centos8 image is gone from `gcloud compute images list`, cleaning up the residue of centos8

## Related issue
b/270136628

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
