### PR TITLE
confgenerator: Structured Ops Agent Health Logs

### DIFF
--- a/cmd/ops_agent_windows/run_windows.go
+++ b/cmd/ops_agent_windows/run_windows.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/apps"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/internal/healthchecks"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/logs"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/debug"
 	"golang.org/x/sys/windows/svc/eventlog"
@@ -145,39 +146,9 @@ func getHealthCheckResults() []healthchecks.HealthCheckResult {
 	return gceHealthChecks.RunAllHealthChecks(logger)
 }
 
-type WindowsServiceLogger struct {
-	srv *service
-}
-
-func (wsl WindowsServiceLogger) Infof(format string, v ...any) {
-	wsl.srv.log.Info(EngineEventID, fmt.Sprintf(format, v...))
-}
-
-func (wsl WindowsServiceLogger) Warnf(format string, v ...any) {
-	wsl.srv.log.Warning(EngineEventID, fmt.Sprintf(format, v...))
-}
-
-func (wsl WindowsServiceLogger) Errorf(format string, v ...any) {
-	wsl.srv.log.Error(EngineEventID, fmt.Sprintf(format, v...))
-}
-
-func (wsl WindowsServiceLogger) Infow(msg string, keysAndValues ...any) {
-	wsl.srv.log.Info(EngineEventID, msg)
-}
-
-func (wsl WindowsServiceLogger) Warnw(msg string, keysAndValues ...any) {
-	wsl.srv.log.Warning(EngineEventID, msg)
-}
-
-func (wsl WindowsServiceLogger) Errorw(msg string, keysAndValues ...any) {
-	wsl.srv.log.Warning(EngineEventID, msg)
-}
-
-func (wsl WindowsServiceLogger) Println(v ...any) {}
-
 func (srv *service) runHealthChecks() {
 	healthCheckResults := getHealthCheckResults()
-	logger := WindowsServiceLogger{srv}
+	logger := logs.WindowsServiceLogger{EventID: EngineEventID, Logger: srv.log}
 	healthchecks.LogHealthCheckResults(healthCheckResults, logger)
 	srv.log.Info(EngineEventID, "Startup checks finished")
 }

