### PR TITLE
Simplify image_lists.gcl by removing its unnecessary bundling into distro families

### DIFF
--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -1,8 +1,7 @@
-// These are the shared lists of test images organized by distro family and
+// These are the shared lists of test images organized by distro and
 // grouped by the most fine-grained build artifact (in this case, the
 // per-distro Ops Agent package).
 
-// A representation of a test distro.
 local template _distro {
   // List of release images.
   release = external
@@ -24,73 +23,73 @@ bullseye = _distro {
 }
 bionic = _distro {
   release = [
-  'ubuntu-1804-lts',
-  'ubuntu-minimal-1804-lts',
+    'ubuntu-1804-lts',
+    'ubuntu-minimal-1804-lts',
   ]
   presubmit = ['ubuntu-1804-lts']
 }
 focal = _distro {
   release = [
-  'ubuntu-2004-lts',
-  'ubuntu-minimal-2004-lts',
+    'ubuntu-2004-lts',
+    'ubuntu-minimal-2004-lts',
   ]
   presubmit = ['ubuntu-minimal-2004-lts']
 }
 jammy = _distro {
   release = [
-  'ubuntu-2204-lts',
-  'ubuntu-minimal-2204-lts',
+    'ubuntu-2204-lts',
+    'ubuntu-minimal-2204-lts',
   ]
 }
 
 // RPM Linux distros.
 centos7 = _distro {
   release = [
-  // CentOS.
-  'centos-7',
-  // RHEL.
-  'rhel-7',
-  'rhel-7-7-sap-ha',
-  'rhel-7-9-sap-ha',
+    // CentOS.
+    'centos-7',
+    // RHEL.
+    'rhel-7',
+    'rhel-7-7-sap-ha',
+    'rhel-7-9-sap-ha',
   ]
   presubmit = ['centos-7']
 }
 centos8 = _distro {
   release = [
-  // RHEL.
-  'rhel-8',
-  'rhel-8-1-sap-ha',
-  'rhel-8-2-sap-ha',
-  'rhel-8-4-sap-ha',
-  'rhel-8-6-sap-ha',
-  // Rocky.
-  'rocky-linux-8',
+    // RHEL.
+    'rhel-8',
+    'rhel-8-1-sap-ha',
+    'rhel-8-2-sap-ha',
+    'rhel-8-4-sap-ha',
+    'rhel-8-6-sap-ha',
+    // Rocky.
+    'rocky-linux-8',
   ]
   presubmit = ['rocky-linux-8']
 }
 rockylinux9 = _distro {
   release = [
-  // RHEL.
-  'rhel-9',
-  // Rocky.
-  'rocky-linux-9',
+    // RHEL.
+    'rhel-9',
+    // Rocky.
+    'rocky-linux-9',
   ]
   presubmit = ['rocky-linux-9']
 }
 sles12 = _distro {
   release = [
-  'sles-12',
-  'sles-12-sp5-sap',
+    'sles-12',
+    'sles-12-sp5-sap',
   ]
   presubmit = ['sles-12']
 }
 sles15 = _distro {
   release = [
-  'sles-15',
-  'sles-15-sp1-sap',
-  'sles-15-sp2-sap',
-  'opensuse-leap',
-  'opensuse-leap-15-4',
+    'sles-15',
+    'sles-15-sp1-sap',
+    'sles-15-sp2-sap',
+    'opensuse-leap',
+    'opensuse-leap-15-4',
   ]
   presubmit = ['sles-15']
 }

--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -13,131 +13,103 @@ local template _distro {
   presubmit = []
 }
 
-local template _family {
-  distros = external
-  // Extract the release image lists for all distros in a given family.
-  releases = sort_asc(flatten(map(lambda d_: d_.release, distros.values())))
-  // Extract the presubmit images for all distros in a given family.
-  presubmits = sort_asc(flatten(map(lambda d_: d_.presubmit, distros.values())))
-}
-
 // DEB Linux distros.
-debian = _family {
-  distros = {
-    buster = _distro {
-      release = ['debian-10']
-      presubmit = ['debian-10']
-    }
-    bullseye = _distro {
-      release = ['debian-11']
-      presubmit = ['debian-11']
-    }
-  }
+buster = _distro {
+  release = ['debian-10']
+  presubmit = ['debian-10']
 }
-ubuntu = _family {
-  distros = {
-    bionic = _distro {
-      release = [
-        'ubuntu-1804-lts',
-        'ubuntu-minimal-1804-lts',
-      ]
-      presubmit = ['ubuntu-1804-lts']
-    }
-    focal = _distro {
-      release = [
-        'ubuntu-2004-lts',
-        'ubuntu-minimal-2004-lts',
-      ]
-      presubmit = ['ubuntu-minimal-2004-lts']
-    }
-    jammy = _distro {
-      release = [
-        'ubuntu-2204-lts',
-        'ubuntu-minimal-2204-lts',
-      ]
-    }
-  }
+bullseye = _distro {
+  release = ['debian-11']
+  presubmit = ['debian-11']
+}
+bionic = _distro {
+  release = [
+  'ubuntu-1804-lts',
+  'ubuntu-minimal-1804-lts',
+  ]
+  presubmit = ['ubuntu-1804-lts']
+}
+focal = _distro {
+  release = [
+  'ubuntu-2004-lts',
+  'ubuntu-minimal-2004-lts',
+  ]
+  presubmit = ['ubuntu-minimal-2004-lts']
+}
+jammy = _distro {
+  release = [
+  'ubuntu-2204-lts',
+  'ubuntu-minimal-2204-lts',
+  ]
 }
 
 // RPM Linux distros.
-centos = _family {
-  distros = {
-    centos7 = _distro {
-      release = [
-        // CentOS.
-        'centos-7',
-        // RHEL.
-        'rhel-7',
-        'rhel-7-7-sap-ha',
-        'rhel-7-9-sap-ha',
-      ]
-      presubmit = ['centos-7']
-    }
-    centos8 = _distro {
-      release = [
-        // RHEL.
-        'rhel-8',
-        'rhel-8-1-sap-ha',
-        'rhel-8-2-sap-ha',
-        'rhel-8-4-sap-ha',
-        'rhel-8-6-sap-ha',
-        // Rocky.
-        'rocky-linux-8',
-      ]
-      presubmit = ['rocky-linux-8']
-    }
-    rockylinux9 = _distro {
-      release = [
-        // RHEL.
-        'rhel-9',
-        // Rocky.
-        'rocky-linux-9',
-      ]
-      presubmit = ['rocky-linux-9']
-    }
-  }
+centos7 = _distro {
+  release = [
+  // CentOS.
+  'centos-7',
+  // RHEL.
+  'rhel-7',
+  'rhel-7-7-sap-ha',
+  'rhel-7-9-sap-ha',
+  ]
+  presubmit = ['centos-7']
 }
-sles = _family {
-  distros = {
-    sles12 = _distro {
-      release = [
-        'sles-12',
-        'sles-12-sp5-sap',
-      ]
-      presubmit = ['sles-12']
-    }
-    sles15 = _distro {
-      release = [
-        'sles-15',
-        'sles-15-sp1-sap',
-        'sles-15-sp2-sap',
-        'opensuse-leap',
-        'opensuse-leap-15-4',
-      ]
-      presubmit = ['sles-15']
-    }
-  }
+centos8 = _distro {
+  release = [
+  // RHEL.
+  'rhel-8',
+  'rhel-8-1-sap-ha',
+  'rhel-8-2-sap-ha',
+  'rhel-8-4-sap-ha',
+  'rhel-8-6-sap-ha',
+  // Rocky.
+  'rocky-linux-8',
+  ]
+  presubmit = ['rocky-linux-8']
+}
+rockylinux9 = _distro {
+  release = [
+  // RHEL.
+  'rhel-9',
+  // Rocky.
+  'rocky-linux-9',
+  ]
+  presubmit = ['rocky-linux-9']
+}
+sles12 = _distro {
+  release = [
+  'sles-12',
+  'sles-12-sp5-sap',
+  ]
+  presubmit = ['sles-12']
+}
+sles15 = _distro {
+  release = [
+  'sles-15',
+  'sles-15-sp1-sap',
+  'sles-15-sp2-sap',
+  'opensuse-leap',
+  'opensuse-leap-15-4',
+  ]
+  presubmit = ['sles-15']
 }
 
 // Windows distros.
-windows = _family {
-  distros = {
-    windows = _distro {
-      release = [
-        'windows-2012-r2',
-        'windows-2012-r2-core',
-        'windows-2016',
-        'windows-2016-core',
-        'windows-2019',
-        'windows-2019-core',
-        'windows-2022',
-        'windows-2022-core',
-      ]
-      presubmit = [
-        'windows-2012-r2',
-        // TODO(martijnvs): Switch this to windows-20h2-core.
-        'windows-2019',
-      ]
-    }
-  }
+windows = _distro {
+  release = [
+    'windows-2012-r2',
+    'windows-2012-r2-core',
+    'windows-2016',
+    'windows-2016-core',
+    'windows-2019',
+    'windows-2019-core',
+    'windows-2022',
+    'windows-2022-core',
+  ]
+  presubmit = [
+    'windows-2012-r2',
+    // TODO(martijnvs): Switch this to windows-20h2-core.
+    'windows-2019',
+  ]
 }

--- a/kokoro/config/test/ops_agent/bullseye.gcl
+++ b/kokoro/config/test/ops_agent/bullseye.gcl
@@ -3,6 +3,6 @@ import '../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.debian.distros.bullseye.presubmit
+    platforms = image_lists.bullseye.presubmit
   }
 }

--- a/kokoro/config/test/ops_agent/bullseye_in_container.gcl
+++ b/kokoro/config/test/ops_agent/bullseye_in_container.gcl
@@ -3,7 +3,7 @@ import '../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.debian.distros.bullseye.presubmit
+    platforms = image_lists.bullseye.presubmit
     build_file = 'unified_agents/kokoro/scripts/test/go_test_for_containers.sh'
   }
 }

--- a/kokoro/config/test/ops_agent/buster.gcl
+++ b/kokoro/config/test/ops_agent/buster.gcl
@@ -3,6 +3,6 @@ import '../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.debian.distros.buster.presubmit
+    platforms = image_lists.buster.presubmit
   }
 }

