### PR TITLE
Add ImageFamily field to VMOptions and silently replace Platform

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1797,7 +1797,7 @@ func SetupLogger(t *testing.T) *logging.DirectoryLogger {
 
 // VMOptions specifies settings when creating a VM via CreateInstance() or SetupVM().
 type VMOptions struct {
-	// Required. Normally passed as --image-family to
+	// Deprecated. Normally passed as --image-family to
 	// "gcloud compute images create".
 	Platform string
 	// Required. Normally passed as --image-family to
@@ -1834,7 +1834,6 @@ type VMOptions struct {
 // If VM creation fails, it will abort the test.
 // At the end of the test, the VM will be cleaned up.
 func SetupVM(ctx context.Context, t *testing.T, logger *log.Logger, options VMOptions) *VM {
-	options.ImageFamily = options.Platform // Temporary until 'Platform' is fully replaced.
 	t.Helper()
 	vm, err := CreateInstance(ctx, logger, options)
 	if err != nil {


### PR DESCRIPTION
## Description

We recently decided to rename the 'Platform' field in VMOptions to 'ImageFamily' to make our code easier to read. 

In this PR, we add a field called 'ImageFamily' and silently replace all usages of Platform internally to use the new field instead. 

In the next PR, we will update all call sites and then eventually remove the Platform field all together. 

## Related issue

[b/295174028](http://b/295174028)

