### PR TITLE
RabbitMQ add expected metrics in metadata

### DIFF
--- a/apps/rabbitmq.go
+++ b/apps/rabbitmq.go
@@ -143,6 +143,11 @@ func (r MetricsReceiverRabbitmq) Pipelines() []otel.ReceiverPipeline {
 			otel.MetricsTransform(
 				otel.AddPrefix("workload.googleapis.com"),
 			),
+			otel.TransformationMetrics(
+				otel.FlattenResourceAttribute("rabbitmq.queue.name", "queue_name"),
+				otel.FlattenResourceAttribute("rabbitmq.node.name", "node_name"),
+				otel.FlattenResourceAttribute("rabbitmq.vhost.name", "vhost_name"),
+			),
 			otel.ModifyInstrumentationScope(r.Type(), "1.0"),
 		}},
 	}}

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/otel.yaml
@@ -423,13 +423,20 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/rabbitmq_2:
+  modifyscope/rabbitmq_3:
     override_scope_name: agent.googleapis.com/rabbitmq
     override_scope_version: "1.0"
   normalizesums/rabbitmq_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/rabbitmq_2:
+    metric_statements:
+      context: datapoint
+      statements:
+      - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
+      - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])
+      - set(attributes["vhost_name"], resource.attributes["rabbitmq.vhost.name"])
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -505,7 +512,8 @@ service:
       processors:
       - normalizesums/rabbitmq_0
       - metricstransform/rabbitmq_1
-      - modifyscope/rabbitmq_2
+      - transform/rabbitmq_2
+      - modifyscope/rabbitmq_3
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/otel.yaml
@@ -423,13 +423,20 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/rabbitmq_2:
+  modifyscope/rabbitmq_3:
     override_scope_name: agent.googleapis.com/rabbitmq
     override_scope_version: "1.0"
   normalizesums/rabbitmq_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/rabbitmq_2:
+    metric_statements:
+      context: datapoint
+      statements:
+      - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
+      - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])
+      - set(attributes["vhost_name"], resource.attributes["rabbitmq.vhost.name"])
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -505,7 +512,8 @@ service:
       processors:
       - normalizesums/rabbitmq_0
       - metricstransform/rabbitmq_1
-      - modifyscope/rabbitmq_2
+      - transform/rabbitmq_2
+      - modifyscope/rabbitmq_3
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/otel.yaml
@@ -423,13 +423,20 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/rabbitmq_2:
+  modifyscope/rabbitmq_3:
     override_scope_name: agent.googleapis.com/rabbitmq
     override_scope_version: "1.0"
   normalizesums/rabbitmq_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/rabbitmq_2:
+    metric_statements:
+      context: datapoint
+      statements:
+      - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
+      - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])
+      - set(attributes["vhost_name"], resource.attributes["rabbitmq.vhost.name"])
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -506,7 +513,8 @@ service:
       processors:
       - normalizesums/rabbitmq_0
       - metricstransform/rabbitmq_1
-      - modifyscope/rabbitmq_2
+      - transform/rabbitmq_2
+      - modifyscope/rabbitmq_3
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/otel.yaml
@@ -423,13 +423,20 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/rabbitmq_2:
+  modifyscope/rabbitmq_3:
     override_scope_name: agent.googleapis.com/rabbitmq
     override_scope_version: "1.0"
   normalizesums/rabbitmq_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/rabbitmq_2:
+    metric_statements:
+      context: datapoint
+      statements:
+      - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
+      - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])
+      - set(attributes["vhost_name"], resource.attributes["rabbitmq.vhost.name"])
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -509,7 +516,8 @@ service:
       processors:
       - normalizesums/rabbitmq_0
       - metricstransform/rabbitmq_1
-      - modifyscope/rabbitmq_2
+      - transform/rabbitmq_2
+      - modifyscope/rabbitmq_3
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq

--- a/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
@@ -32,12 +32,20 @@ expected_metrics:
     value_type: INT64
     kind: GAUGE
     monitored_resource: gce_instance
+    labels:
+      node_name: .*
+      queue_name: .*
+      vhost_name: .*
+    representative: true
   - type: workload.googleapis.com/rabbitmq.message.current
     value_type: INT64
     kind: GAUGE
     monitored_resource: gce_instance
     labels:
       state: .*
+      node_name: .*
+      queue_name: .*
+      vhost_name: .*
     representative: true
 expected_logs:
   - log_name: rabbitmq

--- a/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
@@ -36,7 +36,6 @@ expected_metrics:
       node_name: .*
       queue_name: .*
       vhost_name: .*
-    representative: true
   - type: workload.googleapis.com/rabbitmq.message.current
     value_type: INT64
     kind: GAUGE

--- a/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
@@ -36,6 +36,38 @@ expected_metrics:
       node_name: .*
       queue_name: .*
       vhost_name: .*
+  - type: workload.googleapis.com/rabbitmq.message.delivered
+    value_type: INT64
+    kind: CUMULATIVE
+    monitored_resource: gce_instance
+    labels:
+      node_name: .*
+      queue_name: .*
+      vhost_name: .*
+  - type: workload.googleapis.com/rabbitmq.message.published
+    value_type: INT64
+    kind: CUMULATIVE
+    monitored_resource: gce_instance
+    labels:
+      node_name: .*
+      queue_name: .*
+      vhost_name: .*
+  - type: workload.googleapis.com/rabbitmq.message.acknowledged
+    value_type: INT64
+    kind: CUMULATIVE
+    monitored_resource: gce_instance
+    labels:
+      node_name: .*
+      queue_name: .*
+      vhost_name: .*
+  - type: workload.googleapis.com/rabbitmq.message.dropped
+    value_type: INT64
+    kind: CUMULATIVE
+    monitored_resource: gce_instance
+    labels:
+      node_name: .*
+      queue_name: .*
+      vhost_name: .*
   - type: workload.googleapis.com/rabbitmq.message.current
     value_type: INT64
     kind: GAUGE


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Opentelemetry has 6 metrics for [rabbitmqreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/rabbitmqreceiver/metadata.yaml#L26-L74):

Of which, only [2 are implemented](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml#L30-L41 ) in the ops agent metadata.yaml:
- rabbitmq.consumer.count
- rabbitmq.message.current

Expected metrics that should be added:
- rabbitmq.message.delivered
- rabbitmq.message.published
- rabbitmq.message.acknowledged
- rabbitmq.message.dropped

These metrics are not new to rabbitmq, but somehow got lost when creating the metadata. The [official documentation](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/rabbitmq#monitored-metrics) only shows 2 metrics as well. The [rabbitmq dashboard](https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/blob/master/dashboards/rabbitmq/rabbitmq-gce-overview.png) shows all 6 metrics.



## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
