### PR TITLE
Testing: Set default `LOG_RATE` to a more stable 1MB/s

### DIFF
--- a/kokoro/scripts/test/start_soak_test.sh
+++ b/kokoro/scripts/test/start_soak_test.sh
@@ -13,7 +13,7 @@ for GIT_ALIAS in git github; do
   fi
 done
 
-LOG_RATE=${LOG_RATE-100000} \
+LOG_RATE=${LOG_RATE-1000} \
 LOG_SIZE_IN_BYTES=${LOG_SIZE_IN_BYTES-1000} \
 VM_NAME="${VM_NAME:-github-soak-test-${KOKORO_BUILD_NUMBER}}" \
 DISTRO="${DISTRO:-ubuntu-2004-lts}" \


### PR DESCRIPTION
## Description
TODO: only merge once changelist with description "Set soak test log rate from 100MB/s -> 40MB/s" goes in.

Once changelist with description "Set soak test log rate from 100MB/s -> 40MB/s" goes in, this PR will only affect presubmits (the "Soak test launcher test", not actual soak tests).

This PR is just trying to set a default that is a bit more sane and achievable.

## Related issue
<none>

## How has this been tested?
This only affects the "Soak test launcher test", which is passing.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
