### PR TITLE
Preserve REPO_CODENAME in the environment.

### DIFF
--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -684,6 +684,10 @@ type PackageLocation struct {
 	// Package repository suffix to install from. Setting this and packagesInGCS
 	// to "" means to install the latest stable release.
 	repoSuffix string
+	// Override the codename for the agent repository.
+	// This setting is only used for ARM builds at the moment, and ignored when
+	// installing from Artifact Registry.
+	repoCodename string
 	// Region the packages live in in Artifact Registry. Requires repoSuffix
 	// to be nonempty.
 	artifactRegistryRegion string
@@ -694,6 +698,7 @@ func LocationFromEnvVars() PackageLocation {
 	return PackageLocation{
 		packagesInGCS:          os.Getenv("AGENT_PACKAGES_IN_GCS"),
 		repoSuffix:             os.Getenv("REPO_SUFFIX"),
+		repoCodename:           os.Getenv("REPO_CODENAME"),
 		artifactRegistryRegion: os.Getenv("ARTIFACT_REGISTRY_REGION"),
 	}
 }
@@ -733,6 +738,7 @@ func InstallOpsAgent(ctx context.Context, logger *log.Logger, vm *gce.VM, locati
 
 	preservedEnvironment := map[string]string{
 		"REPO_SUFFIX":              location.repoSuffix,
+		"REPO_CODENAME":            location.repoCodename,
 		"ARTIFACT_REGISTRY_REGION": location.artifactRegistryRegion,
 	}
 


### PR DESCRIPTION
## Description
This change allows passing `REPO_CODENAME` into the test environment, so that agents can be installed from a different repo name (e.g., `bullseye-arm64`).

## Related issue
[b/294439160](http://b/294439160)

## How has this been tested?
I passed `REPO_CODENAME=bullseye` into a set of Debian 11 third-party tests, which [succeeded](https://source.cloud.google.com/results/invocations/3f64e0e9-6f9c-4903-a797-8b81c1fceaeb) as expected.
I've also passed `REPO_CODENAME=bullseye-arm64` into a set of Debian 11 ARM third-party tests, which [failed](https://source.cloud.google.com/results/invocations/beda94d6-8105-4907-8f7f-86929494f904) as expected, but each failed test VM tried to access the correctly named repos.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
