### PR TITLE
[DNM] Update java contrib to v1.23.x

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -10,10 +10,7 @@ FROM mcr.microsoft.com/windows/servercore:$WINDOWS_VERSION as base
 #
 # Basic setup
 #
-RUN setx /M PATH "%PATH%;C:\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
-RUN setx /M PATH "%PATH%;C:\WinFlexBison"
-RUN setx /M PATH "%PATH%;C:\Go\bin"
-RUN setx /M PATH "%PATH%;C:\Java\bin"
+RUN setx /M PATH "%PATH%;C:\WinFlexBison;C:\Go\bin;C:\Java\bin;C:\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
 
 RUN setx /M JAVA_HOME "C:\Java"
 
@@ -124,7 +121,7 @@ COPY submodules/opentelemetry-java-contrib /work/submodules/opentelemetry-java-c
 WORKDIR /work/submodules/opentelemetry-java-contrib
 
 RUN ./gradlew --no-daemon :jmx-metrics:build; `
-    Copy-Item -Path jmx-metrics/build/libs/opentelemetry-jmx-metrics-*-SNAPSHOT.jar -Destination /work/out/bin/opentelemetry-java-contrib-jmx-metrics.jar;
+    Copy-Item -Path jmx-metrics/build/libs/opentelemetry-jmx-metrics-*-alpha.jar -Destination /work/out/bin/opentelemetry-java-contrib-jmx-metrics.jar;
 
 ###############################################################################
 # Build OT collector

--- a/builds/otel.sh
+++ b/builds/otel.sh
@@ -6,7 +6,10 @@ DESTDIR="${DESTDIR}${otel_dir}"
 cd submodules/opentelemetry-java-contrib
 mkdir -p "$DESTDIR"
 ./gradlew --no-daemon :jmx-metrics:build
-cp jmx-metrics/build/libs/opentelemetry-jmx-metrics-*-SNAPSHOT.jar "$DESTDIR/opentelemetry-java-contrib-jmx-metrics.jar"
+
+# Released versions don't have the SNAPSHOT suffix. Since the JMX Metric Gatherer is not
+# marked as stable yet, the jar has the 'alpha' suffix.
+cp jmx-metrics/build/libs/opentelemetry-jmx-metrics-*-alpha.jar "$DESTDIR/opentelemetry-java-contrib-jmx-metrics.jar"
 
 # Rename LICENSE file because it causes issues with file hash consistency due to an unknown
 # issue with the debuild/rpmbuild processes. Something is unzipping the jar in a case-insensitive


### PR DESCRIPTION
## Description
Updating submodule to v1.23.0 and update the jar file name but don't require JDK 17

Do not merge. This PR is testing whether the builds pass for Windows as well.