### PR TITLE
Disable GPG checks when installing MySQL on SLES 12.

### DIFF
--- a/integration_test/third_party_apps_data/applications/mysql/sles/install
+++ b/integration_test/third_party_apps_data/applications/mysql/sles/install
@@ -23,7 +23,7 @@ else
   # Installation followed in: https://dev.mysql.com/doc/mysql-sles-repo-quick-guide/en/
   sudo zypper -n --no-gpg-checks install https://dev.mysql.com/get/${mysql_repo_pkg_name}
   sudo rpm --import https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
-  sudo zypper -n install mysql-community-server
+  sudo zypper -n --no-gpg-checks install mysql-community-server
 fi
 
 if [[ "${SUSE_VERSION}" == 12 ]]; then

--- a/integration_test/third_party_apps_data/applications/mysql5.7/sles/install
+++ b/integration_test/third_party_apps_data/applications/mysql5.7/sles/install
@@ -27,7 +27,7 @@ else
   sudo zypper modifyrepo -d mysql80-community
   sudo zypper modifyrepo -e mysql57-community
 
-  sudo zypper -n install mysql-community-server
+  sudo zypper -n --no-gpg-checks install mysql-community-server
 fi
 
 if [[ "${SUSE_VERSION}" == 12 ]]; then


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Fixes the `Signature verification failed for file 'repomd.xml'` errors on SLES 12 by disabling GPG checks when installing MySQL.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->
[b/291646832](http://b/291646832)

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->
https://source.cloud.google.com/results/invocations/700bac29-0a78-425b-a441-0ccab79e29a9

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
