### PR TITLE
Disable index metrics for elasticsearch that were previously hidden by feature gate

### DIFF
--- a/apps/elasticsearch.go
+++ b/apps/elasticsearch.go
@@ -49,6 +49,18 @@ func (r MetricsReceiverElasticsearch) Pipelines() []otel.ReceiverPipeline {
 		r.Endpoint = defaultElasticsearchEndpoint
 	}
 
+	metricsConfig := map[string]interface{}{}
+
+	// Custom logic needed to skip JVM metrics, since JMX receiver is not used here.
+	if !r.ShouldCollectJVMMetrics() {
+		r.skipJVMMetricsConfig(metricsConfig)
+	}
+
+	// Custom logic needed to disable index metrics, since they were previously locked behind a feature gate.
+	// When support for them is added, this logic can be removed and the index name resource attribute will need
+	// to be flattened to the metrics.
+	r.disableIndexMetrics(metricsConfig)
+
 	cfg := map[string]interface{}{
 		"collection_interval":  r.CollectionIntervalString(),
 		"endpoint":             r.Endpoint,
@@ -57,11 +69,7 @@ func (r MetricsReceiverElasticsearch) Pipelines() []otel.ReceiverPipeline {
 		"nodes":                []string{"_local"},
 		"tls":                  r.TLSConfig(true),
 		"skip_cluster_metrics": !r.ShouldCollectClusterMetrics(),
-	}
-
-	// Custom logic needed to skip JVM metrics, since JMX receiver is not used here.
-	if !r.ShouldCollectJVMMetrics() {
-		cfg["metrics"] = r.skipJVMMetricsConfig()
+		"metrics":              metricsConfig,
 	}
 
 	return []otel.ReceiverPipeline{{
@@ -79,7 +87,7 @@ func (r MetricsReceiverElasticsearch) Pipelines() []otel.ReceiverPipeline {
 	}}
 }
 
-func (r MetricsReceiverElasticsearch) skipJVMMetricsConfig() map[string]interface{} {
+func (r MetricsReceiverElasticsearch) skipJVMMetricsConfig(metricsConfig map[string]interface{}) {
 	jvmMetrics := []string{
 		"jvm.classes.loaded",
 		"jvm.gc.collections.count",
@@ -94,15 +102,37 @@ func (r MetricsReceiverElasticsearch) skipJVMMetricsConfig() map[string]interfac
 		"jvm.threads.count",
 	}
 
-	conf := map[string]interface{}{}
-
 	for _, metric := range jvmMetrics {
-		conf[metric] = map[string]bool{
+		metricsConfig[metric] = map[string]bool{
+			"enabled": false,
+		}
+	}
+}
+
+func (r MetricsReceiverElasticsearch) disableIndexMetrics(metricsConfig map[string]interface{}) {
+	indexMetrics := []string{
+		"elasticsearch.index.cache.evictions",
+		"elasticsearch.index.cache.memory.usage",
+		"elasticsearch.index.cache.size",
+		"elasticsearch.index.documents",
+		"elasticsearch.index.operations.completed",
+		"elasticsearch.index.operations.merge.docs_count",
+		"elasticsearch.index.operations.merge.size",
+		"elasticsearch.index.operations.time",
+		"elasticsearch.index.segments.count",
+		"elasticsearch.index.segments.memory",
+		"elasticsearch.index.segments.size",
+		"elasticsearch.index.shards.size",
+		"elasticsearch.index.translog.operations",
+		"elasticsearch.index.translog.size",
+	}
+
+	for _, metric := range indexMetrics {
+		metricsConfig[metric] = map[string]bool{
 			"enabled": false,
 		}
 	}
 
-	return conf
 }
 
 func init() {

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/otel.yaml
@@ -447,6 +447,35 @@ receivers:
   elasticsearch/elasticsearch:
     collection_interval: 60s
     endpoint: http://localhost:9200
+    metrics:
+      elasticsearch.index.cache.evictions:
+        enabled: false
+      elasticsearch.index.cache.memory.usage:
+        enabled: false
+      elasticsearch.index.cache.size:
+        enabled: false
+      elasticsearch.index.documents:
+        enabled: false
+      elasticsearch.index.operations.completed:
+        enabled: false
+      elasticsearch.index.operations.merge.docs_count:
+        enabled: false
+      elasticsearch.index.operations.merge.size:
+        enabled: false
+      elasticsearch.index.operations.time:
+        enabled: false
+      elasticsearch.index.segments.count:
+        enabled: false
+      elasticsearch.index.segments.memory:
+        enabled: false
+      elasticsearch.index.segments.size:
+        enabled: false
+      elasticsearch.index.shards.size:
+        enabled: false
+      elasticsearch.index.translog.operations:
+        enabled: false
+      elasticsearch.index.translog.size:
+        enabled: false
     nodes:
     - _local
     password: ""

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/otel.yaml
@@ -447,6 +447,35 @@ receivers:
   elasticsearch/elasticsearch:
     collection_interval: 60s
     endpoint: http://localhost:9200
+    metrics:
+      elasticsearch.index.cache.evictions:
+        enabled: false
+      elasticsearch.index.cache.memory.usage:
+        enabled: false
+      elasticsearch.index.cache.size:
+        enabled: false
+      elasticsearch.index.documents:
+        enabled: false
+      elasticsearch.index.operations.completed:
+        enabled: false
+      elasticsearch.index.operations.merge.docs_count:
+        enabled: false
+      elasticsearch.index.operations.merge.size:
+        enabled: false
+      elasticsearch.index.operations.time:
+        enabled: false
+      elasticsearch.index.segments.count:
+        enabled: false
+      elasticsearch.index.segments.memory:
+        enabled: false
+      elasticsearch.index.segments.size:
+        enabled: false
+      elasticsearch.index.shards.size:
+        enabled: false
+      elasticsearch.index.translog.operations:
+        enabled: false
+      elasticsearch.index.translog.size:
+        enabled: false
     nodes:
     - _local
     password: password

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/otel.yaml
@@ -447,6 +447,35 @@ receivers:
   elasticsearch/elasticsearch:
     collection_interval: 60s
     endpoint: https://example.com:7080
+    metrics:
+      elasticsearch.index.cache.evictions:
+        enabled: false
+      elasticsearch.index.cache.memory.usage:
+        enabled: false
+      elasticsearch.index.cache.size:
+        enabled: false
+      elasticsearch.index.documents:
+        enabled: false
+      elasticsearch.index.operations.completed:
+        enabled: false
+      elasticsearch.index.operations.merge.docs_count:
+        enabled: false
+      elasticsearch.index.operations.merge.size:
+        enabled: false
+      elasticsearch.index.operations.time:
+        enabled: false
+      elasticsearch.index.segments.count:
+        enabled: false
+      elasticsearch.index.segments.memory:
+        enabled: false
+      elasticsearch.index.segments.size:
+        enabled: false
+      elasticsearch.index.shards.size:
+        enabled: false
+      elasticsearch.index.translog.operations:
+        enabled: false
+      elasticsearch.index.translog.size:
+        enabled: false
     nodes:
     - _local
     password: ""

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/otel.yaml
@@ -447,6 +447,35 @@ receivers:
   elasticsearch/elasticsearch:
     collection_interval: 60s
     endpoint: http://localhost:9200
+    metrics:
+      elasticsearch.index.cache.evictions:
+        enabled: false
+      elasticsearch.index.cache.memory.usage:
+        enabled: false
+      elasticsearch.index.cache.size:
+        enabled: false
+      elasticsearch.index.documents:
+        enabled: false
+      elasticsearch.index.operations.completed:
+        enabled: false
+      elasticsearch.index.operations.merge.docs_count:
+        enabled: false
+      elasticsearch.index.operations.merge.size:
+        enabled: false
+      elasticsearch.index.operations.time:
+        enabled: false
+      elasticsearch.index.segments.count:
+        enabled: false
+      elasticsearch.index.segments.memory:
+        enabled: false
+      elasticsearch.index.segments.size:
+        enabled: false
+      elasticsearch.index.shards.size:
+        enabled: false
+      elasticsearch.index.translog.operations:
+        enabled: false
+      elasticsearch.index.translog.size:
+        enabled: false
     nodes:
     - _local
     password: ""

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/otel.yaml
@@ -448,6 +448,34 @@ receivers:
     collection_interval: 60s
     endpoint: http://localhost:9200
     metrics:
+      elasticsearch.index.cache.evictions:
+        enabled: false
+      elasticsearch.index.cache.memory.usage:
+        enabled: false
+      elasticsearch.index.cache.size:
+        enabled: false
+      elasticsearch.index.documents:
+        enabled: false
+      elasticsearch.index.operations.completed:
+        enabled: false
+      elasticsearch.index.operations.merge.docs_count:
+        enabled: false
+      elasticsearch.index.operations.merge.size:
+        enabled: false
+      elasticsearch.index.operations.time:
+        enabled: false
+      elasticsearch.index.segments.count:
+        enabled: false
+      elasticsearch.index.segments.memory:
+        enabled: false
+      elasticsearch.index.segments.size:
+        enabled: false
+      elasticsearch.index.shards.size:
+        enabled: false
+      elasticsearch.index.translog.operations:
+        enabled: false
+      elasticsearch.index.translog.size:
+        enabled: false
       jvm.classes.loaded:
         enabled: false
       jvm.gc.collections.count:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/otel.yaml
@@ -447,6 +447,35 @@ receivers:
   elasticsearch/elasticsearch:
     collection_interval: 60s
     endpoint: https://example.com/elasticsearch
+    metrics:
+      elasticsearch.index.cache.evictions:
+        enabled: false
+      elasticsearch.index.cache.memory.usage:
+        enabled: false
+      elasticsearch.index.cache.size:
+        enabled: false
+      elasticsearch.index.documents:
+        enabled: false
+      elasticsearch.index.operations.completed:
+        enabled: false
+      elasticsearch.index.operations.merge.docs_count:
+        enabled: false
+      elasticsearch.index.operations.merge.size:
+        enabled: false
+      elasticsearch.index.operations.time:
+        enabled: false
+      elasticsearch.index.segments.count:
+        enabled: false
+      elasticsearch.index.segments.memory:
+        enabled: false
+      elasticsearch.index.segments.size:
+        enabled: false
+      elasticsearch.index.shards.size:
+        enabled: false
+      elasticsearch.index.translog.operations:
+        enabled: false
+      elasticsearch.index.translog.size:
+        enabled: false
     nodes:
     - _local
     password: password


### PR DESCRIPTION
## Description
Certain elasticsearch metrics were previously not collected due to a feature gate which has been removed. Those metrics have high cardinality and the existing pipeline does not properly surface resource attributes, causing them to occupy the same exact metric and cause Duplicate Time Series errors.

## Related issue
https://github.com/GoogleCloudPlatform/ops-agent/issues/1199

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [X] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
