### PR TITLE
Fluent Bit 2.1.9 Upgrade

### DIFF
--- a/builds/fluent_bit.sh
+++ b/builds/fluent_bit.sh
@@ -19,5 +19,6 @@ make DESTDIR="$DESTDIR" install
 
 # We don't want fluent-bit's service or configuration, but there are no cmake
 # flags to disable them. Prune after build.
-rm "${DESTDIR}/lib/systemd/system/fluent-bit.service"
+rm "${DESTDIR}/lib/systemd/system/fluent-bit.service" || true
+rm "${DESTDIR}/usr/lib/systemd/system/fluent-bit.service" || true
 rm -r "${DESTDIR}${fluent_bit_dir}/etc"


### PR DESCRIPTION
## Description
This PR updates Fluent Bit to the latest mainline (2.1) release since it does not have whatever performance regression 2.0 is currently experiencing.

## Related issue
b/300621016

## How has this been tested?
These integration tests, and I will merge it to run it through our soak testing and will roll back if something is wrong.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
