### PR TITLE
Testing: disable OS Config patch management for soak tests

### DIFF
--- a/integration_test/soak_test/cmd/launcher/main.go
+++ b/integration_test/soak_test/cmd/launcher/main.go
@@ -107,10 +107,10 @@ func mainErr() error {
 			"ttl": strconv.Itoa(int(parsedTTL / time.Minute)),
 		},
 		Metadata: map[string]string{
-			// This is to avoid b/295165549 on Windows and also
-			// to avoid throughput blips when the OS Config agent
-			// runs periodically.
-			"enable-osconfig": "FALSE",
+			// This is to avoid Windows updates and reboots (b/295165549), and
+			// also to avoid throughput blips when the OS Config agent runs
+			// periodically.
+			"osconfig-disabled-features": "tasks",
 		}
 		ExtraCreateArguments: []string{"--boot-disk-size=4000GB"},
 	}

--- a/integration_test/soak_test/cmd/launcher/main.go
+++ b/integration_test/soak_test/cmd/launcher/main.go
@@ -111,7 +111,7 @@ func mainErr() error {
 			// also to avoid throughput blips when the OS Config agent runs
 			// periodically.
 			"osconfig-disabled-features": "tasks",
-		}
+		},
 		ExtraCreateArguments: []string{"--boot-disk-size=4000GB"},
 	}
 	vm, err := gce.CreateInstance(ctx, logger, options)

--- a/integration_test/soak_test/cmd/launcher/main.go
+++ b/integration_test/soak_test/cmd/launcher/main.go
@@ -106,6 +106,12 @@ func mainErr() error {
 		Labels: map[string]string{
 			"ttl": strconv.Itoa(int(parsedTTL / time.Minute)),
 		},
+		Metadata: map[string]string{
+			// This is to avoid b/295165549 on Windows and also
+			// to avoid throughput blips when the OS Config agent
+			// runs periodically.
+			"enable-osconfig": "FALSE",
+		}
 		ExtraCreateArguments: []string{"--boot-disk-size=4000GB"},
 	}
 	vm, err := gce.CreateInstance(ctx, logger, options)


### PR DESCRIPTION
## Description
This is to avoid mid-test reboots. The idea is to disable patch management features in OS Config: https://cloud.google.com/compute/docs/manage-os#disable-features

## Related issue
b/295165549

## How has this been tested?
automated tests only

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
