### PR TITLE
Fix DISTRO for Bullseye ARM64

### DIFF
--- a/kokoro/config/build/presubmit/bullseye_arm64.gcl
+++ b/kokoro/config/build/presubmit/bullseye_arm64.gcl
@@ -3,7 +3,7 @@ import '../common.gcl' as common
 config build = common.build {
   params {
     environment {
-      DISTRO = 'bullseye_arm64'
+      DISTRO = 'bullseye'
       PKGFORMAT = 'deb'
     }
   }


### PR DESCRIPTION
## Description
The build does not need `distro_arch`, just `distro`. Tests should stay as `distro_arch` so we're only changing one file.

## Related issue
cl/543523182

## How has this been tested?
Will let the presubmits run.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