--- a/cmd/ops_agent_windows/run_windows.go
+++ b/cmd/ops_agent_windows/run_windows.go
@@ -152,7 +152,7 @@ type WindowsServiceLogger struct {
 
 func (wsl WindowsServiceLogger) Infof(format string, v ...any) {
 	if len(v) > 0 {
-		wsl.srv.log.Info(EngineEventID, fmt.Sprintf(format, logs.DiscardZapFields(v ...)))
+		wsl.srv.log.Info(EngineEventID, fmt.Sprintf(format, logs.DiscardZapFields(v ...)...))
 	} else {
 		wsl.srv.log.Info(EngineEventID, format)
 	}
@@ -160,7 +160,7 @@ func (wsl WindowsServiceLogger) Infof(format string, v ...any) {
 
 func (wsl WindowsServiceLogger) Warnf(format string, v ...any) {
 	if len(v) > 0 {
-		wsl.srv.log.Warning(EngineEventID, fmt.Sprintf(format, logs.DiscardZapFields(v ...)))
+		wsl.srv.log.Warning(EngineEventID, fmt.Sprintf(format, logs.DiscardZapFields(v ...)...))
 	} else {
 		wsl.srv.log.Warning(EngineEventID, format)
 	}
@@ -168,7 +168,7 @@ func (wsl WindowsServiceLogger) Warnf(format string, v ...any) {
 
 func (wsl WindowsServiceLogger) Errorf(format string, v ...any) {
 	if len(v) > 0 {
-		wsl.srv.log.Error(EngineEventID, fmt.Sprintf(format, logs.DiscardZapFields(v ...)))
+		wsl.srv.log.Error(EngineEventID, fmt.Sprintf(format, logs.DiscardZapFields(v ...)...))
 	} else {
 		wsl.srv.log.Error(EngineEventID, format)
 	}

--- a/cmd/ops_agent_windows/run_windows.go
+++ b/cmd/ops_agent_windows/run_windows.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/apps"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/internal/healthchecks"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/logs"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/debug"
 	"golang.org/x/sys/windows/svc/eventlog"
@@ -151,7 +152,7 @@ type WindowsServiceLogger struct {
 
 func (wsl WindowsServiceLogger) Infof(format string, v ...any) {
 	if len(v) > 0 {
-		wsl.srv.log.Info(EngineEventID, fmt.Sprintf(format, v...))
+		wsl.srv.log.Info(EngineEventID, fmt.Sprintf(format, logs.DiscardZapFields(v ...)))
 	} else {
 		wsl.srv.log.Info(EngineEventID, format)
 	}
@@ -159,7 +160,7 @@ func (wsl WindowsServiceLogger) Infof(format string, v ...any) {
 
 func (wsl WindowsServiceLogger) Warnf(format string, v ...any) {
 	if len(v) > 0 {
-		wsl.srv.log.Warning(EngineEventID, fmt.Sprintf(format, v...))
+		wsl.srv.log.Warning(EngineEventID, fmt.Sprintf(format, logs.DiscardZapFields(v ...)))
 	} else {
 		wsl.srv.log.Warning(EngineEventID, format)
 	}
@@ -167,7 +168,7 @@ func (wsl WindowsServiceLogger) Warnf(format string, v ...any) {
 
 func (wsl WindowsServiceLogger) Errorf(format string, v ...any) {
 	if len(v) > 0 {
-		wsl.srv.log.Error(EngineEventID, fmt.Sprintf(format, v...))
+		wsl.srv.log.Error(EngineEventID, fmt.Sprintf(format, logs.DiscardZapFields(v ...)))
 	} else {
 		wsl.srv.log.Error(EngineEventID, format)
 	}

--- a/cmd/ops_agent_windows/run_windows.go
+++ b/cmd/ops_agent_windows/run_windows.go
@@ -25,7 +25,6 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/apps"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/internal/healthchecks"
-	"github.com/GoogleCloudPlatform/ops-agent/internal/logs"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/debug"
 	"golang.org/x/sys/windows/svc/eventlog"
@@ -151,28 +150,27 @@ type WindowsServiceLogger struct {
 }
 
 func (wsl WindowsServiceLogger) Infof(format string, v ...any) {
-	if len(v) > 0 {
-		wsl.srv.log.Info(EngineEventID, fmt.Sprintf(format, logs.DiscardZapFields(v ...)...))
-	} else {
-		wsl.srv.log.Info(EngineEventID, format)
-	}
+	wsl.srv.log.Info(EngineEventID, fmt.Sprintf(format, v...))
 }
 
 func (wsl WindowsServiceLogger) Warnf(format string, v ...any) {
-	if len(v) > 0 {
-		wsl.srv.log.Warning(EngineEventID, fmt.Sprintf(format, logs.DiscardZapFields(v ...)...))
-	} else {
-		wsl.srv.log.Warning(EngineEventID, format)
-	}
+	wsl.srv.log.Warning(EngineEventID, fmt.Sprintf(format, v...))
 }
 
 func (wsl WindowsServiceLogger) Errorf(format string, v ...any) {
-	if len(v) > 0 {
-		wsl.srv.log.Error(EngineEventID, fmt.Sprintf(format, logs.DiscardZapFields(v ...)...))
-	} else {
-		wsl.srv.log.Error(EngineEventID, format)
-	}
+	wsl.srv.log.Error(EngineEventID, fmt.Sprintf(format, v...))
+}
 
+func (wsl WindowsServiceLogger) Infow(format string, v ...any) {
+	wsl.Infof(format)
+}
+
+func (wsl WindowsServiceLogger) Warnw(format string, v ...any) {
+	wsl.Warnf(format)
+}
+
+func (wsl WindowsServiceLogger) Errorw(format string, v ...any) {
+	wsl.Errorf(format)
 }
 
 func (wsl WindowsServiceLogger) Println(v ...any) {}

--- a/cmd/ops_agent_windows/run_windows.go
+++ b/cmd/ops_agent_windows/run_windows.go
@@ -161,16 +161,16 @@ func (wsl WindowsServiceLogger) Errorf(format string, v ...any) {
 	wsl.srv.log.Error(EngineEventID, fmt.Sprintf(format, v...))
 }
 
-func (wsl WindowsServiceLogger) Infow(format string, v ...any) {
-	wsl.Infof(format)
+func (wsl WindowsServiceLogger) Infow(msg string, keysAndValues ...any) {
+	wsl.srv.log.Info(EngineEventID, msg)
 }
 
-func (wsl WindowsServiceLogger) Warnw(format string, v ...any) {
-	wsl.Warnf(format)
+func (wsl WindowsServiceLogger) Warnw(msg string, keysAndValues ...any) {
+	wsl.srv.log.Warning(EngineEventID, msg)
 }
 
-func (wsl WindowsServiceLogger) Errorw(format string, v ...any) {
-	wsl.Errorf(format)
+func (wsl WindowsServiceLogger) Errorw(msg string, keysAndValues ...any) {
+	wsl.srv.log.Warning(EngineEventID, msg)
 }
 
 func (wsl WindowsServiceLogger) Println(v ...any) {}

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -367,7 +367,7 @@ func (l *Logging) generateFluentbitComponents(ctx context.Context, userAgent str
 			out = append(out, s.components...)
 		}
 		if len(tags) > 0 {
-			out = append(out, stackdriverOutputComponent(strings.Join(tags, "|"), userAgent, "2G", ""))
+			out = append(out, stackdriverOutputComponent(strings.Join(tags, "|"), userAgent, "2G", map[string]string{}))
 		}
 	}
 	out = append(out, generateSelfLogsComponents(ctx, userAgent)...)

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -367,7 +367,7 @@ func (l *Logging) generateFluentbitComponents(ctx context.Context, userAgent str
 			out = append(out, s.components...)
 		}
 		if len(tags) > 0 {
-			out = append(out, stackdriverOutputComponent(strings.Join(tags, "|"), userAgent, "2G", map[string]string{}))
+			out = append(out, stackdriverOutputComponent(strings.Join(tags, "|"), userAgent, "2G"))
 		}
 	}
 	out = append(out, generateSelfLogsComponents(ctx, userAgent)...)

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -367,7 +367,7 @@ func (l *Logging) generateFluentbitComponents(ctx context.Context, userAgent str
 			out = append(out, s.components...)
 		}
 		if len(tags) > 0 {
-			out = append(out, stackdriverOutputComponent(strings.Join(tags, "|"), userAgent, "2G"))
+			out = append(out, stackdriverOutputComponent(strings.Join(tags, "|"), userAgent, "2G", ""))
 		}
 	}
 	out = append(out, generateSelfLogsComponents(ctx, userAgent)...)

--- a/confgenerator/logging.go
+++ b/confgenerator/logging.go
@@ -45,7 +45,7 @@ func setLogNameComponents(ctx context.Context, tag, logName, receiverType string
 }
 
 // stackdriverOutputComponent generates a component that outputs logs matching the regex `match` using `userAgent`.
-func stackdriverOutputComponent(match, userAgent string, storageLimitSize string) fluentbit.Component {
+func stackdriverOutputComponent(match, userAgent string, storageLimitSize string, labels string) fluentbit.Component {
 	config := map[string]string{
 		// https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
 		"Name":              "stackdriver",
@@ -73,6 +73,11 @@ func stackdriverOutputComponent(match, userAgent string, storageLimitSize string
 
 	if storageLimitSize != "" {
 		config["storage.total_limit_size"] = storageLimitSize
+	}
+
+	if labels != "" {
+		// Labels set in the format "key1=value1,key2=value2,..."
+		config["labels"] = labels
 	}
 
 	return fluentbit.Component{

--- a/confgenerator/logging.go
+++ b/confgenerator/logging.go
@@ -17,8 +17,6 @@ package confgenerator
 import (
 	"context"
 	"fmt"
-	"sort"
-	"strings"
 
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
 )
@@ -47,7 +45,7 @@ func setLogNameComponents(ctx context.Context, tag, logName, receiverType string
 }
 
 // stackdriverOutputComponent generates a component that outputs logs matching the regex `match` using `userAgent`.
-func stackdriverOutputComponent(match, userAgent string, storageLimitSize string, labels map[string]string) fluentbit.Component {
+func stackdriverOutputComponent(match, userAgent string, storageLimitSize string) fluentbit.Component {
 	config := map[string]string{
 		// https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
 		"Name":              "stackdriver",
@@ -77,19 +75,6 @@ func stackdriverOutputComponent(match, userAgent string, storageLimitSize string
 		// Limit the maximum number of fluent-bit chunks in the filesystem for the current
 		// output logical destination.
 		config["storage.total_limit_size"] = storageLimitSize
-	}
-
-	if len(labels) > 0 {
-		labelsSlice := []string{}
-		for k, v := range labels {
-			labelsSlice = append(labelsSlice,fmt.Sprintf("%s=%s", k, v))
-		}
-		// Sort labels since map is unordered.
-		sort.Strings(labelsSlice)
-
-		// labels should be set in the format "key1=value1,key2=value2,..."
-		// Link: https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver#configuration-parameters
-		config["labels"] = strings.Join(labelsSlice, ",")
 	}
 
 	return fluentbit.Component{

--- a/confgenerator/logging.go
+++ b/confgenerator/logging.go
@@ -17,6 +17,7 @@ package confgenerator
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
@@ -83,6 +84,8 @@ func stackdriverOutputComponent(match, userAgent string, storageLimitSize string
 		for k, v := range labels {
 			labelsSlice = append(labelsSlice,fmt.Sprintf("%s=%s", k, v))
 		}
+		// Sort labels since map is unordered.
+		sort.Strings(labelsSlice)
 
 		// labels should be set in the format "key1=value1,key2=value2,..."
 		// Link: https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver#configuration-parameters

--- a/confgenerator/self_logs.go
+++ b/confgenerator/self_logs.go
@@ -116,13 +116,12 @@ func generateFluentBitSelfLogsComponents(ctx context.Context) []fluentbit.Compon
 	return out
 }
 
-func structuredHealthLogsLabels() string {
-	labels := []string{
-		fmt.Sprintf("%s=%s", agentKindKey, "ops-agent"),
-		fmt.Sprintf("%s=%s", agentVersionKey, version.Version),
-		fmt.Sprintf("%s=%s", schemaVersionKey, "v1"),
+func structuredHealthLogsLabels() map[string]string {
+	return map[string]string{
+		agentKindKey: "ops-agent",
+		agentVersionKey: version.Version,
+		schemaVersionKey: "v1",
 	}
-	return strings.Join(labels, ",")
 }
 
 func generateSelfLogsComponents(ctx context.Context, userAgent string) []fluentbit.Component {

--- a/confgenerator/self_logs.go
+++ b/confgenerator/self_logs.go
@@ -31,9 +31,9 @@ const (
 	healthLogsTag       = "ops-agent-health"
 	severityKey         = "logging.googleapis.com/severity"
 	sourceLocationKey   = "logging.googleapis.com/sourceLocation"
-	agentVersionKey     = "agent.googleapis.com/health/agent-version"
-	agentKindKey        = "agent.googleapis.com/health/agent-kind"
-	schemaVersionKey    = "agent.googleapis.com/health/schema-version"
+	agentVersionKey     = "agent.googleapis.com/health/agentVersion"
+	agentKindKey        = "agent.googleapis.com/health/agentKind"
+	schemaVersionKey    = "agent.googleapis.com/health/schemaVersion"
 )
 
 func fluentbitSelfLogsPath(p platform.Platform) string {

--- a/confgenerator/self_logs.go
+++ b/confgenerator/self_logs.go
@@ -48,6 +48,8 @@ func healthChecksLogsPath() string {
 	return path.Join("${logs_dir}", "health-checks.log")
 }
 
+// This method creates a file input for the `health-checks.log` file, a json parser for the
+// structured logs and a grep filter to avoid ingesting previous content of the file.
 func generateHealthChecksLogsComponents(ctx context.Context) []fluentbit.Component {
 	out := make([]fluentbit.Component, 0)
 	out = append(out, LoggingReceiverFilesMixin{
@@ -86,6 +88,8 @@ func generateHealthChecksLogsComponents(ctx context.Context) []fluentbit.Compone
 	return out
 }
 
+// This method creates a file input for the `logging-module.log` file, a regex parser for the
+// fluent-bit self logs and a translator of severity to the logging api format.
 func generateFluentBitSelfLogsComponents(ctx context.Context) []fluentbit.Component {
 	out := make([]fluentbit.Component, 0)
 	out = append(out, LoggingReceiverFilesMixin{

--- a/confgenerator/self_logs.go
+++ b/confgenerator/self_logs.go
@@ -1,0 +1,113 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package confgenerator represents the Ops Agent configuration and provides functions to generate subagents configuration from unified agent.
+package confgenerator
+
+import (
+	"context"
+	"path"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/platform"
+)
+
+const fluentBitSelfLogTag = "ops-agent-fluent-bit"
+const healthChecksTag = "ops-agent-health-checks"
+
+func fluentbitSelfLogsPath(p platform.Platform) string {
+	loggingModule := "logging-module.log"
+	if p.Type == platform.Windows {
+		return path.Join("${logs_dir}", loggingModule)
+	}
+	return path.Join("${logs_dir}", "subagents", loggingModule)
+}
+
+func healthChecksLogsPath() string {
+	return path.Join("${logs_dir}", "health-checks.log")
+}
+
+func generateSelfLogsComponents(ctx context.Context, userAgent string) []fluentbit.Component {
+	out := make([]fluentbit.Component, 0)
+	out = append(out, LoggingReceiverFilesMixin{
+		IncludePaths: []string{fluentbitSelfLogsPath(platform.FromContext(ctx))},
+		//Following: b/226668416 temporarily set storage.type to "memory"
+		//to prevent chunk corruption errors
+		BufferInMemory: true,
+	}.Components(ctx, fluentBitSelfLogTag)...)
+
+	out = append(out, LoggingReceiverFilesMixin{
+		IncludePaths:   []string{healthChecksLogsPath()},
+		BufferInMemory: true,
+	}.Components(ctx, healthChecksTag)...)
+
+	out = append(out, generateSeveritySelfLogsParser(ctx)...)
+	out = append(out, generateHealthChecksLogsParser(ctx)...)
+
+	out = append(out, stackdriverOutputComponent(strings.Join([]string{fluentBitSelfLogTag, healthChecksTag}, "|"), userAgent, ""))
+	return out
+}
+
+func generateHealthChecksLogsParser(ctx context.Context) []fluentbit.Component {
+	out := make([]fluentbit.Component, 0)
+	out = append(out, LoggingProcessorParseJson{
+		// TODO(b/282754149): Remove TimeKey and TimeFormat when feature gets implemented.
+		ParserShared: ParserShared{
+			TimeKey:    "time",
+			TimeFormat: "%Y-%m-%dT%H:%M:%S%z",
+		},
+	}.Components(ctx, healthChecksTag, "health-checks-json")...)
+	out = append(out, []fluentbit.Component{
+		// This is used to exclude any previous content of the health-checks file that
+		// does not contain the ops-agent-version field.
+		{
+			Kind: "FILTER",
+			Config: map[string]string{
+				"Name":  "grep",
+				"Match": healthChecksTag,
+				"Regex": "ops-agent-version ^.*",
+			},
+		},
+	}...)
+	return out
+}
+
+func generateSeveritySelfLogsParser(ctx context.Context) []fluentbit.Component {
+	out := make([]fluentbit.Component, 0)
+
+	parser := LoggingProcessorParseRegex{
+		Regex:       `(?<message>\[[ ]*(?<time>\d+\/\d+\/\d+ \d+:\d+:\d+)] \[[ ]*(?<severity>[a-z]+)\].*)`,
+		PreserveKey: true,
+		ParserShared: ParserShared{
+			TimeKey:    "time",
+			TimeFormat: "%Y/%m/%d %H:%M:%S",
+			Types: map[string]string{
+				"severity": "string",
+			},
+		},
+	}.Components(ctx, fluentBitSelfLogTag, "self-logs-severity")
+
+	out = append(out, parser...)
+
+	out = append(out, fluentbit.TranslationComponents(fluentBitSelfLogTag, "severity", "logging.googleapis.com/severity", true,
+		[]struct{ SrcVal, DestVal string }{
+			{"debug", "DEBUG"},
+			{"error", "ERROR"},
+			{"info", "INFO"},
+			{"warn", "WARNING"},
+		})...,
+	)
+	return out
+}

--- a/confgenerator/self_logs.go
+++ b/confgenerator/self_logs.go
@@ -118,10 +118,10 @@ func generateStructuredHealthLogsComponents(ctx context.Context) []fluentbit.Com
 	return LoggingProcessorModifyFields{
 		Fields: map[string]*ModifyField{
 			severityKey: {
-				MoveFrom: logs.SeverityZapKey,
+				MoveFrom: fmt.Sprintf(`jsonPayload."%s"`, logs.SeverityZapKey),
 			},
 			sourceLocationKey: {
-				MoveFrom: logs.SourceLocationZapKey,
+				MoveFrom: fmt.Sprintf(`jsonPayload."%s"`, logs.SourceLocationZapKey),
 			},
 			fmt.Sprintf(`labels."%s"`, agentKindKey): {
 				StaticValue: &agentKind,

--- a/confgenerator/self_logs.go
+++ b/confgenerator/self_logs.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package confgenerator represents the Ops Agent configuration and provides functions to generate subagents configuration from unified agent.
 package confgenerator
 
 import (
@@ -125,6 +124,7 @@ func generateFluentBitSelfLogsComponents(ctx context.Context) []fluentbit.Compon
 	return out
 }
 
+// This method creates a component adds metadata labels to all ops agent health logs.
 func generateStructuredHealthLogsComponents(ctx context.Context) []fluentbit.Component {
 	return LoggingProcessorModifyFields{
 		Fields: map[string]*ModifyField{

--- a/confgenerator/self_logs.go
+++ b/confgenerator/self_logs.go
@@ -63,7 +63,7 @@ func generateHealthChecksLogsComponents(ctx context.Context) []fluentbit.Compone
 	}.Components(ctx, healthLogsTag, "health-checks-json")...)
 	out = append(out, []fluentbit.Component{
 		// This is used to exclude any previous content of the health-checks file that
-		// does not contain the `severityKey` field.
+		// does not contain the `severity` field.
 		{
 			Kind: "FILTER",
 			Config: map[string]string{

--- a/confgenerator/self_logs.go
+++ b/confgenerator/self_logs.go
@@ -56,7 +56,7 @@ func generateHealthChecksLogsParser(ctx context.Context) []fluentbit.Component {
 	}.Components(ctx, healthLogsTag, "health-checks-json")...)
 	out = append(out, []fluentbit.Component{
 		// This is used to exclude any previous content of the health-checks file that
-		// does not contain the ops-agent-version field.
+		// does not contain the `severityKey` field.
 		{
 			Kind: "FILTER",
 			Config: map[string]string{

--- a/confgenerator/self_logs.go
+++ b/confgenerator/self_logs.go
@@ -62,7 +62,7 @@ func generateHealthChecksLogsParser(ctx context.Context) []fluentbit.Component {
 			Config: map[string]string{
 				"Name":  "grep",
 				"Match": healthLogsTag,
-				"Regex": fmt.Sprintf("%s (INFO|ERROR|WARNING|DEBUG|DEFAULT)", severityKey),
+				"Regex": fmt.Sprintf("%s INFO|ERROR|WARNING|DEBUG|DEFAULT", severityKey),
 			},
 		},
 	}...)

--- a/confgenerator/self_logs.go
+++ b/confgenerator/self_logs.go
@@ -17,15 +17,21 @@ package confgenerator
 
 import (
 	"context"
+	"fmt"
 	"path"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
 	"github.com/GoogleCloudPlatform/ops-agent/internal/platform"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/version"
 )
 
-const fluentBitSelfLogTag = "ops-agent-fluent-bit"
-const healthLogsTag = "ops-agent-health"
+
+const (
+	fluentBitSelfLogTag = "ops-agent-fluent-bit"
+	healthLogsTag = "ops-agent-health"
+	severityKey       = "logging.googleapis.com/severity"
+)
 
 func fluentbitSelfLogsPath(p platform.Platform) string {
 	loggingModule := "logging-module.log"
@@ -56,7 +62,7 @@ func generateHealthChecksLogsParser(ctx context.Context) []fluentbit.Component {
 			Config: map[string]string{
 				"Name":  "grep",
 				"Match": healthLogsTag,
-				"Regex": "agent-version ^.*",
+				"Regex": fmt.Sprintf("%s (INFO|ERROR|WARNING|DEBUG|DEFAULT)", severityKey),
 			},
 		},
 	}...)
@@ -101,6 +107,7 @@ func generateHealthLogsComponent(ctx context.Context) []fluentbit.Component {
 				{"Match", healthLogsTag},
 				{"Record", "schema-version v1"},
 				{"Record", "agent-kind ops-agent"},
+				{"Record", fmt.Sprintf("agent-version %s", version.Version)},
 			},
 		},
 		{

--- a/confgenerator/self_logs.go
+++ b/confgenerator/self_logs.go
@@ -129,7 +129,8 @@ func generateSelfLogsComponents(ctx context.Context, userAgent string) []fluentb
 	out = append(out, generateFluentBitSelfLogsComponents(ctx)...)
 	out = append(out, generateHealthChecksLogsComponents(ctx)...)
 
+	outputLogNames := strings.Join([]string{fluentBitSelfLogTag, healthLogsTag}, "|")
 	labels := structuredHealthLogsLabels()
-	out = append(out, stackdriverOutputComponent(strings.Join([]string{fluentBitSelfLogTag, healthLogsTag}, "|"), userAgent, "", labels))
+	out = append(out, stackdriverOutputComponent(outputLogNames, userAgent, "", labels))
 	return out
 }

--- a/confgenerator/testdata/builtin/linux/builtin/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/builtin/linux/builtin/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/builtin/linux/builtin/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/builtin/windows/builtin/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/builtin/windows/builtin/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_main.conf
@@ -185,9 +185,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -209,6 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_main.conf
@@ -185,6 +185,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -206,7 +209,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_main.conf
@@ -206,7 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_main.conf
@@ -202,23 +202,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -159,28 +159,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -196,7 +202,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_main.conf
@@ -188,6 +188,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -206,7 +212,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/builtin/windows/builtin/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
@@ -181,23 +181,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
@@ -185,7 +185,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
@@ -167,6 +167,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|host\.syslog)$
     Name                          stackdriver
@@ -185,7 +191,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
@@ -164,9 +164,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -188,6 +185,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
@@ -164,6 +164,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -185,7 +188,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
@@ -65,7 +65,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -74,7 +74,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -138,28 +138,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|host\.syslog)$
@@ -175,7 +181,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/all-custom_use_built_in_receivers/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/fluent_bit_main.conf
@@ -230,23 +230,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/fluent_bit_main.conf
@@ -213,6 +213,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -234,7 +237,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/fluent_bit_main.conf
@@ -216,6 +216,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.journald)$
     Name                          stackdriver
@@ -234,7 +240,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/fluent_bit_main.conf
@@ -234,7 +234,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/fluent_bit_main.conf
@@ -40,7 +40,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -49,7 +49,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -187,28 +187,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.journald)$
@@ -224,7 +230,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/fluent_bit_main.conf
@@ -213,9 +213,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -237,6 +234,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/all-quoted_map_keys/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/all-user_config_file_deleted/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlecloudmonitoring/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_googlemanagedprometheus/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_grpcendpoint/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_multiple_pipelines/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/combined-receiver_otlp_no_traces/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/global-default-log-rotation_custom/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-custom_log_level/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -126,23 +126,11 @@
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -122,9 +122,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -133,6 +130,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -125,12 +125,17 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -35,7 +35,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -44,7 +44,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -96,31 +96,50 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -130,7 +130,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -122,6 +122,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -130,7 +133,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-default_overrides_disable_all/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
@@ -253,23 +253,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
@@ -87,7 +87,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -96,7 +96,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -210,28 +210,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.test_syslog_source_id_tcp|pipeline4\.test_syslog_source_id_udp)$
@@ -247,7 +253,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
@@ -239,6 +239,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.test_syslog_source_id_tcp|pipeline4\.test_syslog_source_id_udp)$
     Name                          stackdriver
@@ -257,7 +263,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
@@ -257,7 +257,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
@@ -236,9 +236,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -260,6 +257,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
@@ -236,6 +236,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -257,7 +260,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-pipeline_multiple_pipelines/golden/fluent_bit_parser.conf
@@ -32,6 +32,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_main.conf
@@ -65,7 +65,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -74,7 +74,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -529,28 +529,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|p1\.sample_logs)$
@@ -566,7 +572,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_main.conf
@@ -555,9 +555,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -579,6 +576,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_main.conf
@@ -572,23 +572,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_main.conf
@@ -558,6 +558,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|p1\.sample_logs)$
     Name                          stackdriver
@@ -576,7 +582,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_main.conf
@@ -555,6 +555,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -576,7 +579,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_main.conf
@@ -576,7 +576,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_exclude_logs/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_main.conf
@@ -65,7 +65,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -74,7 +74,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -144,28 +144,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|p1\.sample_logs)$
@@ -181,7 +187,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_main.conf
@@ -170,6 +170,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -191,7 +194,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_main.conf
@@ -191,7 +191,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_main.conf
@@ -170,9 +170,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -194,6 +191,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_main.conf
@@ -173,6 +173,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|p1\.sample_logs)$
     Name                          stackdriver
@@ -191,7 +197,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_main.conf
@@ -187,23 +187,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_modify_fields/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_main.conf
@@ -282,7 +282,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_main.conf
@@ -80,7 +80,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -89,7 +89,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -235,28 +235,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|pipeline1\.sample_logs|pipeline2\.sample_logs)$
@@ -272,7 +278,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_main.conf
@@ -261,6 +261,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -282,7 +285,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_main.conf
@@ -278,23 +278,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_main.conf
@@ -264,6 +264,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|pipeline1\.sample_logs|pipeline2\.sample_logs)$
     Name                          stackdriver
@@ -282,7 +288,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_main.conf
@@ -261,9 +261,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -285,6 +282,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_order/golden/fluent_bit_parser.conf
@@ -26,6 +26,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_main.conf
@@ -295,7 +295,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_main.conf
@@ -277,6 +277,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.test_syslog_source_id_tcp|pipeline4\.test_syslog_source_id_udp)$
     Name                          stackdriver
@@ -295,7 +301,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_main.conf
@@ -274,6 +274,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -295,7 +298,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_main.conf
@@ -87,7 +87,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -96,7 +96,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -248,28 +248,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.test_syslog_source_id_tcp|pipeline4\.test_syslog_source_id_udp)$
@@ -285,7 +291,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_main.conf
@@ -291,23 +291,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_main.conf
@@ -274,9 +274,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -298,6 +295,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_json_and_parse_regex_types/golden/fluent_bit_parser.conf
@@ -45,6 +45,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_main.conf
@@ -174,6 +174,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|p1\.files_1)$
     Name                          stackdriver
@@ -192,7 +198,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_main.conf
@@ -188,23 +188,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_main.conf
@@ -171,6 +171,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -192,7 +195,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_main.conf
@@ -192,7 +192,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_main.conf
@@ -67,7 +67,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -76,7 +76,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -145,28 +145,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|p1\.files_1)$
@@ -182,7 +188,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_main.conf
@@ -171,9 +171,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -195,6 +192,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline/golden/fluent_bit_parser.conf
@@ -8,7 +8,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_main.conf
@@ -165,6 +165,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -186,7 +189,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_main.conf
@@ -168,6 +168,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|p1\.files_1)$
     Name                          stackdriver
@@ -186,7 +192,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_main.conf
@@ -66,7 +66,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -75,7 +75,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -139,28 +139,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|p1\.files_1)$
@@ -176,7 +182,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_main.conf
@@ -182,23 +182,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_main.conf
@@ -165,9 +165,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -189,6 +186,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_main.conf
@@ -186,7 +186,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_processor_not_in_use/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_main.conf
@@ -174,6 +174,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|p1\.files_1)$
     Name                          stackdriver
@@ -192,7 +198,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_main.conf
@@ -188,23 +188,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_main.conf
@@ -171,6 +171,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -192,7 +195,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_main.conf
@@ -192,7 +192,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_main.conf
@@ -67,7 +67,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -76,7 +76,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -145,28 +145,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|p1\.files_1)$
@@ -182,7 +188,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_main.conf
@@ -171,9 +171,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -195,6 +192,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_parser.conf
@@ -8,7 +8,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_main.conf
@@ -248,7 +248,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_main.conf
@@ -244,23 +244,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_main.conf
@@ -101,7 +101,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -110,7 +110,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -201,28 +201,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|p1\.files_1|p2\.files_2|p3\.files_3)$
@@ -238,7 +244,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_main.conf
@@ -227,9 +227,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -251,6 +248,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_main.conf
@@ -230,6 +230,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|p1\.files_1|p2\.files_2|p3\.files_3)$
     Name                          stackdriver
@@ -248,7 +254,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_main.conf
@@ -227,6 +227,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -248,7 +251,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_parser.conf
@@ -8,7 +8,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_main.conf
@@ -174,6 +174,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|p1\.files_1)$
     Name                          stackdriver
@@ -192,7 +198,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_main.conf
@@ -188,23 +188,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_main.conf
@@ -171,6 +171,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -192,7 +195,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_main.conf
@@ -192,7 +192,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_main.conf
@@ -67,7 +67,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -76,7 +76,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -145,28 +145,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|p1\.files_1)$
@@ -182,7 +188,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_main.conf
@@ -171,9 +171,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -195,6 +192,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_parser.conf
@@ -8,7 +8,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_main.conf
@@ -220,7 +220,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_main.conf
@@ -199,6 +199,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -220,7 +223,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_main.conf
@@ -199,9 +199,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -223,6 +220,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_main.conf
@@ -202,6 +202,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|p1\.files_1|p2\.files_1)$
     Name                          stackdriver
@@ -220,7 +226,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_main.conf
@@ -84,7 +84,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -93,7 +93,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -173,28 +173,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|p1\.files_1|p2\.files_1)$
@@ -210,7 +216,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_main.conf
@@ -216,23 +216,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_parser.conf
@@ -8,7 +8,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_main.conf
@@ -183,7 +183,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_main.conf
@@ -162,9 +162,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -186,6 +183,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_main.conf
@@ -162,6 +162,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -183,7 +186,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_main.conf
@@ -165,6 +165,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -183,7 +189,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_main.conf
@@ -179,23 +179,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -136,28 +136,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -173,7 +179,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_regex_type_on_default_pipeline/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_main.conf
@@ -235,9 +235,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -259,6 +256,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_main.conf
@@ -238,6 +238,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(apache\.apache_access|apache\.apache_error|default_pipeline\.syslog)$
     Name                          stackdriver
@@ -256,7 +262,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_main.conf
@@ -80,7 +80,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -89,7 +89,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -209,28 +209,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(apache\.apache_access|apache\.apache_error|default_pipeline\.syslog)$
@@ -246,7 +252,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_main.conf
@@ -256,7 +256,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_main.conf
@@ -252,23 +252,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_main.conf
@@ -235,6 +235,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -256,7 +259,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache/golden/fluent_bit_parser.conf
@@ -24,6 +24,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_main.conf
@@ -411,9 +411,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -435,6 +432,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_main.conf
@@ -411,6 +411,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -432,7 +435,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_main.conf
@@ -132,7 +132,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -141,7 +141,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -385,28 +385,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(apache_custom\.apache_custom_access|apache_custom\.apache_custom_error|apache_default\.apache_default_access|apache_default\.apache_default_error|apache_syslog_access\.apache_syslog_access|apache_syslog_error\.apache_syslog_error|default_pipeline\.syslog)$
@@ -422,7 +428,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_main.conf
@@ -432,7 +432,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_main.conf
@@ -414,6 +414,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(apache_custom\.apache_custom_access|apache_custom\.apache_custom_error|apache_default\.apache_default_access|apache_default\.apache_default_error|apache_syslog_access\.apache_syslog_access|apache_syslog_error\.apache_syslog_error|default_pipeline\.syslog)$
     Name                          stackdriver
@@ -432,7 +438,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_main.conf
@@ -428,23 +428,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_apache_custom/golden/fluent_bit_parser.conf
@@ -66,6 +66,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_main.conf
@@ -303,6 +303,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(cassandra\.cassandra_debug|cassandra\.cassandra_gc|cassandra\.cassandra_system|default_pipeline\.syslog)$
     Name                          stackdriver
@@ -321,7 +327,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_main.conf
@@ -300,9 +300,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -324,6 +321,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_main.conf
@@ -321,7 +321,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_main.conf
@@ -300,6 +300,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -321,7 +324,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_main.conf
@@ -317,23 +317,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_main.conf
@@ -95,7 +95,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -104,7 +104,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -274,28 +274,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(cassandra\.cassandra_debug|cassandra\.cassandra_gc|cassandra\.cassandra_system|default_pipeline\.syslog)$
@@ -311,7 +317,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_parser.conf
@@ -40,7 +40,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_main.conf
@@ -793,6 +793,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(cassandra_custom\.cassandra_custom_debug|cassandra_custom\.cassandra_custom_gc|cassandra_custom\.cassandra_custom_system|cassandra_default\.cassandra_default_debug|cassandra_default\.cassandra_default_gc|cassandra_default\.cassandra_default_system|cassandra_syslog_system\.cassandra_syslog_debug|cassandra_syslog_system\.cassandra_syslog_gc|cassandra_syslog_system\.cassandra_syslog_system|default_pipeline\.syslog)$
     Name                          stackdriver
@@ -811,7 +817,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_main.conf
@@ -807,23 +807,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_main.conf
@@ -790,6 +790,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -811,7 +814,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_main.conf
@@ -173,7 +173,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -182,7 +182,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -764,28 +764,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(cassandra_custom\.cassandra_custom_debug|cassandra_custom\.cassandra_custom_gc|cassandra_custom\.cassandra_custom_system|cassandra_default\.cassandra_default_debug|cassandra_default\.cassandra_default_gc|cassandra_default\.cassandra_default_system|cassandra_syslog_system\.cassandra_syslog_debug|cassandra_syslog_system\.cassandra_syslog_gc|cassandra_syslog_system\.cassandra_syslog_system|default_pipeline\.syslog)$
@@ -801,7 +807,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_main.conf
@@ -790,9 +790,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -814,6 +811,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_main.conf
@@ -811,7 +811,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_parser.conf
@@ -183,7 +183,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_main.conf
@@ -293,6 +293,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -314,7 +317,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_main.conf
@@ -95,7 +95,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -104,7 +104,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -267,28 +267,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(couchbase\.couchbase_general|couchbase\.couchbase_goxdcr|couchbase\.couchbase_http_access|default_pipeline\.syslog)$
@@ -304,7 +310,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_main.conf
@@ -314,7 +314,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_main.conf
@@ -293,9 +293,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -317,6 +314,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_main.conf
@@ -310,23 +310,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_main.conf
@@ -296,6 +296,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(couchbase\.couchbase_general|couchbase\.couchbase_goxdcr|couchbase\.couchbase_http_access|default_pipeline\.syslog)$
     Name                          stackdriver
@@ -314,7 +320,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchbase/golden/fluent_bit_parser.conf
@@ -30,7 +30,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_main.conf
@@ -202,9 +202,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -226,6 +223,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_main.conf
@@ -223,7 +223,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_main.conf
@@ -205,6 +205,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(couchdb\.couchdb|default_pipeline\.syslog)$
     Name                          stackdriver
@@ -223,7 +229,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_main.conf
@@ -66,7 +66,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -75,7 +75,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -176,28 +176,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(couchdb\.couchdb|default_pipeline\.syslog)$
@@ -213,7 +219,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_main.conf
@@ -202,6 +202,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -223,7 +226,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_main.conf
@@ -219,23 +219,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_couchdb/golden/fluent_bit_parser.conf
@@ -23,7 +23,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_main.conf
@@ -81,7 +81,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -90,7 +90,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -319,28 +319,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|elasticsearch\.elasticsearch_gc|elasticsearch\.elasticsearch_json)$
@@ -356,7 +362,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_main.conf
@@ -362,23 +362,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_main.conf
@@ -345,9 +345,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -369,6 +366,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_main.conf
@@ -366,7 +366,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_main.conf
@@ -348,6 +348,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|elasticsearch\.elasticsearch_gc|elasticsearch\.elasticsearch_json)$
     Name                          stackdriver
@@ -366,7 +372,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_main.conf
@@ -345,6 +345,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -366,7 +369,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch/golden/fluent_bit_parser.conf
@@ -22,7 +22,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_main.conf
@@ -566,23 +566,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_main.conf
@@ -549,9 +549,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -573,6 +570,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_main.conf
@@ -552,6 +552,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|elasticsearch_custom\.elasticsearch_gc_custom|elasticsearch_custom\.elasticsearch_json_custom|elasticsearch_default\.elasticsearch_gc_default|elasticsearch_default\.elasticsearch_json_default)$
     Name                          stackdriver
@@ -570,7 +576,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_main.conf
@@ -549,6 +549,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -570,7 +573,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_main.conf
@@ -114,7 +114,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -123,7 +123,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -523,28 +523,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|elasticsearch_custom\.elasticsearch_gc_custom|elasticsearch_custom\.elasticsearch_json_custom|elasticsearch_default\.elasticsearch_gc_default|elasticsearch_default\.elasticsearch_json_default)$
@@ -560,7 +566,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_main.conf
@@ -570,7 +570,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_elasticsearch_custom/golden/fluent_bit_parser.conf
@@ -36,7 +36,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/fluent_bit_main.conf
@@ -246,23 +246,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/fluent_bit_main.conf
@@ -229,6 +229,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -250,7 +253,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/fluent_bit_main.conf
@@ -229,9 +229,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -253,6 +250,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/fluent_bit_main.conf
@@ -250,7 +250,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/fluent_bit_main.conf
@@ -232,6 +232,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.log_source_id3|pipeline4\.log_source_id4)$
     Name                          stackdriver
@@ -250,7 +256,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/fluent_bit_main.conf
@@ -112,7 +112,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -121,7 +121,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -203,28 +203,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.log_source_id3|pipeline4\.log_source_id4)$
@@ -240,7 +246,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_log_file_path/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
@@ -165,6 +165,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -186,7 +189,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
@@ -168,6 +168,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|pipeline1\.log_source_id1)$
     Name                          stackdriver
@@ -186,7 +192,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
@@ -66,7 +66,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -75,7 +75,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -139,28 +139,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|pipeline1\.log_source_id1)$
@@ -176,7 +182,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
@@ -182,23 +182,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
@@ -165,9 +165,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -189,6 +186,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
@@ -186,7 +186,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_refresh_interval/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -251,6 +251,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.log_source_id3|pipeline4\.log_source_id4|pipeline5\.log_source_id5)$
     Name                          stackdriver
@@ -269,7 +275,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -269,7 +269,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -112,7 +112,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -121,7 +121,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -222,28 +222,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(pipeline1\.log_source_id1|pipeline2\.log_source_id2|pipeline3\.log_source_id3|pipeline4\.log_source_id4|pipeline5\.log_source_id5)$
@@ -259,7 +265,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -248,6 +248,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -269,7 +272,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -265,23 +265,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -248,9 +248,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -272,6 +269,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_main.conf
@@ -212,23 +212,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_main.conf
@@ -65,7 +65,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -74,7 +74,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -169,28 +169,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|flink\.flink)$
@@ -206,7 +212,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_main.conf
@@ -195,9 +195,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -219,6 +216,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_main.conf
@@ -198,6 +198,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|flink\.flink)$
     Name                          stackdriver
