### PR TITLE
Testing: Add `--no-verbose` to some wget commands

### DIFF
--- a/integration_test/third_party_apps_data/applications/nvml/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/nvml/debian_ubuntu/install
@@ -13,13 +13,13 @@ case $DEVICE_CODE in
         echo "Installing NVIDIA CUDA 11.2.1 with driver 460.32.03"
         curl https://raw.githubusercontent.com/GoogleCloudPlatform/compute-gpu-installation/main/linux/install_gpu_driver.py --output install_gpu_driver.py
         sudo python3 install_gpu_driver.py
-        wget https://developer.download.nvidia.com/compute/cuda/11.2.1/local_installers/cuda_11.2.1_460.32.03_linux.run
+        wget --no-verbose https://developer.download.nvidia.com/compute/cuda/11.2.1/local_installers/cuda_11.2.1_460.32.03_linux.run
         sudo sh cuda_11.2.1_460.32.03_linux.run --toolkit --silent
         sudo apt install -y libcublas10
         ;;
     *)
         echo "Installing latest version of NVIDIA CUDA and driver"
-        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
+        wget --no-verbose https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
         sudo dpkg -i cuda-keyring_1.0-1_all.deb
         sudo apt update
         sudo apt -y install cuda 


### PR DESCRIPTION
## Description
This is to avoid logspam, such as happened here: https://source.cloud.google.com/results/invocations/f72afd11-878e-4fec-affb-5803bcd241d3/log

This logspam causes the XML to fail to parse, which results in no XML, and it's just bad all around.

See also https://github.com/GoogleCloudPlatform/ops-agent/pull/580, where I did this in various other places.

## Related issue
side quest

## How has this been tested?
automated tests should be enough

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
