### PR TITLE
Upgrade Go to 1.20.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,9 @@ RUN set -x; yum -y update && \
 SHELL ["/bin/bash", "-c"]
 
 # Install golang
-ADD https://golang.org/dl/go1.19.linux-amd64.tar.gz /tmp/go1.19.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.20.2.linux-amd64.tar.gz /tmp/go1.20.2.linux-amd64.tar.gz
 RUN set -xe; \
-    tar -xf /tmp/go1.19.linux-amd64.tar.gz -C /usr/local
+    tar -xf /tmp/go1.20.2.linux-amd64.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
 
@@ -132,9 +132,9 @@ RUN set -x; yum -y update && \
 SHELL ["/bin/bash", "-c"]
 
 # Install golang
-ADD https://golang.org/dl/go1.19.linux-amd64.tar.gz /tmp/go1.19.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.20.2.linux-amd64.tar.gz /tmp/go1.20.2.linux-amd64.tar.gz
 RUN set -xe; \
-    tar -xf /tmp/go1.19.linux-amd64.tar.gz -C /usr/local
+    tar -xf /tmp/go1.20.2.linux-amd64.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
 
@@ -225,9 +225,9 @@ RUN set -x; dnf -y update && \
 SHELL ["/bin/bash", "-c"]
 
 # Install golang
-ADD https://golang.org/dl/go1.19.linux-amd64.tar.gz /tmp/go1.19.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.20.2.linux-amd64.tar.gz /tmp/go1.20.2.linux-amd64.tar.gz
 RUN set -xe; \
-    tar -xf /tmp/go1.19.linux-amd64.tar.gz -C /usr/local
+    tar -xf /tmp/go1.20.2.linux-amd64.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
 
@@ -313,9 +313,9 @@ RUN set -x; apt-get update && \
 SHELL ["/bin/bash", "-c"]
 
 # Install golang
-ADD https://golang.org/dl/go1.19.linux-amd64.tar.gz /tmp/go1.19.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.20.2.linux-amd64.tar.gz /tmp/go1.20.2.linux-amd64.tar.gz
 RUN set -xe; \
-    tar -xf /tmp/go1.19.linux-amd64.tar.gz -C /usr/local
+    tar -xf /tmp/go1.20.2.linux-amd64.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
 
@@ -401,9 +401,9 @@ RUN set -x; apt-get update && \
 SHELL ["/bin/bash", "-c"]
 
 # Install golang
-ADD https://golang.org/dl/go1.19.linux-amd64.tar.gz /tmp/go1.19.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.20.2.linux-amd64.tar.gz /tmp/go1.20.2.linux-amd64.tar.gz
 RUN set -xe; \
-    tar -xf /tmp/go1.19.linux-amd64.tar.gz -C /usr/local
+    tar -xf /tmp/go1.20.2.linux-amd64.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
 
@@ -498,9 +498,9 @@ RUN set -x; \
 SHELL ["/bin/bash", "-c"]
 
 # Install golang
-ADD https://golang.org/dl/go1.19.linux-amd64.tar.gz /tmp/go1.19.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.20.2.linux-amd64.tar.gz /tmp/go1.20.2.linux-amd64.tar.gz
 RUN set -xe; \
-    tar -xf /tmp/go1.19.linux-amd64.tar.gz -C /usr/local
+    tar -xf /tmp/go1.20.2.linux-amd64.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
 
@@ -609,9 +609,9 @@ RUN set -x; \
 SHELL ["/bin/bash", "-c"]
 
 # Install golang
-ADD https://golang.org/dl/go1.19.linux-amd64.tar.gz /tmp/go1.19.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.20.2.linux-amd64.tar.gz /tmp/go1.20.2.linux-amd64.tar.gz
 RUN set -xe; \
-    tar -xf /tmp/go1.19.linux-amd64.tar.gz -C /usr/local
+    tar -xf /tmp/go1.20.2.linux-amd64.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
 
@@ -711,9 +711,9 @@ RUN set -x; zypper -n install git systemd autoconf automake flex libtool libcurl
 SHELL ["/bin/bash", "-c"]
 
 # Install golang
