### PR TITLE
x10 increase coro_stack_size to prevent fluent-bit failures due to a …

### DIFF
--- a/systemd/google-cloud-ops-agent-fluent-bit.service
+++ b/systemd/google-cloud-ops-agent-fluent-bit.service
@@ -24,7 +24,7 @@ StateDirectory=google-cloud-ops-agent/fluent-bit
 LogsDirectory=google-cloud-ops-agent/subagents
 Type=simple
 ExecStartPre=@PREFIX@/libexec/google_cloud_ops_agent_engine -service=fluentbit -in @SYSCONFDIR@/google-cloud-ops-agent/config.yaml -logs ${LOGS_DIRECTORY} -state ${STATE_DIRECTORY}
-ExecStart=@PREFIX@/libexec/google_cloud_ops_agent_wrapper -config_path @SYSCONFDIR@/google-cloud-ops-agent/config.yaml -log_path ${LOGS_DIRECTORY}/logging-module.log @PREFIX@/subagents/fluent-bit/bin/fluent-bit --config ${RUNTIME_DIRECTORY}/fluent_bit_main.conf --parser ${RUNTIME_DIRECTORY}/fluent_bit_parser.conf --storage_path ${STATE_DIRECTORY}/buffers
+ExecStart=@PREFIX@/libexec/google_cloud_ops_agent_wrapper -config_path @SYSCONFDIR@/google-cloud-ops-agent/config.yaml -log_path ${LOGS_DIRECTORY}/logging-module.log @PREFIX@/subagents/fluent-bit/bin/fluent-bit --config ${RUNTIME_DIRECTORY}/fluent_bit_main.conf --parser ${RUNTIME_DIRECTORY}/fluent_bit_parser.conf --storage_path ${STATE_DIRECTORY}/buffers -s 245760
 Restart=always
 # For debugging:
 RuntimeDirectoryPreserve=yes


### PR DESCRIPTION
Our team recently encountered issues with the Fluent Bit service failing on various GCP VMs, most of which were running MongoDB, although this was not always the case.

Upon investigating the issue, we found that it was related to the `coro_stack_size` Fluent Bit parameter (https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/yaml/configuration-file), which can also be specified using the `-s` flag.

To address this problem, I submitted a pull request (PR) that proposes to increase the default value of the `coro_stack_size` parameter to `245760` bytes. This change could potentially help prevent similar service failures from occurring for other teams that may have experienced the same issue.

I think that increasing the default value by a factor of ten is a reasonable value, but otherwise this parameter could also be made configurable. I hope that this change will be beneficial for the `ops-agent` service and the users who rely on it.