### PR TITLE
Adding health check self logs

### DIFF
--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -245,9 +245,9 @@ func contains(s []string, str string) bool {
 }
 func healthChecksLog(p platform.Platform) string {
 	if p.Type == platform.Windows {
-		return "${logs_dir}/ops-agent-health-checks.log"
+		return "${logs_dir}/health-checks.log"
 	}
-	return "${logs_dir}/../ops-agent-health-checks.log"
+	return "${logs_dir}/../health-checks.log"
 }
 
 func processUserDefinedMultilineParser(i int, pID string, receiver LoggingReceiver, processor LoggingProcessor, receiverComponents []fluentbit.Component, processorComponents []fluentbit.Component) error {

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -245,9 +245,9 @@ func contains(s []string, str string) bool {
 }
 func healthChecksLog(p platform.Platform) string {
 	if p.Type == platform.Windows {
-		return "${logs_dir}/health-checks.log"
+		return "${logs_dir}/ops-agent-health-checks.log"
 	}
-	return "${logs_dir}/../health-checks.log"
+	return "${logs_dir}/../ops-agent-health-checks.log"
 }
 
 func processUserDefinedMultilineParser(i int, pID string, receiver LoggingReceiver, processor LoggingProcessor, receiverComponents []fluentbit.Component, processorComponents []fluentbit.Component) error {

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -243,6 +243,12 @@ func contains(s []string, str string) bool {
 
 	return false
 }
+func healthChecksLog(p platform.Platform) string {
+	if p.Type == platform.Windows {
+		return "${logs_dir}/health-checks.log"
+	}
+	return "${logs_dir}/../health-checks.log"
+}
 
 func processUserDefinedMultilineParser(i int, pID string, receiver LoggingReceiver, processor LoggingProcessor, receiverComponents []fluentbit.Component, processorComponents []fluentbit.Component) error {
 	var multilineParserNames []string
@@ -381,7 +387,7 @@ func (l *Logging) generateFluentbitComponents(ctx context.Context, userAgent str
 	}.Components(ctx, fluentBitSelfLogTag)...)
 
 	out = append(out, LoggingReceiverFilesMixin{
-		IncludePaths:   []string{"${logs_dir}/../health-checks.log"},
+		IncludePaths:   []string{healthChecksLog(platform.FromContext(ctx))},
 		BufferInMemory: true,
 	}.Components(ctx, healthChecksTag)...)
 

--- a/confgenerator/logging_receivers.go
+++ b/confgenerator/logging_receivers.go
@@ -81,8 +81,8 @@ func (r LoggingReceiverFilesMixin) Components(ctx context.Context, tag string) [
 		// DB.locking specifies that the database will be accessed only by Fluent Bit.
 		// Enabling this feature helps to increase performance when accessing the database
 		// but it restrict any external tool to query the content.
-		"DB.locking": "true",
-		// "Read_from_Head": "True",
+		"DB.locking":     "true",
+		"Read_from_Head": "True",
 		// Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
 		"Buffer_Chunk_Size": "512k",
 		// Set the max size a bit larger to accommodate for long log lines.

--- a/confgenerator/logging_receivers.go
+++ b/confgenerator/logging_receivers.go
@@ -81,8 +81,8 @@ func (r LoggingReceiverFilesMixin) Components(ctx context.Context, tag string) [
 		// DB.locking specifies that the database will be accessed only by Fluent Bit.
 		// Enabling this feature helps to increase performance when accessing the database
 		// but it restrict any external tool to query the content.
-		"DB.locking":     "true",
-		"Read_from_Head": "True",
+		"DB.locking": "true",
+		// "Read_from_Head": "True",
 		// Set the chunk limit conservatively to avoid exceeding the recommended chunk size of 5MB per write request.
 		"Buffer_Chunk_Size": "512k",
 		// Set the max size a bit larger to accommodate for long log lines.

--- a/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -157,7 +172,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
@@ -62,6 +62,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -136,7 +151,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/fluent_bit_main.conf
@@ -45,7 +45,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/fluent_bit_main.conf
@@ -45,7 +45,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/fluent_bit_main.conf
@@ -37,6 +37,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Add       logging.googleapis.com/severity DEBUG
     Condition Key_Value_Equals PRIORITY 7
@@ -185,7 +200,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -40,7 +40,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -32,6 +32,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  ops-agent-fluent-bit
     Name   lua
@@ -81,7 +96,7 @@
     Remove    severity
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -40,7 +40,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
@@ -92,7 +92,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
@@ -84,6 +84,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  pipeline1.log_source_id1
     Name   lua
@@ -208,7 +223,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
@@ -92,7 +92,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_main.conf
@@ -62,6 +62,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -527,7 +542,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_main.conf
@@ -62,6 +62,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -142,7 +157,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_main.conf
@@ -85,7 +85,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_main.conf
@@ -85,7 +85,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_main.conf
@@ -77,6 +77,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -233,7 +248,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_main.conf
@@ -92,7 +92,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_main.conf
@@ -92,7 +92,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_main.conf
@@ -84,6 +84,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  pipeline1.log_source_id1
     Name   lua
@@ -246,7 +261,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_main.conf
@@ -64,6 +64,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -143,7 +158,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_main.conf
@@ -72,7 +72,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_main.conf
@@ -72,7 +72,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_main.conf
@@ -71,7 +71,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_main.conf
@@ -71,7 +71,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_main.conf
@@ -63,6 +63,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -137,7 +152,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_main.conf
@@ -64,6 +64,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -143,7 +158,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_main.conf
@@ -72,7 +72,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_main.conf
@@ -72,7 +72,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_main.conf
@@ -106,7 +106,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_main.conf
@@ -106,7 +106,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_main.conf
@@ -98,6 +98,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -199,7 +214,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_main.conf
@@ -64,6 +64,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -143,7 +158,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_main.conf
@@ -72,7 +72,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_main.conf
@@ -72,7 +72,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_main.conf
@@ -81,6 +81,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -171,7 +186,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_main.conf
@@ -89,7 +89,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_main.conf
@@ -89,7 +89,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -134,7 +149,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_main.conf
@@ -85,7 +85,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_main.conf
@@ -77,6 +77,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  apache.apache_access
     Name   lua
@@ -207,7 +222,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_main.conf
@@ -85,7 +85,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_main.conf
@@ -129,6 +129,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  apache_custom.apache_custom_access
     Name   lua
@@ -383,7 +398,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_main.conf
@@ -137,7 +137,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_main.conf
@@ -137,7 +137,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_main.conf
@@ -100,7 +100,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_main.conf
@@ -100,7 +100,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_main.conf
@@ -92,6 +92,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match                 cassandra.cassandra_debug
     Multiline.Key_Content message
@@ -271,7 +286,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_main.conf
@@ -178,7 +178,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_main.conf
@@ -178,7 +178,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_main.conf
@@ -170,6 +170,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match                 cassandra_custom.cassandra_custom_debug
     Multiline.Key_Content message
@@ -757,7 +772,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_main.conf
@@ -100,7 +100,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_main.conf
@@ -100,7 +100,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_main.conf
@@ -92,6 +92,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match                 couchbase.couchbase_general
     Multiline.Key_Content message
@@ -265,7 +280,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_main.conf
@@ -71,7 +71,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_main.conf
@@ -71,7 +71,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_main.conf
@@ -63,6 +63,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  couchdb.couchdb
     Name   modify
@@ -174,7 +189,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_main.conf
@@ -78,6 +78,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -317,7 +332,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_main.conf
@@ -86,7 +86,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_main.conf
@@ -86,7 +86,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_main.conf
@@ -119,7 +119,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_main.conf
@@ -119,7 +119,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_main.conf
@@ -111,6 +111,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -521,7 +536,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/fluent_bit_main.conf
@@ -117,7 +117,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/fluent_bit_main.conf
@@ -109,6 +109,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -201,7 +216,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/fluent_bit_main.conf
@@ -117,7 +117,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
@@ -71,7 +71,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
@@ -71,7 +71,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
@@ -63,6 +63,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -137,7 +152,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -117,7 +117,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -109,6 +109,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  pipeline1.log_source_id1
     Name   lua
@@ -220,7 +235,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -117,7 +117,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_main.conf
@@ -62,6 +62,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -167,7 +182,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_main.conf
@@ -63,7 +63,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_main.conf
@@ -55,6 +55,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -135,7 +150,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_main.conf
@@ -63,7 +63,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_main.conf
@@ -71,7 +71,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_main.conf
@@ -63,6 +63,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  3d1e3d2de8297b94d50f1b791772d4f9.fluent_forward.fluent_forward_collision.*
     Name   lua
@@ -155,7 +170,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_main.conf
@@ -71,7 +71,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_main.conf
@@ -63,6 +63,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  770ecc55c94dd06217c2f78e09580174.fluent_forward.fluent_forward.*
     Name   lua
@@ -155,7 +170,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_main.conf
@@ -71,7 +71,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_main.conf
@@ -71,7 +71,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_main.conf
@@ -63,7 +63,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_main.conf
@@ -55,6 +55,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  b6547699ccacdc03ba6ae458f9ee5860.fluent_pipeline.fluent_logs.*
     Name   lua
@@ -135,7 +150,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_main.conf
@@ -63,7 +63,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_main.conf
@@ -71,7 +71,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_main.conf
@@ -63,6 +63,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -167,7 +182,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_main.conf
@@ -71,7 +71,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_main.conf
@@ -72,7 +72,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_main.conf
@@ -72,7 +72,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_main.conf
@@ -64,6 +64,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -168,7 +183,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_main.conf
@@ -62,6 +62,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -167,7 +182,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_main.conf
@@ -62,6 +62,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -161,7 +176,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_main.conf
@@ -62,6 +62,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -167,7 +182,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_main.conf
@@ -81,7 +81,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_main.conf
@@ -73,6 +73,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -215,7 +230,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_main.conf
@@ -81,7 +81,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_main.conf
@@ -62,6 +62,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -251,7 +266,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_main.conf
@@ -100,7 +100,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_main.conf
@@ -100,7 +100,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_main.conf
@@ -92,6 +92,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -267,7 +282,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_main.conf
@@ -178,7 +178,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_main.conf
@@ -178,7 +178,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_main.conf
@@ -170,6 +170,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -737,7 +752,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_main.conf
@@ -77,6 +77,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -207,7 +222,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_main.conf
@@ -85,7 +85,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_main.conf
@@ -85,7 +85,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_main.conf
@@ -129,6 +129,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -383,7 +398,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_main.conf
@@ -137,7 +137,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_main.conf
@@ -137,7 +137,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_main.conf
@@ -85,7 +85,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_main.conf
@@ -77,6 +77,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -219,7 +234,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_main.conf
@@ -85,7 +85,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_main.conf
@@ -135,7 +135,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_main.conf
@@ -127,6 +127,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -417,7 +432,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_main.conf
@@ -135,7 +135,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_main.conf
@@ -62,6 +62,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -167,7 +182,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_main.conf
@@ -87,6 +87,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -266,7 +281,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_main.conf
@@ -95,7 +95,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_main.conf
@@ -95,7 +95,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_main.conf
@@ -63,6 +63,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -168,7 +183,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_main.conf
@@ -71,7 +71,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_main.conf
@@ -71,7 +71,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_main.conf
@@ -62,6 +62,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -161,7 +176,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_main.conf
@@ -88,6 +88,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -249,7 +264,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_main.conf
@@ -96,7 +96,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_main.conf
@@ -96,7 +96,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_main.conf
@@ -72,7 +72,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_main.conf
@@ -72,7 +72,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_main.conf
@@ -64,6 +64,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -168,7 +183,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_main.conf
@@ -100,7 +100,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_main.conf
@@ -100,7 +100,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_main.conf
@@ -92,6 +92,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -263,7 +278,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_main.conf
@@ -62,6 +62,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -167,7 +182,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -60,7 +60,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -52,6 +52,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  pipeline1.test_syslog_source_id_tcp
     Name   lua
@@ -164,7 +179,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -60,7 +60,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_main.conf
@@ -60,7 +60,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_main.conf
@@ -60,7 +60,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_main.conf
@@ -52,6 +52,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -200,7 +215,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_main.conf
@@ -64,7 +64,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_main.conf
@@ -64,7 +64,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_main.conf
@@ -56,6 +56,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -130,7 +145,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_main.conf
@@ -64,7 +64,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_main.conf
@@ -64,7 +64,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_main.conf
@@ -56,6 +56,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -130,7 +145,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_main.conf
@@ -64,7 +64,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_main.conf
@@ -64,7 +64,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_main.conf
@@ -56,6 +56,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -130,7 +145,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_main.conf
@@ -85,7 +85,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_main.conf
@@ -77,6 +77,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -213,7 +228,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_main.conf
@@ -85,7 +85,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_main.conf
@@ -135,7 +135,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_main.conf
@@ -135,7 +135,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_main.conf
@@ -127,6 +127,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -455,7 +470,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_main.conf
@@ -62,6 +62,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -161,7 +176,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_main.conf
@@ -70,7 +70,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_main.conf
@@ -71,7 +71,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_main.conf
@@ -63,6 +63,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -167,7 +182,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_main.conf
@@ -71,7 +71,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_main.conf
@@ -71,7 +71,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_main.conf
@@ -63,6 +63,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -167,7 +182,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_main.conf
@@ -71,7 +71,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_main.conf
@@ -63,6 +63,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -168,7 +183,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_main.conf
@@ -71,7 +71,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_main.conf
@@ -71,7 +71,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_main.conf
@@ -63,6 +63,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -168,7 +183,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_main.conf
@@ -71,7 +71,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_main.conf
@@ -71,7 +71,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.syslog
     Name   lua
@@ -115,7 +130,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../ops-agent-health-checks.log
+    Path              ${logs_dir}/../health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/../ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -197,7 +212,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -157,7 +172,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
@@ -54,7 +54,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
@@ -54,7 +54,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
@@ -46,6 +46,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -220,7 +235,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
@@ -54,7 +54,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -40,7 +40,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -40,7 +40,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -32,6 +32,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  ops-agent-fluent-bit
     Name   lua
@@ -81,7 +96,7 @@
     Remove    severity
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -40,7 +40,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_main.conf
@@ -54,7 +54,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_main.conf
@@ -46,6 +46,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  active_directory_ds.active_directory_ds
     Name   lua
@@ -226,7 +241,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_main.conf
@@ -54,7 +54,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_main.conf
@@ -54,7 +54,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
@@ -63,7 +63,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
@@ -55,6 +55,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -179,7 +194,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
@@ -63,7 +63,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
@@ -63,7 +63,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -77,7 +77,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -69,6 +69,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -218,7 +233,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -77,7 +77,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -77,7 +77,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_main.conf
@@ -62,7 +62,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_main.conf
@@ -62,7 +62,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_main.conf
@@ -54,6 +54,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -214,7 +229,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_main.conf
@@ -62,7 +62,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_main.conf
@@ -54,7 +54,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_main.conf
@@ -54,7 +54,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_main.conf
@@ -46,6 +46,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -196,7 +211,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_main.conf
@@ -54,7 +54,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -133,7 +148,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_main.conf
@@ -47,6 +47,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -202,7 +217,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -157,7 +172,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -157,7 +172,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -157,7 +172,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -157,7 +172,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -157,7 +172,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -157,7 +172,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -157,7 +172,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -157,7 +172,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -157,7 +172,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -157,7 +172,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -157,7 +172,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -157,7 +172,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -157,7 +172,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -157,7 +172,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -157,7 +172,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -157,7 +172,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -157,7 +172,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -157,7 +172,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -157,7 +172,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -157,7 +172,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/ops-agent-health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/../health-checks.log
+    Path              ${logs_dir}/health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_main.conf
@@ -39,6 +39,21 @@
     Tag               ops-agent-fluent-bit
     storage.type      memory
 
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health-checks
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/../health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health-checks
+    storage.type      memory
+
 [FILTER]
     Match  default_pipeline.windows_event_log
     Name   lua
@@ -157,7 +172,7 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
+    Match_Regex                   ^((ops-agent-fluent-bit)|(ops-agent-health-checks))$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_main.conf
@@ -47,7 +47,7 @@
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
-    Path              ${logs_dir}/health-checks.log
+    Path              ${logs_dir}/ops-agent-health-checks.log
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On

--- a/dev-docs/dev.md
+++ b/dev-docs/dev.md
@@ -810,7 +810,7 @@ ops-agent$ /google/bin/releases/opensource/thirdparty/cross/cross .
 Description                                                                                          | Link
 ---------------------------------------------------------------------------------------------------- | ----
 Config file - Ops Agent                                                                              | `/etc/google-cloud-ops-agent/config.yaml` (custom agent configurations)
-Logs - Health Checks                                                                                 | `/var/log/google-cloud-ops-agent/ops-agent-health-checks.log`
+Logs - Health Checks                                                                                 | `/var/log/google-cloud-ops-agent/health-checks.log`
 Logs - Fluent Bit                                                                                    | `/var/log/google-cloud-ops-agent/subagents/logging-module.log`
 Logs - OT Metrics Agent                                                                              | `/var/log/syslog` or `/var/log/messages`. This agent does not write logs directly to disk today.
 Config file - Ops Agent (Debug)                                                                      | `/run/google-cloud-ops-agent-fluent-bit/conf/debug/` or `/run/google-cloud-ops-agent-opentelemetry-collector/conf/debug/`
@@ -825,7 +825,7 @@ Buffer files - Fluent Bit                                                       
 Description                               | Link
 ----------------------------------------- | ----
 Config file - Ops Agent                   | `C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml`
-Logs - Health Checks                      | `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\ops-agent-health-checks.log`
+Logs - Health Checks                      | `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\health-checks.log`
 Logs - Fluent Bit                         | `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\logging-module.log`
 Logs - OT Metrics Agent                   | In the `Event Viewer` app, click `Windows Logs` then `Application`, filter by `Source` equal to `Google Cloud Ops Agent - Metrics Agent`. This agent does not write logs directly to disk today.
 Config file - Fluent Bit - Main config    | `C:\ProgramData\Google\Cloud Operations\Ops Agent\generated_configs\fluentbit\fluent_bit_main.conf`

--- a/dev-docs/dev.md
+++ b/dev-docs/dev.md
@@ -810,7 +810,7 @@ ops-agent$ /google/bin/releases/opensource/thirdparty/cross/cross .
 Description                                                                                          | Link
 ---------------------------------------------------------------------------------------------------- | ----
 Config file - Ops Agent                                                                              | `/etc/google-cloud-ops-agent/config.yaml` (custom agent configurations)
-Logs - Health Checks                                                                                 | `/var/log/google-cloud-ops-agent/health-checks.log`
+Logs - Health Checks                                                                                 | `/var/log/google-cloud-ops-agent/ops-agent-health-checks.log`
 Logs - Fluent Bit                                                                                    | `/var/log/google-cloud-ops-agent/subagents/logging-module.log`
 Logs - OT Metrics Agent                                                                              | `/var/log/syslog` or `/var/log/messages`. This agent does not write logs directly to disk today.
 Config file - Ops Agent (Debug)                                                                      | `/run/google-cloud-ops-agent-fluent-bit/conf/debug/` or `/run/google-cloud-ops-agent-opentelemetry-collector/conf/debug/`
@@ -825,7 +825,7 @@ Buffer files - Fluent Bit                                                       
 Description                               | Link
 ----------------------------------------- | ----
 Config file - Ops Agent                   | `C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml`
-Logs - Health Checks                      | `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\health-checks.log`
+Logs - Health Checks                      | `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\ops-agent-health-checks.log`
 Logs - Fluent Bit                         | `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\logging-module.log`
 Logs - OT Metrics Agent                   | In the `Event Viewer` app, click `Windows Logs` then `Application`, filter by `Source` equal to `Google Cloud Ops Agent - Metrics Agent`. This agent does not write logs directly to disk today.
 Config file - Fluent Bit - Main config    | `C:\ProgramData\Google\Cloud Operations\Ops Agent\generated_configs\fluentbit\fluent_bit_main.conf`

--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -182,7 +182,7 @@ func RunOpsAgentDiagnostics(ctx context.Context, logger *logging.DirectoryLogger
 
 	for _, log := range []string{
 		gce.SyslogLocation(vm.Platform),
-		"/var/log/google-cloud-ops-agent/health-checks.log",
+		"/var/log/google-cloud-ops-agent/ops-agent-health-checks.log",
 		"/etc/google-cloud-ops-agent/config.yaml",
 		"/var/log/google-cloud-ops-agent/subagents/logging-module.log",
 		"/var/log/google-cloud-ops-agent/subagents/metrics-module.log",
@@ -205,7 +205,7 @@ func runOpsAgentDiagnosticsWindows(ctx context.Context, logger *logging.Director
 	gce.RunRemotely(ctx, logger.ToFile("open_telemetry_agent_logs.txt"), vm, "", "Get-WinEvent -FilterHashtable @{ Logname='Application'; ProviderName='google-cloud-ops-agent-opentelemetry-collector' } | Format-Table -AutoSize -Wrap")
 	// Fluent-Bit has not implemented exporting logs to the Windows event log yet.
 	gce.RunRemotely(ctx, logger.ToFile("fluent_bit_agent_logs.txt"), vm, "", fmt.Sprintf("Get-Content -Path '%s' -Raw", `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\logging-module.log`))
-	gce.RunRemotely(ctx, logger.ToFile("health-checks.txt"), vm, "", fmt.Sprintf("Get-Content -Path '%s' -Raw", `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\health-checks.log`))
+	gce.RunRemotely(ctx, logger.ToFile("health-checks.txt"), vm, "", fmt.Sprintf("Get-Content -Path '%s' -Raw", `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\ops-agent-health-checks.log`))
 
 	for _, conf := range []string{
 		`C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml`,

--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -182,7 +182,7 @@ func RunOpsAgentDiagnostics(ctx context.Context, logger *logging.DirectoryLogger
 
 	for _, log := range []string{
 		gce.SyslogLocation(vm.Platform),
-		"/var/log/google-cloud-ops-agent/ops-agent-health-checks.log",
+		"/var/log/google-cloud-ops-agent/health-checks.log",
 		"/etc/google-cloud-ops-agent/config.yaml",
 		"/var/log/google-cloud-ops-agent/subagents/logging-module.log",
 		"/var/log/google-cloud-ops-agent/subagents/metrics-module.log",
@@ -205,7 +205,7 @@ func runOpsAgentDiagnosticsWindows(ctx context.Context, logger *logging.Director
 	gce.RunRemotely(ctx, logger.ToFile("open_telemetry_agent_logs.txt"), vm, "", "Get-WinEvent -FilterHashtable @{ Logname='Application'; ProviderName='google-cloud-ops-agent-opentelemetry-collector' } | Format-Table -AutoSize -Wrap")
 	// Fluent-Bit has not implemented exporting logs to the Windows event log yet.
 	gce.RunRemotely(ctx, logger.ToFile("fluent_bit_agent_logs.txt"), vm, "", fmt.Sprintf("Get-Content -Path '%s' -Raw", `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\logging-module.log`))
-	gce.RunRemotely(ctx, logger.ToFile("health-checks.txt"), vm, "", fmt.Sprintf("Get-Content -Path '%s' -Raw", `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\ops-agent-health-checks.log`))
+	gce.RunRemotely(ctx, logger.ToFile("health-checks.txt"), vm, "", fmt.Sprintf("Get-Content -Path '%s' -Raw", `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\health-checks.log`))
 
 	for _, conf := range []string{
 		`C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml`,

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -3095,7 +3095,7 @@ func TestLoggingAgentCrashRestart(t *testing.T) {
 	})
 }
 
-func TestLoggingFluentbitSelfLogs(t *testing.T) {
+func TestLoggingSelfLogs(t *testing.T) {
 	t.Parallel()
 	gce.RunForEachPlatform(t, func(t *testing.T, platform string) {
 		t.Parallel()
@@ -3106,6 +3106,9 @@ func TestLoggingFluentbitSelfLogs(t *testing.T) {
 		}
 
 		if err := gce.WaitForLog(ctx, logger.ToMainLog(), vm, "ops-agent-fluent-bit", time.Hour, `severity="INFO"`); err != nil {
+			t.Error(err)
+		}
+		if err := gce.WaitForLog(ctx, logger.ToMainLog(), vm, "ops-agent-health-checks", time.Hour, `severity="INFO"`); err != nil {
 			t.Error(err)
 		}
 	})

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -3108,7 +3108,8 @@ func TestLoggingSelfLogs(t *testing.T) {
 		if err := gce.WaitForLog(ctx, logger.ToMainLog(), vm, "ops-agent-fluent-bit", time.Hour, `severity="INFO"`); err != nil {
 			t.Error(err)
 		}
-		if _, err := gce.QueryLog(ctx, logger.ToMainLog(), vm, "ops-agent-health-checks", time.Hour, ``, 5); err != nil {
+
+		if err := gce.WaitForLog(ctx, logger.ToMainLog(), vm, "ops-agent-health-checks", time.Hour, ``); err != nil {
 			t.Error(err)
 		}
 	})

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -3108,7 +3108,7 @@ func TestLoggingSelfLogs(t *testing.T) {
 		if err := gce.WaitForLog(ctx, logger.ToMainLog(), vm, "ops-agent-fluent-bit", time.Hour, `severity="INFO"`); err != nil {
 			t.Error(err)
 		}
-		if err := gce.WaitForLog(ctx, logger.ToMainLog(), vm, "ops-agent-health-checks", time.Hour, `severity="INFO"`); err != nil {
+		if _, err := gce.QueryLog(ctx, logger.ToMainLog(), vm, "ops-agent-health-checks", time.Hour, `severity="INFO"`, 5); err != nil {
 			t.Error(err)
 		}
 	})

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -3108,7 +3108,7 @@ func TestLoggingSelfLogs(t *testing.T) {
 		if err := gce.WaitForLog(ctx, logger.ToMainLog(), vm, "ops-agent-fluent-bit", time.Hour, `severity="INFO"`); err != nil {
 			t.Error(err)
 		}
-		if _, err := gce.QueryLog(ctx, logger.ToMainLog(), vm, "ops-agent-health-checks", time.Hour, `severity="INFO"`, 5); err != nil {
+		if _, err := gce.QueryLog(ctx, logger.ToMainLog(), vm, "ops-agent-health-checks", time.Hour, ``, 5); err != nil {
 			t.Error(err)
 		}
 	})

--- a/internal/healthchecks/api_check.go
+++ b/internal/healthchecks/api_check.go
@@ -94,8 +94,9 @@ func monitoringPing(ctx context.Context, client monitoring.MetricClient, gceMeta
 func runLoggingCheck(logger logs.StructuredLogger) error {
 	ctx := context.Background()
 	gceMetadata, err := getGCEMetadata()
+
 	if err != nil {
-		return fmt.Errorf("can't get GCE metadata")
+		return fmt.Errorf("GCE Metadata query failed")
 	}
 	logger.Infof("GCE Metadata queried successfully")
 

--- a/internal/healthchecks/api_check.go
+++ b/internal/healthchecks/api_check.go
@@ -143,7 +143,11 @@ func runMonitoringCheck(logger logs.StructuredLogger) error {
 	ctx := context.Background()
 	gceMetadata, err := getGCEMetadata()
 	if err != nil {
+<<<<<<< HEAD
 		return fmt.Errorf("GCE Metadata query failed")
+=======
+		return fmt.Errorf("can't get GCE metadata: %w", err)
+>>>>>>> c033f967 (Error messages don't expose PII)
 	}
 	logger.Infof("GCE Metadata queried successfully")
 

--- a/internal/healthchecks/api_check.go
+++ b/internal/healthchecks/api_check.go
@@ -94,9 +94,8 @@ func monitoringPing(ctx context.Context, client monitoring.MetricClient, gceMeta
 func runLoggingCheck(logger logs.StructuredLogger) error {
 	ctx := context.Background()
 	gceMetadata, err := getGCEMetadata()
-
 	if err != nil {
-		return fmt.Errorf("GCE Metadata query failed")
+		return fmt.Errorf("can't get GCE metadata")
 	}
 	logger.Infof("GCE Metadata queried successfully")
 
@@ -143,11 +142,7 @@ func runMonitoringCheck(logger logs.StructuredLogger) error {
 	ctx := context.Background()
 	gceMetadata, err := getGCEMetadata()
 	if err != nil {
-<<<<<<< HEAD
-		return fmt.Errorf("GCE Metadata query failed")
-=======
-		return fmt.Errorf("can't get GCE metadata: %w", err)
->>>>>>> c033f967 (Error messages don't expose PII)
+		return fmt.Errorf("can't get GCE metadata")
 	}
 	logger.Infof("GCE Metadata queried successfully")
 

--- a/internal/healthchecks/api_check.go
+++ b/internal/healthchecks/api_check.go
@@ -143,7 +143,7 @@ func runMonitoringCheck(logger logs.StructuredLogger) error {
 	ctx := context.Background()
 	gceMetadata, err := getGCEMetadata()
 	if err != nil {
-		return fmt.Errorf("can't get GCE metadata")
+		return fmt.Errorf("GCE Metadata query failed")
 	}
 	logger.Infof("GCE Metadata queried successfully")
 


### PR DESCRIPTION
## Description
Health checks now have their own logname. This will allow Error Reporting to use logname as a filter.

## Related issue
b/279212943
b/279417452

## How has this been tested?
Installed the version on a linux and windows machine and observed that the logname was showing up on the UI.
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [X] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
