### PR TITLE
logging_processor: update the python multiline regex to include custom string prefixes

### DIFF
--- a/confgenerator/logging_processors.go
+++ b/confgenerator/logging_processors.go
@@ -54,7 +54,7 @@ var multilineRulesLanguageMap = map[string][]string{
 		`"java_after_exception" "/^--- End of stack trace from previous (?x:)location where exception was thrown ---$/" "java_after_exception"`,
 		`"java_after_exception" "/^[\t ]*(?:Caused by|Suppressed):/" "java_after_exception"`,
 		`"java_after_exception" "/^[\t ]*... \d+ (?:more|common frames omitted)/" "java_after_exception"`},
-	"python": {`"start_state, python_start_exception" "/^Traceback \(most recent call last\):$/" "python"`,
+	"python": {`"start_state, python_start_exception" "/Traceback \(most recent call last\):$/" "python"`,
 		`"python" "/^[\t ]+File /" "python_code"`,
 		`"python_code" "/[^\t ]/" "python"`,
 		`"python" "/^(?:[^\s.():]+\.)*[^\s.():]+:/" "python_start_exception"`},

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_languages/golden/fluent_bit_parser.conf
@@ -16,7 +16,7 @@
     flush_timeout 1000
     name          multiline.p1.files_1.0
     type          regex
-    rule          "start_state, python_start_exception" "/^Traceback \(most recent call last\):$/" "python"
+    rule          "start_state, python_start_exception" "/Traceback \(most recent call last\):$/" "python"
     rule          "python" "/^[\t ]+File /" "python_code"
     rule          "python_code" "/[^\t ]/" "python"
     rule          "python" "/^(?:[^\s.():]+\.)*[^\s.():]+:/" "python_start_exception"

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_three_processors_same_language/golden/fluent_bit_parser.conf
@@ -16,7 +16,7 @@
     flush_timeout 1000
     name          multiline.p1.files_1.0
     type          regex
-    rule          "start_state, python_start_exception" "/^Traceback \(most recent call last\):$/" "python"
+    rule          "start_state, python_start_exception" "/Traceback \(most recent call last\):$/" "python"
     rule          "python" "/^[\t ]+File /" "python_code"
     rule          "python_code" "/[^\t ]/" "python"
     rule          "python" "/^(?:[^\s.():]+\.)*[^\s.():]+:/" "python_start_exception"
@@ -25,7 +25,7 @@
     flush_timeout 1000
     name          multiline.p2.files_2.0
     type          regex
-    rule          "start_state, python_start_exception" "/^Traceback \(most recent call last\):$/" "python"
+    rule          "start_state, python_start_exception" "/Traceback \(most recent call last\):$/" "python"
     rule          "python" "/^[\t ]+File /" "python_code"
     rule          "python_code" "/[^\t ]/" "python"
     rule          "python" "/^(?:[^\s.():]+\.)*[^\s.():]+:/" "python_start_exception"
@@ -34,7 +34,7 @@
     flush_timeout 1000
     name          multiline.p3.files_3.0
     type          regex
-    rule          "start_state, python_start_exception" "/^Traceback \(most recent call last\):$/" "python"
+    rule          "start_state, python_start_exception" "/Traceback \(most recent call last\):$/" "python"
     rule          "python" "/^[\t ]+File /" "python_code"
     rule          "python_code" "/[^\t ]/" "python"
     rule          "python" "/^(?:[^\s.():]+\.)*[^\s.():]+:/" "python_start_exception"

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_languages/golden/fluent_bit_parser.conf
@@ -16,7 +16,7 @@
     flush_timeout 1000
     name          multiline.p1.files_1.0
     type          regex
-    rule          "start_state, python_start_exception" "/^Traceback \(most recent call last\):$/" "python"
+    rule          "start_state, python_start_exception" "/Traceback \(most recent call last\):$/" "python"
     rule          "python" "/^[\t ]+File /" "python_code"
     rule          "python_code" "/[^\t ]/" "python"
     rule          "python" "/^(?:[^\s.():]+\.)*[^\s.():]+:/" "python_start_exception"

--- a/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_parser.conf
+++ b/confgenerator/testdata/valid/linux/logging-processor_parse_multiline_two_processors/golden/fluent_bit_parser.conf
@@ -16,7 +16,7 @@
     flush_timeout 1000
     name          multiline.p1.files_1.0
     type          regex
-    rule          "start_state, python_start_exception" "/^Traceback \(most recent call last\):$/" "python"
+    rule          "start_state, python_start_exception" "/Traceback \(most recent call last\):$/" "python"
     rule          "python" "/^[\t ]+File /" "python_code"
     rule          "python_code" "/[^\t ]/" "python"
     rule          "python" "/^(?:[^\s.():]+\.)*[^\s.():]+:/" "python_start_exception"
@@ -25,7 +25,7 @@
     flush_timeout 1000
     name          multiline.p2.files_1.0
     type          regex
-    rule          "start_state, python_start_exception" "/^Traceback \(most recent call last\):$/" "python"
+    rule          "start_state, python_start_exception" "/Traceback \(most recent call last\):$/" "python"
     rule          "python" "/^[\t ]+File /" "python_code"
     rule          "python_code" "/[^\t ]/" "python"
     rule          "python" "/^(?:[^\s.():]+\.)*[^\s.():]+:/" "python_start_exception"

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -522,6 +522,14 @@ Traceback (most recent call last):
   File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 5, in get
     raise Exception('spam', 'eggs')
 Exception: ('spam', 'eggs')
+2023-07-09 00:00:00,000 ERROR    some_app custom string prefix to the exception: Traceback (most recent call last):
+  File "/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.5.2/webapp2.py", line 1535, in __call__
+    rv = self.handle_exception(request, response, e)
+  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 17, in start
+    return get()
+  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 5, in get
+    raise Exception('spam', 'eggs')
+Exception: ('spam', 'eggs')
 java.lang.RuntimeException: javax.mail.SendFailedException: Invalid Addresses;
   nested exception is:
 com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EMAIL_ADDRESS]>... Relaying denied