@@ -216,7 +222,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_main.conf
@@ -216,7 +216,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_main.conf
@@ -195,6 +195,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -216,7 +219,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_flink/golden/fluent_bit_parser.conf
@@ -15,7 +15,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_main.conf
@@ -180,23 +180,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_main.conf
@@ -184,7 +184,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_main.conf
@@ -166,6 +166,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|e8195f91348f8a6c3c046a4e5e97bc49\.fluent_forward\.fluent_forward\..*)$
     Name                          stackdriver
@@ -184,7 +190,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_main.conf
@@ -58,7 +58,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -67,7 +67,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -137,28 +137,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|e8195f91348f8a6c3c046a4e5e97bc49\.fluent_forward\.fluent_forward\..*)$
@@ -174,7 +180,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_main.conf
@@ -163,9 +163,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -187,6 +184,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_main.conf
@@ -163,6 +163,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -184,7 +187,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_main.conf
@@ -66,7 +66,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -75,7 +75,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -157,28 +157,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(3d1e3d2de8297b94d50f1b791772d4f9\.fluent_forward\.fluent_forward_collision\..*|default_pipeline\.syslog|e8195f91348f8a6c3c046a4e5e97bc49\.fluent_forward\.fluent_forward\..*)$
@@ -194,7 +200,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_main.conf
@@ -200,23 +200,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_main.conf
@@ -183,6 +183,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -204,7 +207,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_main.conf
@@ -186,6 +186,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(3d1e3d2de8297b94d50f1b791772d4f9\.fluent_forward\.fluent_forward_collision\..*|default_pipeline\.syslog|e8195f91348f8a6c3c046a4e5e97bc49\.fluent_forward\.fluent_forward\..*)$
     Name                          stackdriver
