### PR TITLE
Document undocumented elasticsearch metrics

### DIFF
--- a/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
@@ -288,6 +288,28 @@ expected_metrics:
     monitored_resource: gce_instance
     labels:
       state: free|used
+  - type: workload.googleapis.com/elasticsearch.cluster.in_flight_fetch
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.cluster.pending_tasks
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.node.cache.count
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+    labels:
+      type: .*
+  - type: workload.googleapis.com/elasticsearch.node.fs.disk.free
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: workload.googleapis.com/elasticsearch.node.fs.disk.total
+    value_type: INT64
+    kind: GAUGE
+    monitored_resource: gce_instance
 expected_logs:
   - log_name: elasticsearch_json
     fields:

--- a/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
@@ -301,7 +301,7 @@ expected_metrics:
     kind: GAUGE
     monitored_resource: gce_instance
     labels:
-      type: .*
+      type: hit|miss
   - type: workload.googleapis.com/elasticsearch.node.fs.disk.free
     value_type: INT64
     kind: GAUGE


### PR DESCRIPTION
## Description
Discovered during elasticsearch issue investigation, several elasticsearch metrics were collected but not documented.

```
Added https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13748
elasticsearch.cluster.in_flight_fetch
elasticsearch.cluster.pending_tasks

Added https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14027
elasticsearch.node.cache.count

Added https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/13571
elasticsearch.node.fs.disk.free
elasticsearch.node.fs.disk.total

Always been there since initial receiver implementation
elasticsearch.node.operations.time
```

## How has this been tested?
Metrics documentation generated from `./cmd/generate_expected_metrics` script after using current version of ops-agent to monitor elasticsearch.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
