### PR TITLE
Increase TCP input buffer from 32k to 512k

### DIFF
--- a/confgenerator/logging_receivers.go
+++ b/confgenerator/logging_receivers.go
@@ -261,6 +261,10 @@ func (r LoggingReceiverTCP) Components(ctx context.Context, tag string) []fluent
 			// When the input plugin hits "mem_buf_limit", because we have enabled filesystem storage type, mem_buf_limit acts
 			// as a hint to set "how much data can be up in memory", once the limit is reached it continues writing to disk.
 			"Mem_Buf_Limit": "10M",
+
+			// Allow incoming logs to occupy the maximum possible size per the Logging API (256k).
+			// Use a safety factor of 2 to account for things like encoding overhead.
+			"Chunk_Size": "512k",
 		},
 	}}
 }

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/linux-gpu/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/linux-gpu/fluent_bit_main.conf
@@ -33,6 +33,7 @@
     storage.type      filesystem
 
 [INPUT]
+    Chunk_Size    512k
     Format        json
     Listen        1.2.3.4
     Mem_Buf_Limit 10M

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/linux/fluent_bit_main.conf
@@ -33,6 +33,7 @@
     storage.type      filesystem
 
 [INPUT]
+    Chunk_Size    512k
     Format        json
     Listen        1.2.3.4
     Mem_Buf_Limit 10M

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows-2012/fluent_bit_main.conf
@@ -25,6 +25,7 @@
     Tag          default_pipeline.windows_event_log
 
 [INPUT]
+    Chunk_Size    512k
     Format        json
     Listen        1.2.3.4
     Mem_Buf_Limit 10M

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows/fluent_bit_main.conf
@@ -25,6 +25,7 @@
     Tag          default_pipeline.windows_event_log
 
 [INPUT]
+    Chunk_Size    512k
     Format        json
     Listen        1.2.3.4
     Mem_Buf_Limit 10M

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/linux-gpu/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/linux-gpu/fluent_bit_main.conf
@@ -33,6 +33,7 @@
     storage.type      filesystem
 
 [INPUT]
+    Chunk_Size    512k
     Format        json
     Listen        1.2.3.4
     Mem_Buf_Limit 10M

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/linux/fluent_bit_main.conf
@@ -33,6 +33,7 @@
     storage.type      filesystem
 
 [INPUT]
+    Chunk_Size    512k
     Format        json
     Listen        1.2.3.4
     Mem_Buf_Limit 10M

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows-2012/fluent_bit_main.conf
@@ -25,6 +25,7 @@
     Tag          default_pipeline.windows_event_log
 
 [INPUT]
+    Chunk_Size    512k
     Format        json
     Listen        1.2.3.4
     Mem_Buf_Limit 10M

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows/fluent_bit_main.conf
@@ -25,6 +25,7 @@
     Tag          default_pipeline.windows_event_log
 
 [INPUT]
+    Chunk_Size    512k
     Format        json
     Listen        1.2.3.4
     Mem_Buf_Limit 10M

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/linux-gpu/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/linux-gpu/fluent_bit_main.conf
@@ -33,6 +33,7 @@
     storage.type      filesystem
 
 [INPUT]
+    Chunk_Size    512k
     Format        json
     Listen        127.0.0.1
     Mem_Buf_Limit 10M

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/linux/fluent_bit_main.conf
@@ -33,6 +33,7 @@
     storage.type      filesystem
 
 [INPUT]
+    Chunk_Size    512k
     Format        json
     Listen        127.0.0.1
     Mem_Buf_Limit 10M

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows-2012/fluent_bit_main.conf
@@ -25,6 +25,7 @@
     Tag          default_pipeline.windows_event_log
 
 [INPUT]
+    Chunk_Size    512k
     Format        json
     Listen        127.0.0.1
     Mem_Buf_Limit 10M

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows/fluent_bit_main.conf
@@ -25,6 +25,7 @@
     Tag          default_pipeline.windows_event_log
 
 [INPUT]
+    Chunk_Size    512k
     Format        json
     Listen        127.0.0.1
     Mem_Buf_Limit 10M

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -1575,10 +1575,6 @@ func TestTCPLog(t *testing.T) {
 	t.Parallel()
 	gce.RunForEachPlatform(t, func(t *testing.T, platform string) {
 		t.Parallel()
-		if gce.IsWindows(platform) {
-			// TODO: Delete when b/285865631 is fixed.
-			t.SkipNow()
-		}
 
 		ctx, logger, vm := agents.CommonSetup(t, platform)
 

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -1598,9 +1598,8 @@ func TestTCPLog(t *testing.T) {
 		// Start a background fluent-bit that outputs to TCP.
 		// The TCP receiver in the Ops Agent already parses to JSON,
 		// so don't double-parse it in the background fluent-bit.
-		var pipePath string
-		var err error
-		if pipePath, err = startFluentBitBackgroundPipe(ctx, logger, vm, platform, false, "-o tcp://127.0.0.1:5170 -p raw_message_key=$log"); err != nil {
+		pipePath, err := startFluentBitBackgroundPipe(ctx, logger, vm, platform, false, "-o tcp://127.0.0.1:5170 -p raw_message_key=$log")
+		if err != nil {
 			t.Fatalf("Error starting fluent-bit background pipe: %v", err)
 		}
 


### PR DESCRIPTION
## Description
Customers were hitting the default 32k limit, but the API allows for 256k, so let's increase the buffer size.

## Related issue
b/298244438

## How has this been tested?
Will let the presubmits run.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
