### PR TITLE
Remove rhel-7-7-sap-ha

### DIFF
--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -72,7 +72,6 @@ centos7 = _distro {
     'centos-7',
     // RHEL.
     'rhel-7',
-    'rhel-7-7-sap-ha',
     'rhel-7-9-sap-ha',
   ]
   presubmit = ['centos-7']


### PR DESCRIPTION
## Description
Image family no longer exists.

## Related issue
[b/300266148](http://b/300266148)

## How has this been tested?
Will let presubmits run.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
