### PR TITLE
activemq: use the jmx auth fields instead of the explicit ones

### DIFF
--- a/apps/activemq.go
+++ b/apps/activemq.go
@@ -17,17 +17,12 @@ package apps
 import (
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
-	"github.com/GoogleCloudPlatform/ops-agent/internal/secret"
 )
 
 type MetricsReceiverActivemq struct {
 	confgenerator.ConfigComponent `yaml:",inline"`
 
-	Endpoint                               string        `yaml:"endpoint" validate:"omitempty,hostname_port|startswith=service:jmx:"`
-	Username                               string        `yaml:"username" validate:"required_with=Password"`
-	Password                               secret.String `yaml:"password" validate:"required_with=Username"`
-	confgenerator.MetricsReceiverSharedJVM `yaml:",inline"`
-
+	confgenerator.MetricsReceiverSharedJVM        `yaml:",inline"`
 	confgenerator.MetricsReceiverSharedCollectJVM `yaml:",inline"`
 }
 

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq/golden/otel.yaml
@@ -461,7 +461,9 @@ receivers:
     collection_interval: 60s
     endpoint: localhost:1099
     jar_path: /path/to/executables/opentelemetry-java-contrib-jmx-metrics.jar
+    password: otelp
     target_system: activemq
+    username: otelu
   prometheus/fluentbit:
     config:
       scrape_configs:

--- a/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/otel.yaml
+++ b/confgenerator/testdata/valid/linux/metrics-receiver_activemq_no_jvm/golden/otel.yaml
@@ -461,7 +461,9 @@ receivers:
     collection_interval: 60s
     endpoint: localhost:1099
     jar_path: /path/to/executables/opentelemetry-java-contrib-jmx-metrics.jar
+    password: otelp
     target_system: activemq
+    username: otelu
   prometheus/fluentbit:
     config:
       scrape_configs:


### PR DESCRIPTION
## Description
Before this change, the username and password changes were ignored in favor of the jvm fields (which never got set because the explicit fields overrode them).

## Related issue
-

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
