### PR TITLE
Add `$arch` suffix to kokoro config files

### DIFF
--- a/kokoro/config/build/amd64_linux/release.gcl
+++ b/kokoro/config/build/amd64_linux/release.gcl
@@ -1,0 +1,17 @@
+import '../common.gcl' as common
+
+// Proper release builds need access to the RPM signing key. This key should not
+// be used for any presubmits triggered by external folks on unreviewed PRs from
+// GitHub. We don't want to expose the RPM signing key to any potential leak
+// from malicious PRs. Note that the key is hidden from GitHub presubmits via
+// Keystore ACLs, which is the way that this is actually enforced.
+config build = common.build {
+  params {
+    keystore_keys = super.keystore_keys + [
+      { keystore_config_id = 71565, keyname = 'rpm-signing-key' },
+    ]
+    environment {
+      SKIP_SIGNING = null
+    }
+  }
+}

--- a/kokoro/config/build/amd64_windows/release.gcl
+++ b/kokoro/config/build/amd64_windows/release.gcl
@@ -1,0 +1,3 @@
+import '../common.gcl' as common
+
+config build = common.windows_build {}

--- a/kokoro/config/build/arm64_linux/release.gcl
+++ b/kokoro/config/build/arm64_linux/release.gcl
@@ -1,0 +1,17 @@
+import '../common.gcl' as common
+
+// Proper release builds need access to the RPM signing key. This key should not
+// be used for any presubmits triggered by external folks on unreviewed PRs from
+// GitHub. We don't want to expose the RPM signing key to any potential leak
+// from malicious PRs. Note that the key is hidden from GitHub presubmits via
+// Keystore ACLs, which is the way that this is actually enforced.
+config build = common.build {
+  params {
+    keystore_keys = super.keystore_keys + [
+      { keystore_config_id = 71565, keyname = 'rpm-signing-key' },
+    ]
+    environment {
+      SKIP_SIGNING = null
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/bookworm_amd64.gcl
+++ b/kokoro/config/build/presubmit/bookworm_amd64.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'bookworm'
+      PKGFORMAT = 'deb'
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/bullseye_amd64.gcl
+++ b/kokoro/config/build/presubmit/bullseye_amd64.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'bullseye'
+      PKGFORMAT = 'deb'
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/buster_amd64.gcl
+++ b/kokoro/config/build/presubmit/buster_amd64.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'buster'
+      PKGFORMAT = 'deb'
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/centos7_amd64.gcl
+++ b/kokoro/config/build/presubmit/centos7_amd64.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'centos7'
+      PKGFORMAT = 'rpm'
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/focal_amd64.gcl
+++ b/kokoro/config/build/presubmit/focal_amd64.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'focal'
+      PKGFORMAT = 'deb'
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/lunar_amd64.gcl
+++ b/kokoro/config/build/presubmit/lunar_amd64.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'lunar'
+      PKGFORMAT = 'deb'
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/rockylinux8_amd64.gcl
+++ b/kokoro/config/build/presubmit/rockylinux8_amd64.gcl
@@ -1,0 +1,12 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      // centos8 actually resolves to "rockylinux:8" in the Dockerfile:
+      // https://github.com/GoogleCloudPlatform/ops-agent/blob/72488e91d2f5dbd5ba5dc8c30f493deb7802dc09/Dockerfile#L163
+      DISTRO = 'centos8'
+      PKGFORMAT = 'rpm'
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/rockylinux9_amd64.gcl
+++ b/kokoro/config/build/presubmit/rockylinux9_amd64.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'rockylinux9'
+      PKGFORMAT = 'rpm'
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/saphana_amd64.gcl
+++ b/kokoro/config/build/presubmit/saphana_amd64.gcl
@@ -1,0 +1,11 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      // The testing image is based on SLES 15, see b/230338826.
+      DISTRO = 'sles15'
+      PKGFORMAT = 'rpm'
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/sles12_amd64.gcl
+++ b/kokoro/config/build/presubmit/sles12_amd64.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'sles12'
+      PKGFORMAT = 'rpm'
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/sles15_amd64.gcl
+++ b/kokoro/config/build/presubmit/sles15_amd64.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'sles15'
+      PKGFORMAT = 'rpm'
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/windows_amd64.gcl
+++ b/kokoro/config/build/presubmit/windows_amd64.gcl
@@ -1,0 +1,3 @@
+import '../common.gcl' as common
+
+config build = common.windows_build {}

--- a/kokoro/config/test/common.gcl
+++ b/kokoro/config/test/common.gcl
@@ -16,16 +16,6 @@ local _zones_for_arch = {
     'us-east1-c=2',
     'us-east1-d=2',
   ], ',')
-  // TODO: b/288442211 - Replace this with amd64 everywhere.
-  x86_64 = join([
-    'us-central1-a=3',
-    'us-central1-b=3',
-    'us-central1-c=3',
-    'us-central1-f=3',
-    'us-east1-b=2',
-    'us-east1-c=2',
-    'us-east1-d=2',
-  ], ',')
 
   // T2A machines are only available on us-central1-{a,b,f}.
   // See warning above about changing regions.

--- a/kokoro/config/test/common.gcl
+++ b/kokoro/config/test/common.gcl
@@ -7,6 +7,16 @@ local _zones_for_arch = {
   // The new Cloud NAT gateway must have "Minimum ports per VM instance"
   // set to 512 as per this article:
   // https://cloud.google.com/knowledge/kb/sles-unable-to-fetch-updates-when-behind-cloud-nat-000004450
+  amd64 = join([
+    'us-central1-a=3',
+    'us-central1-b=3',
+    'us-central1-c=3',
+    'us-central1-f=3',
+    'us-east1-b=2',
+    'us-east1-c=2',
+    'us-east1-d=2',
+  ], ',')
+  // TODO: b/288442211 - Replace this with amd64 everywhere.
   x86_64 = join([
     'us-central1-a=3',
     'us-central1-b=3',

--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -13,6 +13,139 @@ local template _distro {
 }
 
 // DEB Linux distros. (Do not modify this comment.)
+bookworm_amd64 = _distro {
+  release = [
+      'debian-12',
+  ]
+  presubmit = [
+      'debian-12',
+  ]
+}
+lunar_amd64 = _distro {
+  release = [
+      'ubuntu-2304-amd64',
+      'ubuntu-minimal-2304-amd64',
+  ]
+  presubmit = [
+      'ubuntu-2304-amd64',
+  ]
+}
+buster_amd64 = _distro {
+  release = ['debian-10']
+  presubmit = ['debian-10']
+}
+bullseye_amd64 = _distro {
+  release = ['debian-11']
+  presubmit = ['debian-11']
+}
+bullseye_arm64 = _distro {
+  release = ['debian-11-arm64']
+  presubmit = ['debian-11-arm64']
+}
+focal_amd64 = _distro {
+  release = [
+    'ubuntu-2004-lts',
+    'ubuntu-minimal-2004-lts',
+  ]
+  presubmit = ['ubuntu-minimal-2004-lts']
+}
+focal_arm64 = _distro {
+  release = [
+      'ubuntu-2004-lts-arm64',
+      'ubuntu-minimal-2004-lts-arm64',
+  ]
+  presubmit = [
+      'ubuntu-2004-lts-arm64',
+  ]
+}
+jammy_amd64 = _distro {
+  release = [
+    'ubuntu-2204-lts',
+    'ubuntu-minimal-2204-lts',
+  ]
+}
+
+// RPM Linux distros. (Do not modify this comment.)
+centos7_amd64 = _distro {
+  release = [
+    // CentOS.
+    'centos-7',
+    // RHEL.
+    'rhel-7',
+    'rhel-7-9-sap-ha',
+  ]
+  presubmit = ['centos-7']
+}
+centos8_amd64 = _distro {
+  release = [
+    // RHEL.
+    'rhel-8',
+    'rhel-8-1-sap-ha',
+    'rhel-8-2-sap-ha',
+    'rhel-8-4-sap-ha',
+    'rhel-8-6-sap-ha',
+    // Rocky.
+    'rocky-linux-8',
+  ]
+  presubmit = ['rocky-linux-8']
+}
+rockylinux9_amd64 = _distro {
+  release = [
+    // RHEL.
+    'rhel-9',
+    // Rocky.
+    'rocky-linux-9',
+  ]
+  presubmit = ['rocky-linux-9']
+}
+rockylinux9_arm64 = _distro {
+  release = [
+    // RHEL.
+    'rhel-9-arm64',
+    // Rocky.
+    'rocky-linux-9-arm64',
+  ]
+  presubmit = ['rocky-linux-9-arm64']
+}
+sles12_amd64 = _distro {
+  release = [
+    'sles-12',
+    'sles-12-sp5-sap',
+  ]
+  presubmit = ['sles-12']
+}
+sles15_amd64 = _distro {
+  release = [
+    'sles-15',
+    'sles-15-sp1-sap',
+    'sles-15-sp2-sap',
+    'opensuse-leap',
+    'opensuse-leap-15-4',
+  ]
+  presubmit = ['sles-15']
+}
+
+// Windows distros.
+windows_amd64 = _distro {
+  release = [
+    'windows-2012-r2',
+    'windows-2012-r2-core',
+    'windows-2016',
+    'windows-2016-core',
+    'windows-2019',
+    'windows-2019-core',
+    'windows-2022',
+    'windows-2022-core',
+  ]
+  presubmit = [
+    'windows-2012-r2',
+    // TODO(martijnvs): Switch this to windows-20h2-core.
+    'windows-2019',
+  ]
+}
+
+// TODO: b/288442211 - Remove the following distros that lack an $arch suffix.
+
 bookworm = _distro {
   release = [
       'debian-12',
@@ -38,25 +171,12 @@ bullseye = _distro {
   release = ['debian-11']
   presubmit = ['debian-11']
 }
-bullseye_arm64 = _distro {
-  release = ['debian-11-arm64']
-  presubmit = ['debian-11-arm64']
-}
 focal = _distro {
   release = [
     'ubuntu-2004-lts',
     'ubuntu-minimal-2004-lts',
   ]
   presubmit = ['ubuntu-minimal-2004-lts']
-}
-focal_arm64 = _distro {
-  release = [
-      'ubuntu-2004-lts-arm64',
-      'ubuntu-minimal-2004-lts-arm64',
-  ]
-  presubmit = [
-      'ubuntu-2004-lts-arm64',
-  ]
 }
 jammy = _distro {
   release = [
@@ -97,15 +217,6 @@ rockylinux9 = _distro {
     'rocky-linux-9',
   ]
   presubmit = ['rocky-linux-9']
-}
-rockylinux9_arm64 = _distro {
-  release = [
-    // RHEL.
-    'rhel-9-arm64',
-    // Rocky.
-    'rocky-linux-9-arm64',
-  ]
-  presubmit = ['rocky-linux-9-arm64']
 }
 sles12 = _distro {
   release = [

--- a/kokoro/config/test/ops_agent/bookworm_amd64.gcl
+++ b/kokoro/config/test/ops_agent/bookworm_amd64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.bookworm_amd64.presubmit
+  }
+}

--- a/kokoro/config/test/ops_agent/bullseye_amd64.gcl
+++ b/kokoro/config/test/ops_agent/bullseye_amd64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.bullseye_amd64.presubmit
+  }
+}

--- a/kokoro/config/test/ops_agent/buster_amd64.gcl
+++ b/kokoro/config/test/ops_agent/buster_amd64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.buster_amd64.presubmit
+  }
+}

--- a/kokoro/config/test/ops_agent/centos7_amd64.gcl
+++ b/kokoro/config/test/ops_agent/centos7_amd64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.centos7_amd64.presubmit
+  }
+}

--- a/kokoro/config/test/ops_agent/focal_amd64.gcl
+++ b/kokoro/config/test/ops_agent/focal_amd64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.focal_amd64.presubmit
+  }
+}

