### PR TITLE
Add Simulacra Initial Version to Repo 

### DIFF
--- a/integration_test/third_party_apps_data/simulacra.go
+++ b/integration_test/third_party_apps_data/simulacra.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"embed"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"path"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/ops-agent/apps"
+	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
+	"github.com/GoogleCloudPlatform/ops-agent/integration_test/agents"
+	"github.com/GoogleCloudPlatform/ops-agent/integration_test/logging"
+	"github.com/google/uuid"
+
+	"github.com/GoogleCloudPlatform/ops-agent/integration_test/gce"
+)
+
+//go:embed applications
+var scriptsDir embed.FS
+
+func distroFolder(platform string) (string, error) {
+	if gce.IsWindows(platform) {
+		return "windows", nil
+	}
+	firstWord := strings.Split(platform, "-")[0]
+	switch firstWord {
+	case "centos", "rhel", "rocky":
+		return "centos_rhel", nil
+	case "debian", "ubuntu":
+		return "debian_ubuntu", nil
+	case "opensuse", "sles":
+		return "sles", nil
+	}
+	return "", fmt.Errorf("distroFolder() could not find matching folder holding scripts for platform %s", platform)
+}
+
+func setupOpsAgent(ctx context.Context, vm *gce.VM, logger *logging.DirectoryLogger, configFilePath string) error {
+	data, err := ioutil.ReadFile(configFilePath)
+	if err != nil {
+		return err
+	}
+
+	uc, err := confgenerator.UnmarshalYamlToUnifiedConfig(ctx, data)
+	if err != nil {
+		return err
+	}
+
+	if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, uc.String()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getAllReceivers(config *confgenerator.UnifiedConfig) (receivers []string) {
+	for logs := range config.Logging.Receivers {
+		app := config.Logging.Receivers[logs].Type()
+		receivers = append(receivers, app)
+	}
+
+	for logs := range config.Metrics.Receivers {
+		app := config.Metrics.Receivers[logs].Type()
+		receivers = append(receivers, app)
+	}
+	return receivers
+}
+
+// installApps reads an Ops Agent config file and then identifies all the third party apps that need to be installed.
+// The function identifies by third party apps by checking if any of the receiver types have a
+// corresponding install script in the third_party_apps_data directory.
+// If there is a corresponding install script, then that install script is run on the vm.
+func installApps(ctx context.Context, vm *gce.VM, logger *logging.DirectoryLogger, configFilePath string) error {
+	config, err := confgenerator.MergeConfFiles(ctx, configFilePath, apps.BuiltInConfStructs)
+	if err != nil {
+		return err
+	}
+
+	folder, err := distroFolder(vm.Platform)
+
+	if err != nil {
+		return err
+	}
+
+	receivers := getAllReceivers(config)
+
+	for _, app := range receivers {
+		if scriptContent, err := scriptsDir.ReadFile(path.Join("applications", app, folder, "install")); err == nil {
+			logger.ToMainLog().Printf("Installing %s to VM", app)
+			if _, err := gce.RunScriptRemotely(ctx, logger, vm, string(scriptContent), nil, make(map[string]string)); err != nil {
+				return err
+			} else {
+				logger.ToMainLog().Printf("Done Installing %s", app)
+			}
+		}
+	}
+	return nil
+}
+
+func main() {
+	logger, err := logging.NewDirectoryLogger(path.Join("logs"))
+	if err != nil {
+		log.Default().Fatalf("Failed to setup logger %v", err)
+	}
+	ctx := context.Background()
+	platform := flag.String("platform", "debian-10", "Optional. The OS for the VM. If missing, debian-10 is used.")
+	configFile := flag.String("config_file", "", "Optional. Path to the Ops Agent Config File.")
+	project := flag.String("project", "", "Optional. If missing, the environment variable PROJECT will be used.")
+	zone := flag.String("zone", "", "Optional. If missing, the environment variable ZONE will be used.")
+	name := flag.String("name", fmt.Sprintf("simulacra-vm-instance-%s", uuid.NewString()), "Optional. A name for the instance to be created. If missing, a random name with prefix 'simulacra-vm-instance' will be assigned. ")
+	flag.Parse()
+	options := gce.VMOptions{
+		Platform:    *platform,
+		MachineType: agents.RecommendedMachineType(*platform),
+		Name:        *name,
+		Project:     *project,
+		Zone:        *zone,
+	}
+
+	// Create VM Instance.
+	vm, err := gce.CreateInstance(ctx, logger.ToFile("VM_initialization.txt"), options)
+	if err != nil {
+		logger.ToMainLog().Fatalf("Failed to create GCE instance %v", err)
+	}
+
+	// Install Ops Agent on VM.
+	if err := setupOpsAgent(ctx, vm, logger, *configFile); err != nil {
+		logger.ToMainLog().Fatalf("Failed to install Ops Agent %v", err)
+	}
+
+	// Install Third Party Appliations based on Ops Agent Config.
+	if err := installApps(ctx, vm, logger, *configFile); err != nil {
+		logger.ToMainLog().Fatalf("Failed to install apps %v", err)
+	}
+
+	logger.ToMainLog().Printf("VM '%s' is ready.", vm.Name)
+}


### PR DESCRIPTION
## Description

When helping customers solve their issues with Ops Agent, we often have to replicate their environments. This involves spinning up a VM instance with the correct OS, installing Ops Agent and installing all the third party applications that the customer has configured to run with Ops Agent. This is an extremely tedious and time consuming process that can be automated. Although we have several build and install scripts to make it easy for us, we still have to manually go in, create a VM instance, SSH into it, run the scripts and wait for them to complete. 

Simulacra helps us automate this process. Using Simulacra, we can automatically spin up VMs with Ops Agent with specific configurations. Simulacra even installs all third party applications that Ops Agent might be working with.

Note : The main file is in the integration_test/third_party_apps_data directory. This is because we use Embed.FS which can only read files from the current directory. We could have put it in the integration_test directory but that one already has a Go Package 'integration.'

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?

I used the tool with different Ops Agent configuration files to see if the VMs were correctly being instantiated. I later SSH'ed into those VMs to see if all applications were installed. I also checked the logs from the VMs in Pantheon to see that all the logs from the 3rd party apps were present. 

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
