### PR TITLE
Fix integration test to match new otel release

### DIFF
--- a/integration_test/testdata/otlp/metrics.go
+++ b/integration_test/testdata/otlp/metrics.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"time"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/global"
 	metricsdk "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
@@ -21,7 +21,7 @@ func installMetricExportPipeline(ctx context.Context) (func(context.Context) err
 		metricsdk.WithReader(metricsdk.NewPeriodicReader(exporter)),
 		metricsdk.WithResource(resource.Default()),
 	)
-	global.SetMeterProvider(metricProvider)
+	otel.SetMeterProvider(metricProvider)
 	return metricProvider.Shutdown, nil
 }
 
@@ -39,7 +39,7 @@ func main() {
 		}
 	}()
 
-	meter := global.MeterProvider().Meter("foo")
+	meter := otel.GetMeterProvider().Meter("foo")
 
 	// Test gauge metrics
 	testGaugeMetric(meter, "otlp.test.gauge")


### PR DESCRIPTION
## Description
Fixing integration test to match new released version 1.16.0
https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.16.0

## Related issue
b/283996172

## How has this been tested?
Integration tests are now passing.


## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