--- a/kokoro/config/test/ops_agent/centos7.gcl
+++ b/kokoro/config/test/ops_agent/centos7.gcl
@@ -3,6 +3,6 @@ import '../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.centos.distros.centos7.presubmit
+    platforms = image_lists.centos7.presubmit
   }
 }

--- a/kokoro/config/test/ops_agent/focal.gcl
+++ b/kokoro/config/test/ops_agent/focal.gcl
@@ -3,6 +3,6 @@ import '../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.ubuntu.distros.focal.presubmit
+    platforms = image_lists.focal.presubmit
   }
 }

--- a/kokoro/config/test/ops_agent/release/bionic.gcl
+++ b/kokoro/config/test/ops_agent/release/bionic.gcl
@@ -3,6 +3,6 @@ import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.ubuntu.distros.bionic.release
+    platforms = image_lists.bionic.release
   }
 }

--- a/kokoro/config/test/ops_agent/release/bullseye.gcl
+++ b/kokoro/config/test/ops_agent/release/bullseye.gcl
@@ -3,6 +3,6 @@ import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.debian.distros.bullseye.release
+    platforms = image_lists.bullseye.release
   }
 }

--- a/kokoro/config/test/ops_agent/release/buster.gcl
+++ b/kokoro/config/test/ops_agent/release/buster.gcl
@@ -3,6 +3,6 @@ import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.debian.distros.buster.release
+    platforms = image_lists.buster.release
   }
 }

