### PR TITLE
Restructure test dockerfile to be mostly based on `google/cloud-sdk` 

### DIFF
--- a/kokoro/scripts/test/go_test.Dockerfile
+++ b/kokoro/scripts/test/go_test.Dockerfile
@@ -1,7 +1,10 @@
-FROM golang:1.20.1-bullseye
+FROM google/cloud-sdk:latest
 
-RUN curl -sSL https://sdk.cloud.google.com | bash
+RUN rm -rf /usr/local/go
 
-ENV PATH $PATH:/root/google-cloud-sdk/bin
+RUN curl -s https://dl.google.com/go/go1.20.linux-amd64.tar.gz | \
+  tar --directory /usr/local -xzf /dev/stdin
+
+ENV PATH $PATH:/usr/local/go/bin
 
 RUN go install -v github.com/jstemmer/go-junit-report/v2@latest


### PR DESCRIPTION
## Description

Turns out it's no faster:

with my PR:  2m5.544s
master:      1m53.617s

## Related issue

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