@@ -204,7 +210,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_main.conf
@@ -183,9 +183,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -207,6 +204,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_main.conf
@@ -204,7 +204,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_conflicting_id/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_main.conf
@@ -186,6 +186,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(770ecc55c94dd06217c2f78e09580174\.fluent_forward\.fluent_forward\..*|default_pipeline\.syslog|e8195f91348f8a6c3c046a4e5e97bc49\.fluent_forward\.fluent_forward\..*)$
     Name                          stackdriver
@@ -204,7 +210,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_main.conf
@@ -200,23 +200,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_main.conf
@@ -183,6 +183,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -204,7 +207,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_main.conf
@@ -66,7 +66,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -75,7 +75,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -157,28 +157,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(770ecc55c94dd06217c2f78e09580174\.fluent_forward\.fluent_forward\..*|default_pipeline\.syslog|e8195f91348f8a6c3c046a4e5e97bc49\.fluent_forward\.fluent_forward\..*)$
@@ -194,7 +200,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_main.conf
@@ -183,9 +183,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -207,6 +204,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_main.conf
@@ -204,7 +204,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_multiple_receivers_with_dot/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_main.conf
@@ -180,23 +180,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_main.conf
@@ -166,6 +166,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(b6547699ccacdc03ba6ae458f9ee5860\.fluent_pipeline\.fluent_logs\..*|default_pipeline\.syslog)$
     Name                          stackdriver
@@ -184,7 +190,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_main.conf
@@ -58,7 +58,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -67,7 +67,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -137,28 +137,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(b6547699ccacdc03ba6ae458f9ee5860\.fluent_pipeline\.fluent_logs\..*|default_pipeline\.syslog)$
@@ -174,7 +180,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_main.conf
@@ -184,7 +184,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_main.conf
@@ -163,6 +163,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -184,7 +187,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_main.conf
@@ -163,9 +163,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -187,6 +184,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_forward_omitting_optional_parameters/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_main.conf
@@ -66,7 +66,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -75,7 +75,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -169,28 +169,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|hadoop\.hadoop)$
@@ -206,7 +212,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_main.conf
@@ -212,23 +212,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_main.conf
@@ -195,6 +195,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -216,7 +219,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_main.conf
@@ -195,9 +195,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -219,6 +216,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_main.conf
@@ -216,7 +216,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_main.conf
@@ -198,6 +198,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|hadoop\.hadoop)$
     Name                          stackdriver
@@ -216,7 +222,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop/golden/fluent_bit_parser.conf
@@ -15,7 +15,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_main.conf
@@ -213,23 +213,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_main.conf
@@ -196,6 +196,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -217,7 +220,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_main.conf
@@ -217,7 +217,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_main.conf
@@ -199,6 +199,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|hadoop\.hadoop)$
     Name                          stackdriver
@@ -217,7 +223,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_main.conf
@@ -196,9 +196,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -220,6 +217,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_main.conf
@@ -67,7 +67,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -76,7 +76,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -170,28 +170,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|hadoop\.hadoop)$
@@ -207,7 +213,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hadoop_refresh_interval/golden/fluent_bit_parser.conf
@@ -15,7 +15,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_main.conf
@@ -198,6 +198,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|hbase\.hbase_system)$
     Name                          stackdriver
@@ -216,7 +222,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_main.conf
@@ -65,7 +65,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -74,7 +74,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -169,28 +169,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|hbase\.hbase_system)$
@@ -206,7 +212,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_main.conf
@@ -212,23 +212,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_main.conf
@@ -195,9 +195,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -219,6 +216,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_main.conf
@@ -216,7 +216,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_main.conf
@@ -195,6 +195,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -216,7 +219,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_hbase/golden/fluent_bit_parser.conf
@@ -15,7 +15,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_main.conf
@@ -206,23 +206,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_main.conf
@@ -189,6 +189,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -210,7 +213,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_main.conf
@@ -210,7 +210,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_main.conf
@@ -192,6 +192,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|jetty\.jetty_access)$
     Name                          stackdriver
@@ -210,7 +216,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_main.conf
@@ -65,7 +65,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -74,7 +74,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -163,28 +163,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|jetty\.jetty_access)$
@@ -200,7 +206,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_main.conf
@@ -189,9 +189,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -213,6 +210,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_jetty/golden/fluent_bit_parser.conf
@@ -16,6 +16,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_main.conf
@@ -198,6 +198,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|kafka\.kafka)$
     Name                          stackdriver
@@ -216,7 +222,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_main.conf
@@ -212,23 +212,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_main.conf
@@ -195,9 +195,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -219,6 +216,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_main.conf
@@ -65,7 +65,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -74,7 +74,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -169,28 +169,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|kafka\.kafka)$
@@ -206,7 +212,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_main.conf
@@ -216,7 +216,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_main.conf
@@ -195,6 +195,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -216,7 +219,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka/golden/fluent_bit_parser.conf
@@ -15,7 +15,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_main.conf
@@ -243,9 +243,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -267,6 +264,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_main.conf
@@ -246,6 +246,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|kafka_custom\.kafka_custom|kafka_syslog\.kafka_syslog)$
     Name                          stackdriver
@@ -264,7 +270,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_main.conf
@@ -76,7 +76,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -85,7 +85,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -217,28 +217,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|kafka_custom\.kafka_custom|kafka_syslog\.kafka_syslog)$
@@ -254,7 +260,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_main.conf
@@ -264,7 +264,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_main.conf
@@ -243,6 +243,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -264,7 +267,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_main.conf
@@ -260,23 +260,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_kafka_custom/golden/fluent_bit_parser.conf
@@ -27,7 +27,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_main.conf
@@ -282,6 +282,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|mongodb\.mongodb)$
     Name                          stackdriver
@@ -300,7 +306,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_main.conf
@@ -279,9 +279,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -303,6 +300,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_main.conf
@@ -279,6 +279,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -300,7 +303,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_main.conf
@@ -65,7 +65,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -74,7 +74,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -253,28 +253,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|mongodb\.mongodb)$
@@ -290,7 +296,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_main.conf
@@ -300,7 +300,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_main.conf
@@ -296,23 +296,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mongodb/golden/fluent_bit_parser.conf
@@ -24,6 +24,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_main.conf
@@ -312,23 +312,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_main.conf
@@ -298,6 +298,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|mysql\.mysql_error|mysql\.mysql_general|mysql\.mysql_slow)$
     Name                          stackdriver
@@ -316,7 +322,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_main.conf
@@ -316,7 +316,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_main.conf
@@ -95,7 +95,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -104,7 +104,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -269,28 +269,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|mysql\.mysql_error|mysql\.mysql_general|mysql\.mysql_slow)$
@@ -306,7 +312,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_main.conf
@@ -295,9 +295,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -319,6 +316,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_main.conf
@@ -295,6 +295,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -316,7 +319,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql/golden/fluent_bit_parser.conf
@@ -47,7 +47,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_main.conf
@@ -765,6 +765,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -786,7 +789,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_main.conf
@@ -786,7 +786,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_main.conf
@@ -765,9 +765,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -789,6 +786,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_main.conf
@@ -782,23 +782,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_main.conf
@@ -768,6 +768,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|mysql_custom\.mysql_custom_error|mysql_custom\.mysql_custom_general|mysql_custom\.mysql_custom_slow|mysql_default\.mysql_default_error|mysql_default\.mysql_default_general|mysql_default\.mysql_default_slow|mysql_syslog_error\.mysql_syslog_error|mysql_syslog_error\.mysql_syslog_general|mysql_syslog_error\.mysql_syslog_slow)$
     Name                          stackdriver
@@ -786,7 +792,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_main.conf
@@ -173,7 +173,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -182,7 +182,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -739,28 +739,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|mysql_custom\.mysql_custom_error|mysql_custom\.mysql_custom_general|mysql_custom\.mysql_custom_slow|mysql_default\.mysql_default_error|mysql_default\.mysql_default_general|mysql_default\.mysql_default_slow|mysql_syslog_error\.mysql_syslog_error|mysql_syslog_error\.mysql_syslog_general|mysql_syslog_error\.mysql_syslog_slow)$
@@ -776,7 +782,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_mysql_custom/golden/fluent_bit_parser.conf
@@ -218,7 +218,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_main.conf
@@ -235,6 +235,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -256,7 +259,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_main.conf
@@ -235,9 +235,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -259,6 +256,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_main.conf
@@ -80,7 +80,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -89,7 +89,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -209,28 +209,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|nginx\.nginx_access|nginx\.nginx_error)$
@@ -246,7 +252,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_main.conf
@@ -256,7 +256,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_main.conf
@@ -252,23 +252,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_main.conf
@@ -238,6 +238,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|nginx\.nginx_access|nginx\.nginx_error)$
     Name                          stackdriver
@@ -256,7 +262,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx/golden/fluent_bit_parser.conf
@@ -24,6 +24,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_main.conf
@@ -411,9 +411,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -435,6 +432,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_main.conf
@@ -414,6 +414,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|nginx_custom\.nginx_custom_access|nginx_custom\.nginx_custom_error|nginx_default\.nginx_default_access|nginx_default\.nginx_default_error|nginx_syslog_access\.nginx_syslog_access|nginx_syslog_error\.nginx_syslog_error)$
     Name                          stackdriver
@@ -432,7 +438,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_main.conf
@@ -132,7 +132,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -141,7 +141,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -385,28 +385,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|nginx_custom\.nginx_custom_access|nginx_custom\.nginx_custom_error|nginx_default\.nginx_default_access|nginx_default\.nginx_default_error|nginx_syslog_access\.nginx_syslog_access|nginx_syslog_error\.nginx_syslog_error)$
@@ -422,7 +428,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_main.conf
@@ -411,6 +411,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -432,7 +435,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_main.conf
@@ -428,23 +428,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_main.conf
@@ -432,7 +432,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_nginx_custom/golden/fluent_bit_parser.conf
@@ -66,6 +66,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_main.conf
@@ -80,7 +80,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -89,7 +89,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -221,28 +221,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|oracledb\.oracledb_alert|oracledb\.oracledb_audit)$
@@ -258,7 +264,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_main.conf
@@ -247,6 +247,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -268,7 +271,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_main.conf
@@ -264,23 +264,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_main.conf
@@ -268,7 +268,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_main.conf
@@ -250,6 +250,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|oracledb\.oracledb_alert|oracledb\.oracledb_audit)$
     Name                          stackdriver
@@ -268,7 +274,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_main.conf
@@ -247,9 +247,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -271,6 +268,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb/golden/fluent_bit_parser.conf
@@ -23,7 +23,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_main.conf
@@ -445,9 +445,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -469,6 +466,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_main.conf
@@ -462,23 +462,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_main.conf
@@ -448,6 +448,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|oracledb_custom\.oracledb_alert_custom|oracledb_custom\.oracledb_audit_custom|oracledb_default\.oracledb_alert|oracledb_default\.oracledb_audit|oracledb_syslog_alert\.oracledb_syslog_alert|oracledb_syslog_audit\.oracledb_syslog_audit)$
     Name                          stackdriver
@@ -466,7 +472,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_main.conf
@@ -130,7 +130,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -139,7 +139,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -419,28 +419,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|oracledb_custom\.oracledb_alert_custom|oracledb_custom\.oracledb_audit_custom|oracledb_default\.oracledb_alert|oracledb_default\.oracledb_audit|oracledb_syslog_alert\.oracledb_syslog_alert|oracledb_syslog_audit\.oracledb_syslog_audit)$
@@ -456,7 +462,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_main.conf
@@ -445,6 +445,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -466,7 +469,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_main.conf
@@ -466,7 +466,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_oracledb_custom/golden/fluent_bit_parser.conf
@@ -63,7 +63,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_main.conf
@@ -65,7 +65,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -74,7 +74,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -169,28 +169,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|postgresql\.postgresql_general)$
@@ -206,7 +212,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_main.conf
@@ -212,23 +212,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_main.conf
@@ -195,9 +195,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -219,6 +216,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_main.conf
@@ -216,7 +216,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_main.conf
@@ -195,6 +195,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -216,7 +219,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_main.conf
@@ -198,6 +198,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|postgresql\.postgresql_general)$
     Name                          stackdriver
