### PR TITLE
Add Kokoro build configs for new distro lunar

### DIFF
--- a/kokoro/config/build/presubmit/lunar.gcl
+++ b/kokoro/config/build/presubmit/lunar.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'lunar'
+      PKGFORMAT = 'deb'
+    }
+  }
+}

--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -13,6 +13,14 @@ local template _distro {
 }
 
 // DEB Linux distros. (Do not modify this comment.)
+lunar = _distro {
+  release = [
+      'ubuntu-2304',
+  ]
+  presubmit = [
+      'ubuntu-2304',
+  ]
+}
 buster = _distro {
   release = ['debian-10']
   presubmit = ['debian-10']

--- a/kokoro/config/test/ops_agent/lunar.gcl
+++ b/kokoro/config/test/ops_agent/lunar.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.lunar.presubmit
+  }
+}

--- a/kokoro/config/test/ops_agent/release/lunar.gcl
+++ b/kokoro/config/test/ops_agent/release/lunar.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.lunar.release
+  }
+}

--- a/kokoro/config/test/third_party_apps/lunar.gcl
+++ b/kokoro/config/test/third_party_apps/lunar.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = [
+      'ubuntu-2304',
+    ]
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/lunar.gcl
+++ b/kokoro/config/test/third_party_apps/release/lunar.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = [
+      'ubuntu-2304',
+    ]
+  }
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Add Kokoro build configs for new distro Ubuntu 23.04 Lunar

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->
b/279642687

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