@@ -560,6 +568,11 @@ Caused by: com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EM
 
 		// 2nd Python
 		if err := gce.WaitForLog(ctx, logger.ToMainLog(), vm, "files_1", time.Hour, `jsonPayload.message="Traceback (most recent call last):\n  File \"/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.5.2/webapp2.py\", line 1535, in __call__\n    rv = self.handle_exception(request, response, e)\n  File \"/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py\", line 17, in start\n    return get()\n  File \"/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py\", line 5, in get\n    raise Exception('spam', 'eggs')\nException: ('spam', 'eggs')\n"`); err != nil {
+			t.Error(err)
+		}
+
+		// 3nd Python - With custom string prefix, common when using https://docs.python.org/3/library/logging.html#logging.Logger.exception
+		if err := gce.WaitForLog(ctx, logger.ToMainLog(), vm, "files_1", time.Hour, `jsonPayload.message="2023-07-09 00:00:00,000 ERROR    some_app custom string prefix to the exception: Traceback (most recent call last):\n  File \"/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.5.2/webapp2.py\", line 1535, in __call__\n    rv = self.handle_exception(request, response, e)\n  File \"/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py\", line 17, in start\n    return get()\n  File \"/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py\", line 5, in get\n    raise Exception('spam', 'eggs')\nException: ('spam', 'eggs')\n"`); err != nil {
 			t.Error(err)
 		}
 


### PR DESCRIPTION
## Description
Removes the `^` prefix so the multiline parser matches on python exceptions that are handled using https://docs.python.org/3/library/logging.html#logging.Logger.exception. See https://github.com/GoogleCloudPlatform/ops-agent/issues/1315 for an example.


## Related issue
Fixes https://github.com/GoogleCloudPlatform/ops-agent/issues/1315.

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