-ADD https://golang.org/dl/go1.19.linux-amd64.tar.gz /tmp/go1.19.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.20.2.linux-amd64.tar.gz /tmp/go1.20.2.linux-amd64.tar.gz
 RUN set -xe; \
-    tar -xf /tmp/go1.19.linux-amd64.tar.gz -C /usr/local
+    tar -xf /tmp/go1.20.2.linux-amd64.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
 
@@ -803,9 +803,9 @@ RUN set -x; apt-get update && \
 SHELL ["/bin/bash", "-c"]
 
 # Install golang
-ADD https://golang.org/dl/go1.19.linux-amd64.tar.gz /tmp/go1.19.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.20.2.linux-amd64.tar.gz /tmp/go1.20.2.linux-amd64.tar.gz
 RUN set -xe; \
-    tar -xf /tmp/go1.19.linux-amd64.tar.gz -C /usr/local
+    tar -xf /tmp/go1.20.2.linux-amd64.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
 
@@ -891,9 +891,9 @@ RUN set -x; apt-get update && \
 SHELL ["/bin/bash", "-c"]
 
 # Install golang
-ADD https://golang.org/dl/go1.19.linux-amd64.tar.gz /tmp/go1.19.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.20.2.linux-amd64.tar.gz /tmp/go1.20.2.linux-amd64.tar.gz
 RUN set -xe; \
-    tar -xf /tmp/go1.19.linux-amd64.tar.gz -C /usr/local
+    tar -xf /tmp/go1.20.2.linux-amd64.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
 
@@ -979,9 +979,9 @@ RUN set -x; apt-get update && \
 SHELL ["/bin/bash", "-c"]
 
 # Install golang
-ADD https://golang.org/dl/go1.19.linux-amd64.tar.gz /tmp/go1.19.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.20.2.linux-amd64.tar.gz /tmp/go1.20.2.linux-amd64.tar.gz
 RUN set -xe; \
-    tar -xf /tmp/go1.19.linux-amd64.tar.gz -C /usr/local
+    tar -xf /tmp/go1.20.2.linux-amd64.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -78,12 +78,12 @@ RUN Expand-Archive /local/win_flex_bison.zip -Destination /WinFlexBison; `
     Copy-Item -Path /WinFlexBison/win_flex.exe /WinFlexBison/flex.exe;
 
 #
-# Install Golang 1.19
+# Install Golang
 #
-ADD https://go.dev/dl/go1.19.windows-amd64.msi /local/go1.19.windows-amd64.msi
+ADD https://go.dev/dl/go1.20.2.windows-amd64.msi /local/go1.20.2.windows-amd64.msi
 
 RUN Start-Process msiexec.exe `
-    -ArgumentList '/i C:\local\go1.19.windows-amd64.msi ', '/quiet ', `
+    -ArgumentList '/i C:\local\go1.20.2.windows-amd64.msi ', '/quiet ', `
     '/norestart ', 'ALLUSERS=1,INSTALLDIR=C:\Go' -NoNewWindow -Wait;
 
 #

--- a/dev-docs/upgrade-go.md
+++ b/dev-docs/upgrade-go.md
@@ -1,0 +1,10 @@
+# Upgrade Go version
+
+To upgrade the version of Go that the Ops Agent uses:
+
+* Change the version of Go in `go.mod`
+* Ensuring that you are using the same version as the new one stated in `go.mod`, run `make test` and verify whether any code updates are required
+* Edit `dockerfiles/template` to download and extract the new version of Go
+* Run `make compile_dockerfile`
+* Run `make build` to locally ensure the new Dockerfile will build
+* Submit a PR with a title that clearly states the Go upgrade and ensure all CI workflows pass

--- a/dev-docs/upgrade-go.md
+++ b/dev-docs/upgrade-go.md
@@ -1,10 +1,15 @@
 # Upgrade Go version
 
-To upgrade the version of Go that the Ops Agent uses:
+To upgrade the version of Go that the Ops Agent uses, update the version in the following places:
 
-* Change the version of Go in `go.mod`
-* Ensuring that you are using the same version as the new one stated in `go.mod`, run `make test` and verify whether any code updates are required
-* Edit `dockerfiles/template` to download and extract the new version of Go
+* `go.mod` version restriction
+* `dockerfiles/template` which downloads and installs Go and is compiled into the main Dockerfile
+* `Dockerfile.windows` which downloads and runs the Go MSI
+
+Once you have updated the Go version in the following places, verify the new version works:
+
+* Ensure that your local Go version is the same as the new one in `go.mod` 
+* Run `make test` and verify whether any code updates are required
 * Run `make compile_dockerfile`
