### PR TITLE
Testing: Fixes for the new soak test launcher

### DIFF
--- a/kokoro/scripts/test/start_soak_test.sh
+++ b/kokoro/scripts/test/start_soak_test.sh
@@ -18,7 +18,4 @@ LOG_SIZE_IN_BYTES=${LOG_SIZE_IN_BYTES-1000} \
 VM_NAME="${VM_NAME:-soak-test-${KOKORO_BUILD_NUMBER}-$(date +%F)}" \
 DISTRO="${DISTRO:-ubuntu-2004-lts}" \
 TTL="${TTL:-30m}" \
-  go run . \
-  -tags=integration_test \
-  -timeout=1h
-
+  go run -tags=integration_test .

--- a/kokoro/scripts/test/start_soak_test.sh
+++ b/kokoro/scripts/test/start_soak_test.sh
@@ -15,7 +15,7 @@ done
 
 LOG_RATE=${LOG_RATE-100000} \
 LOG_SIZE_IN_BYTES=${LOG_SIZE_IN_BYTES-1000} \
-VM_NAME="${VM_NAME:-soak-test-${KOKORO_BUILD_NUMBER}-$(date +%F)}" \
+VM_NAME="${VM_NAME:-github-soak-test-${KOKORO_BUILD_NUMBER}}" \
 DISTRO="${DISTRO:-ubuntu-2004-lts}" \
 TTL="${TTL:-30m}" \
   go run -tags=integration_test .


### PR DESCRIPTION
## Description

1. The arguments needed adjusting because of differences between `go test` and `go run`.
2. The VM name needs a `github-` prefix for security reasons. I removed the date from the VM name for name length reasons.

## Related issue
b/278590309

## How has this been tested?
The presubmit is now passing.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
