### PR TITLE
Fix Windows 3p test flakes

### DIFF
--- a/integration_test/third_party_apps_data/applications/active_directory_ds/enable
+++ b/integration_test/third_party_apps_data/applications/active_directory_ds/enable
@@ -26,5 +26,7 @@ metrics:
         - active_directory_ds
 "
 
+# Stop-Service may fail if the service isn't in a Running state yet.
+(Get-Service google-cloud-ops-agent*).WaitForStatus('Running', '00:03:00')
 Stop-Service google-cloud-ops-agent -Force
-Start-Service google-cloud-ops-agent*  
+Start-Service google-cloud-ops-agent*

--- a/integration_test/third_party_apps_data/applications/iis/enable
+++ b/integration_test/third_party_apps_data/applications/iis/enable
@@ -32,5 +32,7 @@ logging:
         - iis_access
 "
 
+# Stop-Service may fail if the service isn't in a Running state yet.
+(Get-Service google-cloud-ops-agent*).WaitForStatus('Running', '00:03:00')
 Stop-Service google-cloud-ops-agent -Force
-Start-Service google-cloud-ops-agent* 
+Start-Service google-cloud-ops-agent*

--- a/integration_test/third_party_apps_data/applications/mssql/enable
+++ b/integration_test/third_party_apps_data/applications/mssql/enable
@@ -23,5 +23,7 @@ metrics:
         - mssql_v2
 "
 
+# Stop-Service may fail if the service isn't in a Running state yet.
+(Get-Service google-cloud-ops-agent*).WaitForStatus('Running', '00:03:00')
 Stop-Service google-cloud-ops-agent -Force
-Start-Service google-cloud-ops-agent*  
+Start-Service google-cloud-ops-agent*


### PR DESCRIPTION
## Description
I can produce the same error as the nightlies by calling `Stop-Service` too quickly after starting the Ops Agent -- apparently `Stop-Service` fails if the service isn't 'Running' yet. So just wait for them to be fully running before stopping.

## Related issue
b/295867239

## How has this been tested?
Will let the presubmits + nightlies run

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
