### PR TITLE
confgenerator: escape metadata label values

### DIFF
--- a/confgenerator/confgenerator_test.go
+++ b/confgenerator/confgenerator_test.go
@@ -351,7 +351,7 @@ func init() {
 		InstanceName:  "test-instance-name",
 		Tags:          "test-tag",
 		MachineType:   "test-machine-type",
-		Metadata:      map[string]string{"test-key": "test-value"},
+		Metadata:      map[string]string{"test-key": "test-value", "test-escape": "${foo:bar}"},
 		Label:         map[string]string{"test-label-key": "test-label-value"},
 		InterfaceIPv4: map[string]string{"test-interface": "test-interface-ipv4"},
 	}

--- a/confgenerator/prometheus.go
+++ b/confgenerator/prometheus.go
@@ -163,8 +163,7 @@ func createPrometheusStyleGCEMetadata(gceMetadata resourcedetector.GCEResource) 
 	prefix := "__meta_gce_"
 	for k, v := range gceMetadata.Metadata {
 		sanitizedKey := "metadata_" + strutil.SanitizeLabelName(k)
-		sanitizedValue := sanitizeMetadataLabelValue(v)
-		metaLabels[prefix+sanitizedKey] = sanitizedValue
+		metaLabels[prefix+sanitizedKey] = strings.ReplaceAll(v, "$", "$$")
 	}
 
 	// Labels are not available using the GCE metadata API.
@@ -189,17 +188,6 @@ func createPrometheusStyleGCEMetadata(gceMetadata resourcedetector.GCEResource) 
 	metaLabels["machine_type"] = gceMetadata.MachineType
 
 	return metaLabels
-}
-
-func sanitizeMetadataLabelValue(value string) string {
-	sanitized := []rune{}
-	for _, c := range value {
-		if c == '$' {
-			sanitized = append(sanitized, '$')
-		}
-		sanitized = append(sanitized, c)
-	}
-	return string(sanitized)
 }
 
 func validatePrometheusConfig(sl validator.StructLevel) {

--- a/confgenerator/prometheus.go
+++ b/confgenerator/prometheus.go
@@ -163,7 +163,8 @@ func createPrometheusStyleGCEMetadata(gceMetadata resourcedetector.GCEResource) 
 	prefix := "__meta_gce_"
 	for k, v := range gceMetadata.Metadata {
 		sanitizedKey := "metadata_" + strutil.SanitizeLabelName(k)
-		metaLabels[prefix+sanitizedKey] = v
+		sanitizedValue := sanitizeMetadataLabelValue(v)
+		metaLabels[prefix+sanitizedKey] = sanitizedValue
 	}
 
 	// Labels are not available using the GCE metadata API.
@@ -188,6 +189,17 @@ func createPrometheusStyleGCEMetadata(gceMetadata resourcedetector.GCEResource) 
 	metaLabels["machine_type"] = gceMetadata.MachineType
 
 	return metaLabels
+}
+
+func sanitizeMetadataLabelValue(value string) string {
+	sanitized := []rune{}
+	for _, c := range value {
+		if c == '$' {
+			sanitized = append(sanitized, '$')
+		}
+		sanitized = append(sanitized, c)
+	}
+	return string(sanitized)
 }
 
 func validatePrometheusConfig(sl validator.StructLevel) {

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/otel.yaml
@@ -493,6 +493,7 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
+            __meta_gce_metadata_test_escape: $${foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/otel.yaml
@@ -486,6 +486,7 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
+            __meta_gce_metadata_test_escape: $${foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip
@@ -544,6 +545,7 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
+            __meta_gce_metadata_test_escape: $${foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/otel.yaml
@@ -493,6 +493,7 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
+            __meta_gce_metadata_test_escape: $${foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/otel.yaml
@@ -493,6 +493,7 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
+            __meta_gce_metadata_test_escape: $${foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/otel.yaml
@@ -486,6 +486,7 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
+            __meta_gce_metadata_test_escape: $${foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/otel.yaml
@@ -547,6 +547,7 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
+            __meta_gce_metadata_test_escape: $${foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/otel.yaml
@@ -491,6 +491,7 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
+            __meta_gce_metadata_test_escape: $${foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip


### PR DESCRIPTION
## Description
Metadata label values don't currently escape $ characters. This means that expressions could be collected by Ops Agent that could then be interpreted in the generated Otel config. This PR adds the proper escape method for `$` characters found in metadata values.

## Related issue
#1221
b/280417816

## How has this been tested?
A new test value was added to the unit testing metadata that has the expression `${foo:bar}`. We expect it to be `$${foo:bar}` in the resulting generated config.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
