### PR TITLE
Fix `debug` level fluent-bit self log spam

### DIFF
--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows-2012/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux/fluent_bit_main.conf
@@ -110,32 +110,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -155,17 +133,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux/fluent_bit_main.conf
@@ -159,32 +159,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -204,17 +182,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/builtin/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/builtin/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/builtin/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/builtin/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/builtin/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/builtin/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/builtin/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/builtin/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/builtin/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/builtin/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/builtin/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/builtin/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux/fluent_bit_main.conf
@@ -68,32 +68,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -113,17 +91,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows-2012/fluent_bit_main.conf
@@ -68,32 +68,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -113,17 +91,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows/fluent_bit_main.conf
@@ -68,32 +68,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -113,17 +91,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux/fluent_bit_main.conf
@@ -182,32 +182,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -227,17 +205,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/fluent_bit_main.conf
@@ -182,32 +182,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -227,17 +205,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/fluent_bit_main.conf
@@ -182,32 +182,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -227,17 +205,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/fluent_bit_main.conf
@@ -501,32 +501,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -546,17 +524,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/fluent_bit_main.conf
@@ -543,32 +543,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -588,17 +566,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/fluent_bit_main.conf
@@ -543,32 +543,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -588,17 +566,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux/fluent_bit_main.conf
@@ -135,32 +135,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -180,17 +158,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/fluent_bit_main.conf
@@ -177,32 +177,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -222,17 +200,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/fluent_bit_main.conf
@@ -177,32 +177,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -222,17 +200,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux/fluent_bit_main.conf
@@ -116,32 +116,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -161,17 +139,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/fluent_bit_main.conf
@@ -158,32 +158,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -203,17 +181,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/fluent_bit_main.conf
@@ -158,32 +158,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -203,17 +181,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/linux/fluent_bit_main.conf
@@ -207,32 +207,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -252,17 +230,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/fluent_bit_main.conf
@@ -249,32 +249,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -294,17 +272,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows/fluent_bit_main.conf
@@ -249,32 +249,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -294,17 +272,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux/fluent_bit_main.conf
@@ -220,32 +220,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -265,17 +243,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/fluent_bit_main.conf
@@ -220,32 +220,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -265,17 +243,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/fluent_bit_main.conf
@@ -220,32 +220,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -265,17 +243,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/linux/fluent_bit_main.conf
@@ -117,32 +117,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -162,17 +140,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows-2012/fluent_bit_main.conf
@@ -159,32 +159,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -204,17 +182,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows/fluent_bit_main.conf
@@ -159,32 +159,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -204,17 +182,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/linux/fluent_bit_main.conf
@@ -111,32 +111,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -156,17 +134,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows-2012/fluent_bit_main.conf
@@ -153,32 +153,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -198,17 +176,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows/fluent_bit_main.conf
@@ -153,32 +153,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -198,17 +176,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/linux/fluent_bit_main.conf
@@ -117,32 +117,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -162,17 +140,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows-2012/fluent_bit_main.conf
@@ -159,32 +159,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -204,17 +182,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows/fluent_bit_main.conf
@@ -159,32 +159,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -204,17 +182,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/linux/fluent_bit_main.conf
@@ -173,32 +173,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -218,17 +196,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows-2012/fluent_bit_main.conf
@@ -215,32 +215,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -260,17 +238,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows/fluent_bit_main.conf
@@ -215,32 +215,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -260,17 +238,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/linux/fluent_bit_main.conf
@@ -117,32 +117,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -162,17 +140,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows-2012/fluent_bit_main.conf
@@ -159,32 +159,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -204,17 +182,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows/fluent_bit_main.conf
@@ -159,32 +159,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -204,17 +182,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/linux/fluent_bit_main.conf
@@ -145,32 +145,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -190,17 +168,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows-2012/fluent_bit_main.conf
@@ -187,32 +187,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -232,17 +210,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows/fluent_bit_main.conf
@@ -187,32 +187,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -232,17 +210,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/fluent_bit_main.conf
@@ -108,32 +108,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -153,17 +131,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/fluent_bit_main.conf
@@ -150,32 +150,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -195,17 +173,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/fluent_bit_main.conf
@@ -150,32 +150,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -195,17 +173,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux/fluent_bit_main.conf
@@ -181,32 +181,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -226,17 +204,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows-2012/fluent_bit_main.conf
@@ -223,32 +223,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -268,17 +246,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows/fluent_bit_main.conf
@@ -223,32 +223,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -268,17 +246,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/linux/fluent_bit_main.conf
@@ -357,32 +357,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -402,17 +380,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows-2012/fluent_bit_main.conf
@@ -399,32 +399,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -444,17 +422,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows/fluent_bit_main.conf
@@ -399,32 +399,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -444,17 +422,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux/fluent_bit_main.conf
@@ -246,32 +246,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -291,17 +269,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows-2012/fluent_bit_main.conf
@@ -288,32 +288,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -333,17 +311,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows/fluent_bit_main.conf
@@ -288,32 +288,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -333,17 +311,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/linux/fluent_bit_main.conf
@@ -736,32 +736,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -781,17 +759,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows-2012/fluent_bit_main.conf
@@ -778,32 +778,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -823,17 +801,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows/fluent_bit_main.conf
@@ -778,32 +778,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -823,17 +801,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/linux/fluent_bit_main.conf
@@ -239,32 +239,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -284,17 +262,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows-2012/fluent_bit_main.conf
@@ -281,32 +281,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -326,17 +304,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows/fluent_bit_main.conf
@@ -281,32 +281,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -326,17 +304,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux/fluent_bit_main.conf
@@ -148,32 +148,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -193,17 +171,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows-2012/fluent_bit_main.conf
@@ -190,32 +190,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -235,17 +213,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows/fluent_bit_main.conf
@@ -190,32 +190,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -235,17 +213,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux/fluent_bit_main.conf
@@ -291,32 +291,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -336,17 +314,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows-2012/fluent_bit_main.conf
@@ -333,32 +333,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -378,17 +356,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows/fluent_bit_main.conf
@@ -333,32 +333,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -378,17 +356,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux/fluent_bit_main.conf
@@ -495,32 +495,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -540,17 +518,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows-2012/fluent_bit_main.conf
@@ -537,32 +537,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -582,17 +560,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows/fluent_bit_main.conf
@@ -537,32 +537,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -582,17 +560,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux/fluent_bit_main.conf
@@ -175,32 +175,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -220,17 +198,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows-2012/fluent_bit_main.conf
@@ -217,32 +217,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -262,17 +240,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows/fluent_bit_main.conf
@@ -217,32 +217,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -262,17 +240,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux/fluent_bit_main.conf
@@ -111,32 +111,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -156,17 +134,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows-2012/fluent_bit_main.conf
@@ -153,32 +153,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -198,17 +176,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows/fluent_bit_main.conf
@@ -153,32 +153,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -198,17 +176,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux/fluent_bit_main.conf
@@ -215,32 +215,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -260,17 +238,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/fluent_bit_main.conf
@@ -257,32 +257,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -302,17 +280,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/fluent_bit_main.conf
@@ -257,32 +257,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -302,17 +280,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux/fluent_bit_main.conf
@@ -141,32 +141,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -186,17 +164,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows-2012/fluent_bit_main.conf
@@ -183,32 +183,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -228,17 +206,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows/fluent_bit_main.conf
@@ -183,32 +183,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -228,17 +206,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux/fluent_bit_main.conf
@@ -109,32 +109,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -154,17 +132,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows-2012/fluent_bit_main.conf
@@ -151,32 +151,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -196,17 +174,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows/fluent_bit_main.conf
@@ -151,32 +151,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -196,17 +174,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux/fluent_bit_main.conf
@@ -129,32 +129,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -174,17 +152,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows-2012/fluent_bit_main.conf
@@ -171,32 +171,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -216,17 +194,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows/fluent_bit_main.conf
@@ -171,32 +171,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -216,17 +194,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux/fluent_bit_main.conf
@@ -129,32 +129,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -174,17 +152,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows-2012/fluent_bit_main.conf
@@ -171,32 +171,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -216,17 +194,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows/fluent_bit_main.conf
@@ -171,32 +171,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -216,17 +194,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux/fluent_bit_main.conf
@@ -109,32 +109,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -154,17 +132,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows-2012/fluent_bit_main.conf
@@ -151,32 +151,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -196,17 +174,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows/fluent_bit_main.conf
@@ -151,32 +151,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -196,17 +174,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux/fluent_bit_main.conf
@@ -141,32 +141,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -186,17 +164,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows-2012/fluent_bit_main.conf
@@ -183,32 +183,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -228,17 +206,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows/fluent_bit_main.conf
@@ -183,32 +183,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -228,17 +206,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux/fluent_bit_main.conf
@@ -142,32 +142,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -187,17 +165,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows-2012/fluent_bit_main.conf
@@ -184,32 +184,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -229,17 +207,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows/fluent_bit_main.conf
@@ -184,32 +184,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -229,17 +207,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux/fluent_bit_main.conf
@@ -141,32 +141,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -186,17 +164,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows-2012/fluent_bit_main.conf
@@ -183,32 +183,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -228,17 +206,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows/fluent_bit_main.conf
@@ -183,32 +183,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -228,17 +206,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux/fluent_bit_main.conf
@@ -135,32 +135,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -180,17 +158,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows-2012/fluent_bit_main.conf
@@ -177,32 +177,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -222,17 +200,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows/fluent_bit_main.conf
@@ -177,32 +177,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -222,17 +200,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux/fluent_bit_main.conf
@@ -141,32 +141,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -186,17 +164,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows-2012/fluent_bit_main.conf
@@ -183,32 +183,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -228,17 +206,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows/fluent_bit_main.conf
@@ -183,32 +183,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -228,17 +206,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/linux/fluent_bit_main.conf
@@ -189,32 +189,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -234,17 +212,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows-2012/fluent_bit_main.conf
@@ -231,32 +231,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -276,17 +254,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows/fluent_bit_main.conf
@@ -231,32 +231,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -276,17 +254,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/linux/fluent_bit_main.conf
@@ -225,32 +225,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -270,17 +248,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows-2012/fluent_bit_main.conf
@@ -267,32 +267,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -312,17 +290,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows/fluent_bit_main.conf
@@ -267,32 +267,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -312,17 +290,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux/fluent_bit_main.conf
@@ -241,32 +241,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -286,17 +264,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows-2012/fluent_bit_main.conf
@@ -283,32 +283,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -328,17 +306,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows/fluent_bit_main.conf
@@ -283,32 +283,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -328,17 +306,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/linux/fluent_bit_main.conf
@@ -711,32 +711,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -756,17 +734,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows-2012/fluent_bit_main.conf
@@ -753,32 +753,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -798,17 +776,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows/fluent_bit_main.conf
@@ -753,32 +753,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -798,17 +776,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux/fluent_bit_main.conf
@@ -181,32 +181,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -226,17 +204,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows-2012/fluent_bit_main.conf
@@ -223,32 +223,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -268,17 +246,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows/fluent_bit_main.conf
@@ -223,32 +223,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -268,17 +246,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/linux/fluent_bit_main.conf
@@ -357,32 +357,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -402,17 +380,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows-2012/fluent_bit_main.conf
@@ -399,32 +399,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -444,17 +422,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows/fluent_bit_main.conf
@@ -399,32 +399,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -444,17 +422,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/linux/fluent_bit_main.conf
@@ -193,32 +193,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -238,17 +216,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows-2012/fluent_bit_main.conf
@@ -235,32 +235,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -280,17 +258,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows/fluent_bit_main.conf
@@ -235,32 +235,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -280,17 +258,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/linux/fluent_bit_main.conf
@@ -391,32 +391,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -436,17 +414,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows-2012/fluent_bit_main.conf
@@ -433,32 +433,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -478,17 +456,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows/fluent_bit_main.conf
@@ -433,32 +433,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -478,17 +456,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/fluent_bit_main.conf
@@ -141,32 +141,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -186,17 +164,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/fluent_bit_main.conf
@@ -183,32 +183,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -228,17 +206,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/fluent_bit_main.conf
@@ -183,32 +183,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -228,17 +206,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux/fluent_bit_main.conf
@@ -240,32 +240,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -285,17 +263,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/fluent_bit_main.conf
@@ -282,32 +282,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -327,17 +305,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/fluent_bit_main.conf
@@ -282,32 +282,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -327,17 +305,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux/fluent_bit_main.conf
@@ -142,32 +142,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -187,17 +165,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows-2012/fluent_bit_main.conf
@@ -184,32 +184,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -229,17 +207,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows/fluent_bit_main.conf
@@ -184,32 +184,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -229,17 +207,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux/fluent_bit_main.conf
@@ -135,32 +135,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -180,17 +158,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows-2012/fluent_bit_main.conf
@@ -177,32 +177,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -222,17 +200,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows/fluent_bit_main.conf
@@ -177,32 +177,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -222,17 +200,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/linux/fluent_bit_main.conf
@@ -223,32 +223,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -268,17 +246,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows-2012/fluent_bit_main.conf
@@ -265,32 +265,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -310,17 +288,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows/fluent_bit_main.conf
@@ -265,32 +265,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -310,17 +288,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux/fluent_bit_main.conf
@@ -142,32 +142,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -187,17 +165,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows-2012/fluent_bit_main.conf
@@ -184,32 +184,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -229,17 +207,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows/fluent_bit_main.conf
@@ -184,32 +184,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -229,17 +207,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/linux/fluent_bit_main.conf
@@ -237,32 +237,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -282,17 +260,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows-2012/fluent_bit_main.conf
@@ -279,32 +279,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -324,17 +302,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows/fluent_bit_main.conf
@@ -279,32 +279,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -324,17 +302,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux/fluent_bit_main.conf
@@ -141,32 +141,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -186,17 +164,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows-2012/fluent_bit_main.conf
@@ -183,32 +183,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -228,17 +206,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows/fluent_bit_main.conf
@@ -183,32 +183,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -228,17 +206,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux/fluent_bit_main.conf
@@ -138,32 +138,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -183,17 +161,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/fluent_bit_main.conf
@@ -138,32 +138,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -183,17 +161,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/fluent_bit_main.conf
@@ -138,32 +138,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -183,17 +161,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux/fluent_bit_main.conf
@@ -174,32 +174,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -219,17 +197,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/linux/fluent_bit_main.conf
@@ -104,32 +104,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -149,17 +127,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows-2012/fluent_bit_main.conf
@@ -146,32 +146,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -191,17 +169,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows/fluent_bit_main.conf
@@ -146,32 +146,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -191,17 +169,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/linux/fluent_bit_main.conf
@@ -104,32 +104,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -149,17 +127,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows-2012/fluent_bit_main.conf
@@ -146,32 +146,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -191,17 +169,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows/fluent_bit_main.conf
@@ -146,32 +146,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -191,17 +169,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/linux/fluent_bit_main.conf
@@ -104,32 +104,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -149,17 +127,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows-2012/fluent_bit_main.conf
@@ -146,32 +146,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -191,17 +169,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows/fluent_bit_main.conf
@@ -146,32 +146,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -191,17 +169,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux/fluent_bit_main.conf
@@ -187,32 +187,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -232,17 +210,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows-2012/fluent_bit_main.conf
@@ -229,32 +229,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -274,17 +252,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows/fluent_bit_main.conf
@@ -229,32 +229,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -274,17 +252,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/linux/fluent_bit_main.conf
@@ -429,32 +429,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -474,17 +452,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows-2012/fluent_bit_main.conf
@@ -471,32 +471,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -516,17 +494,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows/fluent_bit_main.conf
@@ -471,32 +471,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -516,17 +494,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux/fluent_bit_main.conf
@@ -135,32 +135,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -180,17 +158,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows-2012/fluent_bit_main.conf
@@ -177,32 +177,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -222,17 +200,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows/fluent_bit_main.conf
@@ -177,32 +177,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -222,17 +200,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux/fluent_bit_main.conf
@@ -141,32 +141,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -186,17 +164,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows-2012/fluent_bit_main.conf
@@ -183,32 +183,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -228,17 +206,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows/fluent_bit_main.conf
@@ -183,32 +183,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -228,17 +206,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux/fluent_bit_main.conf
@@ -141,32 +141,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -186,17 +164,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows-2012/fluent_bit_main.conf
@@ -183,32 +183,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -228,17 +206,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows/fluent_bit_main.conf
@@ -183,32 +183,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -228,17 +206,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux/fluent_bit_main.conf
@@ -142,32 +142,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -187,17 +165,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows-2012/fluent_bit_main.conf
@@ -184,32 +184,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -229,17 +207,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows/fluent_bit_main.conf
@@ -184,32 +184,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -229,17 +207,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux/fluent_bit_main.conf
@@ -142,32 +142,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -187,17 +165,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows-2012/fluent_bit_main.conf
@@ -184,32 +184,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -229,17 +207,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows/fluent_bit_main.conf
@@ -184,32 +184,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -229,17 +207,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/fluent_bit_main.conf
@@ -194,32 +194,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -239,17 +217,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/fluent_bit_main.conf
@@ -194,32 +194,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -239,17 +217,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows-2012/fluent_bit_main.conf
@@ -200,32 +200,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -245,17 +223,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows/fluent_bit_main.conf
@@ -200,32 +200,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -245,17 +223,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/fluent_bit_main.conf
@@ -188,32 +188,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -233,17 +211,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/fluent_bit_main.conf
@@ -188,32 +188,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -233,17 +211,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows-2012/fluent_bit_main.conf
@@ -171,32 +171,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -216,17 +194,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows/fluent_bit_main.conf
@@ -170,32 +170,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -215,17 +193,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows-2012/fluent_bit_main.conf
@@ -108,32 +108,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -153,17 +131,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows/fluent_bit_main.conf
@@ -107,32 +107,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -152,17 +130,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows-2012/fluent_bit_main.conf
@@ -177,32 +177,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -222,17 +200,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows/fluent_bit_main.conf
@@ -176,32 +176,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -221,17 +199,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows-2012/fluent_bit_main.conf
@@ -171,32 +171,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -216,17 +194,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows/fluent_bit_main.conf
@@ -170,32 +170,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -215,17 +193,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/linux/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/linux/fluent_bit_main.conf
@@ -89,32 +89,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -134,17 +112,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/3e10dd4476476f1d0ff47d23c99dbe5e.lua
@@ -1,0 +1,20 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+else v = nil
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/fluent_bit_main.conf
@@ -131,32 +131,10 @@
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
 
 [FILTER]
