### PR TITLE
healthchecks: Handle multiple Health Check failures

### DIFF
--- a/cmd/ops_agent_windows/run_windows.go
+++ b/cmd/ops_agent_windows/run_windows.go
@@ -137,7 +137,7 @@ func (s *service) checkForStandaloneAgents(unified *confgenerator.UnifiedConfig)
 	return nil
 }
 
-func getHealthCheckResults() map[string]healthchecks.HealthCheckResult {
+func getHealthCheckResults() []healthchecks.HealthCheckResult {
 	logsDir := filepath.Join(os.Getenv("PROGRAMDATA"), dataDirectory, "log")
 	gceHealthChecks := healthchecks.HealthCheckRegistryFactory()
 	logger, closer := healthchecks.CreateHealthChecksLogger(logsDir)

--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -205,7 +205,7 @@ func runOpsAgentDiagnosticsWindows(ctx context.Context, logger *logging.Director
 	gce.RunRemotely(ctx, logger.ToFile("open_telemetry_agent_logs.txt"), vm, "", "Get-WinEvent -FilterHashtable @{ Logname='Application'; ProviderName='google-cloud-ops-agent-opentelemetry-collector' } | Format-Table -AutoSize -Wrap")
 	// Fluent-Bit has not implemented exporting logs to the Windows event log yet.
 	gce.RunRemotely(ctx, logger.ToFile("fluent_bit_agent_logs.txt"), vm, "", fmt.Sprintf("Get-Content -Path '%s' -Raw", `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\logging-module.log`))
-	gce.RunRemotely(ctx, logger.ToFile("health-checks.log"), vm, "", fmt.Sprintf("Get-Content -Path '%s' -Raw", `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\health-checks.log`))
+	gce.RunRemotely(ctx, logger.ToFile("health-checks.txt"), vm, "", fmt.Sprintf("Get-Content -Path '%s' -Raw", `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\health-checks.log`))
 
 	for _, conf := range []string{
 		`C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml`,

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -3653,7 +3653,7 @@ func TestNetworkHealthCheck(t *testing.T) {
 		}
 		checkFunc("Network", "PASS")
 		checkFunc("Ports", "PASS")
-		checkFunc("API", "FAIL")
+		checkFunc("API", "PASS")
 
 		if _, err := gce.RunRemotely(ctx, logger.ToMainLog(), vm, "", stopCommandForPlatform(vm.Platform)); err != nil {
 			t.Fatal(err)

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -3589,7 +3589,12 @@ func TestPortsAndAPIHealthChecks(t *testing.T) {
 		ctx, logger, vm := agents.CommonSetupWithExtraCreateArguments(t, platform, []string{"--scopes", customScopes})
 
 		if !gce.IsWindows(vm.Platform) {
-			packages := []string{"netcat"}
+			var packages []string
+			if gce.IsCentOS(vm.Platform) || gce.IsRHEL(vm.Platform) {
+				packages = []string{"nc"}
+			} else {
+				packages = []string{"netcat"}
+			}
 			err := agents.InstallPackages(ctx, logger.ToMainLog(), vm, packages)
 			if err != nil {
 				t.Fatalf("failed to install %v with err: %s", packages, err)
@@ -3660,7 +3665,7 @@ func TestNetworkHealthCheck(t *testing.T) {
 		if _, err := gce.AddTagToVm(ctx, logger.ToMainLog(), vm, []string{gce.DenyEgressTrafficTag}); err != nil {
 			t.Fatal(err)
 		}
-		time.Sleep(30 * time.Second)
+		time.Sleep(time.Minute)
 
 		if _, err := gce.RunRemotely(ctx, logger.ToMainLog(), vm, "", startCommandForPlatform(vm.Platform)); err != nil {
 			t.Fatal(err)

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -3541,7 +3541,7 @@ metrics:
 }
 
 func isHealthCheckTestPlatform(platform string) bool {
-	return platform == "windows-2019" || platform == "debian-11"
+	return true
 }
 
 func healthCheckResultMessage(name string, result string) string {

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -3541,7 +3541,7 @@ metrics:
 }
 
 func isHealthCheckTestPlatform(platform string) bool {
-	return true
+	return platform == "windows-2019" || platform == "debian-11"
 }
 
 func healthCheckResultMessage(name string, result string) string {

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -3623,8 +3623,7 @@ func TestPortsAndAPIHealthChecks(t *testing.T) {
 		}
 		checkFunc("Network", "PASS")
 		checkFunc("Ports", "FAIL")
-		checkFunc("Logging API", "FAIL")
-		checkFunc("Monitoring API", "PASS")
+		checkFunc("API", "FAIL")
 	})
 }
 
@@ -3654,8 +3653,7 @@ func TestNetworkHealthCheck(t *testing.T) {
 		}
 		checkFunc("Network", "PASS")
 		checkFunc("Ports", "PASS")
-		checkFunc("Logging API", "PASS")
-		checkFunc("Monitoring API", "PASS")
+		checkFunc("API", "FAIL")
 
 		if _, err := gce.RunRemotely(ctx, logger.ToMainLog(), vm, "", stopCommandForPlatform(vm.Platform)); err != nil {
 			t.Fatal(err)
@@ -3683,8 +3681,7 @@ func TestNetworkHealthCheck(t *testing.T) {
 		}
 		checkFunc("Network", "FAIL")
 		checkFunc("Ports", "PASS")
-		checkFunc("Logging API", "FAIL")
-		checkFunc("Monitoring API", "FAIL")
+		checkFunc("API", "FAIL")
 	})
 }
 

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -3581,12 +3581,12 @@ func TestPortsAndAPIHealthChecks(t *testing.T) {
 			t.SkipNow()
 		}
 
-		onlyReadScopes := strings.Join([]string{
-			"https://www.googleapis.com/auth/monitoring.read",
+		customScopes := strings.Join([]string{
+			"https://www.googleapis.com/auth/monitoring.write",
 			"https://www.googleapis.com/auth/logging.read",
 			"https://www.googleapis.com/auth/devstorage.read_write",
 		}, ",")
-		ctx, logger, vm := agents.CommonSetupWithExtraCreateArguments(t, platform, []string{"--scopes", onlyReadScopes})
+		ctx, logger, vm := agents.CommonSetupWithExtraCreateArguments(t, platform, []string{"--scopes", customScopes})
 
 		if !gce.IsWindows(vm.Platform) {
 			packages := []string{"netcat"}
@@ -3617,8 +3617,9 @@ func TestPortsAndAPIHealthChecks(t *testing.T) {
 			}
 		}
 		checkFunc("Network", "PASS")
-		checkFunc("API", "FAIL")
 		checkFunc("Ports", "FAIL")
+		checkFunc("Logging API", "FAIL")
+		checkFunc("Monitoring API", "PASS")
 	})
 }
 
@@ -3647,8 +3648,9 @@ func TestNetworkHealthCheck(t *testing.T) {
 			}
 		}
 		checkFunc("Network", "PASS")
-		checkFunc("API", "PASS")
 		checkFunc("Ports", "PASS")
+		checkFunc("Logging API", "PASS")
+		checkFunc("Monitoring API", "PASS")
 
 		if _, err := gce.RunRemotely(ctx, logger.ToMainLog(), vm, "", stopCommandForPlatform(vm.Platform)); err != nil {
 			t.Fatal(err)
@@ -3675,8 +3677,9 @@ func TestNetworkHealthCheck(t *testing.T) {
 			}
 		}
 		checkFunc("Network", "FAIL")
-		checkFunc("API", "ERROR")
 		checkFunc("Ports", "PASS")
+		checkFunc("Logging API", "FAIL")
+		checkFunc("Monitoring API", "FAIL")
 	})
 }
 

