### PR TITLE
Use T2A machine type for ARM tests

### DIFF
--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -794,6 +794,9 @@ func RecommendedMachineType(platform string) string {
 	if gce.IsWindows(platform) {
 		return "e2-standard-4"
 	}
+	if gce.IsARM(platform) {
+		return "t2a-standard-2"
+	}
 	return "e2-standard-2"
 }
 

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1070,6 +1070,9 @@ func attemptCreateInstance(ctx context.Context, logger *log.Logger, options VMOp
 	}
 	if vm.MachineType == "" {
 		vm.MachineType = "e2-standard-4"
+		if IsARM(vm.Platform) {
+			vm.MachineType = "t2a-standard-4"
+		}
 	}
 
 	imgProject := options.ImageProject

--- a/kokoro/config/test/ops_agent/bullseye_arm64.gcl
+++ b/kokoro/config/test/ops_agent/bullseye_arm64.gcl
@@ -4,5 +4,14 @@ import '../image_lists.gcl' as image_lists
 config build = common.ops_agent_test {
   params {
     platforms = image_lists.bullseye_arm64.presubmit
+
+    // T2A machines are only available on us-central1-{a,b,f}
+    environment {
+      ZONES = join([
+        'us-central1-a',
+        'us-central1-b',
+        'us-central1-f',
+      ], ',')
+    }
   }
 }

--- a/kokoro/config/test/ops_agent/release/bullseye_arm64.gcl
+++ b/kokoro/config/test/ops_agent/release/bullseye_arm64.gcl
@@ -4,5 +4,14 @@ import '../../image_lists.gcl' as image_lists
 config build = common.ops_agent_test {
   params {
     platforms = image_lists.bullseye_arm64.release
+
+    // T2A machines are only available on us-central1-{a,b,f}
+    environment {
+      ZONES = join([
+        'us-central1-a',
+        'us-central1-b',
+        'us-central1-f',
+      ], ',')
+    }
   }
 }

--- a/kokoro/config/test/third_party_apps/bullseye_arm64.gcl
+++ b/kokoro/config/test/third_party_apps/bullseye_arm64.gcl
@@ -3,5 +3,14 @@ import 'common.gcl' as common
 config build = common.third_party_apps_test {
   params {
     platforms = ['debian-11-arm64']
+
+    // T2A machines are only available on us-central1-{a,b,f}
+    environment {
+      ZONES = join([
+        'us-central1-a',
+        'us-central1-b',
+        'us-central1-f',
+      ], ',')
+    }
   }
 }

--- a/kokoro/config/test/third_party_apps/release/bullseye_arm64.gcl
+++ b/kokoro/config/test/third_party_apps/release/bullseye_arm64.gcl
@@ -3,5 +3,14 @@ import 'common.gcl' as common
 config build = common.third_party_apps_test {
   params {
     platforms = ['debian-11-arm64']
+
+    // T2A machines are only available on us-central1-{a,b,f}
+    environment {
+      ZONES = join([
+        'us-central1-a',
+        'us-central1-b',
+        'us-central1-f',
+      ], ',')
+    }
   }
 }


### PR DESCRIPTION
## Description
ARM distros need to run on the T2A machine series. We should have enough quota to use the same (CPU, RAM) configuration as E2.

## Related issue
b/274913389

## How has this been tested?
Will let the presubmits run.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
