### PR TITLE
Add comment warning to image_lists.gcl

### DIFF
--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -12,7 +12,7 @@ local template _distro {
   presubmit = []
 }
 
-// DEB Linux distros.
+// DEB Linux distros. (Do not modify this comment.)
 buster = _distro {
   release = ['debian-10']
   presubmit = ['debian-10']
@@ -42,7 +42,7 @@ jammy = _distro {
   ]
 }
 
-// RPM Linux distros.
+// RPM Linux distros. (Do not modify this comment.)
 centos7 = _distro {
   release = [
     // CentOS.


### PR DESCRIPTION
## Description
These comments are needed by a tool called make_ops_agent_changes.go that lives in Piper. It needs to know where in the file to insert new distros, and it does this by finding these particular comments and inserting content afterwards.

## Related issue
b/267226998

## How has this been tested?
no testing needed really

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
