### PR TITLE
Trying another workaround to avoid flake

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -967,12 +967,15 @@ func addFrameworkMetadata(platform string, inputMetadata map[string]string) (map
 	metadataCopy["ssh-keys"] = fmt.Sprintf("%s:%s", sshUserName, string(publicKey))
 
 	if IsWindows(platform) {
-		// TODO(b/255311117): change windows-startup-script-cmd back to sysprep-specialize-script-cmd once the bug is fixed
-		if _, ok := metadataCopy["windows-startup-script-cmd"]; ok {
-			return nil, errors.New("you cannot pass a sysprep script for Windows instances because the sysprep script is needed to enable ssh-ing. Instead, wait for the instance to be ready and then run things with RunRemotely() or RunScriptRemotely()")
+		// TODO(b/255311117#comment38): move `googet update` back to sysprep-specialize-script-cmd once the bug is fixed
+		_, ok1 := metadataCopy["sysprep-specialize-script-cmd"]
+		_, ok2 := metadataCopy["windows-startup-script-cmd"]
+		if ok1 || ok2 {
+			return nil, errors.New("you cannot pass a sysprep or startup script for Windows instances because they are needed to enable ssh-ing. Instead, wait for the instance to be ready and then run things with RunRemotely() or RunScriptRemotely()")
 		}
 		// From https://cloud.google.com/compute/docs/connect/windows-ssh#create_vm
-		metadataCopy["windows-startup-script-cmd"] = "googet -noconfirm=true update && googet -noconfirm=true install google-compute-engine-ssh"
+		metadataCopy["sysprep-specialize-script-cmd"] = "googet -noconfirm=true install google-compute-engine-ssh"
+		metadataCopy["windows-startup-script-cmd"] = "googet -noconfirm=true update"
 
 		if _, ok := metadataCopy["enable-windows-ssh"]; ok {
 			return nil, errors.New("the 'enable-windows-ssh' metadata key is reserved for framework use")


### PR DESCRIPTION
## Description
See b/255311117#comment36 for context.

## Related issue
b/255311117#comment36

## How has this been tested?
Letting presubmits run -- this issue only occurred on windows-2012-r2 overnight, so the presubmit should hopefully catch it if it fails. It was a flake at any rate so we might not know right away.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