-    Add       logging.googleapis.com/severity DEBUG
-    Condition Key_Value_Equals severity debug
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity ERROR
-    Condition Key_Value_Equals severity error
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity INFO
-    Condition Key_Value_Equals severity info
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
-
-[FILTER]
-    Add       logging.googleapis.com/severity WARNING
-    Condition Key_Value_Equals severity warn
-    Match     ops-agent-fluent-bit
-    Name      modify
-    Remove    severity
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   process
+    script 3e10dd4476476f1d0ff47d23c99dbe5e.lua
 
 [FILTER]
     Match  ops-agent-health
@@ -176,17 +154,6 @@
     Name   lua
     call   parser_merge_record
     script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
-
-[FILTER]
-    Match ops-agent-health
-    Name  grep
-    Regex severity INFO|ERROR|WARNING|DEBUG|DEFAULT
-
-[FILTER]
-    Name   modify
-    Match  ops-agent-health
-    Rename severity logging.googleapis.com/severity
-    Rename sourceLocation logging.googleapis.com/sourceLocation
 
 [FILTER]
     Match  ops-agent-health

--- a/internal/logs/logs.go
+++ b/internal/logs/logs.go
@@ -26,8 +26,8 @@ import (
 
 const (
 	MessageZapKey        string = "message"
-	SeverityZapKey       string = "severity"
-	SourceLocationZapKey string = "sourceLocation"
+	SeverityZapKey       string = "logging.googleapis.com/severity"
+	SourceLocationZapKey string = "logging.googleapis.com/sourceLocation"
 	TimeZapKey           string = "time"
 )
 


### PR DESCRIPTION
## Description
Using lua scripts from `modify_filter` and `exclude_logs` will avoid the endless loop of `debug` messages in `logging-module.log`.

## Related issue
b/272779619

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