-* Run `make build` to locally ensure the new Dockerfile will build
-* Submit a PR with a title that clearly states the Go upgrade and ensure all CI workflows pass
+* Run `make build` to ensure the new Dockerfile will build
+* Submit a PR with a title that clearly states the Go upgrade and ensure all Build and Integration Test CI workflows pass

--- a/dockerfiles/template
+++ b/dockerfiles/template
@@ -9,9 +9,9 @@ FROM {from_image} AS {target_name}-build-base
 SHELL ["/bin/bash", "-c"]
 
 # Install golang
-ADD https://golang.org/dl/go1.19.linux-amd64.tar.gz /tmp/go1.19.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.20.2.linux-amd64.tar.gz /tmp/go1.20.2.linux-amd64.tar.gz
 RUN set -xe; \
-    tar -xf /tmp/go1.19.linux-amd64.tar.gz -C /usr/local
+    tar -xf /tmp/go1.20.2.linux-amd64.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/ops-agent
 
-go 1.19
+go 1.20
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.1

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -28,14 +28,13 @@ The following variables are optional:
 
 REPO_SUFFIX: If provided, what package repo suffix to install the ops agent from.
 ARTIFACT_REGISTRY_REGION: If provided, signals to the install scripts that the
-above REPO_SUFFIX is an artifact registry repo and specifies what region it
-is in. If not provided, that means that the packages are accessed through
-packages.cloud.google.com instead, which may point to Cloud Rapture or
-Artifact Registry under the hood.
-
+    above REPO_SUFFIX is an artifact registry repo and specifies what region it
+	is in. If not provided, that means that the packages are accessed through
+	packages.cloud.google.com instead, which may point to Cloud Rapture or
+	Artifact Registry under the hood.
 AGENT_PACKAGES_IN_GCS: If provided, a URL for a directory in GCS containing
-.deb/.rpm/.goo files to install on the testing VMs. Takes precedence over
-REPO_SUFFIX.
+    .deb/.rpm/.goo files to install on the testing VMs. Takes precedence over
+    REPO_SUFFIX.
 */
 package integration_test
 
@@ -260,7 +259,7 @@ func installOpsAgent(ctx context.Context, logger *logging.DirectoryLogger, vm *g
 	}
 
 	runInstallScript := func() error {
-		envVars := "REPO_SUFFIX=" + location.repoSuffix + " ARTIFACT_REGISTRY_REGION=" + location.artifactRegistryRegion
+		envVars := "REPO_SUFFIX="+location.repoSuffix+" ARTIFACT_REGISTRY_REGION="+location.artifactRegistryRegion
 		_, err := gce.RunRemotely(ctx, logger.ToMainLog(), vm, "", "sudo "+envVars+" bash -x add-google-cloud-ops-agent-repo.sh --also-install")
 		return err
 	}
