### PR TITLE
dockerfile: add tzdata-java to build deps for rl9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -279,7 +279,7 @@ RUN set -x; dnf -y update && \
 		dnf -y install git systemd \
 		autoconf libtool libcurl-devel libtool-ltdl-devel openssl-devel yajl-devel \
 		gcc gcc-c++ make cmake bison flex file systemd-devel zlib-devel gtest-devel rpm-build systemd-rpm-macros java-11-openjdk-devel \
-		expect rpm-sign zip
+		expect rpm-sign zip tzdata-java
 	
 		ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk/
 

--- a/dockerfiles/compile.go
+++ b/dockerfiles/compile.go
@@ -99,7 +99,7 @@ var dockerfileArguments = []templateArguments{
 		dnf -y install git systemd \
 		autoconf libtool libcurl-devel libtool-ltdl-devel openssl-devel yajl-devel \
 		gcc gcc-c++ make cmake bison flex file systemd-devel zlib-devel gtest-devel rpm-build systemd-rpm-macros java-11-openjdk-devel \
-		expect rpm-sign zip
+		expect rpm-sign zip tzdata-java
 	
 		ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk/`,
 		package_build:     "RUN ./pkg/rpm/build.sh",


### PR DESCRIPTION
## Description
Fixes the presubmit failures on rl9.

## Related issue
b/293460457


## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
