### PR TITLE
cassandra: Fix cassandra timestamp parser.

### DIFF
--- a/apps/cassandra.go
+++ b/apps/cassandra.go
@@ -180,7 +180,7 @@ func (p LoggingProcessorCassandraGC) Components(ctx context.Context, tag string,
 					// Sample line: [2023-05-16T14:51:23.332+0000][4.595s][5195][5216][info ] GC(1) Concurrent Abortable Preclean 540.253ms
 					// Sample line: [2023-05-16T14:51:23.332+0000][4.595s][5195][5217][info ] Application time: 0.0001203 seconds
 					// Lines may also contain more detailed GC Heap information in the following lines
-					Regex: `^(?<time>\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,6}(?:Z|[+-]\d{2}:?\d{2}))\]\s?\[(?<uptime>\d+\.\d{3,6})s?\]\s?\[(?<pid>\d+)\]\s?\[(?<tid>\d+)\]\s?\[(?<level>\w+)\s?\]\s?(?<message>(?:Total time for which application threads were stopped: (?<timeStopped>\d+\.\d+) seconds, Stopping threads took: (?<timeStopping>\d+\.\d+)[\s\S]*|[\s\S]+))`,
+					Regex: `^\[(?<time>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,6}(?:Z|[+-]\d{2}:?\d{2}))\]\s?\[(?<uptime>\d+\.\d{3,6})s?\]\s?\[(?<pid>\d+)\]\s?\[(?<tid>\d+)\]\s?\[(?<level>\w+)\s?\]\s?(?<message>(?:Total time for which application threads were stopped: (?<timeStopped>\d+\.\d+) seconds, Stopping threads took: (?<timeStopping>\d+\.\d+)[\s\S]*|[\s\S]+))`,
 					Parser: confgenerator.ParserShared{
 						TimeKey:    "time",
 						TimeFormat: "%Y-%m-%dT%H:%M:%S.%L%z",

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra/golden/fluent_bit_parser.conf
@@ -17,7 +17,7 @@
 [PARSER]
     Format      regex
     Name        cassandra.cassandra_gc.cassandra_gc.1
-    Regex       ^(?<time>\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,6}(?:Z|[+-]\d{2}:?\d{2}))\]\s?\[(?<uptime>\d+\.\d{3,6})s?\]\s?\[(?<pid>\d+)\]\s?\[(?<tid>\d+)\]\s?\[(?<level>\w+)\s?\]\s?(?<message>(?:Total time for which application threads were stopped: (?<timeStopped>\d+\.\d+) seconds, Stopping threads took: (?<timeStopping>\d+\.\d+)[\s\S]*|[\s\S]+))
+    Regex       ^\[(?<time>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,6}(?:Z|[+-]\d{2}:?\d{2}))\]\s?\[(?<uptime>\d+\.\d{3,6})s?\]\s?\[(?<pid>\d+)\]\s?\[(?<tid>\d+)\]\s?\[(?<level>\w+)\s?\]\s?(?<message>(?:Total time for which application threads were stopped: (?<timeStopped>\d+\.\d+) seconds, Stopping threads took: (?<timeStopping>\d+\.\d+)[\s\S]*|[\s\S]+))
     Time_Format %Y-%m-%dT%H:%M:%S.%L%z
     Time_Key    time
     Types       pid:integer tid:integer timeStopped:float timeStopping:float uptime:float

--- a/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-receiver_cassandra_custom/golden/fluent_bit_parser.conf
@@ -17,7 +17,7 @@
 [PARSER]
     Format      regex
     Name        cassandra_custom.cassandra_custom_gc.cassandra_gc.1
-    Regex       ^(?<time>\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,6}(?:Z|[+-]\d{2}:?\d{2}))\]\s?\[(?<uptime>\d+\.\d{3,6})s?\]\s?\[(?<pid>\d+)\]\s?\[(?<tid>\d+)\]\s?\[(?<level>\w+)\s?\]\s?(?<message>(?:Total time for which application threads were stopped: (?<timeStopped>\d+\.\d+) seconds, Stopping threads took: (?<timeStopping>\d+\.\d+)[\s\S]*|[\s\S]+))
+    Regex       ^\[(?<time>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,6}(?:Z|[+-]\d{2}:?\d{2}))\]\s?\[(?<uptime>\d+\.\d{3,6})s?\]\s?\[(?<pid>\d+)\]\s?\[(?<tid>\d+)\]\s?\[(?<level>\w+)\s?\]\s?(?<message>(?:Total time for which application threads were stopped: (?<timeStopped>\d+\.\d+) seconds, Stopping threads took: (?<timeStopping>\d+\.\d+)[\s\S]*|[\s\S]+))
     Time_Format %Y-%m-%dT%H:%M:%S.%L%z
     Time_Key    time
     Types       pid:integer tid:integer timeStopped:float timeStopping:float uptime:float
@@ -49,7 +49,7 @@
 [PARSER]
     Format      regex
     Name        cassandra_default.cassandra_default_gc.cassandra_gc.1
