### PR TITLE
Fix failing integration tests on focal-arm64

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -470,9 +470,6 @@ func nonEmptySeriesList(logger *log.Logger, it *monitoring.TimeSeriesIterator, m
 			// Look at the next element(s) of the iterator.
 			continue
 		}
-		if len(tsList) >= minimumRequiredSeries {
-			return tsList, nil
-		}
 		tsList = append(tsList, series)
 	}
 }

--- a/integration_test/third_party_apps_data/applications/couchbase/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/couchbase/debian_ubuntu/install
@@ -2,13 +2,12 @@
 
 set -e
 
-ARCH=$(dpkg --print-architecture)
-
 sudo apt-get update
 sudo apt-get install -y gnupg bzip2 wget curl libncurses5
 
-curl -O "https://packages.couchbase.com/releases/couchbase-release/couchbase-release-1.0-${ARCH}.deb"
-sudo dpkg -i "couchbase-release-1.0-${ARCH}.deb"
+# N.B. Despite having "amd64" in the name, this is an "Architecture: all" package.
+curl -O "https://packages.couchbase.com/releases/couchbase-release/couchbase-release-1.0-amd64.deb"
+sudo dpkg -i "couchbase-release-1.0-amd64.deb"
 sudo apt-get update
 
 sudo apt-get install -y couchbase-server-community

--- a/integration_test/third_party_apps_data/applications/dcgm/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/dcgm/metadata.yaml
@@ -34,6 +34,7 @@ platforms_to_skip:
   - rocky-linux-9
   - sles-12
   - sles-15
+  - ubuntu-2004-lts-arm64
   - ubuntu-2304-amd64
 gpu_models: # p4, k80, p100 don't support DCGM profiling metrics
   - a100

--- a/integration_test/third_party_apps_data/applications/mariadb/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/mariadb/debian_ubuntu/install
@@ -8,6 +8,8 @@ sudo apt install -y \
 # information on how to configure multiple mysql instances on the same
 # machine.
 
+mariadb_version=$(dpkg-query --showformat='${Source}' --show mariadb-server)
+
 # set up replication source to validate replica metrics
 # set main target (replica) to use binary logging for replication to work
 
@@ -15,6 +17,7 @@ sudo apt install -y \
 # log_error forces the log to be written to a file instead, but this means the
 # mysql_error receiver doesn't work with the default MariaDB configuration on
 # Debian 11.
+
 sudo tee /etc/mysql/mariadb.conf.d/99-replicas.cnf >/dev/null <<EOF
 [mysqld]
 general-log
@@ -34,6 +37,24 @@ datadir = /var/lib/mysql2/
 server-id = 2
 log-bin
 EOF
+
+# mariadb 10.3 in focal/buster uses a different config file for secondary instances
+# mariadb >10.3 will refuse to start up if this config file is present, so only install on old distros.
+if [ "$mariadb_version" = "mariadb-10.3" ]; then
+  sudo tee /etc/mysql/conf.d/myprimary.cnf >/dev/null <<EOF
+[client-server]
+!includedir /etc/mysql/conf.d/
+!includedir /etc/mysql/mariadb.conf.d/
+[mysqld]
+pid-file = /run/mysqld/mysqld2.pid
+socket = /run/mysqld/mysql2.sock
+port = 3307
+user = mysql
+datadir = /var/lib/mysql2/
+server-id = 2
+log-bin
+EOF
+fi
 
 # prepare config and data permissions
 sudo mkdir /var/lib/mysql2

--- a/integration_test/third_party_apps_data/applications/mariadb/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/mariadb/debian_ubuntu/install
@@ -41,6 +41,9 @@ EOF
 # mariadb 10.3 in focal/buster uses a different config file for secondary instances
 # mariadb >10.3 will refuse to start up if this config file is present, so only install on old distros.
 if [ "$mariadb_version" = "mariadb-10.3" ]; then
+  # Change the default config file to not read myprimary.cnf. Otherwise the
+  # default instance will also use the alternate paths.
+  sudo sed -i '/\/conf\.d\//d' /etc/mysql/mariadb.cnf
   sudo tee /etc/mysql/conf.d/myprimary.cnf >/dev/null <<EOF
 [client-server]
 !includedir /etc/mysql/conf.d/

--- a/integration_test/third_party_apps_data/applications/mariadb/enable
+++ b/integration_test/third_party_apps_data/applications/mariadb/enable
@@ -24,6 +24,11 @@ logging:
       type: mysql_general
     mysql_slow:
       type: mysql_slow
+    # Collect the primary's error log just for debugging the test
+    mysql_error_2:
+      type: mysql_error
+      include_paths:
+      - /run/mysqld/mysqld2.err
   service:
     pipelines:
       mysql:
@@ -31,6 +36,9 @@ logging:
           - mysql_error
           - mysql_general
           - mysql_slow
