### PR TITLE
Update jetty install for sles12

### DIFF
--- a/integration_test/third_party_apps_data/applications/jetty/sles/install
+++ b/integration_test/third_party_apps_data/applications/jetty/sles/install
@@ -4,11 +4,13 @@ set -e
 # wget https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.4.46.v20220331/jetty-distribution-9.4.46.v20220331.tar.gz
 # wget https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/10.0.9/jetty-home-10.0.9.tar.gz
 
+JETTY_VERSION=11.0.15
+
 sudo zypper install -y wget java-11-openjdk
-sudo wget https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/11.0.15/jetty-home-11.0.15.tar.gz
+sudo wget https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/"$JETTY_VERSION"/jetty-home-"$JETTY_VERSION".tar.gz
 sudo mkdir -p /opt/jetty
 
-sudo tar -xvf jetty-home-11.0.15.tar.gz -C /opt/jetty --strip 1
+sudo tar -xvf jetty-home-"$JETTY_VERSION".tar.gz -C /opt/jetty --strip 1
 
 # to create the remote jmx configuration file
 # set jetty.home and jetty.base

--- a/integration_test/third_party_apps_data/applications/jetty/sles/install
+++ b/integration_test/third_party_apps_data/applications/jetty/sles/install
@@ -4,11 +4,11 @@ set -e
 # wget https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.4.46.v20220331/jetty-distribution-9.4.46.v20220331.tar.gz
 # wget https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/10.0.9/jetty-home-10.0.9.tar.gz
 
-sudo zypper install -y wget java
-sudo wget https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/11.0.9/jetty-home-11.0.9.tar.gz
+sudo zypper install -y wget java-11-openjdk
+sudo wget https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/11.0.15/jetty-home-11.0.15.tar.gz
 sudo mkdir -p /opt/jetty
 
-sudo tar -xvf jetty-home-11.0.9.tar.gz -C /opt/jetty --strip 1
+sudo tar -xvf jetty-home-11.0.15.tar.gz -C /opt/jetty --strip 1
 
 # to create the remote jmx configuration file
 # set jetty.home and jetty.base


### PR DESCRIPTION
## Description
Jetty tests are failing for SLES12 with some strange error like the following during the jetty start call
```
INFO  : download [https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-jdk15on/1.70/bcpkix-jdk15on-1.70.jar](https://www.google.com/url?q=https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-jdk15on/1.70/bcpkix-jdk15on-1.70.jar&sa=D&source=buganizer&usg=AOvVaw0INnYfACt4vpRvy4r3ElxK) to ${jetty.base}/lib/bouncycastle/bcpkix-jdk15on-1.70.jar
fips - softokn: crypto test failed - aborting
```

Updating to latest jetty version and specifying java 11 seems to have resolved the issue.

## Related issue

## How has this been tested?
Tested on an individual sles12 box, integration tests should prove out the fix.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
