### PR TITLE
Experiment with inotify disabled

### DIFF
--- a/confgenerator/logging_receivers.go
+++ b/confgenerator/logging_receivers.go
@@ -104,6 +104,8 @@ func (r LoggingReceiverFilesMixin) Components(ctx context.Context, tag string) [
 		// When the input plugin hits "mem_buf_limit", because we have enabled filesystem storage type, mem_buf_limit acts
 		// as a hint to set "how much data can be up in memory", once the limit is reached it continues writing to disk.
 		"Mem_Buf_Limit": "10M",
+
+		"Inotify_Watcher": "false",
 	}
 	if len(r.ExcludePaths) > 0 {
 		// TODO: Escaping?

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows-2012/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/host_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux/fluent_bit_main.conf
@@ -27,6 +27,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -42,6 +43,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/builtin/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/builtin/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/builtin/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/builtin/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/builtin/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/builtin/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows-2012/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux/fluent_bit_main.conf
@@ -23,6 +23,7 @@
     DB                ${buffers_dir}/pipeline1_log_source_id1
     DB.locking        true
     Exclude_Path      /path/to/log/1/a/exclude_a,/path/to/log/1/b/exclude_b
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -39,6 +40,7 @@
     DB                ${buffers_dir}/pipeline2_log_source_id2
     DB.locking        true
     Exclude_Path      /path/to/log/2/a/exclude_a,/path/to/log/2/b/exclude_b
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +76,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -89,6 +92,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/fluent_bit_main.conf
@@ -23,6 +23,7 @@
     DB                ${buffers_dir}/pipeline1_log_source_id1
     DB.locking        true
     Exclude_Path      /path/to/log/1/a/exclude_a,/path/to/log/1/b/exclude_b
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -39,6 +40,7 @@
     DB                ${buffers_dir}/pipeline2_log_source_id2
     DB.locking        true
     Exclude_Path      /path/to/log/2/a/exclude_a,/path/to/log/2/b/exclude_b
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +76,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -89,6 +92,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/fluent_bit_main.conf
@@ -23,6 +23,7 @@
     DB                ${buffers_dir}/pipeline1_log_source_id1
     DB.locking        true
     Exclude_Path      /path/to/log/1/a/exclude_a,/path/to/log/1/b/exclude_b
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -39,6 +40,7 @@
     DB                ${buffers_dir}/pipeline2_log_source_id2
     DB.locking        true
     Exclude_Path      /path/to/log/2/a/exclude_a,/path/to/log/2/b/exclude_b
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +76,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -89,6 +92,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_sample_logs
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_sample_logs
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_sample_logs
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/test-pipeline_logs
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/test-pipeline_logs
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/test-pipeline_logs
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_sample_logs
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_sample_logs
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_sample_logs
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline1_sample_logs
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline2_sample_logs
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -82,6 +86,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline1_sample_logs
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline2_sample_logs
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +77,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline1_sample_logs
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline2_sample_logs
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +77,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux/fluent_bit_main.conf
@@ -23,6 +23,7 @@
     DB                ${buffers_dir}/pipeline1_log_source_id1
     DB.locking        true
     Exclude_Path      /path/to/log/1/a/exclude_a,/path/to/log/1/b/exclude_b
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -39,6 +40,7 @@
     DB                ${buffers_dir}/pipeline2_log_source_id2
     DB.locking        true
     Exclude_Path      /path/to/log/2/a/exclude_a,/path/to/log/2/b/exclude_b
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +76,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -89,6 +92,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/fluent_bit_main.conf
@@ -23,6 +23,7 @@
     DB                ${buffers_dir}/pipeline1_log_source_id1
     DB.locking        true
     Exclude_Path      /path/to/log/1/a/exclude_a,/path/to/log/1/b/exclude_b
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -39,6 +40,7 @@
     DB                ${buffers_dir}/pipeline2_log_source_id2
     DB.locking        true
     Exclude_Path      /path/to/log/2/a/exclude_a,/path/to/log/2/b/exclude_b
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +76,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -89,6 +92,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/fluent_bit_main.conf
@@ -23,6 +23,7 @@
     DB                ${buffers_dir}/pipeline1_log_source_id1
     DB.locking        true
     Exclude_Path      /path/to/log/1/a/exclude_a,/path/to/log/1/b/exclude_b
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -39,6 +40,7 @@
     DB                ${buffers_dir}/pipeline2_log_source_id2
     DB.locking        true
     Exclude_Path      /path/to/log/2/a/exclude_a,/path/to/log/2/b/exclude_b
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +76,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -89,6 +92,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_files_1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -54,6 +56,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -69,6 +72,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_files_1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -46,6 +47,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -61,6 +63,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_files_1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -46,6 +47,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -61,6 +63,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_files_1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -53,6 +55,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -68,6 +71,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_files_1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_files_1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_files_1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -54,6 +56,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -69,6 +72,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_files_1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -46,6 +47,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -61,6 +63,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_files_1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -46,6 +47,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -61,6 +63,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_files_1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -54,6 +56,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p2_files_2
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -71,6 +74,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p3_files_3
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -88,6 +92,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -103,6 +108,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_files_1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -46,6 +47,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p2_files_2
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -63,6 +65,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p3_files_3
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -80,6 +83,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -95,6 +99,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_files_1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -46,6 +47,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p2_files_2
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -63,6 +65,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p3_files_3
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -80,6 +83,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -95,6 +99,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_files_1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -54,6 +56,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -69,6 +72,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_files_1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -46,6 +47,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -61,6 +63,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_files_1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -46,6 +47,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -61,6 +63,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_files_1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -54,6 +56,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p2_files_1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -71,6 +74,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -86,6 +90,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_files_1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -46,6 +47,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p2_files_1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -63,6 +65,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -78,6 +81,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p1_files_1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -46,6 +47,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/p2_files_1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -63,6 +65,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -78,6 +81,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/apache_apache_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/apache_apache_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -82,6 +86,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows-2012/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/apache_apache_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/apache_apache_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +77,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/apache_apache_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/apache_apache_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +77,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/apache_custom_apache_custom_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -38,6 +39,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/apache_custom_apache_custom_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -54,6 +56,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/apache_default_apache_default_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -69,6 +72,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/apache_default_apache_default_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -104,6 +108,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -119,6 +124,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -134,6 +140,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows-2012/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/apache_custom_apache_custom_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -38,6 +39,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/apache_custom_apache_custom_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -54,6 +56,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/apache_default_apache_default_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -69,6 +72,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/apache_default_apache_default_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -111,6 +115,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -126,6 +131,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/apache_custom_apache_custom_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -38,6 +39,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/apache_custom_apache_custom_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -54,6 +56,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/apache_default_apache_default_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -69,6 +72,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/apache_default_apache_default_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -111,6 +115,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -126,6 +131,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_cassandra_debug
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_cassandra_gc
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_cassandra_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -82,6 +86,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -97,6 +102,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows-2012/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_cassandra_debug
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_cassandra_gc
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_cassandra_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +77,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -89,6 +93,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_cassandra_debug
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_cassandra_gc
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_cassandra_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +77,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -89,6 +93,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_custom_cassandra_custom_debug
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -38,6 +39,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_custom_cassandra_custom_gc
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -54,6 +56,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_custom_cassandra_custom_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -70,6 +73,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_default_cassandra_default_debug
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -85,6 +89,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_default_cassandra_default_gc
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -100,6 +105,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_default_cassandra_default_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -145,6 +151,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -160,6 +167,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -175,6 +183,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows-2012/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_custom_cassandra_custom_debug
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -38,6 +39,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_custom_cassandra_custom_gc
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -54,6 +56,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_custom_cassandra_custom_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -70,6 +73,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_default_cassandra_default_debug
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -85,6 +89,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_default_cassandra_default_gc
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -100,6 +105,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_default_cassandra_default_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -152,6 +158,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -167,6 +174,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_custom_cassandra_custom_debug
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -38,6 +39,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_custom_cassandra_custom_gc
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -54,6 +56,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_custom_cassandra_custom_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -70,6 +73,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_default_cassandra_default_debug
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -85,6 +89,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_default_cassandra_default_gc
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -100,6 +105,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/cassandra_default_cassandra_default_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -152,6 +158,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -167,6 +174,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/couchbase_couchbase_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/couchbase_couchbase_goxdcr
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/couchbase_couchbase_http_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -82,6 +86,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -97,6 +102,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows-2012/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/couchbase_couchbase_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/couchbase_couchbase_goxdcr
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/couchbase_couchbase_http_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +77,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -89,6 +93,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/couchbase_couchbase_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/couchbase_couchbase_goxdcr
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/couchbase_couchbase_http_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +77,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -89,6 +93,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/couchdb_couchdb
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -38,6 +39,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -53,6 +55,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -68,6 +71,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows-2012/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/couchdb_couchdb
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/couchdb_couchdb
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/elasticsearch_elasticsearch_gc
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/elasticsearch_elasticsearch_json
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -68,6 +71,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -83,6 +87,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/elasticsearch_elasticsearch_gc
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/elasticsearch_elasticsearch_json
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -75,6 +78,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/elasticsearch_elasticsearch_gc
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/elasticsearch_elasticsearch_json
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -75,6 +78,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/elasticsearch_custom_elasticsearch_gc_custom
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -53,6 +55,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/elasticsearch_custom_elasticsearch_json_custom
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -70,6 +73,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/elasticsearch_default_elasticsearch_gc_default
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -85,6 +89,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/elasticsearch_default_elasticsearch_json_default
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -101,6 +106,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -116,6 +122,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/elasticsearch_custom_elasticsearch_gc_custom
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/elasticsearch_custom_elasticsearch_json_custom
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -62,6 +64,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/elasticsearch_default_elasticsearch_gc_default
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -77,6 +80,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/elasticsearch_default_elasticsearch_json_default
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -93,6 +97,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -108,6 +113,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/elasticsearch_custom_elasticsearch_gc_custom
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/elasticsearch_custom_elasticsearch_json_custom
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -62,6 +64,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/elasticsearch_default_elasticsearch_gc_default
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -77,6 +80,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/elasticsearch_default_elasticsearch_json_default
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -93,6 +97,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -108,6 +113,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline1_log_source_id1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline2_log_source_id2
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -68,6 +71,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline3_log_source_id3
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -84,6 +88,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline4_log_source_id4
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -99,6 +104,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -114,6 +120,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline1_log_source_id1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline2_log_source_id2
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline3_log_source_id3
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -76,6 +79,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline4_log_source_id4
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -91,6 +95,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -106,6 +111,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline1_log_source_id1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline2_log_source_id2
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline3_log_source_id3
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -76,6 +79,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline4_log_source_id4
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -91,6 +95,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -106,6 +111,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline1_log_source_id1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -53,6 +55,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -68,6 +71,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline1_log_source_id1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline1_log_source_id1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline1_log_source_id1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline2_log_source_id2
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -68,6 +71,7 @@
     DB                ${buffers_dir}/pipeline3_log_source_id3
     DB.locking        true
     Exclude_Path      /path/to/log/3/exclude
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -84,6 +88,7 @@
     DB                ${buffers_dir}/pipeline4_log_source_id4
     DB.locking        true
     Exclude_Path      /path/to/log/4/exclude_a,/path/to/log/4/exclude_b
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -99,6 +104,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline5_log_source_id5
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -114,6 +120,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -129,6 +136,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline1_log_source_id1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline2_log_source_id2
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     DB                ${buffers_dir}/pipeline3_log_source_id3
     DB.locking        true
     Exclude_Path      /path/to/log/3/exclude
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -76,6 +79,7 @@
     DB                ${buffers_dir}/pipeline4_log_source_id4
     DB.locking        true
     Exclude_Path      /path/to/log/4/exclude_a,/path/to/log/4/exclude_b
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -91,6 +95,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline5_log_source_id5
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -106,6 +111,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -121,6 +127,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline1_log_source_id1
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline2_log_source_id2
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     DB                ${buffers_dir}/pipeline3_log_source_id3
     DB.locking        true
     Exclude_Path      /path/to/log/3/exclude
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -76,6 +79,7 @@
     DB                ${buffers_dir}/pipeline4_log_source_id4
     DB.locking        true
     Exclude_Path      /path/to/log/4/exclude_a,/path/to/log/4/exclude_b
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -91,6 +95,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/pipeline5_log_source_id5
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -106,6 +111,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -121,6 +127,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/flink_flink
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/flink_flink
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/flink_flink
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows-2012/fluent_bit_main.conf
@@ -37,6 +37,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +53,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows/fluent_bit_main.conf
@@ -37,6 +37,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +53,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux/fluent_bit_main.conf
@@ -30,6 +30,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -53,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -68,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows-2012/fluent_bit_main.conf
@@ -45,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows/fluent_bit_main.conf
@@ -45,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux/fluent_bit_main.conf
@@ -30,6 +30,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -53,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -68,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows-2012/fluent_bit_main.conf
@@ -45,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows/fluent_bit_main.conf
@@ -45,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux/fluent_bit_main.conf
@@ -30,6 +30,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows-2012/fluent_bit_main.conf
@@ -37,6 +37,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +53,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows/fluent_bit_main.conf
@@ -37,6 +37,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +53,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/hadoop_hadoop
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -53,6 +55,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -68,6 +71,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/hadoop_hadoop
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/hadoop_hadoop
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/hadoop_hadoop
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -54,6 +56,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -69,6 +72,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/hadoop_hadoop
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -46,6 +47,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -61,6 +63,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/hadoop_hadoop
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -46,6 +47,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -61,6 +63,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/hbase_hbase_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/hbase_hbase_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/hbase_hbase_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/jetty_jetty_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/jetty_jetty_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/jetty_jetty_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/kafka_kafka
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/kafka_kafka
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/kafka_kafka
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/kafka_custom_kafka_custom
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -63,6 +65,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -78,6 +81,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/kafka_custom_kafka_custom
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -55,6 +56,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -70,6 +72,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/kafka_custom_kafka_custom
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -55,6 +56,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -70,6 +72,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mongodb_mongodb
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mongodb_mongodb
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mongodb_mongodb
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_mysql_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_mysql_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_mysql_slow
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -82,6 +86,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -97,6 +102,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_mysql_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_mysql_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_mysql_slow
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +77,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -89,6 +93,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_mysql_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_mysql_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_mysql_slow
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +77,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -89,6 +93,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_custom_mysql_custom_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -53,6 +55,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_custom_mysql_custom_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -69,6 +72,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_custom_mysql_custom_slow
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -85,6 +89,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_default_mysql_default_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -100,6 +105,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_default_mysql_default_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -115,6 +121,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_default_mysql_default_slow
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -160,6 +167,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -175,6 +183,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_custom_mysql_custom_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_custom_mysql_custom_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -61,6 +63,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_custom_mysql_custom_slow
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -77,6 +80,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_default_mysql_default_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -92,6 +96,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_default_mysql_default_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -107,6 +112,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_default_mysql_default_slow
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -152,6 +158,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -167,6 +174,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_custom_mysql_custom_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_custom_mysql_custom_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -61,6 +63,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_custom_mysql_custom_slow
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -77,6 +80,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_default_mysql_default_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -92,6 +96,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_default_mysql_default_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -107,6 +112,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/mysql_default_mysql_default_slow
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -152,6 +158,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -167,6 +174,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/nginx_nginx_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/nginx_nginx_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -82,6 +86,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/nginx_nginx_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/nginx_nginx_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +77,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/nginx_nginx_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/nginx_nginx_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +77,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/nginx_custom_nginx_custom_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -53,6 +55,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/nginx_custom_nginx_custom_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -69,6 +72,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/nginx_default_nginx_default_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -84,6 +88,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/nginx_default_nginx_default_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -119,6 +124,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -134,6 +140,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/nginx_custom_nginx_custom_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/nginx_custom_nginx_custom_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -61,6 +63,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/nginx_default_nginx_default_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -76,6 +79,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/nginx_default_nginx_default_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -111,6 +115,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -126,6 +131,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/nginx_custom_nginx_custom_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/nginx_custom_nginx_custom_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -61,6 +63,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/nginx_default_nginx_default_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -76,6 +79,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/nginx_default_nginx_default_error
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -111,6 +115,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -126,6 +131,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/oracledb_oracledb_alert
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/oracledb_oracledb_audit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -82,6 +86,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/oracledb_oracledb_alert
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/oracledb_oracledb_audit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +77,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/oracledb_oracledb_alert
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/oracledb_oracledb_audit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +77,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/oracledb_custom_oracledb_alert_custom
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/oracledb_custom_oracledb_audit_custom
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/oracledb_default_oracledb_alert
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -82,6 +86,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/oracledb_default_oracledb_audit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -117,6 +122,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -132,6 +138,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/oracledb_custom_oracledb_alert_custom
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/oracledb_custom_oracledb_audit_custom
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/oracledb_default_oracledb_alert
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +77,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/oracledb_default_oracledb_audit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -109,6 +113,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -124,6 +129,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/oracledb_custom_oracledb_alert_custom
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/oracledb_custom_oracledb_audit_custom
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/oracledb_default_oracledb_alert
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +77,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/oracledb_default_oracledb_audit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -109,6 +113,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -124,6 +129,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/postgresql_postgresql_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/postgresql_postgresql_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/postgresql_postgresql_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/postgresql_custom_postgresql_custom_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/postgresql_default_postgresql_default_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -77,6 +80,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -92,6 +96,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/postgresql_custom_postgresql_custom_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/postgresql_default_postgresql_default_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -69,6 +71,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -84,6 +87,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/postgresql_custom_postgresql_custom_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/postgresql_default_postgresql_default_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -69,6 +71,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -84,6 +87,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/rabbitmq_rabbitmq
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -53,6 +55,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -68,6 +71,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/rabbitmq_rabbitmq
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/rabbitmq_rabbitmq
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/redis_redis
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/redis_redis
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/redis_redis
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/redis_custom_redis_custom
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -53,6 +55,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/redis_default_redis_default
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -78,6 +81,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -93,6 +97,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/redis_custom_redis_custom
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/redis_default_redis_default
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -70,6 +72,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -85,6 +88,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/redis_custom_redis_custom
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/redis_default_redis_default
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -70,6 +72,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -85,6 +88,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -38,6 +39,7 @@
     DB                ${buffers_dir}/saphana_saphana
     DB.locking        true
     Exclude_Path      /usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver_history*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*loads*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*executed_statements*.trc
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -54,6 +56,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -69,6 +72,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows-2012/fluent_bit_main.conf
@@ -30,6 +30,7 @@
     DB                ${buffers_dir}/saphana_saphana
     DB.locking        true
     Exclude_Path      /usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver_history*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*loads*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*executed_statements*.trc
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -46,6 +47,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -61,6 +63,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows/fluent_bit_main.conf
@@ -30,6 +30,7 @@
     DB                ${buffers_dir}/saphana_saphana
     DB.locking        true
     Exclude_Path      /usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver_history*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*loads*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*executed_statements*.trc
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -46,6 +47,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -61,6 +63,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -38,6 +39,7 @@
     DB                ${buffers_dir}/saphana_custom_saphana_custom
     DB.locking        true
     Exclude_Path      /usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver_history*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*loads*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*executed_statements*.trc
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -56,6 +58,7 @@
     DB                ${buffers_dir}/saphana_default_saphana
     DB.locking        true
     Exclude_Path      /usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver_history*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*loads*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*executed_statements*.trc
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -82,6 +85,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -97,6 +101,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows-2012/fluent_bit_main.conf
@@ -30,6 +30,7 @@
     DB                ${buffers_dir}/saphana_custom_saphana_custom
     DB.locking        true
     Exclude_Path      /usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver_history*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*loads*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*executed_statements*.trc
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -48,6 +49,7 @@
     DB                ${buffers_dir}/saphana_default_saphana
     DB.locking        true
     Exclude_Path      /usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver_history*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*loads*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*executed_statements*.trc
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +76,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -89,6 +92,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows/fluent_bit_main.conf
@@ -30,6 +30,7 @@
     DB                ${buffers_dir}/saphana_custom_saphana_custom
     DB.locking        true
     Exclude_Path      /usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver_history*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*loads*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*executed_statements*.trc
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -48,6 +49,7 @@
     DB                ${buffers_dir}/saphana_default_saphana
     DB.locking        true
     Exclude_Path      /usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver_history*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*loads*.trc,/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*executed_statements*.trc
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +76,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -89,6 +92,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/solr_solr_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/solr_solr_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/solr_solr_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux/fluent_bit_main.conf
@@ -42,6 +42,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -57,6 +58,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/fluent_bit_main.conf
@@ -42,6 +42,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -57,6 +58,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/fluent_bit_main.conf
@@ -42,6 +42,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -57,6 +58,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -42,6 +43,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -57,6 +59,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -46,6 +47,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -61,6 +63,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows-2012/fluent_bit_main.conf
@@ -38,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -53,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows/fluent_bit_main.conf
@@ -38,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -53,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -46,6 +47,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -61,6 +63,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows-2012/fluent_bit_main.conf
@@ -38,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -53,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows/fluent_bit_main.conf
@@ -38,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -53,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -46,6 +47,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -61,6 +63,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows-2012/fluent_bit_main.conf
@@ -38,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -53,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows/fluent_bit_main.conf
@@ -38,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -53,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/tomcat_tomcat_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/tomcat_tomcat_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -82,6 +86,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/tomcat_tomcat_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/tomcat_tomcat_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +77,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/tomcat_tomcat_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/tomcat_tomcat_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +77,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/tomcat_custom_tomcat_custom_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/tomcat_custom_tomcat_custom_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/tomcat_default_tomcat_default_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -82,6 +86,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/tomcat_default_tomcat_default_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -117,6 +122,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -132,6 +138,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/tomcat_custom_tomcat_custom_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/tomcat_custom_tomcat_custom_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/tomcat_default_tomcat_default_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +77,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/tomcat_default_tomcat_default_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -109,6 +113,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -124,6 +129,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/tomcat_custom_tomcat_custom_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/tomcat_custom_tomcat_custom_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/tomcat_default_tomcat_default_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -74,6 +77,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/tomcat_default_tomcat_default_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -109,6 +113,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -124,6 +129,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/varnish_varnish
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -67,6 +70,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/varnish_varnish
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/varnish_varnish
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/vault_vault_audit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -53,6 +55,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -68,6 +71,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/vault_vault_audit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/vault_vault_audit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/wildfly_system_wildfly_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -53,6 +55,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -68,6 +71,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/wildfly_system_wildfly_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/wildfly_system_wildfly_system
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/zookeeper_general_zookeeper_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -53,6 +55,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -68,6 +71,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/zookeeper_general_zookeeper_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/zookeeper_general_zookeeper_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/zookeeper_zookeeper_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -53,6 +55,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -68,6 +71,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/zookeeper_zookeeper_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/zookeeper_zookeeper_general
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -60,6 +62,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/fluent_bit_main.conf
@@ -36,6 +36,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -51,6 +52,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/fluent_bit_main.conf
@@ -36,6 +36,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -51,6 +52,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows-2012/fluent_bit_main.conf
@@ -36,6 +36,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -51,6 +52,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows/fluent_bit_main.conf
@@ -36,6 +36,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -51,6 +52,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/iis_iis_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/iis_iis_access
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -59,6 +61,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows-2012/fluent_bit_main.conf
@@ -37,6 +37,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +53,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows/fluent_bit_main.conf
@@ -36,6 +36,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -51,6 +52,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows-2012/fluent_bit_main.conf
@@ -30,6 +30,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -45,6 +46,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows-2012/fluent_bit_main.conf
@@ -38,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -53,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows/fluent_bit_main.conf
@@ -37,6 +37,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +53,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows-2012/fluent_bit_main.conf
@@ -37,6 +37,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +53,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows/fluent_bit_main.conf
@@ -36,6 +36,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -51,6 +52,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/linux/fluent_bit_main.conf
@@ -22,6 +22,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/default_pipeline_syslog
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -37,6 +38,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -52,6 +54,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/fluent_bit_main.conf
@@ -29,6 +29,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-fluent-bit
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail
@@ -44,6 +45,7 @@
     Buffer_Max_Size   2M
     DB                ${buffers_dir}/ops-agent-health
     DB.locking        true
+    Inotify_Watcher   false
     Key               message
     Mem_Buf_Limit     10M
     Name              tail

--- a/kokoro/scripts/test/start_soak_test.sh
+++ b/kokoro/scripts/test/start_soak_test.sh
@@ -13,9 +13,10 @@ for GIT_ALIAS in git github; do
   fi
 done
 
-LOG_RATE=${LOG_RATE-1000} \
+LOG_RATE="100000" \
 LOG_SIZE_IN_BYTES=${LOG_SIZE_IN_BYTES-1000} \
 VM_NAME="${VM_NAME:-github-soak-test-${KOKORO_BUILD_NUMBER}}" \
 DISTRO="${DISTRO:-ubuntu-2004-lts}" \
-TTL="${TTL:-30m}" \
+TTL="360m" \
+AGENT_PACKAGES_IN_GCS="gs://ops-agents-public-buckets-test-logs/prod/stackdriver_agents/testing/consumer/ops_agent/build/focal/6146/20230718-161937/result" \
   go run -tags=integration_test .


### PR DESCRIPTION
Ad-hoc testing indicates that throughput improves significantly if we disable inotify. Let's set up a proper soak test that measures not just throughput but CPU and RAM as well.

This commit will get us a build, and the next commit will customize the soak test presubmit to use that build at 100 MB/s.

## Description
<!--- Describe your changes in detail. -->

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
