### PR TITLE
Testing: fix conflict for soak test presubmit

### DIFF
--- a/kokoro/scripts/test/start_soak_test.sh
+++ b/kokoro/scripts/test/start_soak_test.sh
@@ -15,6 +15,6 @@ done
 
 LOG_RATE=${LOG_RATE-1000} \
 LOG_SIZE_IN_BYTES=${LOG_SIZE_IN_BYTES-1000} \
-VM_NAME="${VM_NAME:-github-soak-test-${KOKORO_BUILD_NUMBER}}" \
+VM_NAME="${VM_NAME:-github-soak-test-${KOKORO_BUILD_ID}}" \
 TTL="${TTL:-30m}" \
   go run -tags=integration_test .


### PR DESCRIPTION
## Description
I recently added a Windows soak test presubmit. Now the Linux and Windows ones are fighting, and the first one to snag KOKORO_BUILD_NUMBER passes, while the other one, which happens to get the same KOKORO_BUILD_NUMBER because both Linux and Windows presubmits are new and are running in lockstep, clashes with it and fails with a "VM already exists" error: https://source.cloud.google.com/results/invocations/ce014204-a27b-43a9-995c-d3b50a015432/targets/stackdriver_agents%2Ftesting%2Fconsumer%2Fops_agent%2Fsoak_test%2Fpresubmit_windows/log

KOKORO_BUILD_NUMBER was unique when there was only one presubmit job, but it's not unique anymore. So Use KOKORO_BUILD_ID instead.

## Related issue
b/297357060

## How has this been tested?
"Soak test Launcher Test ({Linux,Windows})" should both pass on this PR.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
