### PR TITLE
healthchecks: Improve `monitoringPing` retry logic.

### DIFF
--- a/internal/healthchecks/api_check.go
+++ b/internal/healthchecks/api_check.go
@@ -110,7 +110,6 @@ func monitoringPing(ctx context.Context, client monitoring.MetricClient, gceMeta
 		}
 		return err
 	}
-
 	return backoff.Retry(pingOperation, pingBackoff)
 }
 

--- a/internal/healthchecks/api_check.go
+++ b/internal/healthchecks/api_check.go
@@ -111,11 +111,7 @@ func monitoringPing(ctx context.Context, client monitoring.MetricClient, gceMeta
 		return err
 	}
 
-	err := backoff.Retry(pingOperation, pingBackoff)
-	if errors.Is(err, *backoff.PermanentError) {
-		return err.Unwrap()
-	}
-	return err
+	return backoff.Retry(pingOperation, pingBackoff)
 }
 
 func runLoggingCheck(logger logs.StructuredLogger) error {

--- a/internal/healthchecks/api_check.go
+++ b/internal/healthchecks/api_check.go
@@ -138,6 +138,8 @@ func runLoggingCheck(logger logs.StructuredLogger) error {
 				return LogApiUnauthenticatedErr
 			case codes.DeadlineExceeded:
 				return LogApiConnErr
+			case codes.Unavailable:
+				return LogApiConnErr
 			}
 		}
 		if errors.Is(err, context.DeadlineExceeded) {
@@ -184,6 +186,8 @@ func runMonitoringCheck(logger logs.StructuredLogger) error {
 			case codes.Unauthenticated:
 				return MonApiUnauthenticatedErr
 			case codes.DeadlineExceeded:
+				return MonApiConnErr
+			case codes.Unavailable:
 				return MonApiConnErr
 			}
 		}


### PR DESCRIPTION
## Description
The previously merged PR https://github.com/GoogleCloudPlatform/ops-agent/pull/1415 fixed the following error when restarting the Ops Agent very quickly :
```
[API Check] Result: ERROR, Detail: rpc error: code = InvalidArgument desc = One or more TimeSeries could not be written: One or more points were written more frequently than the maximum sampling period configured for the metric.
```

This PR improves the retry logic to avoid waiting 6 seconds after the second metric write request.

## Related issue
b/291631906

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
