### PR TITLE
Testing: Disable ErrorActionPreference=Stop temporarily

### DIFF
--- a/integration_test/third_party_apps_data/agent/windows/install
+++ b/integration_test/third_party_apps_data/agent/windows/install
@@ -1,4 +1,6 @@
-$ErrorActionPreference = 'Stop'
+# Temporarily disabled while we work out some issues with running the install script
+# with this option.
+#$ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 
 # These are the steps from our public documentation:


### PR DESCRIPTION
## Description
Nightlies are hitting issues with this setting.

## Related issue
no bug filed yet

## How has this been tested?


## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