@@ -216,7 +222,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql/golden/fluent_bit_parser.conf
@@ -16,7 +16,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_main.conf
@@ -297,6 +297,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|postgresql_custom\.postgresql_custom_general|postgresql_default\.postgresql_default_general|postgresql_syslog_error\.postgresql_syslog_general)$
     Name                          stackdriver
@@ -315,7 +321,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_main.conf
@@ -311,23 +311,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_main.conf
@@ -315,7 +315,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_main.conf
@@ -294,9 +294,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -318,6 +315,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_main.conf
@@ -294,6 +294,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -315,7 +318,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_main.conf
@@ -90,7 +90,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -99,7 +99,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -268,28 +268,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|postgresql_custom\.postgresql_custom_general|postgresql_default\.postgresql_default_general|postgresql_syslog_error\.postgresql_syslog_general)$
@@ -305,7 +311,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_postgresql_custom/golden/fluent_bit_parser.conf
@@ -37,7 +37,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_main.conf
@@ -213,23 +213,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_main.conf
@@ -66,7 +66,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -75,7 +75,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -170,28 +170,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|rabbitmq\.rabbitmq)$
@@ -207,7 +213,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_main.conf
@@ -196,6 +196,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -217,7 +220,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_main.conf
@@ -199,6 +199,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|rabbitmq\.rabbitmq)$
     Name                          stackdriver
@@ -217,7 +223,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_main.conf
@@ -217,7 +217,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_main.conf
@@ -196,9 +196,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -220,6 +217,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_rabbitmq/golden/fluent_bit_parser.conf
@@ -22,7 +22,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_main.conf
@@ -65,7 +65,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -74,7 +74,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -163,28 +163,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|redis\.redis)$
@@ -200,7 +206,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_main.conf
@@ -210,7 +210,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_main.conf
@@ -192,6 +192,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|redis\.redis)$
     Name                          stackdriver
@@ -210,7 +216,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_main.conf
@@ -189,9 +189,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -213,6 +210,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_main.conf
@@ -189,6 +189,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -210,7 +213,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_main.conf
@@ -206,23 +206,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis/golden/fluent_bit_parser.conf
@@ -16,6 +16,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_main.conf
@@ -294,23 +294,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_main.conf
@@ -298,7 +298,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_main.conf
@@ -91,7 +91,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -100,7 +100,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -251,28 +251,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|redis_custom\.redis_custom|redis_default\.redis_default|redis_syslog\.redis_syslog)$
@@ -288,7 +294,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_main.conf
@@ -277,6 +277,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -298,7 +301,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_main.conf
@@ -280,6 +280,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|redis_custom\.redis_custom|redis_default\.redis_default|redis_syslog\.redis_syslog)$
     Name                          stackdriver
@@ -298,7 +304,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_main.conf
@@ -277,9 +277,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -301,6 +298,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_redis_custom/golden/fluent_bit_parser.conf
@@ -37,6 +37,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_main.conf
@@ -213,23 +213,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_main.conf
@@ -67,7 +67,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -76,7 +76,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -170,28 +170,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|saphana\.saphana)$
@@ -207,7 +213,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_main.conf
@@ -199,6 +199,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|saphana\.saphana)$
     Name                          stackdriver
@@ -217,7 +223,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_main.conf
@@ -196,6 +196,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -217,7 +220,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_main.conf
@@ -217,7 +217,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_main.conf
@@ -196,9 +196,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -220,6 +217,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana/golden/fluent_bit_parser.conf
@@ -16,7 +16,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_main.conf
@@ -291,9 +291,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -315,6 +312,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_main.conf
@@ -294,6 +294,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|saphana_custom\.saphana_custom|saphana_default\.saphana|saphana_syslog\.saphana_syslog)$
     Name                          stackdriver
@@ -312,7 +318,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_main.conf
@@ -312,7 +312,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_main.conf
@@ -95,7 +95,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -104,7 +104,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -265,28 +265,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|saphana_custom\.saphana_custom|saphana_default\.saphana|saphana_syslog\.saphana_syslog)$
@@ -302,7 +308,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_main.conf
@@ -308,23 +308,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_main.conf
@@ -291,6 +291,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -312,7 +315,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_saphana_custom/golden/fluent_bit_parser.conf
@@ -37,7 +37,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_main.conf
@@ -212,23 +212,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_main.conf
@@ -198,6 +198,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|solr\.solr_system)$
     Name                          stackdriver
@@ -216,7 +222,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_main.conf
@@ -195,9 +195,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -219,6 +216,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_main.conf
@@ -216,7 +216,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_main.conf
@@ -195,6 +195,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -216,7 +219,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_main.conf
@@ -65,7 +65,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -74,7 +74,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -169,28 +169,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|solr\.solr_system)$
@@ -206,7 +212,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_solr/golden/fluent_bit_parser.conf
@@ -15,7 +15,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -209,23 +209,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -64,7 +64,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -166,28 +166,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(pipeline1\.test_syslog_source_id_tcp|pipeline2\.test_syslog_source_id_udp)$
@@ -203,7 +209,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -213,7 +213,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -195,6 +195,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(pipeline1\.test_syslog_source_id_tcp|pipeline2\.test_syslog_source_id_udp)$
     Name                          stackdriver
@@ -213,7 +219,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -192,6 +192,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -213,7 +216,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -192,9 +192,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -216,6 +213,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_syslog_type_multiple_receivers/golden/fluent_bit_parser.conf
@@ -32,6 +32,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_main.conf
@@ -245,23 +245,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_main.conf
@@ -228,9 +228,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -252,6 +249,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_main.conf
@@ -249,7 +249,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_main.conf
@@ -228,6 +228,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -249,7 +252,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_main.conf
@@ -55,7 +55,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -64,7 +64,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -202,28 +202,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|systemd_pipeline\.systemd_logs)$
@@ -239,7 +245,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_main.conf
@@ -231,6 +231,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|systemd_pipeline\.systemd_logs)$
     Name                          stackdriver
@@ -249,7 +255,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_systemd/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_main.conf
@@ -161,6 +161,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|tcp_pipeline\.tcp_logs)$
     Name                          stackdriver
@@ -179,7 +185,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_main.conf
@@ -179,7 +179,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_main.conf
@@ -59,7 +59,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -68,7 +68,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -132,28 +132,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|tcp_pipeline\.tcp_logs)$
@@ -169,7 +175,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_main.conf
@@ -158,9 +158,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -182,6 +179,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_main.conf
@@ -158,6 +158,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -179,7 +182,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_main.conf
@@ -175,23 +175,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_main.conf
@@ -161,6 +161,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|tcp_pipeline\.tcp_logs)$
     Name                          stackdriver
@@ -179,7 +185,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_main.conf
@@ -179,7 +179,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_main.conf
@@ -59,7 +59,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -68,7 +68,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -132,28 +132,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|tcp_pipeline\.tcp_logs)$
@@ -169,7 +175,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_main.conf
@@ -158,9 +158,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -182,6 +179,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_main.conf
@@ -158,6 +158,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -179,7 +182,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_main.conf
@@ -175,23 +175,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_duplicated_port_but_not_used/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_main.conf
@@ -161,6 +161,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|tcp_pipeline\.tcp_logs)$
     Name                          stackdriver
@@ -179,7 +185,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_main.conf
@@ -179,7 +179,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_main.conf
@@ -59,7 +59,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -68,7 +68,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -132,28 +132,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|tcp_pipeline\.tcp_logs)$
@@ -169,7 +175,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_main.conf
@@ -158,9 +158,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -182,6 +179,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_main.conf
@@ -158,6 +158,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -179,7 +182,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_main.conf
@@ -175,23 +175,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tcp_omitting_optional_parameters/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_main.conf
@@ -244,6 +244,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|tomcat\.tomcat_access|tomcat\.tomcat_system)$
     Name                          stackdriver
@@ -262,7 +268,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_main.conf
@@ -80,7 +80,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -89,7 +89,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -215,28 +215,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|tomcat\.tomcat_access|tomcat\.tomcat_system)$
@@ -252,7 +258,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_main.conf
@@ -241,6 +241,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -262,7 +265,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_main.conf
@@ -258,23 +258,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_main.conf
@@ -262,7 +262,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_main.conf
@@ -241,9 +241,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -265,6 +262,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat/golden/fluent_bit_parser.conf
@@ -24,7 +24,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_main.conf
@@ -483,9 +483,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -507,6 +504,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_main.conf
@@ -486,6 +486,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|tomcat_custom\.tomcat_custom_access|tomcat_custom\.tomcat_custom_system|tomcat_default\.tomcat_default_access|tomcat_default\.tomcat_default_system|tomcat_syslog_system\.tomcat_syslog_access|tomcat_syslog_system\.tomcat_syslog_system)$
     Name                          stackdriver
@@ -504,7 +510,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_main.conf
@@ -130,7 +130,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -139,7 +139,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -457,28 +457,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|tomcat_custom\.tomcat_custom_access|tomcat_custom\.tomcat_custom_system|tomcat_default\.tomcat_default_access|tomcat_default\.tomcat_default_system|tomcat_syslog_system\.tomcat_syslog_access|tomcat_syslog_system\.tomcat_syslog_system)$
@@ -494,7 +500,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_main.conf
@@ -483,6 +483,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -504,7 +507,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_main.conf
@@ -500,23 +500,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_main.conf
@@ -504,7 +504,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_tomcat_custom/golden/fluent_bit_parser.conf
@@ -82,7 +82,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_main.conf
@@ -210,7 +210,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_main.conf
@@ -192,6 +192,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|varnish\.varnish)$
     Name                          stackdriver
@@ -210,7 +216,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_main.conf
@@ -189,9 +189,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -213,6 +210,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_main.conf
@@ -189,6 +189,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -210,7 +213,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_main.conf
@@ -206,23 +206,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_main.conf
@@ -65,7 +65,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -74,7 +74,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -163,28 +163,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|varnish\.varnish)$
@@ -200,7 +206,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_varnish/golden/fluent_bit_parser.conf
@@ -16,6 +16,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_main.conf
@@ -66,7 +66,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -75,7 +75,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -169,28 +169,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|vault\.vault_audit)$
@@ -206,7 +212,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_main.conf
@@ -212,23 +212,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_main.conf
@@ -198,6 +198,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|vault\.vault_audit)$
     Name                          stackdriver
@@ -216,7 +222,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_main.conf
@@ -195,9 +195,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -219,6 +216,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_main.conf
@@ -216,7 +216,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_main.conf
@@ -195,6 +195,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -216,7 +219,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_vault/golden/fluent_bit_parser.conf
@@ -14,7 +14,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_main.conf
@@ -212,23 +212,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_main.conf
@@ -195,9 +195,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -219,6 +216,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_main.conf
@@ -66,7 +66,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -75,7 +75,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -169,28 +169,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|wildfly_system\.wildfly_system)$
@@ -206,7 +212,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_main.conf
@@ -198,6 +198,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|wildfly_system\.wildfly_system)$
     Name                          stackdriver
@@ -216,7 +222,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_main.conf
@@ -216,7 +216,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_main.conf
@@ -195,6 +195,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -216,7 +219,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_wildfly/golden/fluent_bit_parser.conf
@@ -15,7 +15,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_main.conf
@@ -199,6 +199,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|zookeeper_general\.zookeeper_general)$
     Name                          stackdriver
@@ -217,7 +223,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_main.conf
@@ -213,23 +213,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_main.conf
@@ -66,7 +66,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -75,7 +75,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -170,28 +170,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|zookeeper_general\.zookeeper_general)$
@@ -207,7 +213,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_main.conf
@@ -196,6 +196,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -217,7 +220,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_main.conf
@@ -217,7 +217,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_main.conf
@@ -196,9 +196,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -220,6 +217,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper/golden/fluent_bit_parser.conf
@@ -24,7 +24,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_main.conf
@@ -213,23 +213,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_main.conf
@@ -199,6 +199,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|zookeeper\.zookeeper_general)$
     Name                          stackdriver
@@ -217,7 +223,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_main.conf
@@ -66,7 +66,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -75,7 +75,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -170,28 +170,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog|zookeeper\.zookeeper_general)$
@@ -207,7 +213,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_main.conf
@@ -196,6 +196,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -217,7 +220,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_main.conf
@@ -217,7 +217,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_main.conf
@@ -196,9 +196,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -220,6 +217,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_zookeeper_custom/golden/fluent_bit_parser.conf
@@ -24,7 +24,7 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time
 

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-custom_log_level/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-default_overrides_disable_all/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver-no-collection_interval/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_aerospike/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_apache_custom/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_cassandra_custom/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchbase/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_couchdb/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_custom_collection_interval/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_credentials/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_custom_endpoint_http/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_no_jvm/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_elasticsearch_tls_credentials/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_flink/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hadoop_no_jvm/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_hbase_no_jvm/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jetty_no_jvm/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_auth/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_jvm_with_endpoint/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_kafka_no_jvm/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_memcached/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mongodb_unix_socket/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_mysql/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_nginx_custom/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_all_params/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_oracledb_unix_socket/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_no_sni/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_postgresql_tls_with_certs/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_complex/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_default_replacement/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_multi_replacement_regex/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_node_exporter/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_relabel/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_prometheus_tlx_with_certs/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_no_sni/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_rabbitmq_tls_with_certs/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_redis_custom/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_saphana/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_solr/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_tomcat_custom/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_varnish/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_tls/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_vault_with_token/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_wildfly_with_host_port/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_main.conf
@@ -160,23 +160,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_main.conf
@@ -164,7 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_main.conf
@@ -146,6 +146,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
     Name                          stackdriver
@@ -164,7 +170,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_main.conf
@@ -143,9 +143,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -167,6 +164,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_main.conf
@@ -143,6 +143,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -164,7 +167,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -117,28 +117,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.syslog)$
@@ -154,7 +160,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_zookeeper_endpoint/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_main.conf
@@ -228,6 +228,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log|winlog2\.winlog2)$
     Name                          stackdriver
