### PR TITLE
Temporary change to third_party_apps_test.go to kick off jammy tests

### DIFF
--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -808,6 +808,7 @@ type test struct {
 var defaultPlatforms = map[string]bool{
 	"debian-10":    true,
 	"windows-2019": true,
+	"jammy":        true, // !!!TEMPORARY: REMOVE THIS!!!
 }
 
 var defaultApps = map[string]bool{


### PR DESCRIPTION
## Description
DO NOT MERGE. At the moment just kicking off tests and will later add to this PR to fix them.

## Related issue
NA

## How has this been tested?
NA

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.
