### PR TITLE
Extend waiting time for http server when testing prom metrics

### DIFF
--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -2629,7 +2629,7 @@ func testPrometheusMetrics(t *testing.T, testFiles map[string]fileToUpload, chec
 			t.Fatalf("failed to start the http server in VM via systemctl with err: %v, stderr: %s", err, setupOut.Stderr)
 		}
 		// Wait until the http server is ready
-		time.Sleep(10 * time.Second)
+		time.Sleep(20 * time.Second)
 		liveCheckOut, liveCheckErr := gce.RunRemotely(ctx, logger.ToMainLog(), vm, "", `curl "http://localhost:8000/data"`)
 		if liveCheckErr != nil || strings.Contains(liveCheckOut.Stderr, "Connection refused") {
 			t.Fatalf("Http server failed to start with stdout %s and stderr %s", liveCheckOut.Stdout, liveCheckOut.Stderr)

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -28,13 +28,16 @@ The following variables are optional:
 
 REPO_SUFFIX: If provided, what package repo suffix to install the ops agent from.
 ARTIFACT_REGISTRY_REGION: If provided, signals to the install scripts that the
-    above REPO_SUFFIX is an artifact registry repo and specifies what region it
-	is in. If not provided, that means that the packages are accessed through
-	packages.cloud.google.com instead, which may point to Cloud Rapture or
-	Artifact Registry under the hood.
+
+	    above REPO_SUFFIX is an artifact registry repo and specifies what region it
+		is in. If not provided, that means that the packages are accessed through
+		packages.cloud.google.com instead, which may point to Cloud Rapture or
+		Artifact Registry under the hood.
+
 AGENT_PACKAGES_IN_GCS: If provided, a URL for a directory in GCS containing
-    .deb/.rpm/.goo files to install on the testing VMs. Takes precedence over
-    REPO_SUFFIX.
+
+	.deb/.rpm/.goo files to install on the testing VMs. Takes precedence over
+	REPO_SUFFIX.
 */
 package integration_test
 
@@ -259,7 +262,7 @@ func installOpsAgent(ctx context.Context, logger *logging.DirectoryLogger, vm *g
 	}
 
 	runInstallScript := func() error {
-		envVars := "REPO_SUFFIX="+location.repoSuffix+" ARTIFACT_REGISTRY_REGION="+location.artifactRegistryRegion
+		envVars := "REPO_SUFFIX=" + location.repoSuffix + " ARTIFACT_REGISTRY_REGION=" + location.artifactRegistryRegion
 		_, err := gce.RunRemotely(ctx, logger.ToMainLog(), vm, "", "sudo "+envVars+" bash -x add-google-cloud-ops-agent-repo.sh --also-install")
 		return err
 	}
@@ -2626,7 +2629,7 @@ func testPrometheusMetrics(t *testing.T, testFiles map[string]fileToUpload, chec
 			t.Fatalf("failed to start the http server in VM via systemctl with err: %v, stderr: %s", err, setupOut.Stderr)
 		}
 		// Wait until the http server is ready
-		time.Sleep(5 * time.Second)
+		time.Sleep(10 * time.Second)
 		liveCheckOut, liveCheckErr := gce.RunRemotely(ctx, logger.ToMainLog(), vm, "", `curl "http://localhost:8000/data"`)
 		if liveCheckErr != nil || strings.Contains(liveCheckOut.Stderr, "Connection refused") {
 			t.Fatalf("Http server failed to start with stdout %s and stderr %s", liveCheckOut.Stdout, liveCheckOut.Stderr)
@@ -3271,7 +3274,7 @@ func unmarshalResource(in string) (*resourcedetector.GCEResource, error) {
 // the PATH before calling `go` as goPath
 func installGolang(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.VM) error {
 	// TODO: use runtime.Version() to extract the go version
-	goVersion := "1.19"
+	goVersion := "1.20"
 	var installCmd string
 	if gce.IsWindows(vm.Platform) {
 		// TODO: host go windows installer in the GCS if `golang.org` throttle


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
