### PR TITLE
confgenerator: redact passwords from 3P integrations

### DIFF
--- a/apps/activemq.go
+++ b/apps/activemq.go
@@ -17,14 +17,15 @@ package apps
 import (
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/secret"
 )
 
 type MetricsReceiverActivemq struct {
 	confgenerator.ConfigComponent `yaml:",inline"`
 
-	Endpoint                               string `yaml:"endpoint" validate:"omitempty,hostname_port|startswith=service:jmx:"`
-	Username                               string `yaml:"username" validate:"required_with=Password"`
-	Password                               string `yaml:"password" validate:"required_with=Username"`
+	Endpoint                               string        `yaml:"endpoint" validate:"omitempty,hostname_port|startswith=service:jmx:"`
+	Username                               string        `yaml:"username" validate:"required_with=Password"`
+	Password                               secret.String `yaml:"password" validate:"required_with=Username"`
 	confgenerator.MetricsReceiverSharedJVM `yaml:",inline"`
 
 	confgenerator.MetricsReceiverSharedCollectJVM `yaml:",inline"`

--- a/apps/aerospike.go
+++ b/apps/aerospike.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/secret"
 )
 
 // MetricsReceiverAerospike is configuration for the Aerospike metrics receiver
@@ -29,7 +30,7 @@ type MetricsReceiverAerospike struct {
 
 	Endpoint string        `yaml:"endpoint" validate:"omitempty,hostname_port"`
 	Username string        `yaml:"username" validate:"required_with=Password"`
-	Password string        `yaml:"password" validate:"required_with=Username"`
+	Password secret.String `yaml:"password" validate:"required_with=Username"`
 	Timeout  time.Duration `yaml:"timeout"`
 }
 
@@ -82,7 +83,7 @@ func (r MetricsReceiverAerospike) Pipelines() []otel.ReceiverPipeline {
 				"endpoint":                endpoint,
 				"collect_cluster_metrics": collectClusterMetrics,
 				"username":                r.Username,
-				"password":                r.Password,
+				"password":                r.Password.SecretValue(),
 				"timeout":                 timeout,
 			},
 		},

--- a/apps/couchbase.go
+++ b/apps/couchbase.go
@@ -22,6 +22,7 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/secret"
 )
 
 // MetricsReceiverCouchbase is the struct for ops agent monitoring metrics for couchbase
@@ -29,9 +30,9 @@ type MetricsReceiverCouchbase struct {
 	confgenerator.ConfigComponent       `yaml:",inline"`
 	confgenerator.MetricsReceiverShared `yaml:",inline"`
 
-	Endpoint string `yaml:"endpoint" validate:"omitempty,hostname_port"`
-	Username string `yaml:"username" validate:"required"`
-	Password string `yaml:"password" validate:"required"`
+	Endpoint string        `yaml:"endpoint" validate:"omitempty,hostname_port"`
+	Username string        `yaml:"username" validate:"required"`
+	Password secret.String `yaml:"password" validate:"required"`
 }
 
 const defaultCouchbaseEndpoint = "localhost:8091"