@@ -246,7 +252,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -199,28 +199,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log|winlog2\.winlog2)$
@@ -236,7 +242,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_main.conf
@@ -225,9 +225,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -249,6 +246,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_main.conf
@@ -246,7 +246,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_main.conf
@@ -225,6 +225,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -246,7 +249,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_main.conf
@@ -242,23 +242,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows-2012/logging-use_ansi/golden/fluent_bit_parser.conf
@@ -22,6 +22,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
@@ -185,9 +185,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -209,6 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
@@ -185,6 +185,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -206,7 +209,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
@@ -206,7 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
@@ -202,23 +202,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -159,28 +159,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -196,7 +202,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_main.conf
@@ -188,6 +188,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -206,7 +212,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/all-backward_compatible_with_explicit_exporters/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
@@ -269,7 +269,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
@@ -248,9 +248,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -272,6 +269,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
@@ -248,6 +248,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -269,7 +272,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
@@ -265,23 +265,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
@@ -251,6 +251,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log|host\.windows_event_log)$
     Name                          stackdriver
@@ -269,7 +275,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_main.conf
@@ -49,7 +49,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -58,7 +58,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -222,28 +222,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log|host\.windows_event_log)$
@@ -259,7 +265,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/all-custom_use_built_in_receivers/golden/fluent_bit_parser.conf
@@ -22,6 +22,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -122,9 +122,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -133,6 +130,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -122,6 +122,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -130,7 +133,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -126,23 +126,11 @@
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -130,7 +130,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -35,7 +35,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -44,7 +44,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -96,31 +96,50 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -125,12 +125,17 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/logging-default_overrides_disable_all/golden/fluent_bit_parser.conf
@@ -8,6 +8,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_main.conf
@@ -271,23 +271,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_main.conf
@@ -257,6 +257,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(active_directory_ds\.active_directory_ds|default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -275,7 +281,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_main.conf
@@ -254,6 +254,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -275,7 +278,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_main.conf
@@ -275,7 +275,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_main.conf
@@ -49,7 +49,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -58,7 +58,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -228,28 +228,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(active_directory_ds\.active_directory_ds|default_pipeline\.windows_event_log)$
@@ -265,7 +271,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_main.conf
@@ -254,9 +254,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -278,6 +275,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_active_directory_ds/golden/fluent_bit_parser.conf
@@ -22,6 +22,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
@@ -58,7 +58,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -67,7 +67,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -181,28 +181,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log|pipeline1\.log_source_id1)$
@@ -218,7 +224,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
@@ -207,6 +207,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -228,7 +231,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
@@ -228,7 +228,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
@@ -207,9 +207,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -231,6 +228,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
@@ -224,23 +224,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_main.conf
@@ -210,6 +210,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log|pipeline1\.log_source_id1)$
     Name                          stackdriver
@@ -228,7 +234,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_refresh_interval/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -72,7 +72,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -81,7 +81,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -220,28 +220,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log|pipeline1\.log_source_id1|pipeline2\.log_source_id2)$
@@ -257,7 +263,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -263,23 +263,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -246,6 +246,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -267,7 +270,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -249,6 +249,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log|pipeline1\.log_source_id1|pipeline2\.log_source_id2)$
     Name                          stackdriver
@@ -267,7 +273,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -267,7 +267,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_main.conf
@@ -246,9 +246,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -270,6 +267,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_files_type_multiple_receivers/golden/fluent_bit_parser.conf
@@ -22,6 +22,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_main.conf
@@ -242,9 +242,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -266,6 +263,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_main.conf
@@ -263,7 +263,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_main.conf
@@ -245,6 +245,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log|iis\.iis_access)$
     Name                          stackdriver
@@ -263,7 +269,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_main.conf
@@ -259,23 +259,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_main.conf
@@ -57,7 +57,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -66,7 +66,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -216,28 +216,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log|iis\.iis_access)$
@@ -253,7 +259,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_main.conf
@@ -242,6 +242,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -263,7 +266,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_iis/golden/fluent_bit_parser.conf
@@ -23,6 +23,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_main.conf
@@ -224,9 +224,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -248,6 +245,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_main.conf
@@ -241,23 +241,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_main.conf
@@ -245,7 +245,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_main.conf
@@ -49,7 +49,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -58,7 +58,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -198,28 +198,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log|winlog2\.winlog2)$
@@ -235,7 +241,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_main.conf
@@ -227,6 +227,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log|winlog2\.winlog2)$
     Name                          stackdriver
@@ -245,7 +251,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_main.conf
@@ -224,6 +224,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -245,7 +248,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_new_channels/golden/fluent_bit_parser.conf
@@ -22,6 +22,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_main.conf
@@ -164,6 +164,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -182,7 +188,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_main.conf
@@ -161,9 +161,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -185,6 +182,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_main.conf
@@ -161,6 +161,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -182,7 +185,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_main.conf
@@ -178,23 +178,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_main.conf
@@ -182,7 +182,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -135,28 +135,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -172,7 +178,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_override_builtin/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_main.conf
@@ -247,23 +247,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_main.conf
@@ -251,7 +251,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_main.conf
@@ -230,9 +230,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -254,6 +251,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_main.conf
@@ -230,6 +230,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -251,7 +254,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_main.conf
@@ -233,6 +233,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log|winlog2\.winlog2)$
     Name                          stackdriver
@@ -251,7 +257,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_main.conf
@@ -50,7 +50,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -59,7 +59,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -204,28 +204,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log|winlog2\.winlog2)$
@@ -241,7 +247,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/logging-receiver_winlog2_xml/golden/fluent_bit_parser.conf
@@ -22,6 +22,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -185,9 +185,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -209,6 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -185,6 +185,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -206,7 +209,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -206,7 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -202,23 +202,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -159,28 +159,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -196,7 +202,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_main.conf
@@ -188,6 +188,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -206,7 +212,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_all/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_main.conf
@@ -185,9 +185,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -209,6 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_main.conf
@@ -185,6 +185,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -206,7 +209,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_main.conf
@@ -206,7 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_main.conf
@@ -202,23 +202,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -159,28 +159,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -196,7 +202,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_main.conf
@@ -188,6 +188,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -206,7 +212,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_iis/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_main.conf
@@ -185,9 +185,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -209,6 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_main.conf
@@ -185,6 +185,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -206,7 +209,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_main.conf
@@ -206,7 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_main.conf
@@ -202,23 +202,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -159,28 +159,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -196,7 +202,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_main.conf
@@ -188,6 +188,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -206,7 +212,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-default_overrides_disable_mssql/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
@@ -185,9 +185,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -209,6 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
@@ -185,6 +185,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -206,7 +209,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
@@ -206,7 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
@@ -202,23 +202,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -159,28 +159,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -196,7 +202,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_main.conf
@@ -188,6 +188,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -206,7 +212,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-pipeline_multiple_pipelines/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
@@ -185,9 +185,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -209,6 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
@@ -185,6 +185,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -206,7 +209,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
@@ -206,7 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -159,28 +159,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -196,7 +202,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
@@ -188,6 +188,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -206,7 +212,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_main.conf
@@ -202,23 +202,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
@@ -185,9 +185,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -209,6 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
@@ -185,6 +185,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -206,7 +209,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
@@ -206,7 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
@@ -202,23 +202,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -159,28 +159,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -196,7 +202,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_main.conf
@@ -188,6 +188,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -206,7 +212,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_globs/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
@@ -185,9 +185,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -209,6 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
@@ -185,6 +185,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -206,7 +209,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
@@ -206,7 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -159,28 +159,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -196,7 +202,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
@@ -188,6 +188,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -206,7 +212,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_main.conf
@@ -202,23 +202,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_main.conf
@@ -185,6 +185,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -206,7 +209,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_main.conf
@@ -185,9 +185,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -209,6 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_main.conf
@@ -202,23 +202,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_main.conf
@@ -206,7 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -159,28 +159,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -196,7 +202,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_main.conf
@@ -188,6 +188,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -206,7 +212,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_active_directory_ds/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_main.conf
@@ -185,9 +185,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -209,6 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_main.conf
@@ -185,6 +185,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -206,7 +209,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_main.conf
@@ -206,7 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_main.conf
@@ -202,23 +202,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -159,28 +159,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -196,7 +202,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_main.conf
@@ -188,6 +188,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -206,7 +212,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_main.conf
@@ -185,9 +185,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -209,6 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_main.conf
@@ -185,6 +185,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -206,7 +209,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_main.conf
@@ -206,7 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -159,28 +159,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -196,7 +202,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_main.conf
@@ -188,6 +188,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -206,7 +212,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_main.conf
@@ -202,23 +202,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_apache_status_url/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
@@ -185,9 +185,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -209,6 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
@@ -185,6 +185,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -206,7 +209,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
@@ -206,7 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
@@ -202,23 +202,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -159,28 +159,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -196,7 +202,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_main.conf
@@ -188,6 +188,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -206,7 +212,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_custom_collection_interval/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_main.conf
@@ -185,9 +185,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -209,6 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_main.conf
@@ -185,6 +185,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -206,7 +209,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_main.conf
@@ -206,7 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_main.conf
@@ -202,23 +202,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -159,28 +159,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -196,7 +202,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_main.conf
@@ -188,6 +188,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -206,7 +212,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_duplicate/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_main.conf
@@ -185,6 +185,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -206,7 +209,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_main.conf
@@ -185,9 +185,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -209,6 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_main.conf
@@ -202,23 +202,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_main.conf
@@ -206,7 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -159,28 +159,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -196,7 +202,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_main.conf
@@ -188,6 +188,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -206,7 +212,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_iis_v2_override/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_main.conf
@@ -185,9 +185,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -209,6 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_main.conf
@@ -185,6 +185,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -206,7 +209,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_main.conf
@@ -206,7 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_main.conf
@@ -202,23 +202,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -159,28 +159,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -196,7 +202,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_main.conf
@@ -188,6 +188,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -206,7 +212,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_main.conf
@@ -185,6 +185,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -206,7 +209,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_main.conf
@@ -185,9 +185,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -209,6 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_main.conf
@@ -202,23 +202,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_main.conf
@@ -206,7 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -159,28 +159,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -196,7 +202,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_main.conf
@@ -188,6 +188,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -206,7 +212,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_jvm_missing_endpoint/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_main.conf
@@ -185,9 +185,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -209,6 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_main.conf
@@ -185,6 +185,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -206,7 +209,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_main.conf
@@ -206,7 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_main.conf
@@ -202,23 +202,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -159,28 +159,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -196,7 +202,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_main.conf
@@ -188,6 +188,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -206,7 +212,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_duplicate/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_main.conf
@@ -185,9 +185,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -209,6 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_main.conf
@@ -185,6 +185,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -206,7 +209,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_main.conf
@@ -206,7 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_main.conf
@@ -202,23 +202,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -159,28 +159,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -196,7 +202,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_main.conf
@@ -188,6 +188,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -206,7 +212,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mssql_v2_override/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_main.conf
@@ -185,9 +185,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -209,6 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_main.conf
@@ -185,6 +185,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -206,7 +209,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_main.conf
@@ -206,7 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_main.conf
@@ -202,23 +202,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -159,28 +159,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -196,7 +202,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_main.conf
@@ -188,6 +188,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -206,7 +212,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_main.conf
@@ -185,9 +185,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -209,6 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_main.conf
@@ -185,6 +185,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -206,7 +209,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_main.conf
@@ -206,7 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_main.conf
@@ -202,23 +202,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -159,28 +159,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -196,7 +202,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_main.conf
@@ -188,6 +188,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -206,7 +212,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_mysql_missing_endpoint/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_main.conf
@@ -185,9 +185,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -209,6 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_main.conf
@@ -185,6 +185,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -206,7 +209,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_main.conf
@@ -206,7 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_main.conf
@@ -202,23 +202,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -159,28 +159,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -196,7 +202,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_main.conf
@@ -188,6 +188,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -206,7 +212,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/0f15dbe303dc7122d43443c9a4c31632.lua
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/0f15dbe303dc7122d43443c9a4c31632.lua
@@ -1,0 +1,28 @@
+
+function process(tag, timestamp, record)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_main.conf
@@ -185,9 +185,6 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
-    Add    agent.googleapis.com/health/agentKind ops-agent
-    Add    agent.googleapis.com/health/agentVersion latest
-    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -209,6 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_main.conf
@@ -185,6 +185,9 @@
 [FILTER]
     Name   modify
     Match  ops-agent-health
+    Add    agent.googleapis.com/health/agentKind ops-agent
+    Add    agent.googleapis.com/health/agentVersion latest
+    Add    agent.googleapis.com/health/schemaVersion v1
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
@@ -206,7 +209,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_main.conf
@@ -206,7 +206,7 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_main.conf
@@ -202,23 +202,11 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-health)$
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
-    net.connect_timeout_log_error False
-    resource                      gce_instance
-    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
-    tls                           On
-    tls.verify                    Off
-    workers                       8
-
-[OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit)$
-    Name                          stackdriver
-    Retry_Limit                   3
-    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/schemaVersion=v1,agent.googleapis.com/health/agentVersion=latest
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_main.conf
@@ -42,7 +42,7 @@
 [INPUT]
     Buffer_Chunk_Size 512k
     Buffer_Max_Size   2M
-    DB                ${buffers_dir}/ops-agent-health-checks
+    DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
     Key               message
     Mem_Buf_Limit     10M
@@ -51,7 +51,7 @@
     Read_from_Head    True
     Rotate_Wait       30
     Skip_Long_Lines   On
-    Tag               ops-agent-health-checks
+    Tag               ops-agent-health
     storage.type      memory
 
 [FILTER]
@@ -159,28 +159,34 @@
     Remove    severity
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_nest
     script b4a0dead382dce7b4fe011d3f59fdb6d.lua
 
 [FILTER]
     Key_Name     message
-    Match        ops-agent-health-checks
+    Match        ops-agent-health
     Name         parser
     Reserve_Data True
-    Parser       ops-agent-health-checks.health-checks-json
+    Parser       ops-agent-health.health-checks-json
 
 [FILTER]
-    Match  ops-agent-health-checks
+    Match  ops-agent-health
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Match ops-agent-health-checks
+    Match ops-agent-health
     Name  grep
-    Regex ops-agent-version ^.*
+    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
+
+[FILTER]
+    Name   modify
+    Match  ops-agent-health
+    Rename severity logging.googleapis.com/severity
+    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
@@ -196,7 +202,20 @@
     workers                       8
 
 [OUTPUT]
