### PR TITLE
Filter out duplicate elasticsearch metric

### DIFF
--- a/apps/elasticsearch.go
+++ b/apps/elasticsearch.go
@@ -79,6 +79,12 @@ func (r MetricsReceiverElasticsearch) Pipelines() []otel.ReceiverPipeline {
 		},
 		Processors: map[string][]otel.Component{"metrics": {
 			otel.NormalizeSums(),
+			// Elasticsearch Cluster metrics come with a summary JVM heap memory that is not useful && causes DuplicateTimeSeries errors
+			otel.MetricsOTTLFilter(
+				[]string{
+					`name == "jvm.memory.heap.used" and resource.attributes["elasticsearch.node.name"] == nil`,
+				},
+				[]string{}),
 			otel.MetricsTransform(
 				otel.AddPrefix("workload.googleapis.com"),
 			),

--- a/confgenerator/otel/processors.go
+++ b/confgenerator/otel/processors.go
@@ -40,6 +40,28 @@ func MetricsFilter(polarity, matchType string, metricNames ...string) Component 
 	}
 }
 
+// MetricsOTTLFilter returns a Component that filters metrics using OTTL.
+// OTTL can only be used as an exclude filter, any metrics or datapoints that match
+// one of the provided queries are dropped.
+// Example query: 'name == "jvm.memory.heap.used" and resource.attributes["elasticsearch.node.name"] == nil'
+func MetricsOTTLFilter(metricQueries []string, datapointQueries []string) Component {
+	metricsConfig := map[string]interface{}{}
+
+	if len(metricQueries) > 0 {
+		metricsConfig["metric"] = metricQueries
+	}
+	if len(datapointQueries) > 0 {
+		metricsConfig["datapoint"] = metricQueries
+	}
+
+	return Component{
+		Type: "filter",
+		Config: map[string]interface{}{
+			"metrics": metricsConfig,
+		},
+	}
+}
+
 // MetricsTransform returns a Component that performs the transformations specified as arguments.
 func MetricsTransform(metrics ...map[string]interface{}) Component {
 	return Component{

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/otel.yaml
@@ -28,6 +28,10 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
+  filter/elasticsearch_1:
+    metrics:
+      metric:
+      - name == "jvm.memory.heap.used" and resource.attributes["elasticsearch.node.name"] == nil
   filter/fluentbit_0:
     metrics:
       include:
@@ -56,7 +60,7 @@ processors:
         - otelcol_process_memory_rss
         - otelcol_grpc_io_client_completed_rpcs
         - otelcol_googlecloudmonitoring_point_count
-  metricstransform/elasticsearch_1:
+  metricstransform/elasticsearch_2:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -436,7 +440,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_2:
+  modifyscope/elasticsearch_3:
     override_scope_name: agent.googleapis.com/elasticsearch
     override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
@@ -531,8 +535,9 @@ service:
       - googlecloud/otel
       processors:
       - normalizesums/elasticsearch_0
-      - metricstransform/elasticsearch_1
-      - modifyscope/elasticsearch_2
+      - filter/elasticsearch_1
+      - metricstransform/elasticsearch_2
+      - modifyscope/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/otel.yaml
@@ -28,6 +28,10 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
+  filter/elasticsearch_1:
+    metrics:
+      metric:
+      - name == "jvm.memory.heap.used" and resource.attributes["elasticsearch.node.name"] == nil
   filter/fluentbit_0:
     metrics:
       include:
@@ -56,7 +60,7 @@ processors:
         - otelcol_process_memory_rss
         - otelcol_grpc_io_client_completed_rpcs
         - otelcol_googlecloudmonitoring_point_count
-  metricstransform/elasticsearch_1:
+  metricstransform/elasticsearch_2:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -436,7 +440,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_2:
+  modifyscope/elasticsearch_3:
     override_scope_name: agent.googleapis.com/elasticsearch
     override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
@@ -531,8 +535,9 @@ service:
       - googlecloud/otel
       processors:
       - normalizesums/elasticsearch_0
-      - metricstransform/elasticsearch_1
-      - modifyscope/elasticsearch_2
+      - filter/elasticsearch_1
+      - metricstransform/elasticsearch_2
+      - modifyscope/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/otel.yaml
@@ -28,6 +28,10 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
+  filter/elasticsearch_1:
+    metrics:
+      metric:
+      - name == "jvm.memory.heap.used" and resource.attributes["elasticsearch.node.name"] == nil
   filter/fluentbit_0:
     metrics:
       include:
@@ -56,7 +60,7 @@ processors:
         - otelcol_process_memory_rss
         - otelcol_grpc_io_client_completed_rpcs
         - otelcol_googlecloudmonitoring_point_count
-  metricstransform/elasticsearch_1:
+  metricstransform/elasticsearch_2:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -436,7 +440,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_2:
+  modifyscope/elasticsearch_3:
     override_scope_name: agent.googleapis.com/elasticsearch
     override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
@@ -531,8 +535,9 @@ service:
       - googlecloud/otel
       processors:
       - normalizesums/elasticsearch_0
-      - metricstransform/elasticsearch_1
-      - modifyscope/elasticsearch_2
+      - filter/elasticsearch_1
+      - metricstransform/elasticsearch_2
+      - modifyscope/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/otel.yaml
@@ -28,6 +28,10 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
+  filter/elasticsearch_1:
+    metrics:
+      metric:
+      - name == "jvm.memory.heap.used" and resource.attributes["elasticsearch.node.name"] == nil
   filter/fluentbit_0:
     metrics:
       include:
@@ -56,7 +60,7 @@ processors:
         - otelcol_process_memory_rss
         - otelcol_grpc_io_client_completed_rpcs
         - otelcol_googlecloudmonitoring_point_count
-  metricstransform/elasticsearch_1:
+  metricstransform/elasticsearch_2:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -436,7 +440,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_2:
+  modifyscope/elasticsearch_3:
     override_scope_name: agent.googleapis.com/elasticsearch
     override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
@@ -531,8 +535,9 @@ service:
       - googlecloud/otel
       processors:
       - normalizesums/elasticsearch_0
-      - metricstransform/elasticsearch_1
-      - modifyscope/elasticsearch_2
+      - filter/elasticsearch_1
+      - metricstransform/elasticsearch_2
+      - modifyscope/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/otel.yaml
@@ -28,6 +28,10 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
+  filter/elasticsearch_1:
+    metrics:
+      metric:
+      - name == "jvm.memory.heap.used" and resource.attributes["elasticsearch.node.name"] == nil
   filter/fluentbit_0:
     metrics:
       include:
@@ -56,7 +60,7 @@ processors:
         - otelcol_process_memory_rss
         - otelcol_grpc_io_client_completed_rpcs
         - otelcol_googlecloudmonitoring_point_count
-  metricstransform/elasticsearch_1:
+  metricstransform/elasticsearch_2:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -436,7 +440,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_2:
+  modifyscope/elasticsearch_3:
     override_scope_name: agent.googleapis.com/elasticsearch
     override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
@@ -553,8 +557,9 @@ service:
       - googlecloud/otel
       processors:
       - normalizesums/elasticsearch_0
-      - metricstransform/elasticsearch_1
-      - modifyscope/elasticsearch_2
+      - filter/elasticsearch_1
+      - metricstransform/elasticsearch_2
+      - modifyscope/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/otel.yaml
@@ -28,6 +28,10 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
+  filter/elasticsearch_1:
+    metrics:
+      metric:
+      - name == "jvm.memory.heap.used" and resource.attributes["elasticsearch.node.name"] == nil
   filter/fluentbit_0:
     metrics:
       include:
@@ -56,7 +60,7 @@ processors:
         - otelcol_process_memory_rss
         - otelcol_grpc_io_client_completed_rpcs
         - otelcol_googlecloudmonitoring_point_count
-  metricstransform/elasticsearch_1:
+  metricstransform/elasticsearch_2:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -436,7 +440,7 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_2:
+  modifyscope/elasticsearch_3:
     override_scope_name: agent.googleapis.com/elasticsearch
     override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
@@ -533,8 +537,9 @@ service:
       - googlecloud/otel
       processors:
       - normalizesums/elasticsearch_0
-      - metricstransform/elasticsearch_1
-      - modifyscope/elasticsearch_2
+      - filter/elasticsearch_1
+      - metricstransform/elasticsearch_2
+      - modifyscope/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch


### PR DESCRIPTION
## Description
While finishing validation of elasticsearch changes to remove index metrics, discovered that there was an additional metric that needed to be removed.

Elasticseach cluster metrics, when collected, will collect a duplicate metric that is a summary JVM memory metric, but that enters into GCM as a duplicate time series. This data can be seen by users by simply summing the existing JVM memory metrics in the end platform, so it should not be collected in this manner anyway.

## Related issue
https://github.com/GoogleCloudPlatform/ops-agent/issues/1199

## How has this been tested?
Manually validated with an ops-agent build locally, unit tests confirm the expected filter processor is created appropriately.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [X] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
