### PR TITLE
[debian-bookworm] Update third party testing for Debian bookworm

### DIFF
--- a/integration_test/third_party_apps_data/applications/activemq/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/activemq/debian_ubuntu/install
@@ -1,7 +1,16 @@
 set -e
 
 sudo apt-get update
-sudo apt-get install -y default-jdk default-jdk-headless activemq
+# Debian 12 very specifically wants openjdk-17-jdk for installing Java via apt
+source /etc/os-release
+if [[ $ID == debian && "${VERSION_ID}" == 12 ]]; then
+    sudo apt-get install -y openjdk-17-jdk openjdk-17-jdk-headless 
+    # There's a strange dependency failure surrounding ca-certificates-java if apt-get update isn't rerun between Java and ActiveMQ installations
+    sudo apt-get update
+    sudo apt-get install -y activemq
+else
+    sudo apt-get install -y default-jdk default-jdk-headless activemq
+fi
 
 sudo sed -i 's/useJmx="false"/useJmx="true"/g' /etc/activemq/instances-available/main/activemq.xml 
 

--- a/integration_test/third_party_apps_data/applications/aerospike/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/aerospike/metadata.yaml
@@ -130,7 +130,8 @@ minimum_supported_agent_version:
   logging: 2.23.0
 supported_operating_systems: linux
 platforms_to_skip:
-  # Unable to install Aerospike on SLES 12 SP5, RHEL 9, or Ubuntu 23.04
+  # Unable to install Aerospike on Debian 12, SLES 12 SP5, RHEL 9, or Ubuntu 23.04
+  - debian-12
   - sles-12
   - rocky-linux-9
   - ubuntu-2304-amd64

--- a/integration_test/third_party_apps_data/applications/cassandra/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/cassandra/metadata.yaml
@@ -51,6 +51,7 @@ platforms_to_skip:
   - centos-7 # see https://issues.apache.org/jira/browse/CASSANDRA-18059 for fix.
   - sles-12 # QueryLog() failed: cassandra_system not found, exhausted retries; QueryLog() failed: cassandra_debug not found, exhausted retries; QueryLog() failed: cassandra_gc not found, exhausted retries
   - sles-15 # QueryLog() failed: cassandra_system not found, exhausted retries; QueryLog() failed: cassandra_debug not found, exhausted retries; QueryLog() failed: cassandra_gc not found, exhausted retries
+  - debian-12 # QueryLog() failed: cassandra_system not found, exhausted retries; QueryLog() failed: cassandra_debug not found, exhausted retries; QueryLog() failed: cassandra_gc not found, exhausted retries
   - ubuntu-2004-lts # GPG error [...] the public key is not available: NO_PUBKEY AA8E81B4331F7F50 NO_PUBKEY 112695A0E562B32A
 supported_app_version: ["3.11", "4.0"]
 expected_metrics:

--- a/integration_test/third_party_apps_data/applications/couchbase/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/couchbase/metadata.yaml
@@ -198,8 +198,9 @@ minimum_supported_agent_version:
   logging: 2.18.2
 supported_operating_systems: linux
 platforms_to_skip:
-  # couchbase is not supported on rhel9, Debian 11, or Ubuntu 23.04
+  # couchbase is not supported on rhel9, Debian 11, Debian 12, or Ubuntu 23.04.
   - rocky-linux-9
   - debian-11
+  - debian-12
   - ubuntu-2304-amd64
 public_url: https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/couchbase

--- a/integration_test/third_party_apps_data/applications/couchdb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/couchdb/metadata.yaml
@@ -28,11 +28,12 @@ minimum_supported_agent_version:
   logging: 2.11.0
 supported_operating_systems: linux
 platforms_to_skip:
-  # couchdb is not supported on sles, rhel9, Ubuntu 23.04
+  # couchdb is not supported on sles, rhel9, Ubuntu 23.04, and Debian 12
   - sles-12
   - sles-15
   - rocky-linux-9
   - ubuntu-2304-amd64
+  - debian-12
 supported_app_version: ["2.3+", "3.1+"]
 expected_metrics:
   - type: workload.googleapis.com/couchdb.average_request_time

--- a/integration_test/third_party_apps_data/applications/elasticsearch/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/elasticsearch/debian_ubuntu/install
@@ -1,7 +1,13 @@
 set -e
 
 sudo apt-get update