--- a/kokoro/config/test/ops_agent/release/centos7.gcl
+++ b/kokoro/config/test/ops_agent/release/centos7.gcl
@@ -3,6 +3,6 @@ import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.centos.distros.centos7.release
+    platforms = image_lists.centos7.release
   }
 }

--- a/kokoro/config/test/ops_agent/release/centos8.gcl
+++ b/kokoro/config/test/ops_agent/release/centos8.gcl
@@ -3,6 +3,6 @@ import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.centos.distros.centos8.release
+    platforms = image_lists.centos8.release
   }
 }

--- a/kokoro/config/test/ops_agent/release/focal.gcl
+++ b/kokoro/config/test/ops_agent/release/focal.gcl
@@ -3,6 +3,6 @@ import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.ubuntu.distros.focal.release
+    platforms = image_lists.focal.release
   }
 }

--- a/kokoro/config/test/ops_agent/release/jammy.gcl
+++ b/kokoro/config/test/ops_agent/release/jammy.gcl
@@ -3,6 +3,6 @@ import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.ubuntu.distros.jammy.release
+    platforms = image_lists.jammy.release
   }
 }

--- a/kokoro/config/test/ops_agent/release/rockylinux9.gcl
+++ b/kokoro/config/test/ops_agent/release/rockylinux9.gcl
@@ -3,6 +3,6 @@ import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.centos.distros.rockylinux9.release
+    platforms = image_lists.rockylinux9.release
   }
 }

