### PR TITLE
Template files to easily create new distros

### DIFF
--- a/kokoro/config/build/presubmit/template.gcl.tmpl
+++ b/kokoro/config/build/presubmit/template.gcl.tmpl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = '{{.Codename}}'
+      PKGFORMAT = '{{.PackageFormat}}'
+    }
+  }
+}

--- a/kokoro/config/test/ops_agent/release/template.gcl.tmpl
+++ b/kokoro/config/test/ops_agent/release/template.gcl.tmpl
@@ -3,6 +3,6 @@ import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.{{.Family}}.distros.{{.Codename}}.release
+    platforms = image_lists.{{.Codename}}.release
   }
 }

--- a/kokoro/config/test/ops_agent/release/template.gcl.tmpl
+++ b/kokoro/config/test/ops_agent/release/template.gcl.tmpl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.{{.Family}}.distros.{{.Codename}}.release
+  }
+}

--- a/kokoro/config/test/ops_agent/template.gcl.tmpl
+++ b/kokoro/config/test/ops_agent/template.gcl.tmpl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.{{.Family}}.distros.{{.Codename}}.presubmit
+  }
+}

--- a/kokoro/config/test/ops_agent/template.gcl.tmpl
+++ b/kokoro/config/test/ops_agent/template.gcl.tmpl
@@ -3,6 +3,6 @@ import '../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.{{.Family}}.distros.{{.Codename}}.presubmit
+    platforms = image_lists.{{.Codename}}.presubmit
   }
 }

--- a/kokoro/config/test/third_party_apps/release/template.gcl.tmpl
+++ b/kokoro/config/test/third_party_apps/release/template.gcl.tmpl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = [{{range .ThirdPartyTestPlatforms}}
+      '{{.}}',{{end}}
+    ]
+  }
+}

--- a/kokoro/config/test/third_party_apps/template.gcl.tmpl
+++ b/kokoro/config/test/third_party_apps/template.gcl.tmpl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = [{{range .ThirdPartyTestPlatforms}}
+      '{{.}}',{{end}}
+    ]
+  }
+}


### PR DESCRIPTION
## Description
Add some new template files, used in a tool stored in Piper to stamp out new .gcl files for new distros.

A follow up PR will get rid of .Family thanks to https://github.com/GoogleCloudPlatform/ops-agent/pull/1192.

## Related issue
b/267226998

## How has this been tested?
Not tested yet

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
