### PR TITLE
Change access log pattern

### DIFF
--- a/apps/tomcat.go
+++ b/apps/tomcat.go
@@ -161,8 +161,8 @@ type AccessSystemLoggingReceiverTomcat struct {
 func (r AccessSystemLoggingReceiverTomcat) Components(tag string) []fluentbit.Component {
 	if len(r.IncludePaths) == 0 {
 		r.IncludePaths = []string{
-			"/opt/tomcat/logs/localhost_access_log.*.txt",
-			"/var/log/tomcat*/localhost_access_log.*.txt",
+			"/opt/tomcat/logs/localhost_access_log*.txt",
+			"/var/log/tomcat*/localhost_access_log*.txt",
 		}
 	}
 	c := r.LoggingReceiverFilesMixin.Components(tag)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_main.conf
@@ -40,7 +40,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              /opt/tomcat/logs/localhost_access_log.*.txt,/var/log/tomcat*/localhost_access_log.*.txt
+    Path              /opt/tomcat/logs/localhost_access_log*.txt,/var/log/tomcat*/localhost_access_log*.txt
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              /opt/tomcat/logs/localhost_access_log.*.txt,/var/log/tomcat*/localhost_access_log.*.txt
+    Path              /opt/tomcat/logs/localhost_access_log*.txt,/var/log/tomcat*/localhost_access_log*.txt
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/integration_test/third_party_apps_data/applications/tomcat/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/tomcat/metadata.yaml
@@ -184,7 +184,7 @@ configuration_options:
           default: null
           description: The value must be tomcat_access.
         - name: include_paths
-          default: '[/opt/tomcat/logs/localhost_access_log.*.txt]'
+          default: '[/opt/tomcat/logs/localhost_access_log*.txt]'
           description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
         - name: exclude_paths
           default: null


### PR DESCRIPTION
## Description
On SLES-15, the date is omitted from the filename -- it's just `localhost_access_log.txt`.

## Related issue
N/A, nightlies started failing

## How has this been tested?
Will let PR presubmits run

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
