### PR TITLE
Fix PATH issues in Dockerfile.windows

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -15,6 +15,8 @@ RUN setx /M PATH "%PATH%;C:\WinFlexBison"
 RUN setx /M PATH "%PATH%;C:\Go\bin"
 RUN setx /M PATH "%PATH%;C:\Java\bin"
 
+RUN echo "%PATH%"
+
 RUN setx /M JAVA_HOME "C:\Java"
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
@@ -36,6 +38,8 @@ WORKDIR /local
 ADD https://aka.ms/vs/16/release/vs_buildtools.exe /local/vs_buildtools.exe
 ADD https://aka.ms/vs/16/release/channel /local/VisualStudio.chman
 
+RUN echo "%PATH%"
+
 RUN Start-Process /local/vs_buildtools.exe `
     -ArgumentList '--quiet ', '--wait ', '--norestart ', '--nocache', `
     '--installPath C:\BuildTools', `
@@ -43,6 +47,8 @@ RUN Start-Process /local/vs_buildtools.exe `
     '--installChannelUri C:\local\VisualStudio.chman', `
     '--add Microsoft.VisualStudio.Workload.VCTools', `
     '--includeRecommended'  -NoNewWindow -Wait;
+
+RUN echo "%PATH%"
 
 #
 # Technique from https://github.com/StefanScherer/dockerfiles-windows/blob/master/mongo/3.6/Dockerfile
@@ -102,6 +108,8 @@ RUN go install github.com/google/googet/v2/goopack@latest;
 COPY submodules/fluent-bit /work/submodules/fluent-bit
 
 WORKDIR /work/submodules/fluent-bit/build
+
+RUN echo "%PATH%"
 
 RUN cmake -G "'Visual Studio 16 2019'" -DCMAKE_BUILD_TYPE=RELWITHDEBINFO -DFLB_OUT_KINESIS_STREAMS=OFF ../;
 


### PR DESCRIPTION
## Description
🤷 

## Related issue
N/A, Windows builds started failing because it couldn't find CMake on PATH.

## How has this been tested?
Presubmits

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