-    Regex       ^(?<time>\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,6}(?:Z|[+-]\d{2}:?\d{2}))\]\s?\[(?<uptime>\d+\.\d{3,6})s?\]\s?\[(?<pid>\d+)\]\s?\[(?<tid>\d+)\]\s?\[(?<level>\w+)\s?\]\s?(?<message>(?:Total time for which application threads were stopped: (?<timeStopped>\d+\.\d+) seconds, Stopping threads took: (?<timeStopping>\d+\.\d+)[\s\S]*|[\s\S]+))
+    Regex       ^\[(?<time>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,6}(?:Z|[+-]\d{2}:?\d{2}))\]\s?\[(?<uptime>\d+\.\d{3,6})s?\]\s?\[(?<pid>\d+)\]\s?\[(?<tid>\d+)\]\s?\[(?<level>\w+)\s?\]\s?(?<message>(?:Total time for which application threads were stopped: (?<timeStopped>\d+\.\d+) seconds, Stopping threads took: (?<timeStopping>\d+\.\d+)[\s\S]*|[\s\S]+))
     Time_Format %Y-%m-%dT%H:%M:%S.%L%z
     Time_Key    time
     Types       pid:integer tid:integer timeStopped:float timeStopping:float uptime:float
@@ -94,7 +94,7 @@
 [PARSER]
     Format      regex
     Name        cassandra_syslog_system.cassandra_syslog_debug.2.1
-    Regex       ^(?<time>\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,6}(?:Z|[+-]\d{2}:?\d{2}))\]\s?\[(?<uptime>\d+\.\d{3,6})s?\]\s?\[(?<pid>\d+)\]\s?\[(?<tid>\d+)\]\s?\[(?<level>\w+)\s?\]\s?(?<message>(?:Total time for which application threads were stopped: (?<timeStopped>\d+\.\d+) seconds, Stopping threads took: (?<timeStopping>\d+\.\d+)[\s\S]*|[\s\S]+))
+    Regex       ^\[(?<time>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,6}(?:Z|[+-]\d{2}:?\d{2}))\]\s?\[(?<uptime>\d+\.\d{3,6})s?\]\s?\[(?<pid>\d+)\]\s?\[(?<tid>\d+)\]\s?\[(?<level>\w+)\s?\]\s?(?<message>(?:Total time for which application threads were stopped: (?<timeStopped>\d+\.\d+) seconds, Stopping threads took: (?<timeStopping>\d+\.\d+)[\s\S]*|[\s\S]+))
     Time_Format %Y-%m-%dT%H:%M:%S.%L%z
     Time_Key    time
     Types       pid:integer tid:integer timeStopped:float timeStopping:float uptime:float
@@ -131,7 +131,7 @@
 [PARSER]
     Format      regex
     Name        cassandra_syslog_system.cassandra_syslog_gc.2.1
-    Regex       ^(?<time>\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,6}(?:Z|[+-]\d{2}:?\d{2}))\]\s?\[(?<uptime>\d+\.\d{3,6})s?\]\s?\[(?<pid>\d+)\]\s?\[(?<tid>\d+)\]\s?\[(?<level>\w+)\s?\]\s?(?<message>(?:Total time for which application threads were stopped: (?<timeStopped>\d+\.\d+) seconds, Stopping threads took: (?<timeStopping>\d+\.\d+)[\s\S]*|[\s\S]+))
+    Regex       ^\[(?<time>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,6}(?:Z|[+-]\d{2}:?\d{2}))\]\s?\[(?<uptime>\d+\.\d{3,6})s?\]\s?\[(?<pid>\d+)\]\s?\[(?<tid>\d+)\]\s?\[(?<level>\w+)\s?\]\s?(?<message>(?:Total time for which application threads were stopped: (?<timeStopped>\d+\.\d+) seconds, Stopping threads took: (?<timeStopping>\d+\.\d+)[\s\S]*|[\s\S]+))
     Time_Format %Y-%m-%dT%H:%M:%S.%L%z
     Time_Key    time
     Types       pid:integer tid:integer timeStopped:float timeStopping:float uptime:float
@@ -168,7 +168,7 @@
 [PARSER]
     Format      regex
     Name        cassandra_syslog_system.cassandra_syslog_system.2.1
-    Regex       ^(?<time>\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,6}(?:Z|[+-]\d{2}:?\d{2}))\]\s?\[(?<uptime>\d+\.\d{3,6})s?\]\s?\[(?<pid>\d+)\]\s?\[(?<tid>\d+)\]\s?\[(?<level>\w+)\s?\]\s?(?<message>(?:Total time for which application threads were stopped: (?<timeStopped>\d+\.\d+) seconds, Stopping threads took: (?<timeStopping>\d+\.\d+)[\s\S]*|[\s\S]+))
+    Regex       ^\[(?<time>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,6}(?:Z|[+-]\d{2}:?\d{2}))\]\s?\[(?<uptime>\d+\.\d{3,6})s?\]\s?\[(?<pid>\d+)\]\s?\[(?<tid>\d+)\]\s?\[(?<level>\w+)\s?\]\s?(?<message>(?:Total time for which application threads were stopped: (?<timeStopped>\d+\.\d+) seconds, Stopping threads took: (?<timeStopping>\d+\.\d+)[\s\S]*|[\s\S]+))
     Time_Format %Y-%m-%dT%H:%M:%S.%L%z
     Time_Key    time
     Types       pid:integer tid:integer timeStopped:float timeStopping:float uptime:float


### PR DESCRIPTION
## Description
The following errors showing in cassandra tests. This PR fixes the cassandra regex parser.
```
[2023/06/27 14:25:46] [error] [parser] cannot parse '[2023-06-27T14:25:23.286+0000'
```

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
