### PR TITLE
dev-docs: Add `health-checks.log` file path to dev-docs.

### DIFF
--- a/dev-docs/dev.md
+++ b/dev-docs/dev.md
@@ -825,7 +825,7 @@ Buffer files - Fluent Bit                                                       
 Description                               | Link
 ----------------------------------------- | ----
 Config file - Ops Agent                   | `C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml`
-Logs - Health Checks                      | `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\heath-checks.log`
+Logs - Health Checks                      | `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\health-checks.log`
 Logs - Fluent Bit                         | `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\logging-module.log`
 Logs - OT Metrics Agent                   | In the `Event Viewer` app, click `Windows Logs` then `Application`, filter by `Source` equal to `Google Cloud Ops Agent - Metrics Agent`. This agent does not write logs directly to disk today.
 Config file - Fluent Bit - Main config    | `C:\ProgramData\Google\Cloud Operations\Ops Agent\generated_configs\fluentbit\fluent_bit_main.conf`

--- a/dev-docs/dev.md
+++ b/dev-docs/dev.md
@@ -810,6 +810,7 @@ ops-agent$ /google/bin/releases/opensource/thirdparty/cross/cross .
 Description                                                                                          | Link
 ---------------------------------------------------------------------------------------------------- | ----
 Config file - Ops Agent                                                                              | `/etc/google-cloud-ops-agent/config.yaml` (custom agent configurations)
+Logs - Health Checks                                                                                 | `/var/log/google-cloud-ops-agent/health-checks.log`
 Logs - Fluent Bit                                                                                    | `/var/log/google-cloud-ops-agent/subagents/logging-module.log`
 Logs - OT Metrics Agent                                                                              | `/var/log/syslog` or `/var/log/messages`. This agent does not write logs directly to disk today.
 Config file - Ops Agent (Debug)                                                                      | `/run/google-cloud-ops-agent-fluent-bit/conf/debug/` or `/run/google-cloud-ops-agent-opentelemetry-collector/conf/debug/`
@@ -824,6 +825,7 @@ Buffer files - Fluent Bit                                                       
 Description                               | Link
 ----------------------------------------- | ----
 Config file - Ops Agent                   | `C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml`
+Logs - Health Checks                      | `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\heath-checks.log`
 Logs - Fluent Bit                         | `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\logging-module.log`
 Logs - OT Metrics Agent                   | In the `Event Viewer` app, click `Windows Logs` then `Application`, filter by `Source` equal to `Google Cloud Ops Agent - Metrics Agent`. This agent does not write logs directly to disk today.
 Config file - Fluent Bit - Main config    | `C:\ProgramData\Google\Cloud Operations\Ops Agent\generated_configs\fluentbit\fluent_bit_main.conf`


### PR DESCRIPTION
## Description
Add `health-checks.log` file path to dev-docs.

## Related issue
b/262563192

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
