### PR TITLE
Testing: Fix logging error in 3p test

### DIFF
--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -944,7 +944,7 @@ func TestThirdPartyApps(t *testing.T) {
 
 				var retryable bool
 				retryable, err = runSingleTest(ctx, logger, vm, tc.app, tc.metadata)
-				log.Printf("Attempt %v of %s test of %s finished with err=%v, retryable=%v", attempt, tc.platform, tc.app, err, retryable)
+				t.Logf("Attempt %v of %s test of %s finished with err=%v, retryable=%v", attempt, tc.platform, tc.app, err, retryable)
 				if err == nil {
 					return
 				}


### PR DESCRIPTION
## Description

Recently I saw some more cases where logs ended up in the wrong expando in the XML. Example:

https://source.cloud.google.com/results/invocations/885c0763-2eaa-4ad1-84ea-ffa3c1387e78/targets/logs/tests;group=command-line-arguments;test=TestThirdPartyApps%2Fcentos-7%2Fapache;row=4

The offending logs look like:

```
{"Time":"2023-03-15T16:53:28.28203098Z","Action":"output","Package":"command-line-arguments","Test":"TestThirdPartyApps/centos-7/apache","Output":"2023/03/15 16:53:28 Attempt 1 of centos-7 test of cassandra finished with err=error installing cassandra: Command failed: cat - \u003e a815eb1e-59e7-4933-b718-f1603ae45cb1.sh \u0026\u0026 sudo bash -x a815eb1e-59e7-4933-b718-f1603ae45cb1.sh \n"}
```

In which apache and cassandra are mixed: cassandra logs are attributed to the apache expando.

I'm guessing that t.Logf will do the log attribution correctly, while log.Printf I guess is racy at times. I think log.Printf shows up even when you don't specify `-v` to `go test`, which is nice, but having everything in the right expandos is nicer.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
Automated tests should be sufficient.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
