### PR TITLE
Disallow zero for log rotation's backup_count parameter

### DIFF
--- a/confgenerator/config_global.go
+++ b/confgenerator/config_global.go
@@ -21,7 +21,7 @@ type Global struct {
 type LogFileRotation struct {
 	Enabled     *bool `yaml:"enabled"`
 	MaxFileSize *int  `yaml:"max_file_size_megabytes" validate:"omitempty,gte=1"`
-	BackupCount *int  `yaml:"backup_count" validate:"omitempty,gte=0"`
+	BackupCount *int  `yaml:"backup_count" validate:"omitempty,gte=1"`
 }
 
 // Get whether log rotation should be enabled. Defaults to true if unset.

--- a/confgenerator/testdata/invalid/linux/global-default-log-rotation_zero_backup/golden/error
+++ b/confgenerator/testdata/invalid/linux/global-default-log-rotation_zero_backup/golden/error
@@ -1,0 +1,5 @@
+[3:19] Key: 'LogFileRotation.backup_count' Error:Field validation for 'backup_count' failed on the 'gte' tag
+   1 | global:
+   2 |   default_self_log_file_rotation:
+>  3 |     backup_count: 0
+                         ^

--- a/confgenerator/testdata/invalid/linux/global-default-log-rotation_zero_backup/input.yaml
+++ b/confgenerator/testdata/invalid/linux/global-default-log-rotation_zero_backup/input.yaml
@@ -1,0 +1,3 @@
+global:
+  default_self_log_file_rotation:
+    backup_count: 0


### PR DESCRIPTION
## Description
This is a follow up to https://github.com/GoogleCloudPlatform/ops-agent/pull/1102. If 0 is passed in to lumberjack for the BackupCount, lumberjack will not limit the number of backup log files. This is counter-intuitive so for now lets disallow 0

## Related issue
[b/203811937](http://b/203811937)

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
