### PR TITLE
fluent-bit[coro_stack_size] make configurable

### DIFF
--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -276,7 +276,11 @@ func (l *Logging) generateFluentbitComponents(ctx context.Context, userAgent str
 	if l.Service.LogLevel == "" {
 		l.Service.LogLevel = "info"
 	}
-	service := fluentbit.Service{LogLevel: l.Service.LogLevel}
+
+	if l.Service.CoroStackSize == "" {
+		l.Service.CoroStackSize = "24576"
+	}
+	service := fluentbit.Service{LogLevel: l.Service.LogLevel, CoroStackSize: l.Service.CoroStackSize}
 	out = append(out, service.Component())
 	out = append(out, fluentbit.MetricsInputComponent())
 

--- a/confgenerator/config.go
+++ b/confgenerator/config.go
@@ -66,6 +66,7 @@ func (uc *UnifiedConfig) DeepCopy(ctx context.Context) (*UnifiedConfig, error) {
 		return nil, fmt.Errorf("failed to convert UnifiedConfig to yaml: %w.", err)
 	}
 	fromYaml, err := UnmarshalYamlToUnifiedConfig(ctx, toYaml)
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert yaml to UnifiedConfig: %w.", err)
 	}
@@ -546,6 +547,7 @@ func (m *loggingProcessorMap) UnmarshalYAML(ctx context.Context, unmarshal func(
 }
 
 type LoggingService struct {
+	CoroStackSize string           `yaml:"coro_stack_size,omitempty"`
 	LogLevel  string               `yaml:"log_level,omitempty" validate:"omitempty,oneof=error warn info debug trace"`
 	Pipelines map[string]*Pipeline `validate:"dive,keys,startsnotwith=lib:"`
 }

--- a/confgenerator/confmerger.go
+++ b/confgenerator/confmerger.go
@@ -86,6 +86,9 @@ func mergeConfigs(original, overrides *UnifiedConfig) {
 			if overrides.Logging.Service.LogLevel != "info" {
 				original.Logging.Service.LogLevel = overrides.Logging.Service.LogLevel
 			}
+			if overrides.Logging.Service.CoroStackSize != "" {
+				original.Logging.Service.CoroStackSize = overrides.Logging.Service.CoroStackSize
+			}
 			for name, pipeline := range overrides.Logging.Service.Pipelines {
 				// skips logging.service.pipelines.*.exporters
 				pipeline.ExporterIDs = nil

--- a/confgenerator/fluentbit/service.go
+++ b/confgenerator/fluentbit/service.go
@@ -17,6 +17,7 @@ package fluentbit
 type Service struct {
 	// Allowed log levels are: error, warn, info, debug, and trace.
 	LogLevel string
+	CoroStackSize string
 }
 
 func (s Service) Component() Component {
@@ -30,6 +31,8 @@ func (s Service) Component() Component {
 			"Daemon": "off",
 			// Log_File is set by Fluent Bit systemd unit (e.g. /var/log/google-cloud-ops-agent/subagents/logging-module.log).
 			"Log_Level": s.LogLevel,
+
+			"coro_stack_size": s.CoroStackSize,
 
 			// Use the legacy DNS resolver mechanism to work around b/206549605 temporarily.
 			"dns.resolver": "legacy",


### PR DESCRIPTION
Our team recently encountered issues with the Fluent Bit service failing on various GCP VMs, most of which were running MongoDB, although this was not always the case.

Upon investigating the issue, we found that it was related to the `coro_stack_size` Fluent Bit parameter (https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/yaml/configuration-file) which default value is too low in our case. 

I think that this parameter should be made configurable and this changes will be beneficial for the `ops-agent` service and the users who rely on it.