### PR TITLE
Revert Fluent Bit to 2.0.14

### DIFF
--- a/builds/fluent_bit.sh
+++ b/builds/fluent_bit.sh
@@ -19,6 +19,5 @@ make DESTDIR="$DESTDIR" install
 
 # We don't want fluent-bit's service or configuration, but there are no cmake
 # flags to disable them. Prune after build.
-rm "${DESTDIR}/lib/systemd/system/fluent-bit.service" || true
-rm "${DESTDIR}/usr/lib/systemd/system/fluent-bit.service" || true
+rm "${DESTDIR}/lib/systemd/system/fluent-bit.service"
 rm -r "${DESTDIR}${fluent_bit_dir}/etc"


### PR DESCRIPTION
## Description
Fluent Bit 2.1.9 has a performance problem that needs to be addressed before we can upgrade it.

## How has this been tested?
Integration tests in this PR. Revert is a result of bad soak test results.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