--- a/kokoro/config/test/ops_agent/lunar_amd64.gcl
+++ b/kokoro/config/test/ops_agent/lunar_amd64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.lunar_amd64.presubmit
+  }
+}

--- a/kokoro/config/test/ops_agent/release/bookworm_amd64.gcl
+++ b/kokoro/config/test/ops_agent/release/bookworm_amd64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.bookworm_amd64.release
+  }
+}

--- a/kokoro/config/test/ops_agent/release/bullseye_amd64.gcl
+++ b/kokoro/config/test/ops_agent/release/bullseye_amd64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.bullseye_amd64.release
+  }
+}

--- a/kokoro/config/test/ops_agent/release/buster_amd64.gcl
+++ b/kokoro/config/test/ops_agent/release/buster_amd64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.buster_amd64.release
+  }
+}

--- a/kokoro/config/test/ops_agent/release/centos7_amd64.gcl
+++ b/kokoro/config/test/ops_agent/release/centos7_amd64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.centos7_amd64.release
+  }
+}

--- a/kokoro/config/test/ops_agent/release/centos8_amd64.gcl
+++ b/kokoro/config/test/ops_agent/release/centos8_amd64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.centos8_amd64.release
+  }
+}

--- a/kokoro/config/test/ops_agent/release/focal_amd64.gcl
+++ b/kokoro/config/test/ops_agent/release/focal_amd64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.focal_amd64.release
+  }
+}

