### PR TITLE
Add Kokoro build configs for new distro bookworm

### DIFF
--- a/kokoro/config/build/presubmit/bookworm.gcl
+++ b/kokoro/config/build/presubmit/bookworm.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'bookworm'
+      PKGFORMAT = 'deb'
+    }
+  }
+}

--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -13,6 +13,14 @@ local template _distro {
 }
 
 // DEB Linux distros. (Do not modify this comment.)
+bookworm = _distro {
+  release = [
+      'debian-12',
+  ]
+  presubmit = [
+      'debian-12',
+  ]
+}
 lunar = _distro {
   release = [
       'ubuntu-2304-amd64',

--- a/kokoro/config/test/ops_agent/bookworm.gcl
+++ b/kokoro/config/test/ops_agent/bookworm.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.bookworm.presubmit
+  }
+}

--- a/kokoro/config/test/ops_agent/release/bookworm.gcl
+++ b/kokoro/config/test/ops_agent/release/bookworm.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.bookworm.release
+  }
+}

--- a/kokoro/config/test/third_party_apps/bookworm.gcl
+++ b/kokoro/config/test/third_party_apps/bookworm.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = [
+      'debian-12',
+    ]
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/bookworm.gcl
+++ b/kokoro/config/test/third_party_apps/release/bookworm.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = [
+      'debian-12',
+    ]
+  }
+}


### PR DESCRIPTION
## Description
Auto created PR from running the tool from the new distro support doc internally.

## Related issue
[b/217366205](http://b/217366205) | Support Debian 12 for Ops Agent 
#1294 

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
