### PR TITLE
Bump RabbitMQ minimum supported metrics agent version 

### DIFF
--- a/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
@@ -23,7 +23,7 @@ description: |-
   RabbitMQ logs and parses them into a JSON payload. The result includes process
   ID, level, and message.
 minimum_supported_agent_version:
-  metrics: 2.11.0
+  metrics: 2.29.0
   logging: 2.12.0
 supported_operating_systems: linux
 platforms_to_skip:


### PR DESCRIPTION
## Description
Bump RabbitMQ minimum supported metrics agent version since new labels introduced from 2.29.0

## Related issue
b/275399738

## How has this been tested?
N/A

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
