### PR TITLE
healthchecks : Retry `monitoringPing` when `InvalidArgument` error.

### DIFF
--- a/internal/healthchecks/api_check.go
+++ b/internal/healthchecks/api_check.go
@@ -36,7 +36,7 @@ const (
 	ServiceDisabled              = "SERVICE_DISABLED"
 	AccessTokenScopeInsufficient = "ACCESS_TOKEN_SCOPE_INSUFFICIENT"
 	IamPermissionDenied          = "IAM_PERMISSION_DENIED"
-	MaxMonitoringPingRetries     = 3
+	MaxMonitoringPingRetries     = 2
 )
 
 func getGCEMetadata() (resourcedetector.GCEResource, error) {
@@ -106,7 +106,7 @@ func monitoringPing(ctx context.Context, client monitoring.MetricClient, gceMeta
 		// This fixes b/291631906 when the monitoringPing is retried very quickly resulting
 		// in an `InvalidArgument` error due a maximum write rate of one point every 5 seconds.
 		// https://cloud.google.com/monitoring/quotas 
-		time.Sleep(5 * time.Second)
+		time.Sleep(6 * time.Second)
 	}
 	return err
 }


### PR DESCRIPTION
## Description
The *API Check* from the `healthchecks` package returns an `InvalidArgument` error when the Ops Agent is restarted very quickly :

```
[API Check] Result: ERROR, Detail: rpc error: code = InvalidArgument desc = One or more TimeSeries could not be written: One or more points were written more frequently than the maximum sampling period configured for the metric.
```

This is due to the [maximum rate of "one point each 5 seconds" at which data can be written to a single time series](https://cloud.google.com/monitoring/quotas#custom_metrics_quotas). This PR retries `monitoringPing` 2 times with a 6 second backoff to avoid going above the rate.

## Related issue
b/291631906

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
