### PR TITLE
Testing: add build configs for soak test launcher test for windows

### DIFF
--- a/integration_test/soak_test/cmd/launcher/main.go
+++ b/integration_test/soak_test/cmd/launcher/main.go
@@ -53,6 +53,7 @@ package main
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -96,6 +97,9 @@ func mainErr() error {
 	parsedTTL, err := time.ParseDuration(ttl)
 	if err != nil {
 		return fmt.Errorf("Could not parse TTL duration %q: %w", ttl, err)
+	}
+	if distro == "" {
+		return errors.New("Env variable DISTRO cannot be empty")
 	}
 
 	// Create the VM.

--- a/kokoro/config/test/soak/presubmit.gcl
+++ b/kokoro/config/test/soak/presubmit.gcl
@@ -1,3 +1,5 @@
+// TODO: Delete this file once presubmit_linux.gcl is hooked up.
+
 import 'common.gcl' as common
 
 config build = common.soak_test {}

--- a/kokoro/config/test/soak/presubmit.gcl
+++ b/kokoro/config/test/soak/presubmit.gcl
@@ -2,4 +2,10 @@
 
 import 'common.gcl' as common
 
-config build = common.soak_test {}
+config build = common.soak_test {
+  params {
+    environment {
+      DISTRO = 'ubuntu-2004-lts'
+    }
+  }
+}

--- a/kokoro/config/test/soak/presubmit_linux.gcl
+++ b/kokoro/config/test/soak/presubmit_linux.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+
+config build = common.soak_test {
+  params {
+    environment {
+      DISTRO = 'ubuntu-2004-lts'
+    }
+  }
+}

--- a/kokoro/config/test/soak/presubmit_windows.gcl
+++ b/kokoro/config/test/soak/presubmit_windows.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+
+config build = common.soak_test {
+  params {
+    environment {
+      DISTRO = 'windows-2022'
+    }
+  }
+}

--- a/kokoro/scripts/test/start_soak_test.sh
+++ b/kokoro/scripts/test/start_soak_test.sh
@@ -16,6 +16,5 @@ done
 LOG_RATE=${LOG_RATE-1000} \
 LOG_SIZE_IN_BYTES=${LOG_SIZE_IN_BYTES-1000} \
 VM_NAME="${VM_NAME:-github-soak-test-${KOKORO_BUILD_NUMBER}}" \
-DISTRO="${DISTRO:-ubuntu-2004-lts}" \
 TTL="${TTL:-30m}" \
   go run -tags=integration_test .


### PR DESCRIPTION
## Description
"Soak Test Launcher Test" is Linux only, so I can't really test https://github.com/GoogleCloudPlatform/ops-agent/pull/1389 without hacking it up a bit.

This PR is the beginning of adding a "Soak Test Launcher Test" for Windows.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
