### PR TITLE
Testing: Remove TODO to go back to using old URL

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1497,7 +1497,6 @@ func InstallGsutilIfNeeded(ctx context.Context, logger *log.Logger, vm *VM) erro
 		if strings.HasPrefix(vm.Platform, "sles-15") {
 			repo = "google-cloud-monitoring-sles15-" + repoArch + "-test-vendor"
 		}
-		// TODO: Revert to packages.cloud.google.com URL once b/296860728 is fixed.
 		repoSetupCmd = `sudo zypper --non-interactive addrepo -g -t YUM https://us-yum.pkg.dev/projects/cloud-ops-agents-artifacts-dev/` + repo + ` test-vendor
 sudo rpm --import https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 sudo zypper --non-interactive refresh test-vendor`


### PR DESCRIPTION
## Description

Today (as opposed to when I wrote the comment) I think it would be better to avoid the redirector and just use artifact registry directly. This is because the redirector gives us no benefits, and adding a new vendored repo is trickier if you have to involve the redirector. I'm hoping to simplify our documentation about these repos just a bit.

## Related issue
[b/265984385](http://b/265984385)

## How has this been tested?
comment-only change

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
