### PR TITLE
Add hard timeout for SSH pokes during VM init

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -156,6 +156,7 @@ const (
 
 	vmInitTimeout                     = 20 * time.Minute
 	vmInitBackoffDuration             = 10 * time.Second
+	vmInitPokeSSHTimeout              = 30 * time.Second
 	vmWinPasswordResetBackoffDuration = 30 * time.Second
 
 	slesStartupDelay           = 60 * time.Second
@@ -1562,6 +1563,8 @@ func waitForStartWindows(ctx context.Context, logger *log.Logger, vm *VM) error 
 	attempt := 0
 	printFoo := func() error {
 		attempt++
+		ctx, cancel := context.WithTimeout(ctx, vmInitPokeSSHTimeout)
+		defer cancel()
 		output, err := RunRemotely(ctx, logger, vm, "", "'foo'")
 		logger.Printf("Printing 'foo' finished with err=%v, attempt #%d\noutput: %v",
 			err, attempt, output)
@@ -1596,6 +1599,8 @@ func waitForStartLinux(ctx context.Context, logger *log.Logger, vm *VM) error {
 	// * b/180518814 (ubuntu, sles)
 	// * b/148612123 (sles)
 	isStartupDone := func() error {
+		ctx, cancel := context.WithTimeout(ctx, vmInitPokeSSHTimeout)
+		defer cancel()
 		output, err := RunRemotely(ctx, logger, vm, "", "systemctl is-system-running")
 
 		// There are a few cases for what is-system-running returns:


### PR DESCRIPTION
## Description
The SSH pokes have been observed to occasionally hang; for example, https://fusion2.corp.google.com/invocations/9d3ddf25-3506-4763-aa66-0b1d5db9f296/targets.

## Related issue
N/A

## How has this been tested?
Will let presubmits run

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
