### PR TITLE
Add tzdata-java to install scripts

### DIFF
--- a/integration_test/third_party_apps_data/applications/jetty/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/jetty/centos_rhel/install
@@ -4,7 +4,7 @@ set -e
 # wget https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.4.46.v20220331/jetty-distribution-9.4.46.v20220331.tar.gz
 # wget https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/10.0.9/jetty-home-10.0.9.tar.gz
 
-sudo yum install -y wget java-11-openjdk-devel
+sudo yum install -y wget java-11-openjdk-devel tzdata-java
 sudo wget -O jetty.tar.gz https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/11.0.9/jetty-home-11.0.9.tar.gz
 sudo mkdir -p /opt/jetty
 

--- a/integration_test/third_party_apps_data/applications/jetty/sles/install
+++ b/integration_test/third_party_apps_data/applications/jetty/sles/install
@@ -6,7 +6,7 @@ set -e
 
 JETTY_VERSION=11.0.15
 
-sudo zypper install -y wget java-11-openjdk
+sudo zypper install -y wget java-11-openjdk tzdata-java
 sudo wget https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/"$JETTY_VERSION"/jetty-home-"$JETTY_VERSION".tar.gz
 sudo mkdir -p /opt/jetty
 

--- a/integration_test/third_party_apps_data/applications/kafka/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/kafka/centos_rhel/install
@@ -1,6 +1,6 @@
 set -e
 
-sudo yum install -y curl java
+sudo yum install -y curl java tzdata-java
 sudo mkdir -p /opt/kafka/stage
 # https://github.com/GoogleCloudPlatform/ops-agent/blob/master/integration_test/README.md#vendored-dependencies
 sudo curl "https://storage.googleapis.com/ops-agents-public-buckets-vendored-deps/mirrored-content/archive.apache.org/dist/kafka/3.0.1/kafka_2.12-3.0.1.tgz" -o /opt/kafka/stage/kafka.tgz

--- a/integration_test/third_party_apps_data/applications/tomcat/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/tomcat/centos_rhel/install
@@ -1,6 +1,6 @@
 set -e
 
-sudo yum install -y curl java
+sudo yum install -y curl java tzdata-java
 sudo mkdir -p /opt/tomcat/stage
 # https://github.com/GoogleCloudPlatform/ops-agent/blob/master/integration_test/README.md#vendored-dependencies
 sudo curl "https://storage.googleapis.com/ops-agents-public-buckets-vendored-deps/mirrored-content/archive.apache.org/dist/tomcat/tomcat-9/v9.0.58/bin/apache-tomcat-9.0.58.tar.gz" -o /opt/tomcat/stage/tomcat.tgz

--- a/integration_test/third_party_apps_data/applications/wildfly/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/wildfly/centos_rhel/install
@@ -1,6 +1,6 @@
 set -e
 
-sudo yum install -y curl java
+sudo yum install -y curl java tzdata-java
 
 curl -L \
     -o wildfly.tar.gz \

--- a/integration_test/third_party_apps_data/applications/zookeeper/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/zookeeper/centos_rhel/install
@@ -1,6 +1,6 @@
 set -e
 
-sudo yum install -y curl java
+sudo yum install -y curl java tzdata-java
 
 sudo mkdir -p /opt/zookeeper/stage
 # https://github.com/GoogleCloudPlatform/ops-agent/blob/master/integration_test/README.md#vendored-dependencies


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Attempting to fix test issues like the following that cropped up overnight for rockylinux & centos builds.

```
        + /opt/kafka/bin/kafka-topics.sh --create --topic quickstart-events --bootstrap-server localhost:9092 --partitions 3 --replication-factor 1
        log4j:WARN Failed to set property [conversionPattern] to value "[%d] %p %m (%c)%n". 
        java.lang.reflect.InvocationTargetException
...
        Caused by: java.lang.Error: java.io.FileNotFoundException: /usr/lib/jvm/java-11-openjdk-11.0.20.0.8-2.el9.x86_64/lib/tzdb.dat (No such file or directory)
...
        Caused by: java.io.FileNotFoundException: /usr/lib/jvm/java-11-openjdk-11.0.20.0.8-2.el9.x86_64/lib/tzdb.dat (No such file or directory)
...
        [AdminClient clientId=adminclient-1] Connection to node -1 (localhost/127.0.0.1:9092) could not be established. Broker may not be available.
```