--- a/internal/healthchecks/api_check.go
+++ b/internal/healthchecks/api_check.go
@@ -91,13 +91,7 @@ func monitoringPing(ctx context.Context, client monitoring.MetricClient, gceMeta
 	return client.CreateTimeSeries(ctx, req)
 }
 
-type LoggingAPICheck struct{}
-
-func (c LoggingAPICheck) Name() string {
-	return "Logging API Check"
-}
-
-func (c LoggingAPICheck) RunCheck(logger *log.Logger) error {
+func runLoggingCheck(logger *log.Logger) error {
 	ctx := context.Background()
 	gceMetadata, err := getGCEMetadata()
 	if err != nil {
@@ -144,13 +138,7 @@ func (c LoggingAPICheck) RunCheck(logger *log.Logger) error {
 	return nil
 }
 
-type MonitoringAPICheck struct{}
-
-func (c MonitoringAPICheck) Name() string {
-	return "Monitoring API Check"
-}
-
-func (c MonitoringAPICheck) RunCheck(logger *log.Logger) error {
+func runMonitoringCheck(logger *log.Logger) error {
 	ctx := context.Background()
 	gceMetadata, err := getGCEMetadata()
 	if err != nil {
@@ -195,4 +183,16 @@ func (c MonitoringAPICheck) RunCheck(logger *log.Logger) error {
 	}
 
 	return nil
+}
+
+type APICheck struct{}
+
+func (c APICheck) Name() string {
+	return "API Check"
+}
+
+func (c APICheck) RunCheck(logger *log.Logger) error {
+	monErr := runMonitoringCheck(logger)
+	logErr := runLoggingCheck(logger)
+	return errors.Join(monErr, logErr)
 }

--- a/internal/healthchecks/api_check.go
+++ b/internal/healthchecks/api_check.go
@@ -130,7 +130,7 @@ func (c LoggingAPICheck) RunCheck(logger *log.Logger) error {
 			case codes.PermissionDenied:
 				return LogApiPermissionErr
 			case codes.Unauthenticated:
-				return LogApiScopeErr
+				return LogApiUnauthenticatedErr
 			}
 		}
 
@@ -179,7 +179,7 @@ func (c MonitoringAPICheck) RunCheck(logger *log.Logger) error {
 			case codes.PermissionDenied:
 				return MonApiPermissionErr
 			case codes.Unauthenticated:
-				return MonApiScopeErr
+				return MonApiUnauthenticatedErr
 			}
 		}
 		return err

--- a/internal/healthchecks/api_check.go
+++ b/internal/healthchecks/api_check.go
@@ -131,9 +131,13 @@ func (c LoggingAPICheck) RunCheck(logger *log.Logger) error {
 				return LogApiPermissionErr
 			case codes.Unauthenticated:
 				return LogApiUnauthenticatedErr
+			case codes.DeadlineExceeded:
+				return LogApiConnErr
 			}
 		}
-
+		if errors.Is(err, context.DeadlineExceeded) {
+			return LogApiConnErr
+		}
 		return err
 	}
 
@@ -180,7 +184,12 @@ func (c MonitoringAPICheck) RunCheck(logger *log.Logger) error {
 				return MonApiPermissionErr
 			case codes.Unauthenticated:
 				return MonApiUnauthenticatedErr
+			case codes.DeadlineExceeded:
+				return MonApiConnErr
 			}
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			return MonApiConnErr
 		}
 		return err
 	}

