### PR TITLE
Fixes for winlog v2 failures

### DIFF
--- a/confgenerator/logging_receivers.go
+++ b/confgenerator/logging_receivers.go
@@ -378,11 +378,11 @@ func commonEventLogComponents(useNewerApi bool, channels []string, tag string) [
 		},
 	}}
 
-	// On Windows Server 2012, there is a known problem where most log fields end
+	// On Windows Server 2012/2016, there is a known problem where most log fields end
 	// up blank. The Use_ANSI configuration is provided to work around this; however,
 	// this also strips Unicode characters away, so we only use it on affected
 	// platforms. This only affects the newer API.
-	if useNewerApi && windows.Is2012() {
+	if useNewerApi && (windows.Is2012() || windows.Is2016()) {
 		input[0].Config["Use_ANSI"] = "True"
 	}
 

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -1687,7 +1687,7 @@ func TestWindowsEventLogV2(t *testing.T) {
       type: windows_event_log
       receiver_version: 2
       channels:
-      - Microsoft-Windows-User Control Panel/Operational
+      - Microsoft-Windows-User Profile Service/Operational
     r2:
       type: windows_event_log
       receiver_version: 2
@@ -1707,7 +1707,7 @@ func TestWindowsEventLogV2(t *testing.T) {
 
 		payloads := map[string]map[string]string{
 			"r1": {
-				"Microsoft-Windows-User Control Panel/Operational": "control_panel_msg",
+				"Microsoft-Windows-User Profile Service/Operational": "control_panel_msg",
 			},
 			"r2": {
 				"Application": "application_msg",

--- a/internal/windows/others.go
+++ b/internal/windows/others.go
@@ -23,6 +23,10 @@ func Is2012() bool {
 	return false
 }
 
+func Is2016() bool {
+	return false
+}
+
 func GetOldWinlogChannels() ([]string, error) {
 	return nil, fmt.Errorf("not a Windows platform")
 }

--- a/internal/windows/windows.go
+++ b/internal/windows/windows.go
@@ -23,18 +23,28 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
-func Is2012() bool {
+func getWindowsBuildNumber() string {
 	key, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.QUERY_VALUE)
 	if err != nil {
 		log.Fatalf("could not open CurrentVersion key: %v", err)
 	}
 	defer key.Close()
-	data, _, err := key.GetStringValue("CurrentBuildNumber")
+	build, _, err := key.GetStringValue("CurrentBuildNumber")
 	if err != nil {
 		log.Fatalf("could not read CurrentBuildNumber: %v", err)
 	}
+	return build
+}
+
+func Is2012() bool {
 	// https://en.wikipedia.org/wiki/List_of_Microsoft_Windows_versions#Server_versions
-	return data == "9200" || data == "9600"
+	build := getWindowsBuildNumber()
+	return build == "9200" || build == "9600"
+}
+
+func Is2016() bool {
+	build := getWindowsBuildNumber()
+	return build == "14393"
 }
 
 // GetOldWinlogChannels returns the set of event logs (channels) under


### PR DESCRIPTION
## Description
Two issues from the nightlies:

1. The channel I originally chose for the integration test is not available on Core versions of Windows, which I missed before the nightlies
2. Windows 2016 apparently also suffers from the ANSI bug that affects 2012: 
![image](https://user-images.githubusercontent.com/89024676/220683022-211b8d2d-3481-45ce-ba84-835fbc71ef4a.png)

This fixes both.

## Related issue
N/A

## How has this been tested?
Reran the failing platforms with the channel change; only 2016[-core] failed. The failure was the ANSI thing so I'll get a build from this PR and re-run the test locally to confirm since 2016 isn't part of the GitHub presubmits.

Tests that have already passed:

```
=== CONT  TestWindowsEventLogV2/windows-2016
    agents.go:680: Test logs: /tmp/695440914/TestWindowsEventLogV2_windows-2016
=== CONT  TestWindowsEventLogV2/windows-2016-core
    agents.go:680: Test logs: /tmp/695440914/TestWindowsEventLogV2_windows-2016-core
=== CONT  TestWindowsEventLogV2/windows-2022
    agents.go:680: Test logs: /tmp/695440914/TestWindowsEventLogV2_windows-2022
=== CONT  TestWindowsEventLogV2/windows-2019
    agents.go:680: Test logs: /tmp/695440914/TestWindowsEventLogV2_windows-2019
=== CONT  TestWindowsEventLogV2/windows-2012-r2-core
    agents.go:680: Test logs: /tmp/695440914/TestWindowsEventLogV2_windows-2012-r2-core
=== CONT  TestWindowsEventLogV2/windows-2022-core
    agents.go:680: Test logs: /tmp/695440914/TestWindowsEventLogV2_windows-2022-core
=== CONT  TestWindowsEventLogV2/windows-2012-r2
    agents.go:680: Test logs: /tmp/695440914/TestWindowsEventLogV2_windows-2012-r2
=== CONT  TestWindowsEventLogV2/windows-2012-r2-core
    agents.go:680: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F327815392088787087&project=stackdriver-kubernetes-1337
=== CONT  TestWindowsEventLogV2/windows-2012-r2
    agents.go:680: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F9181204738314307727&project=stackdriver-kubernetes-1337
=== CONT  TestWindowsEventLogV2/windows-2022-core
    agents.go:680: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F6078879083647436943&project=stackdriver-kubernetes-1337
=== CONT  TestWindowsEventLogV2/windows-2022
    agents.go:680: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F4156395363396978831&project=stackdriver-kubernetes-1337
=== CONT  TestWindowsEventLogV2/windows-2019
    agents.go:680: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F6037366730082977935&project=stackdriver-kubernetes-1337
=== CONT  TestWindowsEventLogV2/windows-2016-core
    agents.go:680: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F3376285137571121295&project=stackdriver-kubernetes-1337
=== CONT  TestWindowsEventLogV2/windows-2016
    agents.go:680: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F982440554859825295&project=stackdriver-kubernetes-1337
=== CONT  TestWindowsEventLogV2/windows-2016-core
    ops_agent_test.go:1732: QueryLog() failed: r1 not found, exhausted retries
=== CONT  TestWindowsEventLogV2/windows-2016
    ops_agent_test.go:1732: QueryLog() failed: r1 not found, exhausted retries
--- FAIL: TestWindowsEventLogV2 (0.00s)
    --- PASS: TestWindowsEventLogV2/windows-2012-r2-core (352.96s)
    --- PASS: TestWindowsEventLogV2/windows-2012-r2 (381.98s)
    --- PASS: TestWindowsEventLogV2/windows-2022-core (409.13s)
    --- PASS: TestWindowsEventLogV2/windows-2022 (466.32s)
    --- PASS: TestWindowsEventLogV2/windows-2019 (469.94s)
    --- FAIL: TestWindowsEventLogV2/windows-2016-core (873.27s)
    --- FAIL: TestWindowsEventLogV2/windows-2016 (931.52s)
FAIL
FAIL    command-line-arguments  932.220s
FAIL
...
=== CONT  TestWindowsEventLogV2/windows-2019-core
    agents.go:680: Test logs: /tmp/3164778685/TestWindowsEventLogV2_windows-2019-core
    agents.go:680: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F8655502145738212350&project=stackdriver-kubernetes-1337
--- PASS: TestWindowsEventLogV2 (0.00s)
    --- PASS: TestWindowsEventLogV2/windows-2019-core (422.06s)
PASS
ok      command-line-arguments  423.303s
```

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
