### PR TITLE
Update the supported agent version of elasticsearch and mysql metadata.yaml files

### DIFF
--- a/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/elasticsearch/metadata.yaml
@@ -29,7 +29,7 @@ configure_integration: |-
   privilege](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/security-privileges.html#privileges-list-cluster)
   {: .external}.
 minimum_supported_agent_version:
-  metrics: 2.21.0
+  metrics: 2.32.0
   logging: 2.9.0
 supported_operating_systems: linux
 supported_app_version: ["7.9+"]

--- a/integration_test/third_party_apps_data/applications/mysql/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mysql/metadata.yaml
@@ -32,7 +32,7 @@ configure_integration: |-
   The `mysql` receiver connects by default to a local MySQL/MariaDB
   server using a Unix socket and Unix authentication as the `root` user.
 minimum_supported_agent_version:
-  metrics: 2.8.0
+  metrics: 2.32.0
   logging: 2.5.0
 supported_operating_systems: linux
 platforms_to_skip: []


### PR DESCRIPTION
## Description
Update the supported agent version of elasticsearch and mysql metadata.yaml files

## Related issue
b/284953125 and https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/pull/554/files#r1196445425

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [x] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