--- a/internal/healthchecks/api_check.go
+++ b/internal/healthchecks/api_check.go
@@ -91,13 +91,13 @@ func monitoringPing(ctx context.Context, client monitoring.MetricClient, gceMeta
 	return client.CreateTimeSeries(ctx, req)
 }
 
-type APICheck struct{}
+type LoggingAPICheck struct{}
 
-func (c APICheck) Name() string {
-	return "API Check"
+func (c LoggingAPICheck) Name() string {
+	return "Logging API Check"
 }
 
-func (c APICheck) RunCheck(logger *log.Logger) error {
+func (c LoggingAPICheck) RunCheck(logger *log.Logger) error {
 	ctx := context.Background()
 	gceMetadata, err := getGCEMetadata()
 	if err != nil {
@@ -136,6 +136,23 @@ func (c APICheck) RunCheck(logger *log.Logger) error {
 
 		return err
 	}
+
+	return nil
+}
+
+type MonitoringAPICheck struct{}
+
+func (c MonitoringAPICheck) Name() string {
+	return "Monitoring API Check"
+}
+
+func (c MonitoringAPICheck) RunCheck(logger *log.Logger) error {
+	ctx := context.Background()
+	gceMetadata, err := getGCEMetadata()
+	if err != nil {
+		return fmt.Errorf("can't get GCE metadata: %w", err)
+	}
+	logger.Printf("gce metadata: %+v", gceMetadata)
 
 	// New Monitoring Client
 	monClient, err := monitoring.NewMetricClient(ctx)

--- a/internal/healthchecks/error.go
+++ b/internal/healthchecks/error.go
@@ -36,6 +36,16 @@ func (e HealthCheckError) Error() string {
 	return e.Message
 }
 
+type MultiHealthCheckError []HealthCheckError
+
+func (m MultiHealthCheckError) Error() string {
+	var message string
+	for _, e := range(m) {
+		message = message + " " + e.Error()
+	}
+	return message
+}
+
 var (
 	FbMetricsPortErr = HealthCheckError{
 		Code:         "FbMetricsPortErr",

--- a/internal/healthchecks/error.go
+++ b/internal/healthchecks/error.go
@@ -36,6 +36,9 @@ func (e HealthCheckError) Error() string {
 	return e.Message
 }
 
+// Interface used to verify if an error implements `Unwrap() []error`.
+// The resulting error from `errors.Join(errs ...error)` implements this interface.
+// This error features were added in Go 1.20 release (https://tip.golang.org/doc/go1.20).
 type MultiWrappedError interface {
 	Unwrap() []error
 }

--- a/internal/healthchecks/error.go
+++ b/internal/healthchecks/error.go
@@ -141,6 +141,22 @@ var (
 		ResourceLink: "https://cloud.google.com/monitoring/api/enable-api",
 		IsFatal:      true,
 	}
+	LogApiUnauthenticatedErr = HealthCheckError{
+		Code:         "LogApiUnauthenticatedErr",
+		Class:        Api,
+		Message:      "The current VM couldn't authenticate to the Logging API.",
+		Action:       "Verify that your credential files, scopes and permissions are setup correctly.",
+		ResourceLink: "https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/authorization",
+		IsFatal:      true,
+	}
+	MonApiUnauthenticatedErr = HealthCheckError{
+		Code:         "MonApiUnauthenticatedErr",
+		Class:        Api,
+		Message:      "The current VM couldn't authenticate to the Monitoring API.",
+		Action:       "Verify that your credential files, scopes and permissions are setup correctly.",
+		ResourceLink: "https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/authorization",
+		IsFatal:      true,
+	}
 	HcFailureErr = HealthCheckError{
 		Code:         "HcFailureErr",
 		Class:        Generic,

--- a/internal/healthchecks/error.go
+++ b/internal/healthchecks/error.go
@@ -149,7 +149,7 @@ var (
 		Code:         "LogApiUnauthenticatedErr",
 		Class:        Api,
 		Message:      "The current VM couldn't authenticate to the Logging API.",
-		Action:       "Verify that your credential files, scopes and permissions are setup correctly.",
+		Action:       "Verify that your credential files, scopes and permissions are set up correctly.",
 		ResourceLink: "https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/authorization",
 		IsFatal:      true,
 	}
@@ -157,7 +157,7 @@ var (
 		Code:         "MonApiUnauthenticatedErr",
 		Class:        Api,
 		Message:      "The current VM couldn't authenticate to the Monitoring API.",
-		Action:       "Verify that your credential files, scopes and permissions are setup correctly.",
+		Action:       "Verify that your credential files, scopes and permissions are set up correctly.",
 		ResourceLink: "https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/authorization",
 		IsFatal:      true,
 	}

--- a/internal/healthchecks/error.go
+++ b/internal/healthchecks/error.go
@@ -36,14 +36,8 @@ func (e HealthCheckError) Error() string {
 	return e.Message
 }
 
-type MultiHealthCheckError []HealthCheckError
-
-func (m MultiHealthCheckError) Error() string {
-	var message string
-	for _, e := range(m) {
-		message = message + " " + e.Error()
-	}
-	return message
+type MultiWrappedError interface {
+	Unwrap() []error
 }
 
 var (

--- a/internal/healthchecks/healthchecks.go
+++ b/internal/healthchecks/healthchecks.go
@@ -19,6 +19,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 var healthChecksLogFile = "health-checks.log"
@@ -45,15 +46,14 @@ func singleErrorResultMessage(e error, Name string) string {
 }
 
 func (r HealthCheckResult) String() string {
-	var message string
 	if mwErr, ok := r.Err.(MultiWrappedError); ok {
+		var messageList []string
 		for _, e := range mwErr.Unwrap() {
-			message = message + singleErrorResultMessage(e, r.Name) + "\n"
+			messageList = append(messageList, singleErrorResultMessage(e, r.Name))
 		}
-	} else {
-		message = singleErrorResultMessage(r.Err, r.Name)
+		return strings.Join(messageList, "\n")
 	}
-	return message
+	return singleErrorResultMessage(r.Err, r.Name)
 }
 
 type HealthCheckRegistry []HealthCheck

--- a/internal/healthchecks/healthchecks.go
+++ b/internal/healthchecks/healthchecks.go
@@ -39,7 +39,8 @@ func HealthCheckRegistryFactory() HealthCheckRegistry {
 	return HealthCheckRegistry{
 		PortsCheck{},
 		NetworkCheck{},
-		APICheck{},
+		LoggingAPICheck{},
+		MonitoringAPICheck{},
 	}
 }
 

--- a/internal/healthchecks/healthchecks.go
+++ b/internal/healthchecks/healthchecks.go
@@ -48,7 +48,7 @@ func (r HealthCheckResult) String() string {
 	var message string
 	if mwErr, ok := r.Err.(MultiWrappedError); ok {
 		for _, e := range mwErr.Unwrap() {
-			message = message + "\n" + singleErrorResultMessage(e, r.Name)
+			message = message + singleErrorResultMessage(e, r.Name) + "\n"
 		}
 	} else {
 		message = singleErrorResultMessage(r.Err, r.Name)

--- a/internal/healthchecks/healthchecks_test.go
+++ b/internal/healthchecks/healthchecks_test.go
@@ -96,7 +96,17 @@ func TestRunAllHealthChecks(t *testing.T) {
 
 	result := allHealthChecks.RunAllHealthChecks(testLogger)
 
-	assert.Check(t, strings.Contains(result[fCheck.Name()].Message, "Result: FAIL"))
-	assert.Check(t, strings.Contains(result[sCheck.Name()].Message, "Result: PASS"))
-	assert.Check(t, strings.Contains(result[eCheck.Name()].Message, "Result: ERROR"))
+	var expected string
+	for _, r := range result {
+		switch r.Name {
+		case "Error Check":
+			expected = "Result: ERROR"
+		case "Success Check":
+			expected = "Result: PASS"
+		case "Failure Check":
+			expected = "Result: FAIL"
+		}
+
+		assert.Check(t, strings.Contains(r.String(), expected))
+	}
 }

--- a/internal/healthchecks/ports_check.go
+++ b/internal/healthchecks/ports_check.go
@@ -15,6 +15,7 @@
 package healthchecks
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -50,15 +51,9 @@ func checkIfPortAvailable(host string, port string, network string) (bool, error
 }
 
 func (c PortsCheck) RunCheck(logger *log.Logger) error {
-	err := runFluentBitCheck(logger)
-	if err != nil {
-		return err
-	}
-	err = runOtelCollectorCheck(logger)
-	if err != nil {
-		return err
-	}
-	return nil
+	fbErr := runFluentBitCheck(logger)
+	otelErr := runOtelCollectorCheck(logger)
+	return errors.Join(fbErr, otelErr)
 }
 
 func runFluentBitCheck(logger *log.Logger) error {


### PR DESCRIPTION
## Description
- Handle multiple Health Check failures using `errros.Join()` and `Unwrap() []errors` from `Go 1.20`.
- Implemented `String()` for `HealthCheckResult` to generate result message on demand.
- Improve message when API responds with `UNAUTHENTICATED`.
- Report `Context Deadline Exceeded` from API as connection failure.
- Save resulting Health Checks log as `health-checks.txt` in Windows.

## Related issue
b/272305209 , b/272501350

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