-    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health-checks)$
+    Match_Regex                   ^(ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    labels                        agent.googleapis.com/health/agent-kind=ops-agent,agent.googleapis.com/health/agent-version=latest,agent.googleapis.com/health/schema-version=v1
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit)$
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_main.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_main.conf
@@ -188,6 +188,12 @@
     Rename severity logging.googleapis.com/severity
     Rename sourceLocation logging.googleapis.com/sourceLocation
 
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 0f15dbe303dc7122d43443c9a4c31632.lua
+
 [OUTPUT]
     Match_Regex                   ^(default_pipeline\.windows_event_log)$
     Name                          stackdriver
@@ -206,7 +212,6 @@
     Name                          stackdriver
     Retry_Limit                   3
     http_request_key              logging.googleapis.com/httpRequest
-    labels                        agent.googleapis.com/health/agentKind=ops-agent,agent.googleapis.com/health/agentVersion=latest,agent.googleapis.com/health/schemaVersion=v1
     net.connect_timeout_log_error False
     resource                      gce_instance
     stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)

--- a/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/windows/metrics-receiver_nginx_missing_status_url/golden/fluent_bit_parser.conf
@@ -15,6 +15,6 @@
 
 [PARSER]
     Format      json
-    Name        ops-agent-health-checks.health-checks-json
+    Name        ops-agent-health.health-checks-json
     Time_Format %Y-%m-%dT%H:%M:%S%z
     Time_Key    time

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -3002,7 +3002,7 @@ func TestLoggingSelfLogs(t *testing.T) {
 			t.Error(err)
 		}
 
-		if err := gce.WaitForLog(ctx, logger.ToMainLog(), vm, "ops-agent-health-checks", time.Hour, `severity="INFO"`); err != nil {
+		if err := gce.WaitForLog(ctx, logger.ToMainLog(), vm, "ops-agent-health", time.Hour, `severity="INFO"`); err != nil {
 			t.Error(err)
 		}
 	})

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -3002,7 +3002,7 @@ func TestLoggingSelfLogs(t *testing.T) {
 			t.Error(err)
 		}
 
-		if err := gce.WaitForLog(ctx, logger.ToMainLog(), vm, "ops-agent-health", time.Hour, `severity="INFO"`); err != nil {
+		if err := gce.WaitForLog(ctx, logger.ToMainLog(), vm, "ops-agent-health", time.Hour, `severity="INFO" AND labels"agent.googleapis.com/health/agentKind"="ops-agent" AND labels"agent.googleapis.com/health/schemaVersion"="v1"`); err != nil {
 			t.Error(err)
 		}
 	})

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -3001,8 +3001,14 @@ func TestLoggingSelfLogs(t *testing.T) {
 		if err := gce.WaitForLog(ctx, logger.ToMainLog(), vm, "ops-agent-fluent-bit", time.Hour, `severity="INFO"`); err != nil {
 			t.Error(err)
 		}
+		
+		pkgVersion, err := agents.FetchPackageVersions(ctx, logger.ToMainLog(), vm, []agents.AgentPackage{agents.OpsPackage});
+		if err != nil {
+			t.Error(err)
+		}
 
-		if err := gce.WaitForLog(ctx, logger.ToMainLog(), vm, "ops-agent-health", time.Hour, `severity="INFO" AND labels"agent.googleapis.com/health/agentKind"="ops-agent" AND labels"agent.googleapis.com/health/schemaVersion"="v1"`); err != nil {
+		query := fmt.Sprintf(`severity="INFO" AND labels."agent.googleapis.com/health/agentKind"="ops-agent" AND labels."agent.googleapis.com/health/agentVersion"="%s" AND labels."agent.googleapis.com/health/schemaVersion"="v1"`, pkgVersion[agents.OpsPackage])
+		if err := gce.WaitForLog(ctx, logger.ToMainLog(), vm, "ops-agent-health", time.Hour, query); err != nil {
 			t.Error(err)
 		}
 	})

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -3547,6 +3547,10 @@ metrics:
 	})
 }
 
