### PR TITLE
Remove Ubuntu 18.04 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -791,106 +791,6 @@ COPY --from=sles15-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent
 COPY --from=sles15-build /google-cloud-ops-agent*.rpm /
 
 # ======================================
-# Build Ops Agent for ubuntu-bionic 
-# ======================================
-
-FROM ubuntu:bionic-20220801 AS bionic-build-base
-
-RUN set -x; apt-get update && \
-		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
-		autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
-		build-essential bison flex file libsystemd-dev \
-		devscripts cdbs pkg-config openjdk-11-jdk zip
-COPY --from=cmake-install-recent /cmake.sh /cmake.sh
-RUN set -x; bash /cmake.sh --skip-license --prefix=/usr/local
-
-
-SHELL ["/bin/bash", "-c"]
-
-# Install golang
-ARG BUILDARCH
-ADD https://golang.org/dl/go1.20.2.linux-${BUILDARCH}.tar.gz /tmp/go1.20.2.tar.gz
-RUN set -xe; \
-    tar -xf /tmp/go1.20.2.tar.gz -C /usr/local
-ENV PATH="${PATH}:/usr/local/go/bin"
-
-
-FROM bionic-build-base AS bionic-build-otel
-WORKDIR /work
-# Download golang deps
-COPY ./submodules/opentelemetry-operations-collector/go.mod ./submodules/opentelemetry-operations-collector/go.sum submodules/opentelemetry-operations-collector/
-RUN cd submodules/opentelemetry-operations-collector && go mod download
-
-COPY ./submodules/opentelemetry-java-contrib submodules/opentelemetry-java-contrib
-# Install gradle. The first invocation of gradlew does this
-RUN cd submodules/opentelemetry-java-contrib && ./gradlew --no-daemon tasks
-COPY ./submodules/opentelemetry-operations-collector submodules/opentelemetry-operations-collector
-COPY ./builds/otel.sh .
-RUN ./otel.sh /work/cache/
-
-FROM bionic-build-base AS bionic-build-fluent-bit
-WORKDIR /work
-COPY ./submodules/fluent-bit submodules/fluent-bit
-COPY ./builds/fluent_bit.sh .
-RUN ./fluent_bit.sh /work/cache/
-
-
-FROM bionic-build-base AS bionic-build-systemd
-WORKDIR /work
-COPY ./systemd systemd
-COPY ./builds/systemd.sh .
-RUN ./systemd.sh /work/cache/
-
-
-FROM bionic-build-base AS bionic-build-golang-base
-WORKDIR /work
-COPY go.mod go.sum ./
-# Fetch dependencies
-RUN go mod download
-COPY confgenerator confgenerator
-COPY apps apps
-COPY internal internal
-
-
-FROM bionic-build-golang-base AS bionic-build-diagnostics
-WORKDIR /work
-COPY cmd/google_cloud_ops_agent_diagnostics cmd/google_cloud_ops_agent_diagnostics
-COPY ./builds/ops_agent_diagnostics.sh .
-RUN ./ops_agent_diagnostics.sh /work/cache/
-
-
-FROM bionic-build-golang-base AS bionic-build-wrapper
-WORKDIR /work
-COPY cmd/agent_wrapper cmd/agent_wrapper
-COPY ./builds/agent_wrapper.sh .
-RUN ./agent_wrapper.sh /work/cache/
-
-
-FROM bionic-build-golang-base AS bionic-build
-WORKDIR /work
-COPY cmd/google_cloud_ops_agent_engine cmd/google_cloud_ops_agent_engine
-COPY VERSION build.sh ./
-COPY debian debian
-COPY pkg pkg
-# Run the build script once to build the ops agent engine to a cache
-RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
-WORKDIR /tmp/cache_run/golang
-RUN ./pkg/deb/build.sh || true
-WORKDIR /work
-
-COPY ./confgenerator/default-config.yaml /work/cache/etc/google-cloud-ops-agent/config.yaml
-COPY --from=bionic-build-otel /work/cache /work/cache
-COPY --from=bionic-build-fluent-bit /work/cache /work/cache
-COPY --from=bionic-build-systemd /work/cache /work/cache
-COPY --from=bionic-build-diagnostics /work/cache /work/cache
-COPY --from=bionic-build-wrapper /work/cache /work/cache
-RUN ./pkg/deb/build.sh
-
-FROM scratch AS bionic
-COPY --from=bionic-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-bionic.tgz
-COPY --from=bionic-build /google-cloud-ops-agent*.deb /
-
-# ======================================
 # Build Ops Agent for ubuntu-focal 
 # ======================================
 
@@ -1189,7 +1089,6 @@ COPY --from=bullseye /* /
 COPY --from=buster /* /
 COPY --from=sles12 /* /
 COPY --from=sles15 /* /
-COPY --from=bionic /* /
 COPY --from=focal /* /
 COPY --from=jammy /* /
 COPY --from=lunar /* /

--- a/dockerfiles/compile.go
+++ b/dockerfiles/compile.go
@@ -186,18 +186,6 @@ var dockerfileArguments = []templateArguments{
 		package_extension: "rpm",
 	},
 	{
-		from_image:  "ubuntu:bionic-20220801",
-		target_name: "bionic",
-		install_packages: `RUN set -x; apt-get update && \
-		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
-		autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
-		build-essential bison flex file libsystemd-dev \
-		devscripts cdbs pkg-config openjdk-11-jdk zip` + installCMake,
-		package_build:     "RUN ./pkg/deb/build.sh",
-		tar_distro_name:   "ubuntu-bionic",
-		package_extension: "deb",
-	},
-	{
 		from_image:  "ubuntu:focal",
 		target_name: "focal",
 		install_packages: `RUN set -x; apt-get update && \

--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -34,13 +34,6 @@ bullseye_arm64 = _distro {
   release = ['debian-11-arm64']
   presubmit = ['debian-11-arm64']
 }
-bionic = _distro {
-  release = [
-    'ubuntu-1804-lts',
-    'ubuntu-minimal-1804-lts',
-  ]
-  presubmit = ['ubuntu-1804-lts']
-}
 focal = _distro {
   release = [
     'ubuntu-2004-lts',

--- a/kokoro/config/test/ops_agent/release/bionic.gcl
+++ b/kokoro/config/test/ops_agent/release/bionic.gcl
@@ -1,8 +1,0 @@
-import 'common.gcl' as common
-import '../../image_lists.gcl' as image_lists
-
-config build = common.ops_agent_test {
-  params {
-    platforms = image_lists.bionic.release
-  }
-}


### PR DESCRIPTION
## Description
This PR removes Ubuntu 18.04 support by removing the release GCL config, removing the entry in the tests GCL file, and removing it from the Dockerfile.

## Related issue
b/287645898

## How has this been tested?
Idk how :disappointed: 

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [x] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [x] *This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

* The minor version bump comes when it's release time
<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