--- a/kokoro/config/test/ops_agent/release/sles12.gcl
+++ b/kokoro/config/test/ops_agent/release/sles12.gcl
@@ -3,6 +3,6 @@ import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.sles.distros.sles12.release
+    platforms = image_lists.sles12.release
   }
 }

--- a/kokoro/config/test/ops_agent/release/sles15.gcl
+++ b/kokoro/config/test/ops_agent/release/sles15.gcl
@@ -3,6 +3,6 @@ import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.sles.distros.sles15.release
+    platforms = image_lists.sles15.release
   }
 }

--- a/kokoro/config/test/ops_agent/release/windows.gcl
+++ b/kokoro/config/test/ops_agent/release/windows.gcl
@@ -3,6 +3,6 @@ import '../../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.windows.distros.windows.release
+    platforms = image_lists.windows.release
   }
 }

--- a/kokoro/config/test/ops_agent/rockylinux8.gcl
+++ b/kokoro/config/test/ops_agent/rockylinux8.gcl
@@ -4,6 +4,6 @@ import '../image_lists.gcl' as image_lists
 config build = common.ops_agent_test {
   params {
     // "centos8.presubmit" resolves to "rocky-linux-8".
-    platforms = image_lists.centos.distros.centos8.presubmit
+    platforms = image_lists.centos8.presubmit
   }
 }

--- a/kokoro/config/test/ops_agent/rockylinux9.gcl
+++ b/kokoro/config/test/ops_agent/rockylinux9.gcl
@@ -3,6 +3,6 @@ import '../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.centos.distros.rockylinux9.presubmit
+    platforms = image_lists.rockylinux9.presubmit
   }
 }

--- a/kokoro/config/test/ops_agent/sles12.gcl
+++ b/kokoro/config/test/ops_agent/sles12.gcl
@@ -3,6 +3,6 @@ import '../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.sles.distros.sles12.presubmit
+    platforms = image_lists.sles12.presubmit
   }
 }

--- a/kokoro/config/test/ops_agent/sles15.gcl
+++ b/kokoro/config/test/ops_agent/sles15.gcl
@@ -3,6 +3,6 @@ import '../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.sles.distros.sles15.presubmit
+    platforms = image_lists.sles15.presubmit
   }
 }

--- a/kokoro/config/test/ops_agent/windows.gcl
+++ b/kokoro/config/test/ops_agent/windows.gcl
@@ -3,6 +3,6 @@ import '../image_lists.gcl' as image_lists
 
 config build = common.ops_agent_test {
   params {
-    platforms = image_lists.windows.distros.windows.presubmit
+    platforms = image_lists.windows.presubmit
   }
 }


### PR DESCRIPTION
## Description
In addition to being nice just because it's simpler, this will also simplify https://github.com/GoogleCloudPlatform/ops-agent/pull/1191 and the tool for generating these files because it won't need to take in a special parameter "debian"/"ubuntu"/"centos"/"sles"/"windows" just for this.

## Related issue
b/267226998

## How has this been tested?
automated tests should be sufficient.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.