### PR TITLE
Removing logging of metadata query result

### DIFF
--- a/internal/healthchecks/api_check.go
+++ b/internal/healthchecks/api_check.go
@@ -97,7 +97,7 @@ func runLoggingCheck(logger *log.Logger) error {
 	if err != nil {
 		return fmt.Errorf("can't get GCE metadata: %w", err)
 	}
-	logger.Printf("gce metadata: %+v", gceMetadata)
+	logger.Printf("GCE Metadata queried successfully")
 
 	// New Logging Client
 	logClient, err := logging.NewClient(ctx, gceMetadata.Project)
@@ -144,7 +144,7 @@ func runMonitoringCheck(logger *log.Logger) error {
 	if err != nil {
 		return fmt.Errorf("can't get GCE metadata: %w", err)
 	}
-	logger.Printf("gce metadata: %+v", gceMetadata)
+	logger.Printf("GCE Metadata queried successfully")
 
 	// New Monitoring Client
 	monClient, err := monitoring.NewMetricClient(ctx)

--- a/internal/healthchecks/api_check.go
+++ b/internal/healthchecks/api_check.go
@@ -95,7 +95,7 @@ func runLoggingCheck(logger *log.Logger) error {
 	ctx := context.Background()
 	gceMetadata, err := getGCEMetadata()
 	if err != nil {
-		return fmt.Errorf("can't get GCE metadata: %w", err)
+		return fmt.Errorf("can't get GCE metadata")
 	}
 	logger.Printf("GCE Metadata queried successfully")
 
@@ -142,7 +142,7 @@ func runMonitoringCheck(logger *log.Logger) error {
 	ctx := context.Background()
 	gceMetadata, err := getGCEMetadata()
 	if err != nil {
-		return fmt.Errorf("can't get GCE metadata: %w", err)
+		return fmt.Errorf("can't get GCE metadata")
 	}
 	logger.Printf("GCE Metadata queried successfully")
 


### PR DESCRIPTION
## Description
Removing the result from metadata query from being added to health-checks.log

## Related issue
b/279212943

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