+      mysql2:
+        receivers:
+          - mysql_error_2
 EOF
 
 sudo service google-cloud-ops-agent restart

--- a/integration_test/third_party_apps_data/applications/mariadb/exercise
+++ b/integration_test/third_party_apps_data/applications/mariadb/exercise
@@ -23,7 +23,12 @@ mysql2 -e "CREATE USER 'repl'@'localhost' IDENTIFIED BY 'password';"
 mysql2 -e "GRANT REPLICATION SLAVE ON *.* TO 'repl'@'localhost';"
 
 # Dump data from replica source
-sudo mysqldump -S /run/mysqld/mysql2.sock --all-databases --apply-slave-statements --master-data | \
+
+# Note: net-buffer-length sets the max size of an INSERT statement,
+# which then trickles down to the max line length in the secondary's
+# slow query log.
+
+sudo mysqldump -S /run/mysqld/mysql2.sock --all-databases --apply-slave-statements --master-data --net-buffer-length=65535 | \
   sed "s/^\(CHANGE MASTER TO\)/\1 MASTER_HOST='localhost', MASTER_PORT=3307, MASTER_USER='repl', MASTER_PASSWORD='password', /" | \
   mysql1
 

--- a/integration_test/third_party_apps_data/applications/mariadb/features.yaml
+++ b/integration_test/third_party_apps_data/applications/mariadb/features.yaml
@@ -7,11 +7,15 @@ features:
   module: logging
   key: "[0].enabled"
   value: true
-- feature: receivers:mysql_general
+- feature: receivers:mysql_error
   module: logging
   key: "[1].enabled"
   value: true
-- feature: receivers:mysql_slow
+- feature: receivers:mysql_general
   module: logging
   key: "[2].enabled"
+  value: true
+- feature: receivers:mysql_slow
+  module: logging
+  key: "[3].enabled"
   value: true

--- a/integration_test/third_party_apps_data/applications/mariadb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mariadb/metadata.yaml
@@ -41,9 +41,7 @@ configure_integration: |-
 supported_operating_systems: linux
 platforms_to_skip:
   # TODO: Enable MariaDB testing on all supported platforms.
-  - debian-10 # Requires different config file location
   - debian-12 # Requires an update to handle HOSTNAME changes
-  - ubuntu-2004-lts # Requires different config file location
   - ubuntu-2304-amd64 # LogEntry max size exceeded errors
   - centos-7
   - rocky-linux-8

--- a/integration_test/third_party_apps_data/applications/mongodb3.6/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mongodb3.6/metadata.yaml
@@ -30,6 +30,7 @@ platforms_to_skip:
   # MongoDB3.6 hit end of life in 2021 and is not supported on Rocky Linux 9, Ubuntu 20.04, Ubuntu 22.04, Ubuntu 23.04, Debian 10, Debian 11, or Debian 12
   - rocky-linux-9
   - ubuntu-2004-lts
+  - ubuntu-2004-lts-arm64
   - ubuntu-2204-lts
   - ubuntu-2304-amd64
   - debian-10

--- a/integration_test/third_party_apps_data/applications/mysql5.7/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mysql5.7/metadata.yaml
@@ -41,6 +41,7 @@ platforms_to_skip:
   - debian-11-arm64
   - debian-12
   - ubuntu-2004-lts
+  - ubuntu-2004-lts-arm64
   - ubuntu-2304-amd64
 supported_app_version: ["8.0", "5.7"]
 expected_metrics:

--- a/integration_test/third_party_apps_data/applications/nvml/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/nvml/metadata.yaml
@@ -34,6 +34,7 @@ platforms_to_skip:
   - rocky-linux-9
   - sles-12
   - sles-15
+  - ubuntu-2004-lts-arm64
   - ubuntu-2304-amd64
 gpu_models:
   - a100

--- a/integration_test/third_party_apps_data/applications/oracledb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/oracledb/metadata.yaml
@@ -54,6 +54,7 @@ platforms_to_skip:
   - debian-11-arm64
   - debian-12
   - ubuntu-2004-lts
+  - ubuntu-2004-lts-arm64
   - ubuntu-2304-amd64
   - sles-12
   - sles-15


### PR DESCRIPTION
## Description
After the latest integration test run, there were a handful of failing integration tests on focal-arm64:
- vault looks like a real failure (we couldn't download their GPG key, nothing ARM-specific about it - let's see if it was just a flake)
- couchbase is a broken test (fixed here - this is the first arm64 distro we're testing couchbase on)
- dcgm/nvml/oracledb/mysql5.7/mongodb3.6 should all be skipped because they don't support focal or arm64
- mariadb 10.3 in focal/buster has a different config file location

Also, I fixed a bug that was causing `AssertFeatureTrackingMetrics` to be flaky. (It was relying on the iteration order of ListTimeSeries output to be stable.)

## Related issue
b/292099394

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
