### PR TITLE
Adds ARM (and non-ARM) build configurations for ubuntu-2204-lts

### DIFF
--- a/kokoro/config/build/presubmit/jammy.gcl
+++ b/kokoro/config/build/presubmit/jammy.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'jammy'
+      PKGFORMAT = 'deb'
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/jammy_arm64.gcl
+++ b/kokoro/config/build/presubmit/jammy_arm64.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'jammy'
+      PKGFORMAT = 'deb'
+    }
+  }
+}

--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -63,6 +63,18 @@ jammy = _distro {
     'ubuntu-2204-lts',
     'ubuntu-minimal-2204-lts',
   ]
+  presubmit = [
+      'ubuntu-minimal-2204-lts',
+  ]
+}
+jammy_arm64 = _distro {
+  release = [
+    'ubuntu-2204-lts-arm64',
+    'ubuntu-minimal-2204-lts-arm64',
+  ]
+  presubmit = [
+      'ubuntu-minimal-2204-lts-arm64',
+  ]
 }
 
 // RPM Linux distros. (Do not modify this comment.)

--- a/kokoro/config/test/ops_agent/jammy.gcl
+++ b/kokoro/config/test/ops_agent/jammy.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.jammy.presubmit
+  }
+}

--- a/kokoro/config/test/ops_agent/jammy_arm64.gcl
+++ b/kokoro/config/test/ops_agent/jammy_arm64.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.jammy_arm64.presubmit
+    arch = 'arm64'
+  }
+}

--- a/kokoro/config/test/ops_agent/release/jammy_arm64.gcl
+++ b/kokoro/config/test/ops_agent/release/jammy_arm64.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.jammy_arm64.release
+    arch = 'arm64'
+  }
+}

--- a/kokoro/config/test/third_party_apps/jammy.gcl
+++ b/kokoro/config/test/third_party_apps/jammy.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['ubuntu-2204-lts']
+  }
+}

--- a/kokoro/config/test/third_party_apps/jammy_arm64.gcl
+++ b/kokoro/config/test/third_party_apps/jammy_arm64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = [
+      'ubuntu-2204-lts-arm64',
+    ]
+    arch = 'arm64'
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/jammy.gcl
+++ b/kokoro/config/test/third_party_apps/release/jammy.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['ubuntu-2204-lts']
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/jammy_arm64.gcl
+++ b/kokoro/config/test/third_party_apps/release/jammy_arm64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = [
+      'ubuntu-2204-lts-arm64',
+    ]
+    arch = 'arm64'
+  }
+}


### PR DESCRIPTION
## Description
Adds ARM (and missing non-ARM) build configurations for ubuntu-2204-lts

## Related issue

## How has this been tested?
There is a google3 counterpart to this PR that still needs to be done after this is merged.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.
