### PR TITLE
Revert "Update common.gcl to use go_test_for_containers again"

### DIFF
--- a/kokoro/config/test/ops_agent/release/common.gcl
+++ b/kokoro/config/test/ops_agent/release/common.gcl
@@ -2,6 +2,9 @@ import '../common.gcl' as common
 
 template config ops_agent_test = common.ops_agent_test {
   params {
+    // TODO(subbarker): Migrate this to use go_test_for_containers.sh. 
+    build_file = 'unified_agents/kokoro/scripts/test/go_test.sh'
+
     environment {
       // The release builds run as a different service account.
       TRANSFERS_BUCKET = 'stackdriver-test-143416-file-transfers'

--- a/kokoro/config/test/third_party_apps/release/common.gcl
+++ b/kokoro/config/test/third_party_apps/release/common.gcl
@@ -2,6 +2,9 @@ import '../common.gcl' as common
 
 template config third_party_apps_test = common.third_party_apps_test {
   params {
+    // TODO(subbarker): Migrate this to use go_test_for_containers.sh. 
+    build_file = 'unified_agents/kokoro/scripts/test/go_test.sh'
+
     environment {
       // Disable -test.short mode when testing nightly releases.
       SHORT = null


### PR DESCRIPTION
Reverts GoogleCloudPlatform/ops-agent#1189