### PR TITLE
Testing: Further reduce use of DirectoryLogger

### DIFF
--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -744,13 +744,13 @@ func InstallOpsAgent(ctx context.Context, logger *log.Logger, vm *gce.VM, locati
 }
 
 // SetupOpsAgent installs the Ops Agent and installs the given config.
-func SetupOpsAgent(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.VM, config string) error {
+func SetupOpsAgent(ctx context.Context, logger *log.Logger, vm *gce.VM, config string) error {
 	return SetupOpsAgentFrom(ctx, logger, vm, config, LocationFromEnvVars())
 }
 
 // restartOpsAgent restarts the Ops Agent and waits for it to become available.
-func restartOpsAgent(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.VM) error {
-	if _, err := gce.RunRemotely(ctx, logger.ToMainLog(), vm, "", restartOpsAgentForPlatform(vm.Platform)); err != nil {
+func restartOpsAgent(ctx context.Context, logger *log.Logger, vm *gce.VM) error {
+	if _, err := gce.RunRemotely(ctx, logger, vm, "", restartOpsAgentForPlatform(vm.Platform)); err != nil {
 		return fmt.Errorf("restartOpsAgent() failed to restart ops agent: %v", err)
 	}
 	// Give agents time to shut down. Fluent-Bit's default shutdown grace period
@@ -761,7 +761,7 @@ func restartOpsAgent(ctx context.Context, logger *logging.DirectoryLogger, vm *g
 
 // SetupOpsAgentFrom is an overload of setupOpsAgent that allows the callsite to
 // decide which version of the agent gets installed.
-func SetupOpsAgentFrom(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.VM, config string, location PackageLocation) error {
+func SetupOpsAgentFrom(ctx context.Context, logger *log.Logger, vm *gce.VM, config string, location PackageLocation) error {
 	if err := InstallOpsAgent(ctx, logger.ToMainLog(), vm, location); err != nil {
 		return err
 	}

--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -762,7 +762,7 @@ func restartOpsAgent(ctx context.Context, logger *log.Logger, vm *gce.VM) error 
 // SetupOpsAgentFrom is an overload of setupOpsAgent that allows the callsite to
 // decide which version of the agent gets installed.
 func SetupOpsAgentFrom(ctx context.Context, logger *log.Logger, vm *gce.VM, config string, location PackageLocation) error {
-	if err := InstallOpsAgent(ctx, logger.ToMainLog(), vm, location); err != nil {
+	if err := InstallOpsAgent(ctx, logger, vm, location); err != nil {
 		return err
 	}
 	startupDelay := 20 * time.Second

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -808,18 +808,16 @@ func RunRemotely(ctx context.Context, logger *log.Logger, vm *VM, stdin string, 
 // given permission to read from that bucket. This was accomplished by adding
 // the "Compute Engine default service account" for PROJECT as
 // a "Storage Object Viewer" and "Storage Object Creator" on the bucket.
-func UploadContent(ctx context.Context, dirLog *logging.DirectoryLogger, vm *VM, content io.Reader, remotePath string) (err error) {
+func UploadContent(ctx context.Context, logger *log.Logger, vm *VM, content io.Reader, remotePath string) (err error) {
 	defer func() {
-		dirLog.ToMainLog().Printf("Uploading file finished. For details see file_uploads.txt. err=%v", err)
+		logger.Printf("Uploading file finished with err=%v", err)
 	}()
-	logger := dirLog.ToFile("file_uploads.txt")
 	object := storageClient.Bucket(transfersBucket).Object(path.Join(vm.Name, remotePath))
 	writer := object.NewWriter(ctx)
 	_, copyErr := io.Copy(writer, content)
 	// We have to make sure to call Close() here in order to tell it to finish
 	// the upload operation.
 	closeErr := writer.Close()
-	logger.Printf("Upload to %v finished with copyErr=%v, closeErr=%v", object, copyErr, closeErr)
 	err = multierr.Combine(copyErr, closeErr)
 	if err != nil {
 		return fmt.Errorf("UploadContent() could not write data into storage object: %v", err)
@@ -831,7 +829,6 @@ func UploadContent(ctx context.Context, dirLog *logging.DirectoryLogger, vm *VM,
 	// (note that the go client libraries use resumable uploads).
 	defer func() {
 		deleteErr := object.Delete(ctx)
-		logger.Printf("Deleting %v finished with deleteErr=%v", object, deleteErr)
 		if deleteErr != nil {
 			err = fmt.Errorf("UploadContent() finished with err=%v, then cleanup of %v finished with err=%v", err, object.ObjectName(), deleteErr)
 		}
@@ -886,7 +883,7 @@ func RunScriptRemotely(ctx context.Context, logger *logging.DirectoryLogger, vm 
 		// Use a UUID for the script name in case RunScriptRemotely is being
 		// called concurrently on the same VM.
 		scriptPath := "C:\\" + uuid.NewString() + ".ps1"
-		if err := UploadContent(ctx, logger, vm, strings.NewReader(scriptContents), scriptPath); err != nil {
+		if err := UploadContent(ctx, logger.ToFile("file_uploads.txt"), vm, strings.NewReader(scriptContents), scriptPath); err != nil {
 			return CommandOutput{}, err
 		}
 		return RunRemotely(ctx, logger.ToMainLog(), vm, "", envVarMapToPowershellPrefix(env)+"powershell -File "+scriptPath+" "+flagsStr)

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -278,8 +278,8 @@ func setupOpsAgent(ctx context.Context, logger *log.Logger, vm *gce.VM, config s
 }
 
 // restartOpsAgent restarts the Ops Agent and waits for it to become available.
-func restartOpsAgent(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.VM) error {
-	if _, err := gce.RunRemotely(ctx, logger.ToMainLog(), vm, "", restartCommandForPlatform(vm.Platform)); err != nil {
+func restartOpsAgent(ctx context.Context, logger *log.Logger, vm *gce.VM) error {
+	if _, err := gce.RunRemotely(ctx, logger, vm, "", restartCommandForPlatform(vm.Platform)); err != nil {
 		return fmt.Errorf("restartOpsAgent() failed to restart ops agent: %v", err)
 	}
 	// Give agents time to shut down. Fluent-Bit's default shutdown grace period

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -273,7 +273,7 @@ func installOpsAgent(ctx context.Context, logger *log.Logger, vm *gce.VM, locati
 }
 
 // setupOpsAgent installs the Ops Agent and installs the given config.
-func setupOpsAgent(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.VM, config string) error {
+func setupOpsAgent(ctx context.Context, logger *log.Logger, vm *gce.VM, config string) error {
 	return setupOpsAgentFrom(ctx, logger, vm, config, locationFromEnvVars())
 }
 
@@ -290,8 +290,8 @@ func restartOpsAgent(ctx context.Context, logger *logging.DirectoryLogger, vm *g
 
 // setupOpsAgentFrom is an overload of setupOpsAgent that allows the callsite to
 // decide which version of the agent gets installed.
-func setupOpsAgentFrom(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.VM, config string, location packageLocation) error {
-	if err := installOpsAgent(ctx, logger.ToMainLog(), vm, location); err != nil {
+func setupOpsAgentFrom(ctx context.Context, logger *log.Logger, vm *gce.VM, config string, location packageLocation) error {
+	if err := installOpsAgent(ctx, logger, vm, location); err != nil {
 		return err
 	}
 	startupDelay := 20 * time.Second
@@ -342,7 +342,7 @@ func TestParseMultilineFileJava(t *testing.T) {
         processors: [multiline_parser_1]`, logPath)
 
 		//Below lines comes from 3 java exception stacktraces, thus expect 3 logEntries.
-		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(`Jul 09, 2015 3:23:29 PM com.google.devtools.search.cloud.feeder.MakeLog: RuntimeException: Run from this message!
+		if err := gce.UploadContent(ctx, logger.ToMainLog(), vm, strings.NewReader(`Jul 09, 2015 3:23:29 PM com.google.devtools.search.cloud.feeder.MakeLog: RuntimeException: Run from this message!
   at com.my.app.Object.do$a1(MakeLog.java:50)
   at java.lang.Thing.call(Thing.java:10)
 javax.servlet.ServletException: Something bad happened
@@ -401,7 +401,7 @@ Caused by: com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EM
 			t.Fatalf("error writing dummy log lines for Java: %v", err)
 		}
 
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -444,7 +444,7 @@ func TestParseMultilineFileJavaPython(t *testing.T) {
         processors: [multiline_parser_1]`, logPath)
 
 		//Below lines comes from 3 java and 3 python exception stacktraces, thus expect 6 logEntries.
-		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(`Jul 09, 2015 3:23:29 PM com.google.devtools.search.cloud.feeder.MakeLog: RuntimeException: Run from this message!
+		if err := gce.UploadContent(ctx, logger.ToMainLog(), vm, strings.NewReader(`Jul 09, 2015 3:23:29 PM com.google.devtools.search.cloud.feeder.MakeLog: RuntimeException: Run from this message!
   at com.my.app.Object.do$a1(MakeLog.java:50)
   at java.lang.Thing.call(Thing.java:10)
 Traceback (most recent call last):
@@ -535,7 +535,7 @@ TypeError: can only concatenate str (not "int") to str
 			t.Fatalf("error writing dummy log lines for Java + Python: %v", err)
 		}
 
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -603,7 +603,7 @@ func TestParseMultilineFileGolangJavaPython(t *testing.T) {
         processors: [multiline_parser_1]`, logPath)
 
 		//Below lines comes from Go, Python and Java exception stacktraces.
-		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(`2019/01/15 07:48:05 http: panic serving [::1]:54143: test panic
+		if err := gce.UploadContent(ctx, logger.ToMainLog(), vm, strings.NewReader(`2019/01/15 07:48:05 http: panic serving [::1]:54143: test panic
 goroutine 24 [running]:
 net/http.(*conn).serve.func1(0xc00007eaa0)
 	/usr/local/go/src/net/http/server.go:1746 +0xd0
@@ -656,7 +656,7 @@ Caused by: com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EM
 			t.Fatalf("error writing dummy log lines for Go + Java + Python: %v", err)
 		}
 
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -706,7 +706,7 @@ func TestParseMultilineFileMissingParser(t *testing.T) {
         processors: [multiline_parser_1]`, logPath)
 
 		//Below lines comes from Go, Python and Java exception stacktraces.
-		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(`2019/01/15 07:48:05 http: panic serving [::1]:54143: test panic
+		if err := gce.UploadContent(ctx, logger.ToMainLog(), vm, strings.NewReader(`2019/01/15 07:48:05 http: panic serving [::1]:54143: test panic
 goroutine 24 [running]:
 net/http.(*conn).serve.func1(0xc00007eaa0)
 	/usr/local/go/src/net/http/server.go:1746 +0xd0
@@ -759,7 +759,7 @@ Caused by: com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EM
 			t.Fatalf("error writing dummy log lines for Go + Java + Python: %v", err)
 		}
 
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -817,11 +817,11 @@ func TestCustomLogFile(t *testing.T) {
         exporters: [google]
 `, logPath)
 
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
-		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader("abc test pattern xyz\n7654321\n"), logPath); err != nil {
+		if err := gce.UploadContent(ctx, logger.ToMainLog(), vm, strings.NewReader("abc test pattern xyz\n7654321\n"), logPath); err != nil {
 			t.Fatalf("error writing dummy log line: %v", err)
 		}
 
@@ -868,13 +868,13 @@ func TestCustomLogFormat(t *testing.T) {
         exporters: [google]
 `, logPath, "%Y-%m-%dT%H:%M:%S.%L%z")
 
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
 		zone := time.FixedZone("UTC-8", int((-8 * time.Hour).Seconds()))
 		line := fmt.Sprintf("<13>1 %s %s my_app_id - - - qqqqrrrr\n", time.Now().In(zone).Format(time.RFC3339Nano), vm.Name)
-		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(line), logPath); err != nil {
+		if err := gce.UploadContent(ctx, logger.ToMainLog(), vm, strings.NewReader(line), logPath); err != nil {
 			t.Fatalf("error writing dummy log line: %v", err)
 		}
 
@@ -912,7 +912,7 @@ func TestHTTPRequestLog(t *testing.T) {
         processors: [json1]
         exporters: [google]`, logPath)
 
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -950,7 +950,7 @@ func TestHTTPRequestLog(t *testing.T) {
 		// Write both logs to log source file at the same time.
 		err = gce.UploadContent(
 			ctx,
-			logger,
+			logger.ToMainLog(),
 			vm,
 			strings.NewReader(fmt.Sprintf("%s\n%s\n", string(newLogBytes), string(oldLogBytes))),
 			logPath)
@@ -1034,7 +1034,7 @@ func TestInvalidConfig(t *testing.T) {
 `
 
 		// Run install with an invalid config. We expect to see an error.
-		if err := setupOpsAgent(ctx, logger, vm, config); err == nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err == nil {
 			t.Fatal("Expected agent to reject bad config.")
 		}
 	})
@@ -1079,14 +1079,14 @@ func TestProcessorOrder(t *testing.T) {
         exporters: [google]
 `, logPath, "%Y-%m-%dT%H:%M:%S.%L%z")
 
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
 		// When not using UTC timestamps, the parsing with "%Y-%m-%dT%H:%M:%S.%L%z" doesn't work
 		// correctly in windows (b/218888265).
 		line := fmt.Sprintf(`{"log":"{\"level\":\"info\",\"message\":\"start\"}\n","time":"%s"}`, time.Now().UTC().Format(time.RFC3339Nano)) + "\n"
-		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(line), logPath); err != nil {
+		if err := gce.UploadContent(ctx, logger.ToMainLog(), vm, strings.NewReader(line), logPath); err != nil {
 			t.Fatalf("error writing dummy log line: %v", err)
 		}
 
@@ -1142,7 +1142,7 @@ func TestSyslogTCP(t *testing.T) {
         exporters: [google]
 `
 
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1198,7 +1198,7 @@ func TestSyslogUDP(t *testing.T) {
         exporters: [google]
 `
 
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1265,15 +1265,15 @@ func TestExcludeLogsParseJsonOrder(t *testing.T) {
         exporters: [google]
 `, file1, file2)
 
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
 		line := `{"field":"value"}` + "\n"
-		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(line), file2); err != nil {
+		if err := gce.UploadContent(ctx, logger.ToMainLog(), vm, strings.NewReader(line), file2); err != nil {
 			t.Fatalf("error uploading log: %v", err)
 		}
-		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(line), file1); err != nil {
+		if err := gce.UploadContent(ctx, logger.ToMainLog(), vm, strings.NewReader(line), file1); err != nil {
 			t.Fatalf("error uploading log: %v", err)
 		}
 
@@ -1351,12 +1351,12 @@ func TestModifyFields(t *testing.T) {
         exporters: [google]
 `, file1)
 
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
 		line := `{"field":"value", "default_present":"original", "logging.googleapis.com/labels": {"label1":"value"}}` + "\n"
-		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(line), file1); err != nil {
+		if err := gce.UploadContent(ctx, logger.ToMainLog(), vm, strings.NewReader(line), file1); err != nil {
 			t.Fatalf("error uploading log: %v", err)
 		}
 
@@ -1417,12 +1417,12 @@ logging:
           - google
 `
 		config := fmt.Sprintf(configStr, file1)
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
 		line := `{"parsed-field":"parsed-value", "overwritten-field":"overwritten", "logging.googleapis.com/labels": {"parsed-label":"parsed-label", "overwritten-label":"overwritten"}, "logging.googleapis.com/sourceLocation": {"file": "overwritten-file-path"}}` + "\n"
-		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(line), file1); err != nil {
+		if err := gce.UploadContent(ctx, logger.ToMainLog(), vm, strings.NewReader(line), file1); err != nil {
 			t.Fatalf("error uploading log: %v", err)
 		}
 
@@ -1457,12 +1457,12 @@ func TestResourceNameLabel(t *testing.T) {
         processors: [json]
 `, file1)
 
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
 		line := `{"default_present":"original"}` + "\n"
-		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(line), file1); err != nil {
+		if err := gce.UploadContent(ctx, logger.ToMainLog(), vm, strings.NewReader(line), file1); err != nil {
 			t.Fatalf("error uploading log: %v", err)
 		}
 
@@ -1498,12 +1498,12 @@ func TestLogFilePathLabel(t *testing.T) {
         processors: [json]
 `, file1)
 
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
 		line := `{"default_present":"original"}` + "\n"
-		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(line), file1); err != nil {
+		if err := gce.UploadContent(ctx, logger.ToMainLog(), vm, strings.NewReader(line), file1); err != nil {
 			t.Fatalf("error uploading log: %v", err)
 		}
 
@@ -1544,7 +1544,7 @@ func TestTCPLog(t *testing.T) {
         receivers: [tcp_logs]
 `
 
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1584,7 +1584,7 @@ func TestFluentForwardLog(t *testing.T) {
       fluent_pipeline:
         receivers: [fluent_logs]
 `
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1626,7 +1626,7 @@ func TestWindowsEventLog(t *testing.T) {
         receivers: [windows_event_log]
         exporters: [google]
 `
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1671,7 +1671,7 @@ func TestWindowsEventLogV1UnsupportedChannel(t *testing.T) {
       default_pipeline:
         receivers: [%s]
 `, log, channel, log)
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1730,7 +1730,7 @@ func TestWindowsEventLogV2(t *testing.T) {
       pipeline_xml:
         receivers: [winlog2_xml]
 `
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1949,7 +1949,7 @@ func TestWindowsEventLogWithNonDefaultTimeZone(t *testing.T) {
 		if _, err := gce.RunRemotely(ctx, logger.ToMainLog(), vm, "", `Set-TimeZone -Id "Eastern Standard Time"`); err != nil {
 			t.Fatal(err)
 		}
-		if err := setupOpsAgent(ctx, logger, vm, ""); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1992,7 +1992,7 @@ func TestSystemdLog(t *testing.T) {
         receivers: [systemd_logs]
 `
 
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2012,7 +2012,7 @@ func TestSystemLogByDefault(t *testing.T) {
 		t.Parallel()
 		ctx, logger, vm := agents.CommonSetup(t, platform)
 
-		if err := setupOpsAgent(ctx, logger, vm, ""); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2149,7 +2149,7 @@ func TestDefaultMetricsNoProxy(t *testing.T) {
 		t.Parallel()
 
 		ctx, logger, vm := agents.CommonSetup(t, platform)
-		if err := setupOpsAgent(ctx, logger, vm, ""); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2177,7 +2177,7 @@ func TestDefaultMetricsWithProxy(t *testing.T) {
 		if err := gce.SetEnvironmentVariables(ctx, logger.ToMainLog(), vm, settings); err != nil {
 			t.Fatal(err)
 		}
-		if err := setupOpsAgent(ctx, logger, vm, ""); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2246,7 +2246,7 @@ func TestPrometheusMetrics(t *testing.T) {
           - prometheus
 `
 
-		if err := setupOpsAgent(ctx, logger, vm, promConfig); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, promConfig); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2479,7 +2479,7 @@ func TestPrometheusMetricsWithJSONExporter(t *testing.T) {
       prom_pipeline:
         receivers: [prom_app]
 `
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2723,7 +2723,7 @@ func testPrometheusMetrics(t *testing.T, testFiles map[string]fileToUpload, chec
       prom_pipeline:
         receivers: [prom_app]
 `
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2898,7 +2898,7 @@ func uploadFiles(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.V
 				return err
 			}
 			defer f.Close()
-			err = gce.UploadContent(ctx, logger, vm, f, upload.remote)
+			err = gce.UploadContent(ctx, logger.ToMainLog(), vm, f, upload.remote)
 			return err
 		}()
 		if err != nil {
@@ -2943,7 +2943,7 @@ metrics:
         processors: [metrics_filter]
 `
 
-		if err := setupOpsAgent(ctx, logger, vm, excludeConfig); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, excludeConfig); err != nil {
 			t.Fatal(err)
 		}
 
@@ -3025,7 +3025,7 @@ func terminateProcess(ctx context.Context, logger *log.Logger, vm *gce.VM, proce
 }
 
 func testAgentCrashRestart(ctx context.Context, t *testing.T, logger *logging.DirectoryLogger, vm *gce.VM, processNames []string, livenessChecker func(context.Context, *log.Logger, *gce.VM) error) {
-	if err := setupOpsAgent(ctx, logger, vm, ""); err != nil {
+	if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3101,7 +3101,7 @@ func TestLoggingFluentbitSelfLogs(t *testing.T) {
 		t.Parallel()
 		ctx, logger, vm := agents.CommonSetup(t, platform)
 
-		if err := setupOpsAgent(ctx, logger, vm, ""); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -3188,7 +3188,7 @@ func TestUpgradeOpsAgent(t *testing.T) {
 		ctx, logger, vm := agents.CommonSetup(t, platform)
 
 		// This will install the stable Ops Agent (REPO_SUFFIX="").
-		if err := setupOpsAgentFrom(ctx, logger, vm, "", packageLocation{}); err != nil {
+		if err := setupOpsAgentFrom(ctx, logger.ToMainLog(), vm, "", packageLocation{}); err != nil {
 			// Installation from stable may fail before the first release on
 			// a new platform.
 			if strings.HasPrefix(err.Error(), "installOpsAgent() failed to run googet") ||
@@ -3205,7 +3205,7 @@ func TestUpgradeOpsAgent(t *testing.T) {
 
 		// Install the Ops agent from AGENT_PACKAGES_IN_GCS or REPO_SUFFIX.
 		secondVersion := locationFromEnvVars()
-		if err := setupOpsAgentFrom(ctx, logger, vm, "", secondVersion); err != nil {
+		if err := setupOpsAgentFrom(ctx, logger.ToMainLog(), vm, "", secondVersion); err != nil {
 			t.Fatal(err)
 		}
 
@@ -3302,7 +3302,7 @@ func runResourceDetectorCli(ctx context.Context, logger *logging.DirectoryLogger
 			return nil, err
 		}
 		defer f.Close()
-		err = gce.UploadContent(ctx, logger, vm, f, path.Join(workDir, file.remote))
+		err = gce.UploadContent(ctx, logger.ToMainLog(), vm, f, path.Join(workDir, file.remote))
 		if err != nil {
 			return nil, err
 		}
@@ -3374,7 +3374,7 @@ func runGoCode(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.VM,
 	if err := makeDirectory(ctx, logger, vm, workDir); err != nil {
 		return err
 	}
-	if err := gce.UploadContent(ctx, logger, vm, content, path.Join(workDir, "main.go")); err != nil {
+	if err := gce.UploadContent(ctx, logger.ToMainLog(), vm, content, path.Join(workDir, "main.go")); err != nil {
 		return err
 	}
 	goInitAndRun := fmt.Sprintf(`
@@ -3415,7 +3415,7 @@ traces:
   service:
     pipelines:
 `
-		if err := setupOpsAgent(ctx, logger, vm, otlpConfig); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, otlpConfig); err != nil {
 			t.Fatal(err)
 		}
 
@@ -3519,7 +3519,7 @@ traces:
   service:
     pipelines:
 `
-		if err := setupOpsAgent(ctx, logger, vm, otlpConfig); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, otlpConfig); err != nil {
 			t.Fatal(err)
 		}
 
@@ -3622,7 +3622,7 @@ metrics:
   service:
     pipelines:
 `
-		if err := setupOpsAgent(ctx, logger, vm, otlpConfig); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, otlpConfig); err != nil {
 			t.Fatal(err)
 		}
 
@@ -3712,7 +3712,7 @@ func TestPortsAndAPIHealthChecks(t *testing.T) {
 		// Wait for port to be in listen mode.
 		time.Sleep(30 * time.Second)
 
-		if err := setupOpsAgent(ctx, logger, vm, ""); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -3742,7 +3742,7 @@ func TestNetworkHealthCheck(t *testing.T) {
 
 		ctx, logger, vm := agents.CommonSetup(t, platform)
 
-		if err := setupOpsAgent(ctx, logger, vm, ""); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -3814,7 +3814,7 @@ func TestBufferLimitSizeOpsAgent(t *testing.T) {
         receivers: [log_syslog]
         processors: []`, logPath)
 
-		if err := setupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := setupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 		var bufferDir string

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -294,7 +294,7 @@ Caused by: com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EM
 			t.Fatalf("error writing dummy log lines for Java: %v", err)
 		}
 
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -428,7 +428,7 @@ TypeError: can only concatenate str (not "int") to str
 			t.Fatalf("error writing dummy log lines for Java + Python: %v", err)
 		}
 
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -549,7 +549,7 @@ Caused by: com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EM
 			t.Fatalf("error writing dummy log lines for Go + Java + Python: %v", err)
 		}
 
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -652,7 +652,7 @@ Caused by: com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EM
 			t.Fatalf("error writing dummy log lines for Go + Java + Python: %v", err)
 		}
 
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -710,7 +710,7 @@ func TestCustomLogFile(t *testing.T) {
         exporters: [google]
 `, logPath)
 
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -761,7 +761,7 @@ func TestCustomLogFormat(t *testing.T) {
         exporters: [google]
 `, logPath, "%Y-%m-%dT%H:%M:%S.%L%z")
 
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -805,7 +805,7 @@ func TestHTTPRequestLog(t *testing.T) {
         processors: [json1]
         exporters: [google]`, logPath)
 
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -927,7 +927,7 @@ func TestInvalidConfig(t *testing.T) {
 `
 
 		// Run install with an invalid config. We expect to see an error.
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err == nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err == nil {
 			t.Fatal("Expected agent to reject bad config.")
 		}
 	})
@@ -972,7 +972,7 @@ func TestProcessorOrder(t *testing.T) {
         exporters: [google]
 `, logPath, "%Y-%m-%dT%H:%M:%S.%L%z")
 
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1035,7 +1035,7 @@ func TestSyslogTCP(t *testing.T) {
         exporters: [google]
 `
 
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1091,7 +1091,7 @@ func TestSyslogUDP(t *testing.T) {
         exporters: [google]
 `
 
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1158,7 +1158,7 @@ func TestExcludeLogsParseJsonOrder(t *testing.T) {
         exporters: [google]
 `, file1, file2)
 
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1244,7 +1244,7 @@ func TestModifyFields(t *testing.T) {
         exporters: [google]
 `, file1)
 
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1310,7 +1310,7 @@ logging:
           - google
 `
 		config := fmt.Sprintf(configStr, file1)
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1350,7 +1350,7 @@ func TestResourceNameLabel(t *testing.T) {
         processors: [json]
 `, file1)
 
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1391,7 +1391,7 @@ func TestLogFilePathLabel(t *testing.T) {
         processors: [json]
 `, file1)
 
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1437,7 +1437,7 @@ func TestTCPLog(t *testing.T) {
         receivers: [tcp_logs]
 `
 
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1477,7 +1477,7 @@ func TestFluentForwardLog(t *testing.T) {
       fluent_pipeline:
         receivers: [fluent_logs]
 `
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1519,7 +1519,7 @@ func TestWindowsEventLog(t *testing.T) {
         receivers: [windows_event_log]
         exporters: [google]
 `
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1564,7 +1564,7 @@ func TestWindowsEventLogV1UnsupportedChannel(t *testing.T) {
       default_pipeline:
         receivers: [%s]
 `, log, channel, log)
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1623,7 +1623,7 @@ func TestWindowsEventLogV2(t *testing.T) {
       pipeline_xml:
         receivers: [winlog2_xml]
 `
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1842,7 +1842,7 @@ func TestWindowsEventLogWithNonDefaultTimeZone(t *testing.T) {
 		if _, err := gce.RunRemotely(ctx, logger.ToMainLog(), vm, "", `Set-TimeZone -Id "Eastern Standard Time"`); err != nil {
 			t.Fatal(err)
 		}
-		if err := agents.SetupOpsAgent(ctx, logger, vm, ""); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1885,7 +1885,7 @@ func TestSystemdLog(t *testing.T) {
         receivers: [systemd_logs]
 `
 
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1905,7 +1905,7 @@ func TestSystemLogByDefault(t *testing.T) {
 		t.Parallel()
 		ctx, logger, vm := agents.CommonSetup(t, platform)
 
-		if err := agents.SetupOpsAgent(ctx, logger, vm, ""); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2042,7 +2042,7 @@ func TestDefaultMetricsNoProxy(t *testing.T) {
 		t.Parallel()
 
 		ctx, logger, vm := agents.CommonSetup(t, platform)
-		if err := agents.SetupOpsAgent(ctx, logger, vm, ""); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2070,7 +2070,7 @@ func TestDefaultMetricsWithProxy(t *testing.T) {
 		if err := gce.SetEnvironmentVariables(ctx, logger.ToMainLog(), vm, settings); err != nil {
 			t.Fatal(err)
 		}
-		if err := agents.SetupOpsAgent(ctx, logger, vm, ""); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2139,7 +2139,7 @@ func TestPrometheusMetrics(t *testing.T) {
           - prometheus
 `
 
-		if err := agents.SetupOpsAgent(ctx, logger, vm, promConfig); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, promConfig); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2372,7 +2372,7 @@ func TestPrometheusMetricsWithJSONExporter(t *testing.T) {
       prom_pipeline:
         receivers: [prom_app]
 `
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2616,7 +2616,7 @@ func testPrometheusMetrics(t *testing.T, testFiles map[string]fileToUpload, chec
       prom_pipeline:
         receivers: [prom_app]
 `
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2836,7 +2836,7 @@ metrics:
         processors: [metrics_filter]
 `
 
-		if err := agents.SetupOpsAgent(ctx, logger, vm, excludeConfig); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, excludeConfig); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2918,7 +2918,7 @@ func terminateProcess(ctx context.Context, logger *log.Logger, vm *gce.VM, proce
 }
 
 func testAgentCrashRestart(ctx context.Context, t *testing.T, logger *logging.DirectoryLogger, vm *gce.VM, processNames []string, livenessChecker func(context.Context, *log.Logger, *gce.VM) error) {
-	if err := agents.SetupOpsAgent(ctx, logger, vm, ""); err != nil {
+	if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2994,7 +2994,7 @@ func TestLoggingFluentbitSelfLogs(t *testing.T) {
 		t.Parallel()
 		ctx, logger, vm := agents.CommonSetup(t, platform)
 
-		if err := agents.SetupOpsAgent(ctx, logger, vm, ""); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -3081,7 +3081,7 @@ func TestUpgradeOpsAgent(t *testing.T) {
 		ctx, logger, vm := agents.CommonSetup(t, platform)
 
 		// This will install the stable Ops Agent (REPO_SUFFIX="").
-		if err := agents.SetupOpsAgentFrom(ctx, logger, vm, "", agents.PackageLocation{}); err != nil {
+		if err := agents.SetupOpsAgentFrom(ctx, logger.ToMainLog(), vm, "", agents.PackageLocation{}); err != nil {
 			// Installation from stable may fail before the first release on
 			// a new platform.
 			if strings.HasPrefix(err.Error(), "InstallOpsAgent() failed to run googet") ||
@@ -3098,7 +3098,7 @@ func TestUpgradeOpsAgent(t *testing.T) {
 
 		// Install the Ops agent from AGENT_PACKAGES_IN_GCS or REPO_SUFFIX.
 		secondVersion := agents.LocationFromEnvVars()
-		if err := agents.SetupOpsAgentFrom(ctx, logger, vm, "", secondVersion); err != nil {
+		if err := agents.SetupOpsAgentFrom(ctx, logger.ToMainLog(), vm, "", secondVersion); err != nil {
 			t.Fatal(err)
 		}
 
@@ -3312,7 +3312,7 @@ traces:
   service:
     pipelines:
 `
-		if err := agents.SetupOpsAgent(ctx, logger, vm, otlpConfig); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, otlpConfig); err != nil {
 			t.Fatal(err)
 		}
 
@@ -3416,7 +3416,7 @@ traces:
   service:
     pipelines:
 `
-		if err := agents.SetupOpsAgent(ctx, logger, vm, otlpConfig); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, otlpConfig); err != nil {
 			t.Fatal(err)
 		}
 
@@ -3519,7 +3519,7 @@ metrics:
   service:
     pipelines:
 `
-		if err := agents.SetupOpsAgent(ctx, logger, vm, otlpConfig); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, otlpConfig); err != nil {
 			t.Fatal(err)
 		}
 
@@ -3609,7 +3609,7 @@ func TestPortsAndAPIHealthChecks(t *testing.T) {
 		// Wait for port to be in listen mode.
 		time.Sleep(30 * time.Second)
 
-		if err := agents.SetupOpsAgent(ctx, logger, vm, ""); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -3639,7 +3639,7 @@ func TestNetworkHealthCheck(t *testing.T) {
 
 		ctx, logger, vm := agents.CommonSetup(t, platform)
 
-		if err := agents.SetupOpsAgent(ctx, logger, vm, ""); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -3711,7 +3711,7 @@ func TestBufferLimitSizeOpsAgent(t *testing.T) {
         receivers: [log_syslog]
         processors: []`, logPath)
 
-		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 		var bufferDir string

--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -166,7 +166,7 @@ func installAgent(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.
 	if packagesInGCS == "" {
 		return installUsingScript(ctx, logger, vm)
 	}
-	return nonRetryable, agents.InstallPackageFromGCS(ctx, logger, vm, packagesInGCS)
+	return nonRetryable, agents.InstallPackageFromGCS(ctx, logger.ToMainLog(), vm, packagesInGCS)
 }
 
 // updateSSHKeysForActiveDirectory alters the ssh-keys metadata value for the


### PR DESCRIPTION
## Description
This PR allows us to call setupOpsAgentFrom() with a simple log.Logger() instead of a DirectoryLogger. This will allow me to call it and tell it to log to standard error for soak tests instead of needing to hunt through files logged to disk.

The cost of this CL is a bit more fluff (content from file_uploads.txt) appearing in main_log.txt, but I think it's worth it.

## Related issue
none filed yet

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
