### PR TITLE
Fix ARM distro name

### DIFF
--- a/kokoro/config/build/presubmit/rockylinux9_arm64.gcl
+++ b/kokoro/config/build/presubmit/rockylinux9_arm64.gcl
@@ -3,7 +3,7 @@ import '../common.gcl' as common
 config build = common.build {
   params {
     environment {
-      DISTRO = 'rockylinux9'
+      DISTRO = 'rockylinux9_arm64'
       PKGFORMAT = 'rpm'
     }
   }


### PR DESCRIPTION
## Description
Was making my initial PR based off of a previous example which was later fixed to include this related change. This adds a _arm64 suffix

## Related issue
NA

## How has this been tested?
NA

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.
