### PR TITLE
Testing: get release soak tests to use protected service account

### DIFF
--- a/kokoro/config/test/soak/release.gcl
+++ b/kokoro/config/test/soak/release.gcl
@@ -1,3 +1,11 @@
 import 'common.gcl' as common
 
-config build = common.soak_test {}
+config build = common.soak_test {
+  params {
+    environment {
+      TRANSFERS_BUCKET = 'stackdriver-test-143416-file-transfers'
+      SERVICE_EMAIL =
+          'build-and-test@stackdriver-test-143416.iam.gserviceaccount.com'
+    }
+  }
+}


### PR DESCRIPTION
## Description
This should fix issues like http://sponge2/346f6348-9c7c-440e-b03d-cb6cf937e3df.

## Related issue
b/278590309

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