@@ -3272,7 +3271,7 @@ func unmarshalResource(in string) (*resourcedetector.GCEResource, error) {
 // the PATH before calling `go` as goPath
 func installGolang(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.VM) error {
 	// TODO: use runtime.Version() to extract the go version
-	goVersion := "1.20"
+	goVersion := "1.19"
 	var installCmd string
 	if gce.IsWindows(vm.Platform) {
 		// TODO: host go windows installer in the GCS if `golang.org` throttle

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -28,16 +28,14 @@ The following variables are optional:
 
 REPO_SUFFIX: If provided, what package repo suffix to install the ops agent from.
 ARTIFACT_REGISTRY_REGION: If provided, signals to the install scripts that the
-
-	    above REPO_SUFFIX is an artifact registry repo and specifies what region it
-		is in. If not provided, that means that the packages are accessed through
-		packages.cloud.google.com instead, which may point to Cloud Rapture or
-		Artifact Registry under the hood.
+above REPO_SUFFIX is an artifact registry repo and specifies what region it
+is in. If not provided, that means that the packages are accessed through
+packages.cloud.google.com instead, which may point to Cloud Rapture or
+Artifact Registry under the hood.
 
 AGENT_PACKAGES_IN_GCS: If provided, a URL for a directory in GCS containing
-
-	.deb/.rpm/.goo files to install on the testing VMs. Takes precedence over
-	REPO_SUFFIX.
+.deb/.rpm/.goo files to install on the testing VMs. Takes precedence over
+REPO_SUFFIX.
 */
 package integration_test
 
@@ -52,7 +50,6 @@ import (
 	"os"
 	"path"
 	"regexp"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -3274,20 +3271,20 @@ func unmarshalResource(in string) (*resourcedetector.GCEResource, error) {
 // installGolang downloads and setup go, and return the required command to set
 // the PATH before calling `go` as goPath
 func installGolang(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.VM) error {
-	// Format: `go<version number>`
-	goVersion := runtime.Version()
+	// TODO: use runtime.Version() to extract the go version
+	goVersion := "1.20"
 	var installCmd string
 	if gce.IsWindows(vm.Platform) {
 		// TODO: host go windows installer in the GCS if `golang.org` throttle
 		installCmd = fmt.Sprintf(`
 			cd (New-TemporaryFile | %% { Remove-Item $_; New-Item -ItemType Directory -Path $_ })
-			Invoke-WebRequest "https://go.dev/dl/%s.windows-amd64.msi" -OutFile golang.msi
+			Invoke-WebRequest "https://go.dev/dl/go%s.windows-amd64.msi" -OutFile golang.msi
 			Start-Process msiexec.exe -ArgumentList "/i","golang.msi","/quiet" -Wait `, goVersion)
 	} else {
 		installCmd = fmt.Sprintf(`
 			set -e
 			gsutil cp \
-				"gs://stackdriver-test-143416-go-install/%s.linux-amd64.tar.gz" - | \
+				"gs://stackdriver-test-143416-go-install/go%s.linux-amd64.tar.gz" - | \
 				tar --directory /usr/local -xzf /dev/stdin`, goVersion)
 	}
 	_, err := gce.RunScriptRemotely(ctx, logger, vm, installCmd, nil, nil)

--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -152,7 +152,7 @@ func runScriptFromScriptsDir(ctx context.Context, logger *logging.DirectoryLogge
 // stored in the scripts directory.
 func installUsingScript(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.VM) (bool, error) {
 	environmentVariables := map[string]string{
-		"REPO_SUFFIX": os.Getenv("REPO_SUFFIX"),
+		"REPO_SUFFIX":              os.Getenv("REPO_SUFFIX"),
 		"ARTIFACT_REGISTRY_REGION": os.Getenv("ARTIFACT_REGISTRY_REGION"),
 	}
 	if _, err := runScriptFromScriptsDir(ctx, logger, vm, path.Join("agent", gce.PlatformKind(vm.Platform), "install"), environmentVariables); err != nil {
@@ -740,7 +740,7 @@ func determineImpactedApps(modifiedFiles []string, allApps map[string]metadata.I
 	for _, f := range modifiedFiles {
 		if isCriticalFile(f) {
 			// Consider all apps as impacted.
-			for app, _ := range allApps {
+			for app := range allApps {
 				impactedApps[app] = true
 			}
 			return impactedApps
@@ -758,7 +758,7 @@ func determineImpactedApps(modifiedFiles []string, allApps map[string]metadata.I
 			// in allApps to be a match if they have <f> as a prefix.
 			// For example, consider f = "mongodb". Then all of
 			// {mongodb3.6, mongodb} are considered impacted.
-			for app, _ := range allApps {
+			for app := range allApps {
 				if strings.HasPrefix(app, f) {
 					impactedApps[app] = true
 				}

--- a/tasks.mak
+++ b/tasks.mak
@@ -56,6 +56,9 @@ yaml_format:
 yaml_lint:
 	yamlfmt -lint
 
+compile_dockerfile:
+	go run ./dockerfiles
+
 ############
 # Unit Tests
 ############


### PR DESCRIPTION
## Description
This PR upgrades the version of Go required by the Ops Agent and updates build containers to install go1.20.2.

## Related issue
b/274799145

## How has this been tested?
Ran `make test` and `make build` after changing everything.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
