### PR TITLE
Update common.gcl to use go_test_for_containers again

### DIFF
--- a/kokoro/config/test/ops_agent/release/common.gcl
+++ b/kokoro/config/test/ops_agent/release/common.gcl
@@ -2,9 +2,6 @@ import '../common.gcl' as common
 
 template config ops_agent_test = common.ops_agent_test {
   params {
-    // TODO(subbarker): Migrate this to use go_test_for_containers.sh. 
-    build_file = 'unified_agents/kokoro/scripts/test/go_test.sh'
-
     environment {
       // The release builds run as a different service account.
       TRANSFERS_BUCKET = 'stackdriver-test-143416-file-transfers'

--- a/kokoro/config/test/third_party_apps/release/common.gcl
+++ b/kokoro/config/test/third_party_apps/release/common.gcl
@@ -3,7 +3,7 @@ import '../common.gcl' as common
 template config third_party_apps_test = common.third_party_apps_test {
   params {
     // TODO(subbarker): Migrate this to use go_test_for_containers.sh. 
-    build_file = 'unified_agents/kokoro/scripts/test/go_test.sh'
+    build_file = 'unified_agents/kokoro/scripts/test/go_test_for_containers.sh'
 
     environment {
       // Disable -test.short mode when testing nightly releases.

--- a/kokoro/config/test/third_party_apps/release/common.gcl
+++ b/kokoro/config/test/third_party_apps/release/common.gcl
@@ -2,9 +2,6 @@ import '../common.gcl' as common
 
 template config third_party_apps_test = common.third_party_apps_test {
   params {
-    // TODO(subbarker): Migrate this to use go_test_for_containers.sh. 
-    build_file = 'unified_agents/kokoro/scripts/test/go_test_for_containers.sh'
-
     environment {
       // Disable -test.short mode when testing nightly releases.
       SHORT = null


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
A release pool has been created for docker jobs

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
