### PR TITLE
Template assumes `aarch64` for `.Arch`

### DIFF
--- a/kokoro/config/test/ops_agent/release/template.gcl.tmpl
+++ b/kokoro/config/test/ops_agent/release/template.gcl.tmpl
@@ -4,6 +4,6 @@ import '../../image_lists.gcl' as image_lists
 config build = common.ops_agent_test {
   params {
     platforms = image_lists.{{.Codename}}.release
-{{with .Arch}}    arch = '{{.}}'
+{{if eq .Arch "aarch64"}}    arch = 'arm64'
 {{end}}  }
 }

--- a/kokoro/config/test/ops_agent/template.gcl.tmpl
+++ b/kokoro/config/test/ops_agent/template.gcl.tmpl
@@ -4,6 +4,6 @@ import '../image_lists.gcl' as image_lists
 config build = common.ops_agent_test {
   params {
     platforms = image_lists.{{.Codename}}.presubmit
-{{with .Arch}}    arch = '{{.}}'
+{{if eq .Arch "aarch64"}}    arch = 'arm64'
 {{end}}  }
 }

--- a/kokoro/config/test/third_party_apps/release/template.gcl.tmpl
+++ b/kokoro/config/test/third_party_apps/release/template.gcl.tmpl
@@ -5,6 +5,6 @@ config build = common.third_party_apps_test {
     platforms = [{{range .ThirdPartyTestPlatforms}}
       '{{.}}',{{end}}
     ]
-{{with .Arch}}    arch = '{{.}}'
+{{if eq .Arch "aarch64"}}    arch = 'arm64'
 {{end}}  }
 }

--- a/kokoro/config/test/third_party_apps/template.gcl.tmpl
+++ b/kokoro/config/test/third_party_apps/template.gcl.tmpl
@@ -5,6 +5,6 @@ config build = common.third_party_apps_test {
     platforms = [{{range .ThirdPartyTestPlatforms}}
       '{{.}}',{{end}}
     ]
-{{with .Arch}}    arch = '{{.}}'
+{{if eq .Arch "aarch64"}}    arch = 'arm64'
 {{end}}  }
 }


### PR DESCRIPTION
## Description
`.Arch` comes directly from the user-provided env variable into the helper script, which I'd prefer to be `aarch64` for the sake of being the more common ARM counterpart to `x86_64`.

That being said, all of the ARM configs here are already suffixed with `_arm64`, so it makes sense for the generated files to still contain `arm64`, hence the conversion inside the template.

## Related issue
b/292100890

## How has this been tested?
Will test on my internal CL after this is merged.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
