### PR TITLE
healthchecks: Add timestamp parser to health check logs.

### DIFF
--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -404,6 +404,7 @@ func (l *Logging) generateFluentbitComponents(ctx context.Context, userAgent str
 func generateHealthChecksLogsParser(ctx context.Context) []fluentbit.Component {
 	out := make([]fluentbit.Component, 0)
 	out = append(out, LoggingProcessorParseJson{
+		// TODO(b/282754149): Remove TimeKey and TimeFormat when feature gets implemented.
 		ParserShared: ParserShared{
 			TimeKey:    "time",
 			TimeFormat: "%Y-%m-%dT%H:%M:%S%z",

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -403,7 +403,12 @@ func (l *Logging) generateFluentbitComponents(ctx context.Context, userAgent str
 
 func generateHealthChecksLogsParser(ctx context.Context) []fluentbit.Component {
 	out := make([]fluentbit.Component, 0)
-	out = append(out, LoggingProcessorParseJson{}.Components(ctx, healthChecksTag, "health-checks-json")...)
+	out = append(out, LoggingProcessorParseJson{
+		ParserShared: ParserShared{
+			TimeKey:    "time",
+			TimeFormat: "%Y-%m-%dT%H:%M:%S%z",
+		},
+	}.Components(ctx, healthChecksTag, "health-checks-json")...)
 	out = append(out, []fluentbit.Component{
 		// This is used to exclude any previous content of the health-checks file that
 		// does not contain the ops-agent-version field.

--- a/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_parser.conf
@@ -31,5 +31,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_parser.conf
@@ -25,5 +25,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_parser.conf
@@ -44,5 +44,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_parser.conf
@@ -7,8 +7,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     flush_timeout 1000

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_parser.conf
@@ -7,8 +7,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     flush_timeout 1000

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_parser.conf
@@ -7,8 +7,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     flush_timeout 1000

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_parser.conf
@@ -7,8 +7,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     flush_timeout 1000

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_parser.conf
@@ -7,8 +7,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     flush_timeout 1000

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_parser.conf
@@ -23,5 +23,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_parser.conf
@@ -65,5 +65,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_parser.conf
@@ -31,8 +31,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     Name cassandra.cassandra_debug.cassandra_debug.multiline

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_parser.conf
@@ -142,8 +142,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     Name cassandra_custom.cassandra_custom_debug.cassandra_debug.multiline

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_parser.conf
@@ -29,8 +29,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     Name couchbase.couchbase_general.couchbase_general.multiline

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_parser.conf
@@ -22,8 +22,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     flush_timeout 5000

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_parser.conf
@@ -21,8 +21,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     flush_timeout 5000

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_parser.conf
@@ -35,8 +35,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     flush_timeout 5000

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_parser.conf
@@ -14,8 +14,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     Name flink.flink.flink.multiline

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_parser.conf
@@ -14,8 +14,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     flush_timeout 5000

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_parser.conf
@@ -14,8 +14,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     flush_timeout 5000

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_parser.conf
@@ -14,8 +14,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     Name hbase.hbase_system.hbase_system.multiline

--- a/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_parser.conf
@@ -15,5 +15,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_parser.conf
@@ -14,8 +14,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     Name kafka.kafka.kafka.multiline

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_parser.conf
@@ -26,8 +26,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     Name kafka_custom.kafka_custom.kafka.multiline

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_parser.conf
@@ -23,5 +23,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_parser.conf
@@ -46,8 +46,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     Name mysql.mysql_general.mysql_general.multiline

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_parser.conf
@@ -217,8 +217,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     Name mysql_custom.mysql_custom_general.mysql_general.multiline

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_parser.conf
@@ -23,5 +23,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_parser.conf
@@ -65,5 +65,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_parser.conf
@@ -22,8 +22,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     Name oracledb.oracledb_alert.oracledb_alert.multiline

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_parser.conf
@@ -62,8 +62,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     Name oracledb_custom.oracledb_alert_custom.oracledb_alert.multiline

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_parser.conf
@@ -15,8 +15,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     Name postgresql.postgresql_general.postgresql.multiline

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_parser.conf
@@ -36,8 +36,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     Name postgresql_custom.postgresql_custom_general.postgresql.multiline

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_parser.conf
@@ -21,8 +21,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     flush_timeout 5000

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_parser.conf
@@ -15,5 +15,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_parser.conf
@@ -36,5 +36,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_parser.conf
@@ -15,8 +15,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     flush_timeout 5000

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_parser.conf
@@ -36,8 +36,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     flush_timeout 5000

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_parser.conf
@@ -14,8 +14,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     Name solr.solr_system.solr_system.multiline

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_parser.conf
@@ -31,5 +31,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_parser.conf
@@ -23,8 +23,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     Name tomcat.tomcat_system.tomcat_system.multiline

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_parser.conf
@@ -81,8 +81,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     Name tomcat_custom.tomcat_custom_system.tomcat_system.multiline

--- a/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_parser.conf
@@ -15,5 +15,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_parser.conf
@@ -13,8 +13,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     flush_timeout 5000

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_parser.conf
@@ -14,8 +14,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     flush_timeout 5000

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_parser.conf
@@ -23,8 +23,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     flush_timeout 5000

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_parser.conf
@@ -23,8 +23,10 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time
 
 [MULTILINE_PARSER]
     flush_timeout 5000

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_parser.conf
@@ -21,5 +21,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_parser.conf
@@ -21,5 +21,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_parser.conf
@@ -7,5 +7,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_parser.conf
@@ -21,5 +21,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_parser.conf
@@ -21,5 +21,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_parser.conf
@@ -22,5 +22,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_parser.conf
@@ -21,5 +21,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_parser.conf
@@ -21,5 +21,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_parser.conf
@@ -14,5 +14,7 @@
     Types       severity:string
 
 [PARSER]
-    Format json
-    Name   ops-agent-health-checks.health-checks-json
+    Format      json
+    Name        ops-agent-health-checks.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/internal/logs/logs.go
+++ b/internal/logs/logs.go
@@ -15,11 +15,9 @@
 package logs
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"strconv"
-	"time"
 
 	"github.com/GoogleCloudPlatform/ops-agent/internal/version"
 	"go.uber.org/zap"
@@ -69,19 +67,6 @@ func (sm stringMap) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 		enc.AddString(k, v)
 	}
 	return nil
-}
-func timeEncoder(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
-	ae, ok := enc.(zapcore.ArrayEncoder)
-	if !ok {
-		zapcore.RFC3339NanoTimeEncoder(t, enc)
-		return
-	}
-	nanos := t.UnixNano()
-	sec := float64(nanos) / float64(time.Second)
-	ae.AppendObject(stringMap{
-		"seconds": fmt.Sprintf("%f", sec),
-		"nanos":   fmt.Sprintf("%d", nanos),
-	})
 }
 
 func sourceLocationEncoder(caller zapcore.EntryCaller, enc zapcore.PrimitiveArrayEncoder) {

--- a/internal/logs/logs.go
+++ b/internal/logs/logs.go
@@ -31,7 +31,7 @@ const (
 	messageKey        = "message"
 	severityKey       = "logging.googleapis.com/severity"
 	sourceLocationKey = "logging.googleapis.com/sourceLocation"
-	timeKey           = "timestamp"
+	timeKey           = "time"
 )
 
 type StructuredLogger interface {
@@ -103,7 +103,7 @@ func New(file string) *ZapStructuredLogger {
 	cfg.EncoderConfig.MessageKey = messageKey
 	cfg.EncoderConfig.LevelKey = severityKey
 	cfg.EncoderConfig.TimeKey = timeKey
-	cfg.EncoderConfig.EncodeTime = timeEncoder
+	cfg.EncoderConfig.EncodeTime = zapcore.RFC3339TimeEncoder
 	cfg.EncoderConfig.EncodeLevel = severityEncoder
 	cfg.EncoderConfig.EncodeCaller = sourceLocationEncoder
 


### PR DESCRIPTION
## Description
Add timestamp parser to health check logs using `RFC3339` format to get human readable timestamps in `health-checks.log`.

## Related issue
b/282754149

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
