### PR TITLE
healthchecks: Improve Health Check result messages.

### DIFF
--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -3650,7 +3650,7 @@ func isHealthCheckTestPlatform(platform string) bool {
 }
 
 func healthCheckResultMessage(name string, result string) string {
-	return fmt.Sprintf("%s Check - Result: %s", name, result)
+	return fmt.Sprintf("[%s Check] Result: %s", name, result)
 }
 
 func getRecentServiceOutputForPlatform(platform string) string {

--- a/internal/healthchecks/error.go
+++ b/internal/healthchecks/error.go
@@ -152,7 +152,7 @@ var (
 		Code:         "LogApiUnauthenticatedErr",
 		Class:        Api,
 		Message:      "The current VM couldn't authenticate to the Logging API.",
-		Action:       "Verify that your credential files, scopes and permissions are set up correctly.",
+		Action:       "Verify that your credential files, VM access scopes and permissions are set up correctly.",
 		ResourceLink: "https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/authorization",
 		IsFatal:      true,
 	}
@@ -160,7 +160,7 @@ var (
 		Code:         "MonApiUnauthenticatedErr",
 		Class:        Api,
 		Message:      "The current VM couldn't authenticate to the Monitoring API.",
-		Action:       "Verify that your credential files, scopes and permissions are set up correctly.",
+		Action:       "Verify that your credential files, VM access scopes and permissions are set up correctly.",
 		ResourceLink: "https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/authorization",
 		IsFatal:      true,
 	}

--- a/internal/healthchecks/healthchecks.go
+++ b/internal/healthchecks/healthchecks.go
@@ -96,9 +96,7 @@ func (r HealthCheckRegistry) RunAllHealthChecks(logger *log.Logger) []HealthChec
 	var result []HealthCheckResult
 
 	for _, c := range r {
-		err := c.RunCheck(logger)
-
-		r := HealthCheckResult{Name: c.Name(), Err: err}
+		r := HealthCheckResult{Name: c.Name(), Err: c.RunCheck(logger)}
 		logger.Println(r)
 		result = append(result, r)
 	}

--- a/internal/healthchecks/healthchecks_test.go
+++ b/internal/healthchecks/healthchecks_test.go
@@ -28,7 +28,7 @@ import (
 
 var testLogger *log.Logger = log.New(ioutil.Discard, "", 0)
 
-func expectedResultMessage(name string, result string) string {
+func generateExpectedResultMessage(name string, result string) string {
 	return fmt.Sprintf("[%s] Result: %s", name, result)
 }
 
@@ -111,7 +111,7 @@ func TestRunAllHealthChecks(t *testing.T) {
 		case "Failure Check":
 			result = "FAIL"
 		}
-		expected = expectedResultMessage(r.Name, result)
+		expected = generateExpectedResultMessage(r.Name, result)
 		assert.Check(t, strings.Contains(r.String(), expected))
 	}
 }
@@ -129,8 +129,8 @@ func (c MultipleFailureResultCheck) RunCheck(logger *log.Logger) error {
 func TestMultipleFailureResultCheck(t *testing.T) {
 	mCheck := MultipleFailureResultCheck{}
 	wantErrorMessage := "Test error."
-	expectedFailure := expectedResultMessage(mCheck.Name(), "FAIL")
-	expectedError := expectedResultMessage(mCheck.Name(), "ERROR")
+	expectedFailure := generateExpectedResultMessage(mCheck.Name(), "FAIL")
+	expectedError := generateExpectedResultMessage(mCheck.Name(), "ERROR")
 	
 	err := mCheck.RunCheck(testLogger)
 	result := healthchecks.HealthCheckResult{Name: mCheck.Name(), Err: err}
@@ -154,7 +154,7 @@ func (c MultipleSuccessResultCheck) RunCheck(logger *log.Logger) error {
 
 func TestMultipleSuccessResultCheck(t *testing.T) {
 	sCheck := MultipleSuccessResultCheck{}
-	expectedSuccess := expectedResultMessage(sCheck.Name(), "PASS")
+	expectedSuccess := generateExpectedResultMessage(sCheck.Name(), "PASS")
 	fmt.Println(expectedSuccess)
 	
 	err := sCheck.RunCheck(testLogger)

--- a/internal/healthchecks/healthchecks_test.go
+++ b/internal/healthchecks/healthchecks_test.go
@@ -28,6 +28,10 @@ import (
 
 var testLogger *log.Logger = log.New(ioutil.Discard, "", 0)
 
+func expectedResultMessage(name string, result string) string {
+	return fmt.Sprintf("[%s Check] Result: %s", name, result)
+}
+
 type FailureCheck struct{}
 
 func (c FailureCheck) Name() string {
@@ -107,7 +111,7 @@ func TestRunAllHealthChecks(t *testing.T) {
 		case "Failure Check":
 			result = "FAIL"
 		}
-		expected = fmt.Sprintf("[%s] Result: %s", r.Name, result)
+		expected = expectedResultMessage(r.Name, result)
 		assert.Check(t, strings.Contains(r.String(), expected))
 	}
 }
@@ -125,8 +129,8 @@ func (c MultipleFailureResultCheck) RunCheck(logger *log.Logger) error {
 func TestMultipleFailureResultCheck(t *testing.T) {
 	mCheck := MultipleFailureResultCheck{}
 	wantErrorMessage := "Test error."
-	expectedFailure := fmt.Sprintf("[%s] Result: FAIL", mCheck.Name())
-	expectedError := fmt.Sprintf("[%s] Result: ERROR", mCheck.Name())
+	expectedFailure := expectedResultMessage(mCheck.Name(), "FAIL")
+	expectedError := expectedResultMessage(mCheck.Name(), "ERROR")
 	
 	err := mCheck.RunCheck(testLogger)
 	result := healthchecks.HealthCheckResult{Name: mCheck.Name(), Err: err}
@@ -150,7 +154,7 @@ func (c MultipleSuccessResultCheck) RunCheck(logger *log.Logger) error {
 
 func TestMultipleSuccessResultCheck(t *testing.T) {
 	sCheck := MultipleSuccessResultCheck{}
-	expectedSuccess := fmt.Sprintf("[%s] Result: PASS", sCheck.Name())
+	expectedSuccess := expectedResultMessage(sCheck.Name(), "PASS")
 	
 	err := sCheck.RunCheck(testLogger)
 	result := healthchecks.HealthCheckResult{Name: sCheck.Name(), Err: err}

--- a/internal/healthchecks/healthchecks_test.go
+++ b/internal/healthchecks/healthchecks_test.go
@@ -76,8 +76,7 @@ func (c ErrorCheck) Name() string {
 }
 
 func (c ErrorCheck) RunCheck(logger *log.Logger) error {
-	err := errors.New("Test error.")
-	return err
+	return errors.New("Test error.")
 }
 
 func TestCheckError(t *testing.T) {
@@ -111,4 +110,51 @@ func TestRunAllHealthChecks(t *testing.T) {
 		expected = fmt.Sprintf("[%s] Result: %s", r.Name, result)
 		assert.Check(t, strings.Contains(r.String(), expected))
 	}
+}
+
+type MultipleFailureResultCheck struct{}
+
+func (c MultipleFailureResultCheck) Name() string {
+	return "MultipleResult Check"
+}
+
+func (c MultipleFailureResultCheck) RunCheck(logger *log.Logger) error {
+	return errors.Join(nil, errors.New("Test error."), healthchecks.HcFailureErr)
+}
+
+func TestMultipleFailureResultHealthCheck(t *testing.T) {
+	mCheck := MultipleFailureResultCheck{}
+	wantErrorMessage := "Test error."
+	expectedFailure := fmt.Sprintf("[%s] Result: FAIL", mCheck.Name())
+	expectedError := fmt.Sprintf("[%s] Result: ERROR", mCheck.Name())
+	
+	err := mCheck.RunCheck(testLogger)
+	result := healthchecks.HealthCheckResult{Name: mCheck.Name(), Err: err}
+
+	assert.ErrorContains(t, err, wantErrorMessage)
+	assert.ErrorIs(t, err, healthchecks.HcFailureErr)
+	assert.Check(t, strings.Contains(result.String(), expectedFailure))
+	assert.Check(t, strings.Contains(result.String(), expectedError))
+
+}
+
+type MultipleSuccessResultCheck struct{}
+
+func (c MultipleSuccessResultCheck) Name() string {
+	return "MultipleResult Check"
+}
+
+func (c MultipleSuccessResultCheck) RunCheck(logger *log.Logger) error {
+	return errors.Join(nil, nil, nil)
+}
+
+func TestMultipleFailureHealthCheck(t *testing.T) {
+	sCheck := MultipleSuccessResultCheck{}
+	expectedSuccess := fmt.Sprintf("[%s] Result: PASS", sCheck.Name())
+	
+	err := sCheck.RunCheck(testLogger)
+	result := healthchecks.HealthCheckResult{Name: sCheck.Name(), Err: err}
+
+	assert.NilError(t, err)
+	assert.Check(t, strings.Contains(result.String(), expectedSuccess))
 }

--- a/internal/healthchecks/healthchecks_test.go
+++ b/internal/healthchecks/healthchecks_test.go
@@ -29,7 +29,7 @@ import (
 var testLogger *log.Logger = log.New(ioutil.Discard, "", 0)
 
 func expectedResultMessage(name string, result string) string {
-	return fmt.Sprintf("[%s Check] Result: %s", name, result)
+	return fmt.Sprintf("[%s] Result: %s", name, result)
 }
 
 type FailureCheck struct{}
@@ -155,6 +155,7 @@ func (c MultipleSuccessResultCheck) RunCheck(logger *log.Logger) error {
 func TestMultipleSuccessResultCheck(t *testing.T) {
 	sCheck := MultipleSuccessResultCheck{}
 	expectedSuccess := expectedResultMessage(sCheck.Name(), "PASS")
+	fmt.Println(expectedSuccess)
 	
 	err := sCheck.RunCheck(testLogger)
 	result := healthchecks.HealthCheckResult{Name: sCheck.Name(), Err: err}

--- a/internal/healthchecks/healthchecks_test.go
+++ b/internal/healthchecks/healthchecks_test.go
@@ -16,6 +16,7 @@ package healthchecks_test
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"strings"
@@ -94,19 +95,20 @@ func TestRunAllHealthChecks(t *testing.T) {
 	eCheck := ErrorCheck{}
 	allHealthChecks := healthchecks.HealthCheckRegistry{fCheck, sCheck, eCheck}
 
-	result := allHealthChecks.RunAllHealthChecks(testLogger)
+	allCheckResults := allHealthChecks.RunAllHealthChecks(testLogger)
 
 	var expected string
-	for _, r := range result {
+	var result string
+	for _, r := range allCheckResults {
 		switch r.Name {
 		case "Error Check":
-			expected = "Result: ERROR"
+			result = "ERROR"
 		case "Success Check":
-			expected = "Result: PASS"
+			result = "PASS"
 		case "Failure Check":
-			expected = "Result: FAIL"
+			result = "FAIL"
 		}
-
+		expected = fmt.Sprintf("[%s] Result: %s", r.Name, result)
 		assert.Check(t, strings.Contains(r.String(), expected))
 	}
 }

--- a/internal/healthchecks/healthchecks_test.go
+++ b/internal/healthchecks/healthchecks_test.go
@@ -122,7 +122,7 @@ func (c MultipleFailureResultCheck) RunCheck(logger *log.Logger) error {
 	return errors.Join(nil, errors.New("Test error."), healthchecks.HcFailureErr)
 }
 
-func TestMultipleFailureResultHealthCheck(t *testing.T) {
+func TestMultipleFailureResultCheck(t *testing.T) {
 	mCheck := MultipleFailureResultCheck{}
 	wantErrorMessage := "Test error."
 	expectedFailure := fmt.Sprintf("[%s] Result: FAIL", mCheck.Name())
@@ -148,7 +148,7 @@ func (c MultipleSuccessResultCheck) RunCheck(logger *log.Logger) error {
 	return errors.Join(nil, nil, nil)
 }
 
-func TestMultipleFailureHealthCheck(t *testing.T) {
+func TestMultipleSuccessResultCheck(t *testing.T) {
 	sCheck := MultipleSuccessResultCheck{}
 	expectedSuccess := fmt.Sprintf("[%s] Result: PASS", sCheck.Name())
 	


### PR DESCRIPTION
## Description
A new feature in https://github.com/GoogleCloudPlatform/ops-agent/pull/1139 enabled Health Checks to  report multiple errors/failures from the same check. The results appear in multiple lines the following way in `health-checks.log` :
```
2023/04/19 14:53:06 healthchecks.go:92: API Check - Result: FAIL, Error code: MonApiConnErr, Failure: Request to Monitoring API failed., Solution: Check your internet connection and firewall rules., Resource: https://cloud.google.com/monitoring/agent/ops-agent/troubleshooting
API Check - Result: FAIL, Error code: LogApiConnErr, Failure: Request to Logging API failed., Solution: Check your internet connection and firewall rules., Resource: https://cloud.google.com/logging/docs/agent/ops-agent/troubleshooting
```

And in multiple lines of the `systemd` service output  :
```
Apr 19 14:53:06 github-test-20230419-92925-a6f09232-87a7-43ea-9565-89d8ca48628f google_cloud_ops_agent_engine[1535]: 2023/04/19 14:53:06 API Check - Result: FAIL, Error code: MonApiConnErr, Failure: Request to Monitoring API failed., Solution: Check your internet connection and firewall rules., Resource: https://cloud.google.com/monitoring/agent/ops-agent/troubleshooting
Apr 19 14:53:06 github-test-20230419-92925-a6f09232-87a7-43ea-9565-89d8ca48628f google_cloud_ops_agent_engine[1535]: API Check - Result: FAIL, Error code: LogApiConnErr, Failure: Request to Logging API failed., Solution: Check your internet connection and firewall rules., Resource: https://cloud.google.com/logging/docs/agent/ops-agent/troubleshooting
```

This PR introduces a new format for Health Check results messages to improve readability of multiple lines (`health-checks.log`) : 
```
2023/04/19 14:53:06 healthchecks.go:92: [API Check] Result: FAIL, Error code: MonApiConnErr, Failure: Request to Monitoring API failed., Solution: Check your internet connection and firewall rules., Resource: https://cloud.google.com/monitoring/agent/ops-agent/troubleshooting
[API Check] Result: FAIL, Error code: LogApiConnErr, Failure: Request to Logging API failed., Solution: Check your internet connection and firewall rules., Resource: https://cloud.google.com/logging/docs/agent/ops-agent/troubleshooting
```
and (`systemd`)
```
Apr 19 14:53:06 github-test-20230419-92925-a6f09232-87a7-43ea-9565-89d8ca48628f google_cloud_ops_agent_engine[1535]: 2023/04/19 14:53:06 [API Check] Result: FAIL, Error code: MonApiConnErr, Failure: Request to Monitoring API failed., Solution: Check your internet connection and firewall rules., Resource: https://cloud.google.com/monitoring/agent/ops-agent/troubleshooting
Apr 19 14:53:06 github-test-20230419-92925-a6f09232-87a7-43ea-9565-89d8ca48628f google_cloud_ops_agent_engine[1535]: [API Check] Result: FAIL, Error code: LogApiConnErr, Failure: Request to Logging API failed., Solution: Check your internet connection and firewall rules., Resource: https://cloud.google.com/logging/docs/agent/ops-agent/troubleshooting
```

## Related issue
b/279075421

## How has this been tested?
Added or updated the following unit tests : 
- `TestMultipleFailureResultHealthCheck`
- `TestMultipleSuccessResultCheck`
- `TestRunAllHealthChecks`

Updated `healthCheckResultMessage` function used on integration tests.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [x] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
