### PR TITLE
Add sql-std-2022-win-2022 image to nightly tests

### DIFF
--- a/integration_test/third_party_apps_data/applications/mssql/windows/install
+++ b/integration_test/third_party_apps_data/applications/mssql/windows/install
@@ -1,13 +1,13 @@
-function Install-SQLServer2019 {
-    Write-Host "Downloading SQL Server 2019..."
-    $Path = $env:TEMP
-    $Installer = "SQL2019-SSEI-Dev.exe"
-    $URL = "https://go.microsoft.com/fwlink/?linkid=866662"
-    Invoke-WebRequest $URL -OutFile $Path\$Installer
+# function Install-SQLServer2019 {
+#     Write-Host "Downloading SQL Server 2019..."
+#     $Path = $env:TEMP
+#     $Installer = "SQL2019-SSEI-Dev.exe"
+#     $URL = "https://go.microsoft.com/fwlink/?linkid=866662"
+#     Invoke-WebRequest $URL -OutFile $Path\$Installer
 
-    Write-Host "Installing SQL Server..."
-    Start-Process -FilePath $Path\$Installer -Args "/ACTION=INSTALL /IACCEPTSQLSERVERLICENSETERMS /QUIET" -Verb RunAs -Wait
-    Remove-Item $Path\$Installer
-}
+#     Write-Host "Installing SQL Server..."
+#     Start-Process -FilePath $Path\$Installer -Args "/ACTION=INSTALL /IACCEPTSQLSERVERLICENSETERMS /QUIET" -Verb RunAs -Wait
+#     Remove-Item $Path\$Installer
+# }
 
-Install-SQLServer2019 
+# Install-SQLServer2019 

--- a/integration_test/third_party_apps_data/applications/mssql/windows/install
+++ b/integration_test/third_party_apps_data/applications/mssql/windows/install
@@ -1,13 +1,1 @@
-# function Install-SQLServer2019 {
-#     Write-Host "Downloading SQL Server 2019..."
-#     $Path = $env:TEMP
-#     $Installer = "SQL2019-SSEI-Dev.exe"
-#     $URL = "https://go.microsoft.com/fwlink/?linkid=866662"
-#     Invoke-WebRequest $URL -OutFile $Path\$Installer
-
-#     Write-Host "Installing SQL Server..."
-#     Start-Process -FilePath $Path\$Installer -Args "/ACTION=INSTALL /IACCEPTSQLSERVERLICENSETERMS /QUIET" -Verb RunAs -Wait
-#     Remove-Item $Path\$Installer
-# }
-
-# Install-SQLServer2019 
+# MSSQL integration will be tested on images with MSSQL pre-installed

--- a/kokoro/config/test/third_party_apps/release/windows.gcl
+++ b/kokoro/config/test/third_party_apps/release/windows.gcl
@@ -7,6 +7,7 @@ config build = common.third_party_apps_test {
       'windows-2019',
       'sql-std-2019-win-2019',
       'windows-2022', 
+      'sql-std-2022-win-2022',
     ]
   }
 }

--- a/kokoro/config/test/third_party_apps/windows.gcl
+++ b/kokoro/config/test/third_party_apps/windows.gcl
@@ -5,6 +5,7 @@ config build = common.third_party_apps_test {
     platforms = [
       'windows-2012-r2',
       'sql-std-2019-win-2019',
+      'sql-std-2022-win-2022',
     ]
   }
 }

--- a/kokoro/config/test/third_party_apps/windows.gcl
+++ b/kokoro/config/test/third_party_apps/windows.gcl
@@ -5,7 +5,6 @@ config build = common.third_party_apps_test {
     platforms = [
       'windows-2012-r2',
       'sql-std-2019-win-2019',
-      'sql-std-2022-win-2022',
     ]
   }
 }


### PR DESCRIPTION
## Description
This is a followup for #1113 . Since we only test the MSSQL integration on `sql-*` images, expand the nightly coverage to also test this integration on `sql-std-2022-win-2022`. 

The `install` script for MSSQL should be no longer needed since all `sql-*` images should have the corresponding version of MSSQL server pre-installed.  

## Related issue
b/269650726

## How has this been tested?
First tried to trigger the MSSQL test on `sql-std-2022-win-2022` in this PR and all tests have passed. Now remove that image from presubmit and only keep it in nightly. 

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