-sudo apt-get install -y apt-transport-https wget default-jre
+# Debian 12 very specifically wants openjdk-17-jdk for installing Java via apt
+source /etc/os-release
+if [[ $ID == debian && "${VERSION_ID}" == 12 ]]; then
+    sudo apt-get install -y apt-transport-https wget openjdk-17-jdk
+else
+    sudo apt-get install -y apt-transport-https wget default-jre
+fi
 
 wget --no-verbose --output-document=- https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
 echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | \

--- a/integration_test/third_party_apps_data/applications/flink/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/flink/metadata.yaml
@@ -18,6 +18,9 @@ long_name: Apache Flink
 description: |-
   The Apache Flink integration collects client, jobmanager and taskmanager logs and parses them into a JSON payload.
   The result includes fields for source, level, and message.
+platforms_to_skip:
+  # Flink only supports Java 11, which has no installation candidate for Debian 12
+  - debian-12
 supported_app_version: ["1.12.5", "1.13.6", "1.14.4"]
 configure_integration: ""
 expected_metrics:

--- a/integration_test/third_party_apps_data/applications/hadoop/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/hadoop/debian_ubuntu/install
@@ -1,7 +1,13 @@
 set -e
 
 sudo apt-get update
-sudo apt-get install -y default-jdk default-jdk-headless wget
+# Debian 12 very specifically wants openjdk-17-jdk for installing Java via apt
+source /etc/os-release
+if [[ $ID == debian && "${VERSION_ID}" == 12 ]]; then
+    sudo apt-get install -y openjdk-17-jdk openjdk-17-jdk-headless wget
+else
+    sudo apt-get install -y default-jdk default-jdk-headless wget
+fi
 
 sudo mkdir -p \
     /opt/hadoop/logs \

--- a/integration_test/third_party_apps_data/applications/hbase/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/hbase/metadata.yaml
@@ -44,6 +44,9 @@ configure_integration: |-
 minimum_supported_agent_version:
   metrics: 2.11.0
   logging: 2.11.0
+platforms_to_skip:
+  # Hbase only supports Java 11, which has no installation candidate for Debian 12
+  - debian-12
 supported_operating_systems: linux
 supported_app_version: ["1.7.x", "2.3.x", "2.4.x"]
 expected_metrics:

--- a/integration_test/third_party_apps_data/applications/jetty/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/jetty/debian_ubuntu/install
@@ -14,7 +14,12 @@ then
 fi
 
 sudo apt-get update
-sudo apt-get install -y wget default-jre
+# Debian 12 very specifically wants openjdk-17-jdk for installing Java via apt
+if [[ $ID == debian && "${VERSION_ID}" == 12 ]]; then
+    sudo apt-get install -y wget openjdk-17-jdk
+else
+    sudo apt-get install -y wget default-jre
+fi
 sudo wget -O jetty.tar.gz $jetty_download_url
 sudo mkdir -p /opt/jetty
 

--- a/integration_test/third_party_apps_data/applications/jvm/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/jvm/debian_ubuntu/install
@@ -1,7 +1,13 @@
 set -e
 
 sudo apt update
-sudo apt install -y default-jdk
+# Debian 12 very specifically wants openjdk-17-jdk for installing Java via apt
+source /etc/os-release
+if [[ $ID == debian && "${VERSION_ID}" == 12 ]]; then
+    sudo apt-get install -y openjdk-17-jdk
+else
+    sudo apt-get install -y default-jdk
+fi
 
 # TODO(sophieyfang): Below file is the same across all distros.
 # Have a single source file to be copied across all distros.

--- a/integration_test/third_party_apps_data/applications/kafka/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/kafka/debian_ubuntu/install
@@ -1,7 +1,13 @@
 set -e
 
 sudo apt-get update
-sudo apt-get install -y curl default-jre
+# Debian 12 very specifically wants openjdk-17-jdk for installing Java via apt
+source /etc/os-release
+if [[ $ID == debian && "${VERSION_ID}" == 12 ]]; then
+    sudo apt-get install -y curl openjdk-17-jdk
+else
+    sudo apt-get install -y curl default-jre
+fi
 sudo mkdir -p /opt/kafka/stage
 # https://github.com/GoogleCloudPlatform/ops-agent/blob/master/integration_test/README.md#vendored-dependencies
 sudo curl "https://storage.googleapis.com/ops-agents-public-buckets-vendored-deps/mirrored-content/archive.apache.org/dist/kafka/3.0.1/kafka_2.12-3.0.1.tgz" -o /opt/kafka/stage/kafka.tgz

