### PR TITLE
Fix Bug in Diagnostic Tool Integratioon

### DIFF
--- a/cmd/simulacra/simulacra.go
+++ b/cmd/simulacra/simulacra.go
@@ -237,7 +237,7 @@ func parseImageFromMetadata(name string) (string, string, string, error) {
 // prefix, "/projects", the value is parsed for the project, scope, image.
 // Otherwise, we ask for the image family from the user using command line input.
 func getImageInfo(name string) (string, string, string, string, error) {
-	if strings.HasPrefix(name, "/projects") {
+	if strings.HasPrefix(name, "projects/") {
 		imgProject, scope, image, err := parseImageFromMetadata(name)
 		return imgProject, scope, image, "", err
 	}

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1130,7 +1130,7 @@ func attemptCreateInstance(ctx context.Context, logger *log.Logger, options VMOp
 		return nil, fmt.Errorf("attemptCreateInstance() could not construct valid labels: %v", err)
 	}
 
-	imageOrImageFamilyFlag := "--image=" + options.Platform
+	imageOrImageFamilyFlag := "--image=" + options.Image
 
 	if options.Platform != "" {
 		imageOrImageFamilyFlag = "--image-family=" + options.Platform


### PR DESCRIPTION
## Description

There was 2 bugs in the diagnostic tool integration. The first was in the prefix i used. I used "/projects" instead of "projects/". The second was on the integration testing side where I used the Platform field of the options struct instead of image. 

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