+func isHealthCheckTestPlatform(platform string) bool {
+	return platform == "windows-2019" || platform == "debian-11"
+}
+
 func healthCheckResultMessage(name string, result string, code string) string {
 	if result == "FAIL" || result == "WARNING" {
 		return fmt.Sprintf("[%s Check] Result: %s, Error code: %s", name, result, code)
@@ -3589,6 +3593,10 @@ func TestPortsAndAPIHealthChecks(t *testing.T) {
 	t.Parallel()
 	gce.RunForEachPlatform(t, func(t *testing.T, platform string) {
 		t.Parallel()
+		if !isHealthCheckTestPlatform(platform) {
+			t.SkipNow()
+		}
+
 		customScopes := strings.Join([]string{
 			"https://www.googleapis.com/auth/monitoring.read",
 			"https://www.googleapis.com/auth/logging.write",
@@ -3639,6 +3647,10 @@ func TestNetworkHealthCheck(t *testing.T) {
 	t.Parallel()
 	gce.RunForEachPlatform(t, func(t *testing.T, platform string) {
 		t.Parallel()
+		if !isHealthCheckTestPlatform(platform) {
+			t.SkipNow()
+		}
+
 		ctx, logger, vm := agents.CommonSetup(t, platform)
 
 		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, ""); err != nil {

--- a/internal/healthchecks/api_check.go
+++ b/internal/healthchecks/api_check.go
@@ -108,7 +108,7 @@ func runLoggingCheck(logger logs.StructuredLogger) error {
 	logger.Infof("logging client was created successfully")
 
 	if err := logClient.Ping(ctx); err != nil {
-		logger.Println(err)
+		logger.Errorf(err.Error())
 		var apiErr *apierror.APIError
 		if errors.As(err, &apiErr) {
 			switch apiErr.Reason() {
@@ -155,7 +155,7 @@ func runMonitoringCheck(logger logs.StructuredLogger) error {
 	logger.Infof("monitoring client was created successfully")
 
 	if err := monitoringPing(ctx, *monClient, gceMetadata); err != nil {
-		logger.Println(err)
+		logger.Errorf(err.Error())
 		var apiErr *apierror.APIError
 		if errors.As(err, &apiErr) {
 			switch apiErr.Reason() {

--- a/internal/healthchecks/api_check.go
+++ b/internal/healthchecks/api_check.go
@@ -108,7 +108,7 @@ func runLoggingCheck(logger logs.StructuredLogger) error {
 	logger.Infof("logging client was created successfully")
 
 	if err := logClient.Ping(ctx); err != nil {
-		logger.Errorf(err.Error())
+		logger.Warnf(err.Error())
 		var apiErr *apierror.APIError
 		if errors.As(err, &apiErr) {
 			switch apiErr.Reason() {
@@ -155,7 +155,7 @@ func runMonitoringCheck(logger logs.StructuredLogger) error {
 	logger.Infof("monitoring client was created successfully")
 
 	if err := monitoringPing(ctx, *monClient, gceMetadata); err != nil {
-		logger.Errorf(err.Error())
+		logger.Warnf(err.Error())
 		var apiErr *apierror.APIError
 		if errors.As(err, &apiErr) {
 			switch apiErr.Reason() {

--- a/internal/healthchecks/api_check.go
+++ b/internal/healthchecks/api_check.go
@@ -108,7 +108,7 @@ func runLoggingCheck(logger logs.StructuredLogger) error {
 	logger.Infof("logging client was created successfully")
 
 	if err := logClient.Ping(ctx); err != nil {
-		logger.Warnf(err.Error())
+		logger.Infof(err.Error())
 		var apiErr *apierror.APIError
 		if errors.As(err, &apiErr) {
 			switch apiErr.Reason() {
@@ -155,7 +155,7 @@ func runMonitoringCheck(logger logs.StructuredLogger) error {
 	logger.Infof("monitoring client was created successfully")
 
 	if err := monitoringPing(ctx, *monClient, gceMetadata); err != nil {
-		logger.Warnf(err.Error())
+		logger.Infof(err.Error())
 		var apiErr *apierror.APIError
 		if errors.As(err, &apiErr) {
 			switch apiErr.Reason() {

--- a/internal/healthchecks/healthchecks.go
+++ b/internal/healthchecks/healthchecks.go
@@ -59,12 +59,13 @@ func (r HealthCheckResult) LogResult(logger logs.StructuredLogger) {
 		} else {
 			if healthError, ok := e.(HealthCheckError); ok {
 				if healthError.IsFatal {
-					logger.Warnf(singleErrorResultMessage(e, r.Name), zap.String("code", healthError.Code))
-				} else {
 					logger.Errorf(singleErrorResultMessage(e, r.Name), zap.String("code", healthError.Code))
+				} else {
+					logger.Warnf(singleErrorResultMessage(e, r.Name), zap.String("code", healthError.Code))
 				}
+			} else {
+				logger.Errorf(singleErrorResultMessage(e, r.Name))
 			}
-			logger.Errorf(singleErrorResultMessage(e, r.Name))
 		}
 	}
 }

--- a/internal/healthchecks/healthchecks.go
+++ b/internal/healthchecks/healthchecks.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 
 	"github.com/GoogleCloudPlatform/ops-agent/internal/logs"
-	"go.uber.org/zap"
 )
 
 var healthChecksLogFile = "health-checks.log"
@@ -59,9 +58,9 @@ func (r HealthCheckResult) LogResult(logger logs.StructuredLogger) {
 		} else {
 			if healthError, ok := e.(HealthCheckError); ok {
 				if healthError.IsFatal {
-					logger.Errorf(singleErrorResultMessage(e, r.Name), zap.String("code", healthError.Code))
+					logger.Errorw(singleErrorResultMessage(e, r.Name), "code", healthError.Code)
 				} else {
-					logger.Warnf(singleErrorResultMessage(e, r.Name), zap.String("code", healthError.Code))
+					logger.Warnw(singleErrorResultMessage(e, r.Name), "code", healthError.Code)
 				}
 			} else {
 				logger.Errorf(singleErrorResultMessage(e, r.Name))

--- a/internal/logs/logs.go
+++ b/internal/logs/logs.go
@@ -32,6 +32,7 @@ const (
 )
 
 type StructuredLogger interface {
+	// Infof, Warnf, Errorf use fmt.Sprintf to log a templated message.
 	Infof(format string, v ...any)
 	Warnf(format string, v ...any)
 	Errorf(format string, v ...any)

--- a/internal/logs/logs.go
+++ b/internal/logs/logs.go
@@ -25,10 +25,10 @@ import (
 )
 
 const (
-	messageKey        = "message"
-	severityKey       = "severity"
-	sourceLocationKey = "sourceLocation"
-	timeKey           = "time"
+	MessageZapKey        = "message"
+	SeverityZapKey       = "severity"
+	SourceLocationZapKey = "sourceLocation"
+	TimeZapKey           = "time"
 )
 
 type StructuredLogger interface {
@@ -92,10 +92,10 @@ func sourceLocationEncoder(caller zapcore.EntryCaller, enc zapcore.PrimitiveArra
 func New(file string) *ZapStructuredLogger {
 	cfg := zap.NewProductionConfig()
 	cfg.DisableStacktrace = true
-	cfg.EncoderConfig.CallerKey = sourceLocationKey
-	cfg.EncoderConfig.MessageKey = messageKey
-	cfg.EncoderConfig.LevelKey = severityKey
-	cfg.EncoderConfig.TimeKey = timeKey
+	cfg.EncoderConfig.CallerKey = SourceLocationZapKey
+	cfg.EncoderConfig.MessageKey = MessageZapKey
+	cfg.EncoderConfig.LevelKey = SeverityZapKey
+	cfg.EncoderConfig.TimeKey = TimeZapKey
 	cfg.EncoderConfig.EncodeTime = zapcore.RFC3339TimeEncoder
 	cfg.EncoderConfig.EncodeLevel = severityEncoder
 	cfg.EncoderConfig.EncodeCaller = sourceLocationEncoder

--- a/internal/logs/logs.go
+++ b/internal/logs/logs.go
@@ -87,6 +87,7 @@ func sourceLocationEncoder(caller zapcore.EntryCaller, enc zapcore.PrimitiveArra
 
 func New(file string) *ZapStructuredLogger {
 	cfg := zap.NewProductionConfig()
+	cfg.DisableStacktrace = true
 	cfg.EncoderConfig.CallerKey = sourceLocationKey
 	cfg.EncoderConfig.MessageKey = messageKey
 	cfg.EncoderConfig.LevelKey = severityKey

--- a/internal/logs/logs.go
+++ b/internal/logs/logs.go
@@ -35,6 +35,9 @@ type StructuredLogger interface {
 	Infof(format string, v ...any)
 	Warnf(format string, v ...any)
 	Errorf(format string, v ...any)
+	Infow(format string, v ...any)
+	Warnw(format string, v ...any)
+	Errorw(format string, v ...any)
 	Println(v ...any)
 }
 
@@ -136,18 +139,20 @@ func (f ZapStructuredLogger) Errorf(format string, v ...any) {
 	f.logger.Errorf(format, v...)
 }
 
-func (f ZapStructuredLogger) Println(v ...any) {
-	f.logger.Infoln(v...)
+func (f ZapStructuredLogger) Infow(format string, v ...any) {
+	f.logger.Infow(format, v...)
 }
 
-func DiscardZapFields(v ...interface{}) []interface{} {
-	var fields []interface{}
-	for _, f := range v {
-		if _, ok := f.(zap.Field); !ok {
-			fields = append(fields, f)
-		}
-	}
-	return fields
+func (f ZapStructuredLogger) Warnw(format string, v ...any) {
+	f.logger.Warnw(format, v...)
+}
+
+func (f ZapStructuredLogger) Errorw(format string, v ...any) {
+	f.logger.Errorw(format, v...)
+}
+
+func (f ZapStructuredLogger) Println(v ...any) {
+	f.logger.Infoln(v...)
 }
 
 type SimpleLogger struct {
@@ -155,27 +160,39 @@ type SimpleLogger struct {
 }
 
 func (sl SimpleLogger) Fatalf(format string, v ...any) {
-	sl.l.Fatalf(format, DiscardZapFields(v...)...)
+	sl.l.Fatalf(format, v...)
 }
 
 func (sl SimpleLogger) Printf(format string, v ...any) {
-	sl.l.Printf(format, DiscardZapFields(v...)...)
+	sl.l.Printf(format, v...)
 }
 
 func (sl SimpleLogger) Infof(format string, v ...any) {
-	sl.l.Printf(format, DiscardZapFields(v...)...)
+	sl.l.Printf(format, v...)
 }
 
 func (sl SimpleLogger) Warnf(format string, v ...any) {
-	sl.l.Printf(format, DiscardZapFields(v...)...)
+	sl.l.Printf(format, v...)
 }
 
 func (sl SimpleLogger) Errorf(format string, v ...any) {
-	sl.l.Printf(format, DiscardZapFields(v...)...)
+	sl.l.Printf(format, v...)
+}
+
+func (sl SimpleLogger) Infow(format string, v ...any) {
+	sl.l.Println(format)
+}
+
+func (sl SimpleLogger) Warnw(format string, v ...any) {
+	sl.l.Println(format)
+}
+
+func (sl SimpleLogger) Errorw(format string, v ...any) {
+	sl.l.Println(format)
 }
 
 func (sl SimpleLogger) Println(v ...any) {
-	sl.l.Println(DiscardZapFields(v...)...)
+	sl.l.Println(v...)
 }
 
 func NewSimpleLogger() SimpleLogger {

--- a/internal/logs/logs.go
+++ b/internal/logs/logs.go
@@ -140,32 +140,42 @@ func (f ZapStructuredLogger) Println(v ...any) {
 	f.logger.Infoln(v...)
 }
 
+func DiscardZapFields(v ...interface{}) ([]interface{}) {
+	var fields []interface{}
+	for _, f := range(v) {
+		if _, ok := f.(zap.Field); !ok {
+			fields = append(fields, f)
+		}
+	}
+	return fields
+}
+
 type SimpleLogger struct {
 	l *log.Logger
 }
 
 func (sl SimpleLogger) Fatalf(format string, v ...any) {
-	sl.l.Fatalf(format, v...)
+	sl.l.Fatalf(format, DiscardZapFields(v...))
 }
 
 func (sl SimpleLogger) Printf(format string, v ...any) {
-	sl.l.Printf(format, v...)
+	sl.l.Printf(format, DiscardZapFields(v...))
 }
 
 func (sl SimpleLogger) Infof(format string, v ...any) {
-	sl.l.Printf(format, v...)
+	sl.l.Printf(format, DiscardZapFields(v...))
 }
 
 func (sl SimpleLogger) Warnf(format string, v ...any) {
-	sl.l.Printf(format, v...)
+	sl.l.Printf(format, DiscardZapFields(v...))
 }
 
 func (sl SimpleLogger) Errorf(format string, v ...any) {
-	sl.l.Printf(format, v...)
+	sl.l.Printf(format, DiscardZapFields(v...))
 }
 
 func (sl SimpleLogger) Println(v ...any) {
-	sl.l.Println(v...)
+	sl.l.Println(DiscardZapFields(v...))
 }
 
 func NewSimpleLogger() SimpleLogger {

--- a/internal/logs/logs.go
+++ b/internal/logs/logs.go
@@ -102,7 +102,7 @@ func New(file string) *ZapStructuredLogger {
 	}
 
 	sugar := logger.Sugar().With(
-		zap.String("ops-agent-version", version.Version))
+		zap.String("agent-version", version.Version))
 	return &ZapStructuredLogger{
 		logger: sugar,
 	}

--- a/internal/logs/logs.go
+++ b/internal/logs/logs.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/GoogleCloudPlatform/ops-agent/internal/version"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
@@ -100,11 +99,8 @@ func New(file string) *ZapStructuredLogger {
 	if err != nil {
 		return Default()
 	}
-
-	sugar := logger.Sugar().With(
-		zap.String("agent-version", version.Version))
 	return &ZapStructuredLogger{
-		logger: sugar,
+		logger: logger.Sugar(),
 	}
 }
 
@@ -123,10 +119,8 @@ func Default() *ZapStructuredLogger {
 		logger, _ := DiscardLogger()
 		return logger
 	}
-	sugar := logger.Sugar().With(
-		zap.String("version", version.Version))
 	return &ZapStructuredLogger{
-		logger: sugar,
+		logger: logger.Sugar(),
 	}
 }
 

--- a/internal/logs/logs.go
+++ b/internal/logs/logs.go
@@ -26,8 +26,8 @@ import (
 
 const (
 	messageKey        = "message"
-	severityKey       = "logging.googleapis.com/severity"
-	sourceLocationKey = "logging.googleapis.com/sourceLocation"
+	severityKey       = "severity"
+	sourceLocationKey = "sourceLocation"
 	timeKey           = "time"
 )
 
@@ -140,9 +140,9 @@ func (f ZapStructuredLogger) Println(v ...any) {
 	f.logger.Infoln(v...)
 }
 
-func DiscardZapFields(v ...interface{}) ([]interface{}) {
+func DiscardZapFields(v ...interface{}) []interface{} {
 	var fields []interface{}
-	for _, f := range(v) {
+	for _, f := range v {
 		if _, ok := f.(zap.Field); !ok {
 			fields = append(fields, f)
 		}
@@ -155,27 +155,27 @@ type SimpleLogger struct {
 }
 
 func (sl SimpleLogger) Fatalf(format string, v ...any) {
-	sl.l.Fatalf(format, DiscardZapFields(v...))
+	sl.l.Fatalf(format, DiscardZapFields(v...)...)
 }
 
 func (sl SimpleLogger) Printf(format string, v ...any) {
-	sl.l.Printf(format, DiscardZapFields(v...))
+	sl.l.Printf(format, DiscardZapFields(v...)...)
 }
 
 func (sl SimpleLogger) Infof(format string, v ...any) {
-	sl.l.Printf(format, DiscardZapFields(v...))
+	sl.l.Printf(format, DiscardZapFields(v...)...)
 }
 
 func (sl SimpleLogger) Warnf(format string, v ...any) {
-	sl.l.Printf(format, DiscardZapFields(v...))
+	sl.l.Printf(format, DiscardZapFields(v...)...)
 }
 
 func (sl SimpleLogger) Errorf(format string, v ...any) {
-	sl.l.Printf(format, DiscardZapFields(v...))
+	sl.l.Printf(format, DiscardZapFields(v...)...)
 }
 
 func (sl SimpleLogger) Println(v ...any) {
-	sl.l.Println(DiscardZapFields(v...))
+	sl.l.Println(DiscardZapFields(v...)...)
 }
 
 func NewSimpleLogger() SimpleLogger {

--- a/internal/logs/logs.go
+++ b/internal/logs/logs.go
@@ -35,9 +35,9 @@ type StructuredLogger interface {
 	Infof(format string, v ...any)
 	Warnf(format string, v ...any)
 	Errorf(format string, v ...any)
-	Infow(format string, v ...any)
-	Warnw(format string, v ...any)
-	Errorw(format string, v ...any)
+	Infow(msg string, keysAndValues ...any)
+	Warnw(msg string, keysAndValues ...any)
+	Errorw(msg string, keysAndValues ...any)
 	Println(v ...any)
 }
 
@@ -140,16 +140,16 @@ func (f ZapStructuredLogger) Errorf(format string, v ...any) {
 	f.logger.Errorf(format, v...)
 }
 
-func (f ZapStructuredLogger) Infow(format string, v ...any) {
-	f.logger.Infow(format, v...)
+func (f ZapStructuredLogger) Infow(msg string, keysAndValues ...any) {
+	f.logger.Infow(msg, keysAndValues...)
 }
 
-func (f ZapStructuredLogger) Warnw(format string, v ...any) {
-	f.logger.Warnw(format, v...)
+func (f ZapStructuredLogger) Warnw(msg string, keysAndValues ...any) {
+	f.logger.Warnw(msg, keysAndValues...)
 }
 
-func (f ZapStructuredLogger) Errorw(format string, v ...any) {
-	f.logger.Errorw(format, v...)
+func (f ZapStructuredLogger) Errorw(msg string, keysAndValues ...any) {
+	f.logger.Errorw(msg, keysAndValues...)
 }
 
 func (f ZapStructuredLogger) Println(v ...any) {
@@ -180,16 +180,16 @@ func (sl SimpleLogger) Errorf(format string, v ...any) {
 	sl.l.Printf(format, v...)
 }
 
-func (sl SimpleLogger) Infow(format string, v ...any) {
-	sl.l.Println(format)
+func (sl SimpleLogger) Infow(msg string, keysAndValues ...any) {
+	sl.l.Println(msg)
 }
 
-func (sl SimpleLogger) Warnw(format string, v ...any) {
-	sl.l.Println(format)
+func (sl SimpleLogger) Warnw(msg string, keysAndValues ...any) {
+	sl.l.Println(msg)
 }
 
-func (sl SimpleLogger) Errorw(format string, v ...any) {
-	sl.l.Println(format)
+func (sl SimpleLogger) Errorw(msg string, keysAndValues ...any) {
+	sl.l.Println(msg)
 }
 
 func (sl SimpleLogger) Println(v ...any) {

--- a/internal/logs/logs.go
+++ b/internal/logs/logs.go
@@ -25,10 +25,10 @@ import (
 )
 
 const (
-	MessageZapKey        = "message"
-	SeverityZapKey       = "severity"
-	SourceLocationZapKey = "sourceLocation"
-	TimeZapKey           = "time"
+	MessageZapKey        string = "message"
+	SeverityZapKey       string = "severity"
+	SourceLocationZapKey string = "sourceLocation"
+	TimeZapKey           string = "time"
 )
 
 type StructuredLogger interface {

--- a/internal/logs/logs.go
+++ b/internal/logs/logs.go
@@ -35,6 +35,9 @@ type StructuredLogger interface {
 	Infof(format string, v ...any)
 	Warnf(format string, v ...any)
 	Errorf(format string, v ...any)
+	// Infow, Warnw, Errorw log a string message and optionally
+	// can add key, value pairs of metadata to the log depending
+	// on the underlying implementation of the interface.
 	Infow(msg string, keysAndValues ...any)
 	Warnw(msg string, keysAndValues ...any)
 	Errorw(msg string, keysAndValues ...any)
@@ -140,6 +143,9 @@ func (f ZapStructuredLogger) Errorf(format string, v ...any) {
 	f.logger.Errorf(format, v...)
 }
 
+// A zap logger has an implementation of Infow, Warnw, Errorw that will
+// add a key, value pairs to the output json structured log.
+// Link: https://pkg.go.dev/go.uber.org/zap#SugaredLogger.Infow
 func (f ZapStructuredLogger) Infow(msg string, keysAndValues ...any) {
 	f.logger.Infow(msg, keysAndValues...)
 }
@@ -180,6 +186,8 @@ func (sl SimpleLogger) Errorf(format string, v ...any) {
 	sl.l.Printf(format, v...)
 }
 
+// A SimpleLogger doesn't have the capability of adding metadata
+// to the resulting log.
 func (sl SimpleLogger) Infow(msg string, keysAndValues ...any) {
 	sl.l.Println(msg)
 }

--- a/internal/logs/windows.go
+++ b/internal/logs/windows.go
@@ -49,7 +49,7 @@ func (wsl WindowsServiceLogger) Warnw(msg string, keysAndValues ...any) {
 }
 
 func (wsl WindowsServiceLogger) Errorw(msg string, keysAndValues ...any) {
-	wsl.Logger.Warning(wsl.EventID, msg)
+	wsl.Logger.Error(wsl.EventID, msg)
 }
 
 func (wsl WindowsServiceLogger) Println(v ...any) {}

--- a/internal/logs/windows.go
+++ b/internal/logs/windows.go
@@ -40,6 +40,8 @@ func (wsl WindowsServiceLogger) Errorf(format string, v ...any) {
 	wsl.Logger.Error(wsl.EventID, fmt.Sprintf(format, v...))
 }
 
+// A WindowsServiceLogger doesn't have the capability of adding metadata
+// to the resulting windows event log.
 func (wsl WindowsServiceLogger) Infow(msg string, keysAndValues ...any) {
 	wsl.Logger.Info(wsl.EventID, msg)
 }

--- a/internal/logs/windows.go
+++ b/internal/logs/windows.go
@@ -1,0 +1,55 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+// +build windows
+
+package logs
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows/svc/debug"
+)
+
+type WindowsServiceLogger struct {
+	EventID uint32
+	Logger  debug.Log
+}
+
+func (wsl WindowsServiceLogger) Infof(format string, v ...any) {
+	wsl.Logger.Info(wsl.EventID, fmt.Sprintf(format, v...))
+}
+
+func (wsl WindowsServiceLogger) Warnf(format string, v ...any) {
+	wsl.Logger.Warning(wsl.EventID, fmt.Sprintf(format, v...))
+}
+
+func (wsl WindowsServiceLogger) Errorf(format string, v ...any) {
+	wsl.Logger.Error(wsl.EventID, fmt.Sprintf(format, v...))
+}
+
+func (wsl WindowsServiceLogger) Infow(msg string, keysAndValues ...any) {
+	wsl.Logger.Info(wsl.EventID, msg)
+}
+
+func (wsl WindowsServiceLogger) Warnw(msg string, keysAndValues ...any) {
+	wsl.Logger.Warning(wsl.EventID, msg)
+}
+
+func (wsl WindowsServiceLogger) Errorw(msg string, keysAndValues ...any) {
+	wsl.Logger.Warning(wsl.EventID, msg)
+}
+
+func (wsl WindowsServiceLogger) Println(v ...any) {}


### PR DESCRIPTION
## Description
This change creates the `confgenerator/self_logs.go` as a first step to organize all self logs into the same structured format. This is PR only applies the format for `health-checks.log` and the followup https://github.com/GoogleCloudPlatform/ops-agent/pull/1300 will enforce the format to a sample of `logging-module.log` logs.


Every Ops Agent Health Logs should have the following fields : 

1. Inherited Fields
    - [MonitoredResource](https://cloud.google.com/logging/docs/reference/v2/rest/v2/MonitoredResource) : The resource from which telemetry is being collected.

2. Required Fields
    - Code : A code to uniquely identify signals.
    - Agent : Description of agent collecting telemetry.
    - Message : A full description of the signal.
    - [LogSeverity](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logseverity) : A description of how impactful the problem is.
    - SchemaVersion : The version of the current schema used for the Health Signal.
3. Optional Fields
    - [SourceLocation](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logentrysourcelocation) : Location in source code of agent where the signal originated.

Google Cloud Logging LogEntry Output Format : 
<img src="https://github.com/GoogleCloudPlatform/ops-agent/assets/1435136/c397ea35-af36-4b5e-b6e4-5ea48b01bdc2" width="600">

## Related issue
b/287980723

## How has this been tested?
Some details about the testing of this PR : 
- Health Checks unit tests passed.
- Improved integration test `TestLoggingSelfLogs`.
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [x] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
