### PR TITLE
Testing: Minimize uses of DirectoryLogger

### DIFF
--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -166,7 +166,7 @@ func installAgent(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.
 	if packagesInGCS == "" {
 		return installUsingScript(ctx, logger, vm)
 	}
-	return nonRetryable, agents.InstallPackageFromGCS(ctx, logger, vm, packagesInGCS)
+	return nonRetryable, agents.InstallPackageFromGCS(ctx, logger.ToMainLog(), vm, packagesInGCS)
 }
 
 // updateSSHKeysForActiveDirectory alters the ssh-keys metadata value for the


### PR DESCRIPTION
## Description
The goal (not achieved in this PR) is to be able to call `setupOpsAgentFrom()` with a simple *log.Logger argument instead of a *logging.DirectoryLogger argument. This PR is a step in that direction. It's a simple step because `InstallPackageFromGCS` and `installOpsAgent` don't use anything from the DirectoryLogger except .ToMainLog() anyway, so we can just move that to the callsite.

The next PR will address `setupOpsAgentFrom()` and `gce.UploadContent()`.

## Related issue

## How has this been tested?
automated tests

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
