### PR TITLE
healthchecks : Add `WARNING` Health Check result.

### DIFF
--- a/cmd/ops_agent_windows/run_windows.go
+++ b/cmd/ops_agent_windows/run_windows.go
@@ -157,6 +157,14 @@ func (wsl WindowsServiceLogger) Infof(format string, v ...any) {
 	}
 }
 
+func (wsl WindowsServiceLogger) Warnf(format string, v ...any) {
+	if len(v) > 0 {
+		wsl.srv.log.Warning(EngineEventID, fmt.Sprintf(format, v...))
+	} else {
+		wsl.srv.log.Warning(EngineEventID, format)
+	}
+}
+
 func (wsl WindowsServiceLogger) Errorf(format string, v ...any) {
 	if len(v) > 0 {
 		wsl.srv.log.Error(EngineEventID, fmt.Sprintf(format, v...))

--- a/internal/logs/logs.go
+++ b/internal/logs/logs.go
@@ -34,6 +34,7 @@ const (
 
 type StructuredLogger interface {
 	Infof(format string, v ...any)
+	Warnf(format string, v ...any)
 	Errorf(format string, v ...any)
 	Println(v ...any)
 }
@@ -133,6 +134,10 @@ func (f ZapStructuredLogger) Infof(format string, v ...any) {
 	f.logger.Infof(format, v...)
 }
 
+func (f ZapStructuredLogger) Warnf(format string, v ...any) {
+	f.logger.Warnf(format, v...)
+}
+
 func (f ZapStructuredLogger) Errorf(format string, v ...any) {
 	f.logger.Errorf(format, v...)
 }
@@ -154,6 +159,10 @@ func (sl SimpleLogger) Printf(format string, v ...any) {
 }
 
 func (sl SimpleLogger) Infof(format string, v ...any) {
+	sl.l.Printf(format, v...)
+}
+
+func (sl SimpleLogger) Warnf(format string, v ...any) {
 	sl.l.Printf(format, v...)
 }
 


### PR DESCRIPTION
## Description
 Some Health Check failures are not fatal like `PacApiConnErr` or `DLApiConnErr`. This should communicated as `WARNING` instead of `FAIL` o `ERROR` to avoid confusing the user.

## Related issue
b/282975771

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