@@ -56,7 +57,7 @@ func (r MetricsReceiverCouchbase) Pipelines() []otel.ReceiverPipeline {
 					"scrape_interval": r.CollectionIntervalString(),
 					"basic_auth": map[string]interface{}{
 						"username": r.Username,
-						"password": r.Password,
+						"password": r.Password.SecretValue(),
 					},
 					"metric_relabel_configs": []map[string]interface{}{
 						{

--- a/apps/couchdb.go
+++ b/apps/couchdb.go
@@ -21,6 +21,7 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/secret"
 )
 
 type MetricsReceiverCouchdb struct {
@@ -28,9 +29,9 @@ type MetricsReceiverCouchdb struct {
 
 	confgenerator.MetricsReceiverShared `yaml:",inline"`
 
-	Endpoint string `yaml:"endpoint" validate:"omitempty,url,startswith=http:"`
-	Username string `yaml:"username" validate:"required_with=Password"`
-	Password string `yaml:"password" validate:"required_with=Username"`
+	Endpoint string        `yaml:"endpoint" validate:"omitempty,url,startswith=http:"`
+	Username string        `yaml:"username" validate:"required_with=Password"`
+	Password secret.String `yaml:"password" validate:"required_with=Username"`
 }
 
 const defaultCouchdbEndpoint = "http://localhost:5984"
@@ -50,7 +51,7 @@ func (r MetricsReceiverCouchdb) Pipelines() []otel.ReceiverPipeline {
 				"collection_interval": r.CollectionIntervalString(),
 				"endpoint":            r.Endpoint,
 				"username":            r.Username,
-				"password":            r.Password,
+				"password":            r.Password.SecretValue(),
 			},
 		},
 		Processors: map[string][]otel.Component{"metrics": {

--- a/apps/elasticsearch.go
+++ b/apps/elasticsearch.go
@@ -21,6 +21,7 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/secret"
 )
 
 type MetricsReceiverElasticsearch struct {
@@ -32,8 +33,8 @@ type MetricsReceiverElasticsearch struct {
 
 	Endpoint string `yaml:"endpoint" validate:"omitempty,url,startswith=http:|startswith=https:"`
 
-	Username string `yaml:"username" validate:"required_with=Password"`
-	Password string `yaml:"password" validate:"required_with=Username"`
+	Username string        `yaml:"username" validate:"required_with=Password"`
+	Password secret.String `yaml:"password" validate:"required_with=Username"`
 }
 
 const (
@@ -65,7 +66,7 @@ func (r MetricsReceiverElasticsearch) Pipelines() []otel.ReceiverPipeline {
 		"collection_interval":  r.CollectionIntervalString(),
 		"endpoint":             r.Endpoint,
 		"username":             r.Username,
-		"password":             r.Password,
+		"password":             r.Password.SecretValue(),
 		"nodes":                []string{"_local"},
 		"tls":                  r.TLSConfig(true),
 		"skip_cluster_metrics": !r.ShouldCollectClusterMetrics(),

--- a/apps/mongodb.go
+++ b/apps/mongodb.go
@@ -23,15 +23,16 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit/modify"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/secret"
 )
 
 type MetricsReceiverMongoDB struct {
 	confgenerator.ConfigComponent          `yaml:",inline"`
 	confgenerator.MetricsReceiverSharedTLS `yaml:",inline"`
 	confgenerator.MetricsReceiverShared    `yaml:",inline"`
-	Endpoint                               string `yaml:"endpoint,omitempty"`
-	Username                               string `yaml:"username,omitempty"`
-	Password                               string `yaml:"password,omitempty"`
+	Endpoint                               string        `yaml:"endpoint,omitempty"`
+	Username                               string        `yaml:"username,omitempty"`
+	Password                               secret.String `yaml:"password,omitempty"`
 }
 
 type MetricsReceiverMongoDBHosts struct {
@@ -63,7 +64,7 @@ func (r MetricsReceiverMongoDB) Pipelines() []otel.ReceiverPipeline {
 	config := map[string]interface{}{
 		"hosts":               hosts,
 		"username":            r.Username,
-		"password":            r.Password,
+		"password":            r.Password.SecretValue(),
 		"collection_interval": r.CollectionIntervalString(),
 	}
 

--- a/apps/oracledb.go
+++ b/apps/oracledb.go
@@ -24,6 +24,7 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/secret"
 )
 
 type MetricsReceiverOracleDB struct {
@@ -33,9 +34,9 @@ type MetricsReceiverOracleDB struct {
 	Insecure           *bool `yaml:"insecure" validate:"omitempty"`
 	InsecureSkipVerify *bool `yaml:"insecure_skip_verify" validate:"omitempty"`
 
-	Endpoint string `yaml:"endpoint" validate:"omitempty,hostname_port|startswith=/"`
-	Username string `yaml:"username"`
-	Password string `yaml:"password"`
+	Endpoint string        `yaml:"endpoint" validate:"omitempty,hostname_port|startswith=/"`
+	Username string        `yaml:"username"`
+	Password secret.String `yaml:"password"`
 
 	SID         string `yaml:"sid" validate:"omitempty"`
 	ServiceName string `yaml:"service_name" validate:"omitempty"`
@@ -75,8 +76,9 @@ func (r MetricsReceiverOracleDB) Pipelines() []otel.ReceiverPipeline {
 	}
 
 	auth := url.QueryEscape(r.Username)
-	if len(r.Password) > 0 {
-		auth = fmt.Sprintf("%s:%s", auth, url.QueryEscape(r.Password))
+	secretPassword := r.Password.SecretValue()
+	if len(secretPassword) > 0 {
+		auth = fmt.Sprintf("%s:%s", auth, url.QueryEscape(secretPassword))
 	}
 
 	// create a datasource in the form oracle://username:password@host:port/ServiceName?SID=sid&ssl=enable&...

--- a/apps/postgresql.go
+++ b/apps/postgresql.go
@@ -20,6 +20,7 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/secret"
 
 	"strings"
 )
@@ -32,9 +33,9 @@ type MetricsReceiverPostgresql struct {
 
 	Endpoint string `yaml:"endpoint" validate:"omitempty,hostname_port|startswith=/"`
 
-	Password  string   `yaml:"password" validate:"omitempty"`
-	Username  string   `yaml:"username" validate:"omitempty"`
-	Databases []string `yaml:"databases" validate:"omitempty"`
+	Password  secret.String `yaml:"password" validate:"omitempty"`
+	Username  string        `yaml:"username" validate:"omitempty"`
+	Databases []string      `yaml:"databases" validate:"omitempty"`
 }
 
 // Actual socket is /var/run/postgresql/.s.PGSQL.5432 but the lib/pq go module used by
@@ -60,7 +61,7 @@ func (r MetricsReceiverPostgresql) Pipelines() []otel.ReceiverPipeline {
 		"collection_interval": r.CollectionIntervalString(),
 		"endpoint":            r.Endpoint,
 		"username":            r.Username,
-		"password":            r.Password,
+		"password":            r.Password.SecretValue(),
 		"transport":           transport,
 	}
 

--- a/apps/rabbitmq.go
+++ b/apps/rabbitmq.go
@@ -20,6 +20,7 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/secret"
 )
 
 type LoggingProcessorRabbitmq struct {
@@ -122,9 +123,9 @@ type MetricsReceiverRabbitmq struct {
 	confgenerator.MetricsReceiverShared    `yaml:",inline"`
 	confgenerator.MetricsReceiverSharedTLS `yaml:",inline"`
 
-	Password string `yaml:"password" validate:"required"`
-	Username string `yaml:"username" validate:"required"`
-	Endpoint string `yaml:"endpoint" validate:"omitempty,url"`
+	Password secret.String `yaml:"password" validate:"required"`
+	Username string        `yaml:"username" validate:"required"`
+	Endpoint string        `yaml:"endpoint" validate:"omitempty,url"`
 }
 
 const defaultRabbitmqTCPEndpoint = "http://localhost:15672"
@@ -142,7 +143,7 @@ func (r MetricsReceiverRabbitmq) Pipelines() []otel.ReceiverPipeline {
 		"collection_interval": r.CollectionIntervalString(),
 		"endpoint":            r.Endpoint,
 		"username":            r.Username,
-		"password":            r.Password,
+		"password":            r.Password.SecretValue(),
 		"tls":                 r.TLSConfig(true),
 	}
 

--- a/apps/redis.go
+++ b/apps/redis.go
@@ -21,6 +21,7 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/secret"
 )
 
 type MetricsReceiverRedis struct {
@@ -29,8 +30,8 @@ type MetricsReceiverRedis struct {
 	confgenerator.MetricsReceiverShared    `yaml:",inline"`
 
 	// TODO: Add support for ACL Authentication
-	Address  string `yaml:"address" validate:"omitempty,hostname_port|startswith=/"`
-	Password string `yaml:"password" validate:"omitempty"`
+	Address  string        `yaml:"address" validate:"omitempty,hostname_port|startswith=/"`
+	Password secret.String `yaml:"password" validate:"omitempty"`
 }
 
 const defaultRedisEndpoint = "localhost:6379"
@@ -57,7 +58,7 @@ func (r MetricsReceiverRedis) Pipelines() []otel.ReceiverPipeline {
 			Config: map[string]interface{}{
 				"collection_interval": r.CollectionIntervalString(),
 				"endpoint":            r.Address,
-				"password":            r.Password,
+				"password":            r.Password.SecretValue(),
 				"tls":                 r.TLSConfig(true),
 				"transport":           transport,
 			},

--- a/apps/saphana.go
+++ b/apps/saphana.go
@@ -20,6 +20,7 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/secret"
 )
 
 type LoggingProcessorSapHanaTrace struct {
@@ -143,8 +144,8 @@ type MetricsReceiverSapHana struct {
 
 	Endpoint string `yaml:"endpoint" validate:"omitempty,hostname_port|startswith=/"`
 
-	Password string `yaml:"password" validate:"omitempty"`
-	Username string `yaml:"username" validate:"omitempty"`
+	Password secret.String `yaml:"password" validate:"omitempty"`
+	Username string        `yaml:"username" validate:"omitempty"`
 }
 
 const defaultSapHanaEndpoint = "localhost:30015"
@@ -164,7 +165,7 @@ func (s MetricsReceiverSapHana) Pipelines() []otel.ReceiverPipeline {
 			Config: map[string]interface{}{
 				"collection_interval": s.CollectionIntervalString(),
 				"endpoint":            s.Endpoint,
-				"password":            s.Password,
+				"password":            s.Password.SecretValue(),
 				"username":            s.Username,
 				"tls":                 s.TLSConfig(true),
 			},

--- a/confgenerator/config.go
+++ b/confgenerator/config.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
 	"github.com/GoogleCloudPlatform/ops-agent/internal/platform"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/secret"
 	"github.com/GoogleCloudPlatform/ops-agent/internal/set"
 	"github.com/go-playground/validator/v10"
 	yaml "github.com/goccy/go-yaml"
@@ -630,10 +631,10 @@ func (m MetricsReceiverSharedTLS) TLSConfig(defaultInsecure bool) map[string]int
 type MetricsReceiverSharedJVM struct {
 	MetricsReceiverShared `yaml:",inline"`
 
-	Endpoint       string   `yaml:"endpoint" validate:"omitempty,hostname_port|startswith=service:jmx:"`
-	Username       string   `yaml:"username" validate:"required_with=Password"`
-	Password       string   `yaml:"password" validate:"required_with=Username"`
-	AdditionalJars []string `yaml:"additional_jars" validate:"omitempty,dive,file"`
+	Endpoint       string        `yaml:"endpoint" validate:"omitempty,hostname_port|startswith=service:jmx:"`
+	Username       string        `yaml:"username" validate:"required_with=Password"`
+	Password       secret.String `yaml:"password" validate:"required_with=Username"`
+	AdditionalJars []string      `yaml:"additional_jars" validate:"omitempty,dive,file"`
 }
 
 // WithDefaultEndpoint overrides the MetricReceiverSharedJVM's Endpoint if it is empty.
@@ -679,8 +680,9 @@ func (m MetricsReceiverSharedJVM) ConfigurePipelines(targetSystem string, proces
 	if m.Username != "" {
 		config["username"] = m.Username
 	}
-	if m.Password != "" {
-		config["password"] = m.Password
+	secretPassword := m.Password.SecretValue()
+	if secretPassword != "" {
+		config["password"] = secretPassword
 	}
 
 	return []otel.ReceiverPipeline{{


### PR DESCRIPTION
## Description
This change replaces all the Passwords to use the `secret.String` type so when the config is logged, it doesn't leak sensitive data.

## Related issue
[b/290250205](http://b/290250205) | OracleDB Metrics integration logs password in plain text

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
