### PR TITLE
Fix Cassandra repo URLs and update to Cassandra 4.1.x.

### DIFF
--- a/integration_test/third_party_apps_data/applications/cassandra/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/cassandra/centos_rhel/install
@@ -10,7 +10,7 @@ esac
 sudo cat <<EOF > cassandra.repo
 [cassandra]
 name=Apache Cassandra
-baseurl=https://redhat.cassandra.apache.org/40x/
+baseurl=https://redhat.cassandra.apache.org/41x/
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=https://www.apache.org/dist/cassandra/KEYS

--- a/integration_test/third_party_apps_data/applications/cassandra/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/cassandra/centos_rhel/install
@@ -10,7 +10,7 @@ esac
 sudo cat <<EOF > cassandra.repo
 [cassandra]
 name=Apache Cassandra
-baseurl=https://www.apache.org/dist/cassandra/redhat/40x/
+baseurl=https://redhat.cassandra.apache.org/40x/
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=https://www.apache.org/dist/cassandra/KEYS

--- a/integration_test/third_party_apps_data/applications/cassandra/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/cassandra/debian_ubuntu/install
@@ -11,7 +11,7 @@ if [[ "${VERSION_ID}" == 23* || "$(uname -m)" == aarch64 ]]; then
     sudo apt update
     sudo apt install -y openjdk-11-jre cassandra
 else
-    echo "deb https://www.apache.org/dist/cassandra/debian 22x main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
+    echo "deb https://debian.cassandra.apache.org 22x main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
     # Required to install java8 (JVM properties of cassandra 2.2 are incompatible with >9)
     echo "deb https://archive.debian.org/debian-security stretch/updates main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
 

--- a/integration_test/third_party_apps_data/applications/cassandra/sles/install
+++ b/integration_test/third_party_apps_data/applications/cassandra/sles/install
@@ -16,10 +16,10 @@ sudo zypper -n install java-1_8_0-openjdk java-1_8_0-openjdk-devel
 
 # There is no official or even semi-official zypper package for cassandra
 # https://github.com/GoogleCloudPlatform/ops-agent/blob/master/integration_test/README.md#vendored-dependencies
-curl -OL https://storage.googleapis.com/ops-agents-public-buckets-vendored-deps/mirrored-content/archive.apache.org/dist/cassandra/4.0.1/apache-cassandra-4.0.1-bin.tar.gz
+curl -OL https://storage.googleapis.com/ops-agents-public-buckets-vendored-deps/mirrored-content/archive.apache.org/dist/cassandra/4.1.3/apache-cassandra-4.1.3-bin.tar.gz
 
-tar xzvf apache-cassandra-4.0.1-bin.tar.gz
-mv apache-cassandra-4.0.1 apache-cassandra
+tar xzvf apache-cassandra-4.1.3-bin.tar.gz
+mv apache-cassandra-4.1.3 apache-cassandra
 
 apache-cassandra/bin/cassandra -f &
 ps -f -p $!


### PR DESCRIPTION
## Description
Updates to the correct repo URLs to install Cassandra on RedHat and older Debian platforms. Uniformly uses Cassandra 4.1.x unless installing Cassandra 2.2.x.

## Related issue
[b/299912836](http://b/299912836)

## How has this been tested?
Presubmits.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