--- a/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
@@ -29,9 +29,9 @@ supported_operating_systems: linux
 platforms_to_skip:
   # when we add support for mongo 6 in integration tests we can support RHEL 9
   - rocky-linux-9
-  # mongodb is not currently supported on Ubuntu 23.04 or Debian 11
+  # mongodb is not currently supported on Ubuntu 23.04, and Debian 12
   - ubuntu-2304-amd64
-  - debian-11
+  - debian-12
 supported_app_version: ["2.6", "3.0+", "4.0+", "5.0"]
 expected_metrics:
   - type: workload.googleapis.com/mongodb.cache.operations

--- a/integration_test/third_party_apps_data/applications/mongodb3.6/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mongodb3.6/metadata.yaml
@@ -27,13 +27,14 @@ minimum_supported_agent_version:
   logging: 2.10.0
 supported_operating_systems: linux
 platforms_to_skip:
-  # MongoDB3.6 hit end of life in 2021 and is not supported on Rocky Linux 9, Ubuntu 20.04, Ubuntu 22.04, Ubuntu 23.04, Debian 10, or Debian 11
+  # MongoDB3.6 hit end of life in 2021 and is not supported on Rocky Linux 9, Ubuntu 20.04, Ubuntu 22.04, Ubuntu 23.04, Debian 10, Debian 11, or Debian 12
   - rocky-linux-9
   - ubuntu-2004-lts
   - ubuntu-2204-lts
   - ubuntu-2304-amd64
   - debian-10
   - debian-11
+  - debian-12
 supported_app_version: ["2.6", "3.0+", "4.0+", "5.0"]
 expected_metrics:
   - type: workload.googleapis.com/mongodb.cache.operations

--- a/integration_test/third_party_apps_data/applications/mysql/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mysql/metadata.yaml
@@ -35,7 +35,9 @@ minimum_supported_agent_version:
   metrics: 2.32.0
   logging: 2.5.0
 supported_operating_systems: linux
-platforms_to_skip: []
+platforms_to_skip:
+  # MySQL is not currently supported on Debian 12
+  - debian-12
 supported_app_version: ["8.0", "5.7"]
 expected_metrics:
   - type: workload.googleapis.com/mysql.buffer_pool_data_pages

--- a/integration_test/third_party_apps_data/applications/mysql5.7/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mysql5.7/metadata.yaml
@@ -33,11 +33,12 @@ configure_integration: |-
   server using a Unix socket and Unix authentication as the `root` user.
 supported_operating_systems: linux
 platforms_to_skip:
-  # MySQL5.7 is not supported on SLES 15, Rocky Linux 8, Rocky Linux 9, Ubuntu 20.04, Ubuntu 23.04, or Debian 11
+  # MySQL5.7 is not supported on SLES 15, Rocky Linux 8, Rocky Linux 9, Ubuntu 20.04, Ubuntu 23.04, Debian 11, or Debian 12
   - sles-15
   - rocky-linux-8
   - rocky-linux-9
   - debian-11
+  - debian-12
   - ubuntu-2004-lts
   - ubuntu-2304-amd64
 supported_app_version: ["8.0", "5.7"]

--- a/integration_test/third_party_apps_data/applications/oracledb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/oracledb/metadata.yaml
@@ -51,6 +51,7 @@ supported_operating_systems: linux
 platforms_to_skip:
   - debian-10
   - debian-11
+  - debian-12
   - ubuntu-2004-lts
   - ubuntu-2304-amd64
   - sles-12

--- a/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
@@ -27,7 +27,8 @@ minimum_supported_agent_version:
   logging: 2.12.0
 supported_operating_systems: linux
 platforms_to_skip:
-  # rabbitmq is not supported on sles-12 or Ubuntu 23.04
+  # RabbitMQ is not supported on Debian 12, sles-12 or Ubuntu 23.04
+  - debian-12
   - sles-12
   - ubuntu-2304-amd64
 supported_app_version: ["3.8", "3.9"]

--- a/integration_test/third_party_apps_data/applications/solr/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/solr/debian_ubuntu/install
@@ -1,7 +1,13 @@
 set -e
 
 sudo apt-get update
-sudo apt-get install -y default-jdk default-jdk-headless curl lsof
+# Debian 12 very specifically wants openjdk-17-jdk for installing Java via apt
+source /etc/os-release
+if [[ $ID == debian && "${VERSION_ID}" == 12 ]]; then
+    sudo apt-get install -y openjdk-17-jdk openjdk-17-jdk-headless curl lsof
+else
+    sudo apt-get install -y default-jdk default-jdk-headless curl lsof
+fi
 
 # https://github.com/GoogleCloudPlatform/ops-agent/blob/master/integration_test/README.md#vendored-dependencies
 curl -L -o \