--- a/kokoro/config/test/ops_agent/release/jammy_amd64.gcl
+++ b/kokoro/config/test/ops_agent/release/jammy_amd64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.jammy_amd64.release
+  }
+}

--- a/kokoro/config/test/ops_agent/release/lunar_amd64.gcl
+++ b/kokoro/config/test/ops_agent/release/lunar_amd64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.lunar_amd64.release
+  }
+}

--- a/kokoro/config/test/ops_agent/release/rockylinux9_amd64.gcl
+++ b/kokoro/config/test/ops_agent/release/rockylinux9_amd64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.rockylinux9_amd64.release
+  }
+}

--- a/kokoro/config/test/ops_agent/release/sles12_amd64.gcl
+++ b/kokoro/config/test/ops_agent/release/sles12_amd64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.sles12_amd64.release
+  }
+}

--- a/kokoro/config/test/ops_agent/release/sles15_amd64.gcl
+++ b/kokoro/config/test/ops_agent/release/sles15_amd64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.sles15_amd64.release
+  }
+}

--- a/kokoro/config/test/ops_agent/release/windows_amd64.gcl
+++ b/kokoro/config/test/ops_agent/release/windows_amd64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.windows_amd64.release
+  }
+}

--- a/kokoro/config/test/ops_agent/rockylinux8_amd64.gcl
+++ b/kokoro/config/test/ops_agent/rockylinux8_amd64.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    // "centos8_amd64.presubmit" resolves to "rocky-linux-8".
+    platforms = image_lists.centos8_amd64.presubmit
+  }
+}

