### PR TITLE
Remove Windows 2012 hack

### DIFF
--- a/cmd/ops_agent_windows/main_windows.go
+++ b/cmd/ops_agent_windows/main_windows.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/GoogleCloudPlatform/ops-agent/internal/windows"
 	"github.com/kardianos/osext"
 	"golang.org/x/sys/windows/svc"
 )
@@ -101,26 +100,6 @@ func initServices() error {
 	if err := os.MkdirAll(logDirectory, 0644); err != nil {
 		return err
 	}
-	fluentbitExe := filepath.Join(base, "fluent-bit.exe")
-	fluentbitArgs := []string{
-		"-c", filepath.Join(configOutDir, `fluentbit\fluent_bit_main.conf`),
-		"-R", filepath.Join(configOutDir, `fluentbit\fluent_bit_parser.conf`),
-		"--storage_path", fluentbitStoragePath,
-		"--log_file", filepath.Join(logDirectory, "logging-module.log"),
-	}
-	// TODO(b/240564518): Workaround for fluent-bit lockups on Windows 2012
-	if windows.Is2012() {
-		fluentbitArgs = append([]string{
-			"/k",
-			"start",
-			"/AFFINITY",
-			"FF",
-			"/WAIT",
-			"",
-			fluentbitExe,
-		}, fluentbitArgs...)
-		fluentbitExe = "cmd.exe"
-	}
 	// TODO: Write meaningful descriptions for these services
 	services = []struct {
 		name        string
@@ -149,8 +128,13 @@ func initServices() error {
 			// TODO: fluent-bit hardcodes a service name of "fluent-bit"; do we need to match that?
 			fmt.Sprintf("%s-fluent-bit", serviceName),
 			fmt.Sprintf("%s - Logging Agent", serviceDisplayName),
-			fluentbitExe,
-			fluentbitArgs,
+			filepath.Join(base, "fluent-bit.exe"),
+			[]string{
+				"-c", filepath.Join(configOutDir, `fluentbit\fluent_bit_main.conf`),
+				"-R", filepath.Join(configOutDir, `fluentbit\fluent_bit_parser.conf`),
+				"--storage_path", fluentbitStoragePath,
+				"--log_file", filepath.Join(logDirectory, "logging-module.log"),
+			},
 		},
 		{
 			fmt.Sprintf("%s-diagnostics", serviceName),


### PR DESCRIPTION
## Description
This never really worked well, but it's obsolete now that fluent-bit is upgraded to 2.x which fixes the underlying lockup issue.

Partial revert of #952.

## Related issue
b/240564518

## How has this been tested?
Letting the integration tests run in the PR

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
