### PR TITLE
Unenforce the `otlp_receiver` feature flag

### DIFF
--- a/confgenerator/confgenerator_test.go
+++ b/confgenerator/confgenerator_test.go
@@ -315,6 +315,6 @@ func init() {
 	// Set up the test environment with mocked data.
 	confgenerator.MetadataResource = testResource
 
-	// Enable experimental features.
-	os.Setenv("EXPERIMENTAL_FEATURES", "otlp_receiver")
+	// Enable experimental features here by calling:
+	//	 os.Setenv("EXPERIMENTAL_FEATURES", "...(comma-separated feature list)...")
 }

--- a/confgenerator/experimental.go
+++ b/confgenerator/experimental.go
@@ -22,9 +22,18 @@ import (
 	"github.com/go-playground/validator/v10"
 )
 
-var requiredFeatureForType = map[string]string{
-	"otlp": "otlp_receiver",
-}
+// requiredFeatureForType maps a component type to a feature that must
+// be enabled (via EXPERIMENTAL_FEATURES) in order to use that component
+// in an Ops Agent configuration.
+// For example, the following would require the user to define the
+// "otlp_receiver" feature flag inside EXPERIMENTAL_FEATURES in order to
+// be able to use the "otlp" combined receiver:
+//
+//	"otlp": "otlp_receiver"
+//
+// N.B. There are no enforced feature flags today, so this map is
+// intentionally left empty.
+var requiredFeatureForType = map[string]string{}
 
 func IsExperimentalFeatureEnabled(feature string) bool {
 	enabledList := strings.Split(os.Getenv("EXPERIMENTAL_FEATURES"), ",")

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -3603,12 +3603,6 @@ func TestOTLPMetricsGCM(t *testing.T) {
 	gce.RunForEachPlatform(t, func(t *testing.T, platform string) {
 		t.Parallel()
 		ctx, logger, vm := agents.CommonSetup(t, platform)
-
-		// Turn on the otlp feature gate.
-		if err := gce.SetEnvironmentVariables(ctx, logger.ToMainLog(), vm, map[string]string{"EXPERIMENTAL_FEATURES": "otlp_receiver"}); err != nil {
-			t.Fatal(err)
-		}
-
 		otlpConfig := `
 combined:
   receivers:
@@ -3714,12 +3708,6 @@ func TestOTLPMetricsGMP(t *testing.T) {
 	gce.RunForEachPlatform(t, func(t *testing.T, platform string) {
 		t.Parallel()
 		ctx, logger, vm := agents.CommonSetup(t, platform)
-
-		// Turn on the otlp feature gate.
-		if err := gce.SetEnvironmentVariables(ctx, logger.ToMainLog(), vm, map[string]string{"EXPERIMENTAL_FEATURES": "otlp_receiver"}); err != nil {
-			t.Fatal(err)
-		}
-
 		otlpConfig := `
 combined:
   receivers:
@@ -3818,12 +3806,6 @@ func TestOTLPTraces(t *testing.T) {
 	gce.RunForEachPlatform(t, func(t *testing.T, platform string) {
 		t.Parallel()
 		ctx, logger, vm := agents.CommonSetup(t, platform)
-
-		// Turn on the otlp feature gate.
-		if err := gce.SetEnvironmentVariables(ctx, logger.ToMainLog(), vm, map[string]string{"EXPERIMENTAL_FEATURES": "otlp_receiver"}); err != nil {
-			t.Fatal(err)
-		}
-
 		otlpConfig := `
 combined:
   receivers:
@@ -4056,7 +4038,6 @@ func TestParsingFailureCheck(t *testing.T) {
 
 	})
 }
-
 
 func TestBufferLimitSizeOpsAgent(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Description
Unenforce the `otlp_receiver` feature flag

## Related issue
b/292091381

## How has this been tested?
Unit tests pass, will let the presubmits run the integration tests.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
  - [x] This PR introduces user visible changes and the corresponding documentation changes are planned for a later date.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [x] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
