### PR TITLE
Add ARM build configurations for rocky-linux-9

### DIFF
--- a/kokoro/config/build/presubmit/rockylinux9_arm64.gcl
+++ b/kokoro/config/build/presubmit/rockylinux9_arm64.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'rockylinux9'
+      PKGFORMAT = 'rpm'
+    }
+  }
+}

--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -99,6 +99,15 @@ rockylinux9 = _distro {
   ]
   presubmit = ['rocky-linux-9']
 }
+rockylinux9_arm64 = _distro {
+  release = [
+    // RHEL.
+    'rhel-9-arm64',
+    // Rocky.
+    'rocky-linux-9-arm64',
+  ]
+  presubmit = ['rocky-linux-9-arm64']
+}
 sles12 = _distro {
   release = [
     'sles-12',

--- a/kokoro/config/test/ops_agent/release/rockylinux9_arm64.gcl
+++ b/kokoro/config/test/ops_agent/release/rockylinux9_arm64.gcl
@@ -1,0 +1,17 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.rockylinux9_arm64.release
+
+    // T2A machines are only available on us-central1-{a,b,f}
+    environment {
+      ZONES = join([
+        'us-central1-a',
+        'us-central1-b',
+        'us-central1-f',
+      ], ',')
+    }
+  }
+}

--- a/kokoro/config/test/ops_agent/rockylinux9_arm64.gcl
+++ b/kokoro/config/test/ops_agent/rockylinux9_arm64.gcl
@@ -1,0 +1,17 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.rockylinux9_arm64.presubmit
+
+    // T2A machines are only available on us-central1-{a,b,f}
+    environment {
+      ZONES = join([
+        'us-central1-a',
+        'us-central1-b',
+        'us-central1-f',
+      ], ',')
+    }
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/rockylinux9_arm64.gcl
+++ b/kokoro/config/test/third_party_apps/release/rockylinux9_arm64.gcl
@@ -1,0 +1,16 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['rocky-linux-9-arm64']
+
+    // T2A machines are only available on us-central1-{a,b,f}
+    environment {
+      ZONES = join([
+        'us-central1-a',
+        'us-central1-b',
+        'us-central1-f',
+      ], ',')
+    }
+  }
+}

--- a/kokoro/config/test/third_party_apps/rockylinux9_arm64.gcl
+++ b/kokoro/config/test/third_party_apps/rockylinux9_arm64.gcl
@@ -1,0 +1,16 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['rocky-linux-9-arm64']
+
+    // T2A machines are only available on us-central1-{a,b,f}
+    environment {
+      ZONES = join([
+        'us-central1-a',
+        'us-central1-b',
+        'us-central1-f',
+      ], ',')
+    }
+  }
+}


### PR DESCRIPTION
## Description
Add ARM build configurations for rocky-linux-9.

## Related issue

## How has this been tested?
For now, let the existing non-ARM GitHub presubmits run and not break. There is a google3 counterpart to this PR that still needs to be done after this is merged.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.
