### PR TITLE
Testing: Make release builds use `go_test.sh`

### DIFF
--- a/kokoro/config/test/ops_agent/release/common.gcl
+++ b/kokoro/config/test/ops_agent/release/common.gcl
@@ -2,6 +2,9 @@ import '../common.gcl' as common
 
 template config ops_agent_test = common.ops_agent_test {
   params {
+    // TODO(subbarker): Migrate this to use go_test_for_containers.sh. 
+    build_file = 'unified_agents/kokoro/scripts/test/go_test.sh'
+
     environment {
       // The release builds run as a different service account.
       TRANSFERS_BUCKET = 'stackdriver-test-143416-file-transfers'

--- a/kokoro/config/test/third_party_apps/release/common.gcl
+++ b/kokoro/config/test/third_party_apps/release/common.gcl
@@ -2,6 +2,9 @@ import '../common.gcl' as common
 
 template config third_party_apps_test = common.third_party_apps_test {
   params {
+    // TODO(subbarker): Migrate this to use go_test_for_containers.sh. 
+    build_file = 'unified_agents/kokoro/scripts/test/go_test.sh'
+
     environment {
       // Disable -test.short mode when testing nightly releases.
       SHORT = null


### PR DESCRIPTION
## Description
This is to fix last night's failures, which were due to the release builds using the new script `go_test_for_containers.sh` with the old non-docker-based pool.

## Related issue
nightlies failed

## How has this been tested?
Not sure how to test this besides merging it and trying it out.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
