### PR TITLE
Add ARM build configurations for debian-11

### DIFF
--- a/kokoro/config/build/aarch64_linux/release.gcl
+++ b/kokoro/config/build/aarch64_linux/release.gcl
@@ -1,0 +1,17 @@
+import '../common.gcl' as common
+
+// Proper release builds need access to the RPM signing key. This key should not
+// be used for any presubmits triggered by external folks on unreviewed PRs from
+// GitHub. We don't want to expose the RPM signing key to any potential leak
+// from malicious PRs. Note that the key is hidden from GitHub presubmits via
+// Keystore ACLs, which is the way that this is actually enforced.
+config build = common.build {
+  params {
+    keystore_keys = super.keystore_keys + [
+      { keystore_config_id = 71565, keyname = 'rpm-signing-key' },
+    ]
+    environment {
+      SKIP_SIGNING = null
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/bullseye_arm.gcl
+++ b/kokoro/config/build/presubmit/bullseye_arm.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'bullseye'
+      PKGFORMAT = 'deb'
+    }
+  }
+}

--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -21,6 +21,9 @@ bullseye = _distro {
   release = ['debian-11']
   presubmit = ['debian-11']
 }
+bullseye_arm = _distro {
+  release = ['debian-11-arm64']
+}
 bionic = _distro {
   release = [
     'ubuntu-1804-lts',

--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -23,6 +23,7 @@ bullseye = _distro {
 }
 bullseye_arm = _distro {
   release = ['debian-11-arm64']
+  presubmit = ['debian-11-arm64']
 }
 bionic = _distro {
   release = [

--- a/kokoro/config/test/ops_agent/bullseye_arm.gcl
+++ b/kokoro/config/test/ops_agent/bullseye_arm.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.bullseye_arm.presubmit
+  }
+}

--- a/kokoro/config/test/ops_agent/release/bullseye_arm.gcl
+++ b/kokoro/config/test/ops_agent/release/bullseye_arm.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.bullseye_arm.release
+  }
+}

--- a/kokoro/config/test/third_party_apps/bullseye_arm.gcl
+++ b/kokoro/config/test/third_party_apps/bullseye_arm.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['debian-11-arm64']
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/bullseye_arm.gcl
+++ b/kokoro/config/test/third_party_apps/release/bullseye_arm.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['debian-11-arm64']
+  }
+}

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -78,7 +78,16 @@ GO_VERSION="1.19"
 
 # Download and install a newer version of go.
 # Install from a GCS bucket to avoid being throttled by go.dev.
-gsutil cp "gs://stackdriver-test-143416-go-install/go${GO_VERSION}.linux-amd64.tar.gz" - | \
+unset ARCH
+case "$(uname -m)" in
+  "x86_64")
+    ARCH="amd64"
+    ;;
+  "aarch64")
+    ARCH="arm64"
+    ;;
+esac
+gsutil cp "gs://stackdriver-test-143416-go-install/go${GO_VERSION}.linux-${ARCH}.tar.gz" - | \
   sudo tar --directory /usr/local -xzf /dev/stdin
 
 PATH=$PATH:/usr/local/go/bin


### PR DESCRIPTION
## Description
Add ARM build configurations for debian-11. Also add ARM support in a few spots in the tests where x86_64 had been hard-coded.

## Related issue
b/282003946

## How has this been tested?
For now, let the existing non-ARM GitHub presubmits run and not break. There is a google3 counterpart to this PR that still needs to be done after this is merged.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