--- a/kokoro/config/test/ops_agent/rockylinux9_amd64.gcl
+++ b/kokoro/config/test/ops_agent/rockylinux9_amd64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.rockylinux9_amd64.presubmit
+  }
+}

--- a/kokoro/config/test/ops_agent/sles12_amd64.gcl
+++ b/kokoro/config/test/ops_agent/sles12_amd64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.sles12_amd64.presubmit
+  }
+}

--- a/kokoro/config/test/ops_agent/sles15_amd64.gcl
+++ b/kokoro/config/test/ops_agent/sles15_amd64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.sles15_amd64.presubmit
+  }
+}

--- a/kokoro/config/test/ops_agent/stretch_amd64.gcl
+++ b/kokoro/config/test/ops_agent/stretch_amd64.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    platforms = ['debian-9']
+  }
+}

--- a/kokoro/config/test/ops_agent/windows_amd64.gcl
+++ b/kokoro/config/test/ops_agent/windows_amd64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.windows_amd64.presubmit
+  }
+}

--- a/kokoro/config/test/soak/presubmit_amd64_linux.gcl
+++ b/kokoro/config/test/soak/presubmit_amd64_linux.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+
+config build = common.soak_test {
+  params {
+    environment {
+      DISTRO = 'ubuntu-2004-lts'
+    }
+  }
+}