--- a/integration_test/third_party_apps_data/applications/tomcat/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/tomcat/debian_ubuntu/install
@@ -1,9 +1,19 @@
 set -e
 sudo apt update
-sudo apt-get install -y curl default-jdk default-jdk-headless
-sudo apt install tomcat9 -y
-sudo mkdir -p /etc/systemd/system/tomcat9.service.d
-sudo cat >> /etc/systemd/system/tomcat9.service.d/local.conf << EOF
+# Debian 12 very specifically wants openjdk-17-jdk for installing Java via apt
+# Additonally, Debian 12 only has an apt installation candidate for tomcat10
+source /etc/os-release
+if [[ $ID == debian && "${VERSION_ID}" == 12 ]]; then
+    TOMCAT_VERSION=tomcat10
+    sudo apt-get install -y curl openjdk-17-jdk openjdk-17-jdk-headless
+else
+    TOMCAT_VERSION=tomcat9
+    sudo apt-get install -y curl default-jdk default-jdk-headless
+fi
+
+sudo apt install ${TOMCAT_VERSION} -y
+sudo mkdir -p /etc/systemd/system/${TOMCAT_VERSION}.service.d
+sudo cat >> /etc/systemd/system/${TOMCAT_VERSION}.service.d/local.conf << EOF
 [Service]
 # Configuration
 Environment="CATALINA_OPTS=-Dcom.sun.management.jmxremote.port=8050 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
@@ -12,5 +22,5 @@ EOF
 
 sudo systemctl daemon-reload
 
-sudo systemctl restart tomcat9
+sudo systemctl restart ${TOMCAT_VERSION}
 sleep 60

--- a/integration_test/third_party_apps_data/applications/wildfly/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/wildfly/debian_ubuntu/install
@@ -1,7 +1,13 @@
 set -e
 
 sudo apt-get update
-sudo apt-get install -y curl default-jre
+# Debian 12 very specifically wants openjdk-17-jdk for installing Java via apt
+source /etc/os-release
+if [[ $ID == debian && "${VERSION_ID}" == 12 ]]; then
+    sudo apt-get install -y curl openjdk-17-jdk
+else
+    sudo apt-get install -y curl default-jre
+fi
 
 curl -L \
     -o wildfly.tar.gz \

--- a/integration_test/third_party_apps_data/applications/zookeeper/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/zookeeper/debian_ubuntu/install
@@ -1,13 +1,20 @@
 set -e
 
 sudo apt-get update
+
+# Debian 12 very specifically wants openjdk-17-jdk for installing Java via apt
+source /etc/os-release
+if [[ $ID == debian && "${VERSION_ID}" == 12 ]]; then
+    sudo apt-get install -y openjdk-17-jdk
+fi
+
 sudo apt install -y zookeeper-bin zookeeperd
 
 # TODO: Investigate why this happens and if this is the correct solution.
 # For some reason the zookeeper package doesn't set the CLASSPATH in the environment file
-# on Ubuntu 23.04, which it does on previous versions of Ubuntu.
+# on Ubuntu 23.04 and Debian 12, which it does on previous versions of Ubuntu and Debian.
 source /etc/os-release
-if [[ "${VERSION_ID}" == 23* ]]; then
+if [[ "${VERSION_ID}" == 23* || "${VERSION_ID}" == 12 ]]; then
     sudo tee -a /etc/zookeeper/conf/environment >/dev/null <<EOF
 CLASSPATH="/etc/zookeeper/conf:/usr/share/java/jline.jar:/usr/share/java/log4j-1.2.jar:/usr/share/java/xercesImpl.jar:/usr/share/java/xmlParserAPIs.jar:/usr/share/java/netty.jar:/usr/share/java/slf4j-api.jar:/usr/share/java/slf4j-log4j12.jar:/usr/share/java/zookeeper.jar"
 JAVA_OPTS="-Dzookeeper.4lw.commands.whitelist=*"


### PR DESCRIPTION
## Description
Third party application testing updates for Debian 12 (bookworm)

## How has this been tested?
Testing bookworm: https://github.com/GoogleCloudPlatform/ops-agent/pull/1298
Confirming bullseye still works with the new changes: https://github.com/GoogleCloudPlatform/ops-agent/pull/1301

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [X] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