--- a/kokoro/config/test/soak/presubmit_amd64_windows.gcl
+++ b/kokoro/config/test/soak/presubmit_amd64_windows.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+
+config build = common.soak_test {
+  params {
+    environment {
+      DISTRO = 'windows-2022'
+    }
+  }
+}

--- a/kokoro/config/test/third_party_apps/bookworm_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/bookworm_amd64.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = [
+      'debian-12',
+    ]
+  }
+}

--- a/kokoro/config/test/third_party_apps/bullseye_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/bullseye_amd64.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['debian-11']
+  }
+}

--- a/kokoro/config/test/third_party_apps/buster_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/buster_amd64.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['debian-10']
+  }
+}

--- a/kokoro/config/test/third_party_apps/centos7_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/centos7_amd64.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['centos-7']
+  }
+}

--- a/kokoro/config/test/third_party_apps/focal_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/focal_amd64.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['ubuntu-2004-lts']
+  }
+}

--- a/kokoro/config/test/third_party_apps/lunar_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/lunar_amd64.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = [
+      'ubuntu-2304-amd64',
+    ]
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/bookworm_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/release/bookworm_amd64.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = [
+      'debian-12',
+    ]
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/bullseye_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/release/bullseye_amd64.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['debian-11']
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/buster_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/release/buster_amd64.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['debian-10']
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/centos7_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/release/centos7_amd64.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['centos-7']
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/centos8_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/release/centos8_amd64.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['rocky-linux-8']
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/focal_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/release/focal_amd64.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['ubuntu-2004-lts']
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/lunar_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/release/lunar_amd64.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = [
+      'ubuntu-2304-amd64',
+    ]
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/oracledb_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/release/oracledb_amd64.gcl
@@ -1,0 +1,11 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['rhel-7']
+
+    environment {
+      INSTANCE_SIZE = 'n2-highmem-8'
+    }
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/rockylinux9_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/release/rockylinux9_amd64.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['rocky-linux-9']
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/saphana_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/release/saphana_amd64.gcl
@@ -1,0 +1,13 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    // Created in b/230338826.
+    platforms = ['sles-15-sp4-sap-saphana']
+
+    environment {
+      // These instances need a lot of RAM.
+      INSTANCE_SIZE = 'n2-highmem-8'
+    }
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/sles12_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/release/sles12_amd64.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['sles-12']
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/sles15_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/release/sles15_amd64.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['sles-15']
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/windows_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/release/windows_amd64.gcl
@@ -1,0 +1,13 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = [
+      'windows-2012-r2',
+      'windows-2019',
+      'sql-std-2019-win-2019',
+      'windows-2022', 
+      'sql-std-2022-win-2022',
+    ]
+  }
+}

--- a/kokoro/config/test/third_party_apps/rockylinux8_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/rockylinux8_amd64.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['rocky-linux-8']
+  }
+}

--- a/kokoro/config/test/third_party_apps/rockylinux9_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/rockylinux9_amd64.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['rocky-linux-9']
+  }
+}

--- a/kokoro/config/test/third_party_apps/saphana_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/saphana_amd64.gcl
@@ -1,0 +1,13 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    // Created in b/230338826.
+    platforms = ['sles-15-sp4-sap-saphana']
+
+    environment {
+      // These instances need a lot of RAM.
+      INSTANCE_SIZE = 'n2-highmem-8'
+    }
+  }
+}

--- a/kokoro/config/test/third_party_apps/sles12_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/sles12_amd64.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['sles-12']
+  }
+}

--- a/kokoro/config/test/third_party_apps/sles15_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/sles15_amd64.gcl
@@ -1,0 +1,7 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['sles-15']
+  }
+}

--- a/kokoro/config/test/third_party_apps/windows_amd64.gcl
+++ b/kokoro/config/test/third_party_apps/windows_amd64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = [
+      'windows-2012-r2',
+      'sql-std-2019-win-2019',
+    ]
+  }
+}


### PR DESCRIPTION
## Description
Part of a broad cleanup that will make all our Kokoro files consistently named across architectures.

## Related issue
[b/288442211](http://b/288442211)

## How has this been tested?
None of the newly-introduced build configs will be triggered right away, there is a (large) CL inside google3 that is needed first.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
