### PR TITLE
add self logs debug severity grep filter

### DIFF
--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -379,7 +379,7 @@ func (l *Logging) generateFluentbitComponents(ctx context.Context, userAgent str
 			out = append(out, stackdriverOutputComponent(strings.Join(tags, "|"), userAgent, "2G"))
 		}
 	}
-	out = append(out, generateSelfLogsComponents(ctx, userAgent)...)
+	out = append(out, generateSelfLogsComponents(ctx, userAgent, l.Service.LogLevel)...)
 	out = append(out, fluentbit.MetricsOutputComponent())
 
 	return out, nil

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux-gpu/4d6012ff003886818fb9b9285b4af962.lua
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux-gpu/4d6012ff003886818fb9b9285b4af962.lua
@@ -1,0 +1,19 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux-gpu/5fc5f42c16c9e1ab8292e3d42f74f3be.lua
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux-gpu/5fc5f42c16c9e1ab8292e3d42f74f3be.lua
@@ -1,0 +1,49 @@
+
+  function shallow_merge(record, parsedRecord)
+    -- If no exiting record exists
+    if (record == nil) then 
+        return parsedRecord
+    end
+    
+    for k, v in pairs(parsedRecord) do
+        record[k] = v
+    end
+
+    return record
+end
+
+function merge(record, parsedRecord)
+    -- If no exiting record exists
+    if record == nil then 
+        return parsedRecord
+    end
+    
+    -- Potentially overwrite or merge the original records.
+    for k, v in pairs(parsedRecord) do
+        -- If there is no conflict
+        if k == "logging.googleapis.com/logName" then 
+            -- Ignore the parsed payload since the logName is controlled
+            -- by the OpsAgent.
+        elseif k == "logging.googleapis.com/labels" then 
+            -- LogEntry.labels are basically a map[string]string and so only require a
+            -- shallow merge (one level deep merge).
+            record[k] = shallow_merge(record[k], v)
+        else
+            record[k] = v
+        end
+    end
+
+    return record
+end
+
+function parser_merge_record(tag, timestamp, record)
+    originalPayload = record["logging.googleapis.com/__tmp"]
+    if originalPayload == nil then
+        return 0, timestamp, record
+    end
+    
+    -- Remove original payload
+    record["logging.googleapis.com/__tmp"] = nil
+    record = merge(originalPayload, record)
+    return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux-gpu/68d6a3a0e8edf37868e1bf94adc737f4.lua
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux-gpu/68d6a3a0e8edf37868e1bf94adc737f4.lua
@@ -1,0 +1,38 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["message"]
+end)();
+local v = __field_0;
+if v == "LogParseErr" then v = "Ops Agent failed to parse logs, Code: LogParseErr, Documentation: https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/troubleshoot-find-info"
+elseif v == "LogPipelineErr" then v = "Ops Agent logging pipeline failed, Code: LogPipelineErr, Documentation: https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/troubleshoot-find-info"
+end
+(function(value)
+record["message"] = value
+end)(v)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux-gpu/b4a0dead382dce7b4fe011d3f59fdb6d.lua
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux-gpu/b4a0dead382dce7b4fe011d3f59fdb6d.lua
@@ -1,0 +1,17 @@
+
+function parser_nest(tag, timestamp, record)
+  local nestedRecord = {}
+  local parseKey = "message"
+  for k, v in pairs(record) do
+      if k ~= parseKey then
+          nestedRecord[k] = v
+      end
+  end
+
+  local result = {}
+  result[parseKey] = record[parseKey]
+  result["logging.googleapis.com/__tmp"] = nestedRecord
+
+  return 2, timestamp, result
+end
+

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux-gpu/f120d4527bd717cab023dbbe5fbdc332.lua
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux-gpu/f120d4527bd717cab023dbbe5fbdc332.lua
@@ -1,0 +1,42 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["agent.googleapis.com/log_file_path"]
+end)();
+local __field_1 = (function()
+if record["logging.googleapis.com/labels"] == nil
+then
+return nil
+end
+return record["logging.googleapis.com/labels"]["compute.googleapis.com/resource_name"]
+end)();
+local __field_2 = (function()
+return record["logging.googleapis.com/logName"]
+end)();
+(function(value)
+record["agent.googleapis.com/log_file_path"] = value
+end)(nil);
+local v = __field_0;
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/log_file_path"] = value
+end)(v)
+local v = __field_1;
+if v == nil then v = "" end;
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["compute.googleapis.com/resource_name"] = value
+end)(v)
+local v = __field_2;
+if v == nil then v = "syslog" end;
+(function(value)
+record["logging.googleapis.com/logName"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux-gpu/features.yaml
@@ -1,0 +1,8 @@
+- module: logging
+  feature: service:pipelines
+  key: default_pipeline_overridden
+  value: "false"
+- module: metrics
+  feature: service:pipelines
+  key: default_pipeline_overridden
+  value: "false"

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux-gpu/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux-gpu/fluent_bit_main.conf
@@ -1,0 +1,185 @@
+@SET buffers_dir=/var/lib/google-cloud-ops-agent/fluent-bit/buffers
+@SET logs_dir=/var/log/google-cloud-ops-agent
+
+[SERVICE]
+    Daemon                    off
+    Flush                     1
+    Log_Level                 debug
+    dns.resolver              legacy
+    storage.backlog.mem_limit 50M
+    storage.checksum          off
+    storage.max_chunks_up     128
+    storage.metrics           on
+    storage.sync              normal
+
+[INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 60
+    Scrape_On_Start True
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              /var/log/messages,/var/log/syslog
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               default_pipeline.syslog
+    storage.type      filesystem
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/subagents/logging-module.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-fluent-bit
+    storage.type      memory
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health
+    storage.type      memory
+
+[FILTER]
+    Match  default_pipeline.syslog
+    Name   lua
+    call   process
+    script f120d4527bd717cab023dbbe5fbdc332.lua
+
+[FILTER]
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   parser_nest
+    script b4a0dead382dce7b4fe011d3f59fdb6d.lua
+
+[FILTER]
+    Key_Name     message
+    Match        ops-agent-fluent-bit
+    Name         parser
+    Preserve_Key True
+    Reserve_Data True
+    Parser       ops-agent-fluent-bit.fluent-bit-self-log-regex-parsing
+
+[FILTER]
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   parser_merge_record
+    script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
+
+[FILTER]
+    Exclude severity DEBUG
+    Match   ops-agent-fluent-bit
+    Name    grep
+
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   parser_nest
+    script b4a0dead382dce7b4fe011d3f59fdb6d.lua
+
+[FILTER]
+    Key_Name     message
+    Match        ops-agent-health
+    Name         parser
+    Reserve_Data True
+    Parser       ops-agent-health.health-checks-json
+
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   parser_merge_record
+    script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
+
+[FILTER]
+    Match ops-agent-health
+    Name  grep
+    Regex severity INFO|ERROR|WARNING|DEBUG|info|error|warning|debug
+
+[FILTER]
+    Match ops-agent-fluent-bit
+    Name  rewrite_tag
+    Rule  message \[error\]\s\[lib\]\sbackend\sfailed ops-agent-health true
+
+[FILTER]
+    Name      modify
+    Match     ops-agent-health
+    Condition Key_value_matches message \[error\]\s\[lib\]\sbackend\sfailed
+    Set       message LogPipelineErr
+    Set       code LogPipelineErr
+
+[FILTER]
+    Match ops-agent-fluent-bit
+    Name  rewrite_tag
+    Rule  message \[error\]\s\[parser\]\scannot\sparse ops-agent-health true
+
+[FILTER]
+    Name      modify
+    Match     ops-agent-health
+    Condition Key_value_matches message \[error\]\s\[parser\]\scannot\sparse
+    Set       message LogParseErr
+    Set       code LogParseErr
+
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 68d6a3a0e8edf37868e1bf94adc737f4.lua
+
+[FILTER]
+    Match  ops-agent-*
+    Name   lua
+    call   process
+    script 4d6012ff003886818fb9b9285b4af962.lua
+
+[OUTPUT]
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      2G
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  20202

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux-gpu/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux-gpu/fluent_bit_parser.conf
@@ -1,0 +1,13 @@
+[PARSER]
+    Format      regex
+    Name        ops-agent-fluent-bit.fluent-bit-self-log-regex-parsing
+    Regex       (?<message>\[[ ]*(?<time>\d+\/\d+\/\d+ \d+:\d+:\d+)] \[[ ]*(?<severity>[a-z]+)\].*)
+    Time_Format %Y/%m/%d %H:%M:%S
+    Time_Key    time
+    Types       severity:string
+
+[PARSER]
+    Format      json
+    Name        ops-agent-health.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux-gpu/otel.yaml
@@ -1,0 +1,530 @@
+exporters:
+  googlecloud:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    retry_on_failure:
+      enabled: false
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+processors:
+  agentmetrics/hostmetrics_0:
+    blank_label_metrics:
+    - system.cpu.utilization
+  filter/default__pipeline_hostmetrics_0:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names: []
+  filter/default__pipeline_hostmetrics_1_0:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names: []
+  filter/fluentbit_0:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+        - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
+        - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
+  filter/hostmetrics_1:
+    metrics:
+      exclude:
+        match_type: strict
+        metric_names:
+        - system.cpu.time
+        - system.network.dropped
+        - system.filesystem.inodes.usage
+        - system.paging.faults
+        - system.disk.operation_time
+  filter/otel_0:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+        - otelcol_process_uptime
+        - otelcol_process_memory_rss
+        - otelcol_grpc_io_client_completed_rpcs
+        - otelcol_googlecloudmonitoring_point_count
+  metricstransform/fluentbit_1:
+    transforms:
+    - action: update
+      include: fluentbit_uptime
+      new_name: agent/uptime
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: version
+        new_value: google-cloud-ops-agent-logging/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_proc_records_total
+      new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/hostmetrics_1_0:
+    transforms:
+    - action: update
+      include: nvml.gpu.utilization
+      new_name: gpu/utilization
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 100.0
+    - action: update
+      include: nvml.gpu.memory.bytes_used
+      new_name: gpu/memory/bytes_used
+    - action: update
+      include: nvml.gpu.processes.utilization
+      new_name: gpu/processes/utilization
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 100.0
+    - action: update
+      include: nvml.gpu.processes.max_bytes_used
+      new_name: gpu/processes/max_bytes_used
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/hostmetrics_2:
+    transforms:
+    - action: update
+      include: system.cpu.time
+      new_name: cpu/usage_time
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: cpu
+        new_label: cpu_number
+      - action: update_label
+        label: state
+        new_label: cpu_state
+    - action: update
+      include: system.cpu.utilization
+      new_name: cpu/utilization
+      operations:
+      - action: aggregate_labels
+        aggregation_type: mean
+        label_set:
+        - state
+        - blank
+      - action: update_label
+        label: blank
+        new_label: cpu_number
+      - action: update_label
+        label: state
+        new_label: cpu_state
+    - action: update
+      include: system.cpu.load_average.1m
+      new_name: cpu/load_1m
+    - action: update
+      include: system.cpu.load_average.5m
+      new_name: cpu/load_5m
+    - action: update
+      include: system.cpu.load_average.15m
+      new_name: cpu/load_15m
+    - action: update
+      include: system.disk.read_io
+      new_name: disk/read_bytes_count
+    - action: update
+      include: system.disk.write_io
+      new_name: disk/write_bytes_count
+    - action: update
+      include: system.disk.operations
+      new_name: disk/operation_count
+    - action: update
+      include: system.disk.io_time
+      new_name: disk/io_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.weighted_io_time
+      new_name: disk/weighted_io_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.average_operation_time
+      new_name: disk/operation_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.pending_operations
+      new_name: disk/pending_operations
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.merged
+      new_name: disk/merged_operations
+    - action: update
+      include: system.filesystem.usage
+      new_name: disk/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: max
+        label_set:
+        - device
+        - state
+    - action: update
+      include: system.filesystem.utilization
+      new_name: disk/percent_used
+      operations:
+      - action: aggregate_labels
+        aggregation_type: max
+        label_set:
+        - device
+        - state
+    - action: update
+      include: system.memory.usage
+      new_name: memory/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_label_values
+        aggregated_values:
+        - slab_reclaimable
+        - slab_unreclaimable
+        aggregation_type: sum
+        label: state
+        new_value: slab
+    - action: update
+      include: system.memory.utilization
+      new_name: memory/percent_used
+      operations:
+      - action: aggregate_label_values
+        aggregated_values:
+        - slab_reclaimable
+        - slab_unreclaimable
+        aggregation_type: sum
+        label: state
+        new_value: slab
+    - action: update
+      include: system.network.io
+      new_name: interface/traffic
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.errors
+      new_name: interface/errors
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.packets
+      new_name: interface/packets
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.connections
+      new_name: network/tcp_connections
+      operations:
+      - action: toggle_scalar_data_type
+      - action: delete_label_value
+        label: protocol
+        label_value: udp
+      - action: update_label
+        label: state
+        new_label: tcp_state
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - tcp_state
+      - action: add_label
+        new_label: port
+        new_value: all
+    - action: update
+      include: system.processes.created
+      new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
+    - action: update
+      include: system.paging.usage
+      new_name: swap/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.paging.utilization
+      new_name: swap/percent_used
+    - action: insert
+      include: swap/percent_used
+      new_name: pagefile/percent_used
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - state
+    - action: update
+      include: system.paging.operations
+      new_name: swap/io
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - direction
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: in
+          value: page_in
+        - new_value: out
+          value: page_out
+    - action: update
+      include: process.cpu.time
+      new_name: processes/cpu_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1e+06
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+      - action: delete_label_value
+        label: state
+        label_value: wait
+      - action: update_label
+        label: state
+        new_label: user_or_syst
+      - action: update_label
+        label: user_or_syst
+        value_actions:
+        - new_value: syst
+          value: system
+    - action: update
+      include: process.disk.read_io
+      new_name: processes/disk/read_bytes_count
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.disk.write_io
+      new_name: processes/disk/write_bytes_count
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.memory.usage
+      new_name: processes/rss_usage
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.memory.virtual
+      new_name: processes/vm_usage
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/otel_1:
+    transforms:
+    - action: update
+      include: otelcol_process_uptime
+      new_name: agent/uptime
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: version
+        new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
+    - action: update
+      include: otelcol_process_memory_rss
+      new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
+    - action: update
+      include: otelcol_grpc_io_client_completed_rpcs
+      new_name: agent/api_request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: grpc_client_status
+        new_label: state
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - state
+    - action: update
+      include: otelcol_googlecloudmonitoring_point_count
+      new_name: agent/monitoring/point_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  resourcedetection/_global_0:
+    detectors:
+    - gcp
+receivers:
+  hostmetrics/hostmetrics:
+    collection_interval: 60s
+    scrapers:
+      cpu: {}
+      disk: {}
+      filesystem: {}
+      load: {}
+      memory: {}
+      network: {}
+      paging: {}
+      process:
+        mute_process_name_error: true
+      processes: {}
+  nvml/hostmetrics_1:
+    collection_interval: 60s
+  prometheus/fluentbit:
+    config:
+      scrape_configs:
+      - job_name: logging-collector
+        metrics_path: /metrics
+        scrape_interval: 1m
+        static_configs:
+        - targets:
+          - 0.0.0.0:20202
+  prometheus/otel:
+    config:
+      scrape_configs:
+      - job_name: otel-collector
+        scrape_interval: 1m
+        static_configs:
+        - targets:
+          - 0.0.0.0:20201
+service:
+  pipelines:
+    metrics/default__pipeline_hostmetrics:
+      exporters:
+      - googlecloud
+      processors:
+      - agentmetrics/hostmetrics_0
+      - filter/hostmetrics_1
+      - metricstransform/hostmetrics_2
+      - filter/default__pipeline_hostmetrics_0
+      - resourcedetection/_global_0
+      receivers:
+      - hostmetrics/hostmetrics
+    metrics/default__pipeline_hostmetrics_1:
+      exporters:
+      - googlecloud
+      processors:
+      - metricstransform/hostmetrics_1_0
+      - filter/default__pipeline_hostmetrics_1_0
+      - resourcedetection/_global_0
+      receivers:
+      - nvml/hostmetrics_1
+    metrics/fluentbit:
+      exporters:
+      - googlecloud
+      processors:
+      - filter/fluentbit_0
+      - metricstransform/fluentbit_1
+      - resourcedetection/_global_0
+      receivers:
+      - prometheus/fluentbit
+    metrics/otel:
+      exporters:
+      - googlecloud
+      processors:
+      - filter/otel_0
+      - metricstransform/otel_1
+      - resourcedetection/_global_0
+      receivers:
+      - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux/4d6012ff003886818fb9b9285b4af962.lua
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux/4d6012ff003886818fb9b9285b4af962.lua
@@ -1,0 +1,19 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux/5fc5f42c16c9e1ab8292e3d42f74f3be.lua
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux/5fc5f42c16c9e1ab8292e3d42f74f3be.lua
@@ -1,0 +1,49 @@
+
+  function shallow_merge(record, parsedRecord)
+    -- If no exiting record exists
+    if (record == nil) then 
+        return parsedRecord
+    end
+    
+    for k, v in pairs(parsedRecord) do
+        record[k] = v
+    end
+
+    return record
+end
+
+function merge(record, parsedRecord)
+    -- If no exiting record exists
+    if record == nil then 
+        return parsedRecord
+    end
+    
+    -- Potentially overwrite or merge the original records.
+    for k, v in pairs(parsedRecord) do
+        -- If there is no conflict
+        if k == "logging.googleapis.com/logName" then 
+            -- Ignore the parsed payload since the logName is controlled
+            -- by the OpsAgent.
+        elseif k == "logging.googleapis.com/labels" then 
+            -- LogEntry.labels are basically a map[string]string and so only require a
+            -- shallow merge (one level deep merge).
+            record[k] = shallow_merge(record[k], v)
+        else
+            record[k] = v
+        end
+    end
+
+    return record
+end
+
+function parser_merge_record(tag, timestamp, record)
+    originalPayload = record["logging.googleapis.com/__tmp"]
+    if originalPayload == nil then
+        return 0, timestamp, record
+    end
+    
+    -- Remove original payload
+    record["logging.googleapis.com/__tmp"] = nil
+    record = merge(originalPayload, record)
+    return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux/68d6a3a0e8edf37868e1bf94adc737f4.lua
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux/68d6a3a0e8edf37868e1bf94adc737f4.lua
@@ -1,0 +1,38 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["message"]
+end)();
+local v = __field_0;
+if v == "LogParseErr" then v = "Ops Agent failed to parse logs, Code: LogParseErr, Documentation: https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/troubleshoot-find-info"
+elseif v == "LogPipelineErr" then v = "Ops Agent logging pipeline failed, Code: LogPipelineErr, Documentation: https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/troubleshoot-find-info"
+end
+(function(value)
+record["message"] = value
+end)(v)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux/b4a0dead382dce7b4fe011d3f59fdb6d.lua
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux/b4a0dead382dce7b4fe011d3f59fdb6d.lua
@@ -1,0 +1,17 @@
+
+function parser_nest(tag, timestamp, record)
+  local nestedRecord = {}
+  local parseKey = "message"
+  for k, v in pairs(record) do
+      if k ~= parseKey then
+          nestedRecord[k] = v
+      end
+  end
+
+  local result = {}
+  result[parseKey] = record[parseKey]
+  result["logging.googleapis.com/__tmp"] = nestedRecord
+
+  return 2, timestamp, result
+end
+

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux/f120d4527bd717cab023dbbe5fbdc332.lua
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux/f120d4527bd717cab023dbbe5fbdc332.lua
@@ -1,0 +1,42 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["agent.googleapis.com/log_file_path"]
+end)();
+local __field_1 = (function()
+if record["logging.googleapis.com/labels"] == nil
+then
+return nil
+end
+return record["logging.googleapis.com/labels"]["compute.googleapis.com/resource_name"]
+end)();
+local __field_2 = (function()
+return record["logging.googleapis.com/logName"]
+end)();
+(function(value)
+record["agent.googleapis.com/log_file_path"] = value
+end)(nil);
+local v = __field_0;
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/log_file_path"] = value
+end)(v)
+local v = __field_1;
+if v == nil then v = "" end;
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["compute.googleapis.com/resource_name"] = value
+end)(v)
+local v = __field_2;
+if v == nil then v = "syslog" end;
+(function(value)
+record["logging.googleapis.com/logName"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux/features.yaml
@@ -1,0 +1,8 @@
+- module: logging
+  feature: service:pipelines
+  key: default_pipeline_overridden
+  value: "false"
+- module: metrics
+  feature: service:pipelines
+  key: default_pipeline_overridden
+  value: "false"

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux/fluent_bit_main.conf
@@ -1,0 +1,185 @@
+@SET buffers_dir=/var/lib/google-cloud-ops-agent/fluent-bit/buffers
+@SET logs_dir=/var/log/google-cloud-ops-agent
+
+[SERVICE]
+    Daemon                    off
+    Flush                     1
+    Log_Level                 debug
+    dns.resolver              legacy
+    storage.backlog.mem_limit 50M
+    storage.checksum          off
+    storage.max_chunks_up     128
+    storage.metrics           on
+    storage.sync              normal
+
+[INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 60
+    Scrape_On_Start True
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/default_pipeline_syslog
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              /var/log/messages,/var/log/syslog
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               default_pipeline.syslog
+    storage.type      filesystem
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/subagents/logging-module.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-fluent-bit
+    storage.type      memory
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health
+    storage.type      memory
+
+[FILTER]
+    Match  default_pipeline.syslog
+    Name   lua
+    call   process
+    script f120d4527bd717cab023dbbe5fbdc332.lua
+
+[FILTER]
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   parser_nest
+    script b4a0dead382dce7b4fe011d3f59fdb6d.lua
+
+[FILTER]
+    Key_Name     message
+    Match        ops-agent-fluent-bit
+    Name         parser
+    Preserve_Key True
+    Reserve_Data True
+    Parser       ops-agent-fluent-bit.fluent-bit-self-log-regex-parsing
+
+[FILTER]
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   parser_merge_record
+    script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
+
+[FILTER]
+    Exclude severity DEBUG
+    Match   ops-agent-fluent-bit
+    Name    grep
+
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   parser_nest
+    script b4a0dead382dce7b4fe011d3f59fdb6d.lua
+
+[FILTER]
+    Key_Name     message
+    Match        ops-agent-health
+    Name         parser
+    Reserve_Data True
+    Parser       ops-agent-health.health-checks-json
+
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   parser_merge_record
+    script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
+
+[FILTER]
+    Match ops-agent-health
+    Name  grep
+    Regex severity INFO|ERROR|WARNING|DEBUG|info|error|warning|debug
+
+[FILTER]
+    Match ops-agent-fluent-bit
+    Name  rewrite_tag
+    Rule  message \[error\]\s\[lib\]\sbackend\sfailed ops-agent-health true
+
+[FILTER]
+    Name      modify
+    Match     ops-agent-health
+    Condition Key_value_matches message \[error\]\s\[lib\]\sbackend\sfailed
+    Set       message LogPipelineErr
+    Set       code LogPipelineErr
+
+[FILTER]
+    Match ops-agent-fluent-bit
+    Name  rewrite_tag
+    Rule  message \[error\]\s\[parser\]\scannot\sparse ops-agent-health true
+
+[FILTER]
+    Name      modify
+    Match     ops-agent-health
+    Condition Key_value_matches message \[error\]\s\[parser\]\scannot\sparse
+    Set       message LogParseErr
+    Set       code LogParseErr
+
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 68d6a3a0e8edf37868e1bf94adc737f4.lua
+
+[FILTER]
+    Match  ops-agent-*
+    Name   lua
+    call   process
+    script 4d6012ff003886818fb9b9285b4af962.lua
+
+[OUTPUT]
+    Match_Regex                   ^(default_pipeline\.syslog)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    storage.total_limit_size      2G
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  20202

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux/fluent_bit_parser.conf
@@ -1,0 +1,13 @@
+[PARSER]
+    Format      regex
+    Name        ops-agent-fluent-bit.fluent-bit-self-log-regex-parsing
+    Regex       (?<message>\[[ ]*(?<time>\d+\/\d+\/\d+ \d+:\d+:\d+)] \[[ ]*(?<severity>[a-z]+)\].*)
+    Time_Format %Y/%m/%d %H:%M:%S
+    Time_Key    time
+    Types       severity:string
+
+[PARSER]
+    Format      json
+    Name        ops-agent-health.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/linux/otel.yaml
@@ -1,0 +1,490 @@
+exporters:
+  googlecloud:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    retry_on_failure:
+      enabled: false
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+processors:
+  agentmetrics/hostmetrics_0:
+    blank_label_metrics:
+    - system.cpu.utilization
+  filter/default__pipeline_hostmetrics_0:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names: []
+  filter/fluentbit_0:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+        - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
+        - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
+  filter/hostmetrics_1:
+    metrics:
+      exclude:
+        match_type: strict
+        metric_names:
+        - system.cpu.time
+        - system.network.dropped
+        - system.filesystem.inodes.usage
+        - system.paging.faults
+        - system.disk.operation_time
+  filter/otel_0:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+        - otelcol_process_uptime
+        - otelcol_process_memory_rss
+        - otelcol_grpc_io_client_completed_rpcs
+        - otelcol_googlecloudmonitoring_point_count
+  metricstransform/fluentbit_1:
+    transforms:
+    - action: update
+      include: fluentbit_uptime
+      new_name: agent/uptime
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: version
+        new_value: google-cloud-ops-agent-logging/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_proc_records_total
+      new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/hostmetrics_2:
+    transforms:
+    - action: update
+      include: system.cpu.time
+      new_name: cpu/usage_time
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: cpu
+        new_label: cpu_number
+      - action: update_label
+        label: state
+        new_label: cpu_state
+    - action: update
+      include: system.cpu.utilization
+      new_name: cpu/utilization
+      operations:
+      - action: aggregate_labels
+        aggregation_type: mean
+        label_set:
+        - state
+        - blank
+      - action: update_label
+        label: blank
+        new_label: cpu_number
+      - action: update_label
+        label: state
+        new_label: cpu_state
+    - action: update
+      include: system.cpu.load_average.1m
+      new_name: cpu/load_1m
+    - action: update
+      include: system.cpu.load_average.5m
+      new_name: cpu/load_5m
+    - action: update
+      include: system.cpu.load_average.15m
+      new_name: cpu/load_15m
+    - action: update
+      include: system.disk.read_io
+      new_name: disk/read_bytes_count
+    - action: update
+      include: system.disk.write_io
+      new_name: disk/write_bytes_count
+    - action: update
+      include: system.disk.operations
+      new_name: disk/operation_count
+    - action: update
+      include: system.disk.io_time
+      new_name: disk/io_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.weighted_io_time
+      new_name: disk/weighted_io_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.average_operation_time
+      new_name: disk/operation_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.pending_operations
+      new_name: disk/pending_operations
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.merged
+      new_name: disk/merged_operations
+    - action: update
+      include: system.filesystem.usage
+      new_name: disk/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: max
+        label_set:
+        - device
+        - state
+    - action: update
+      include: system.filesystem.utilization
+      new_name: disk/percent_used
+      operations:
+      - action: aggregate_labels
+        aggregation_type: max
+        label_set:
+        - device
+        - state
+    - action: update
+      include: system.memory.usage
+      new_name: memory/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_label_values
+        aggregated_values:
+        - slab_reclaimable
+        - slab_unreclaimable
+        aggregation_type: sum
+        label: state
+        new_value: slab
+    - action: update
+      include: system.memory.utilization
+      new_name: memory/percent_used
+      operations:
+      - action: aggregate_label_values
+        aggregated_values:
+        - slab_reclaimable
+        - slab_unreclaimable
+        aggregation_type: sum
+        label: state
+        new_value: slab
+    - action: update
+      include: system.network.io
+      new_name: interface/traffic
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.errors
+      new_name: interface/errors
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.packets
+      new_name: interface/packets
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.connections
+      new_name: network/tcp_connections
+      operations:
+      - action: toggle_scalar_data_type
+      - action: delete_label_value
+        label: protocol
+        label_value: udp
+      - action: update_label
+        label: state
+        new_label: tcp_state
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - tcp_state
+      - action: add_label
+        new_label: port
+        new_value: all
+    - action: update
+      include: system.processes.created
+      new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
+    - action: update
+      include: system.paging.usage
+      new_name: swap/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.paging.utilization
+      new_name: swap/percent_used
+    - action: insert
+      include: swap/percent_used
+      new_name: pagefile/percent_used
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - state
+    - action: update
+      include: system.paging.operations
+      new_name: swap/io
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - direction
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: in
+          value: page_in
+        - new_value: out
+          value: page_out
+    - action: update
+      include: process.cpu.time
+      new_name: processes/cpu_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1e+06
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+      - action: delete_label_value
+        label: state
+        label_value: wait
+      - action: update_label
+        label: state
+        new_label: user_or_syst
+      - action: update_label
+        label: user_or_syst
+        value_actions:
+        - new_value: syst
+          value: system
+    - action: update
+      include: process.disk.read_io
+      new_name: processes/disk/read_bytes_count
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.disk.write_io
+      new_name: processes/disk/write_bytes_count
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.memory.usage
+      new_name: processes/rss_usage
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.memory.virtual
+      new_name: processes/vm_usage
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/otel_1:
+    transforms:
+    - action: update
+      include: otelcol_process_uptime
+      new_name: agent/uptime
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: version
+        new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
+    - action: update
+      include: otelcol_process_memory_rss
+      new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
+    - action: update
+      include: otelcol_grpc_io_client_completed_rpcs
+      new_name: agent/api_request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: grpc_client_status
+        new_label: state
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - state
+    - action: update
+      include: otelcol_googlecloudmonitoring_point_count
+      new_name: agent/monitoring/point_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  resourcedetection/_global_0:
+    detectors:
+    - gcp
+receivers:
+  hostmetrics/hostmetrics:
+    collection_interval: 60s
+    scrapers:
+      cpu: {}
+      disk: {}
+      filesystem: {}
+      load: {}
+      memory: {}
+      network: {}
+      paging: {}
+      process:
+        mute_process_name_error: true
+      processes: {}
+  prometheus/fluentbit:
+    config:
+      scrape_configs:
+      - job_name: logging-collector
+        metrics_path: /metrics
+        scrape_interval: 1m
+        static_configs:
+        - targets:
+          - 0.0.0.0:20202
+  prometheus/otel:
+    config:
+      scrape_configs:
+      - job_name: otel-collector
+        scrape_interval: 1m
+        static_configs:
+        - targets:
+          - 0.0.0.0:20201
+service:
+  pipelines:
+    metrics/default__pipeline_hostmetrics:
+      exporters:
+      - googlecloud
+      processors:
+      - agentmetrics/hostmetrics_0
+      - filter/hostmetrics_1
+      - metricstransform/hostmetrics_2
+      - filter/default__pipeline_hostmetrics_0
+      - resourcedetection/_global_0
+      receivers:
+      - hostmetrics/hostmetrics
+    metrics/fluentbit:
+      exporters:
+      - googlecloud
+      processors:
+      - filter/fluentbit_0
+      - metricstransform/fluentbit_1
+      - resourcedetection/_global_0
+      receivers:
+      - prometheus/fluentbit
+    metrics/otel:
+      exporters:
+      - googlecloud
+      processors:
+      - filter/otel_0
+      - metricstransform/otel_1
+      - resourcedetection/_global_0
+      receivers:
+      - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows-2012/4d6012ff003886818fb9b9285b4af962.lua
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows-2012/4d6012ff003886818fb9b9285b4af962.lua
@@ -1,0 +1,19 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows-2012/5fc5f42c16c9e1ab8292e3d42f74f3be.lua
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows-2012/5fc5f42c16c9e1ab8292e3d42f74f3be.lua
@@ -1,0 +1,49 @@
+
+  function shallow_merge(record, parsedRecord)
+    -- If no exiting record exists
+    if (record == nil) then 
+        return parsedRecord
+    end
+    
+    for k, v in pairs(parsedRecord) do
+        record[k] = v
+    end
+
+    return record
+end
+
+function merge(record, parsedRecord)
+    -- If no exiting record exists
+    if record == nil then 
+        return parsedRecord
+    end
+    
+    -- Potentially overwrite or merge the original records.
+    for k, v in pairs(parsedRecord) do
+        -- If there is no conflict
+        if k == "logging.googleapis.com/logName" then 
+            -- Ignore the parsed payload since the logName is controlled
+            -- by the OpsAgent.
+        elseif k == "logging.googleapis.com/labels" then 
+            -- LogEntry.labels are basically a map[string]string and so only require a
+            -- shallow merge (one level deep merge).
+            record[k] = shallow_merge(record[k], v)
+        else
+            record[k] = v
+        end
+    end
+
+    return record
+end
+
+function parser_merge_record(tag, timestamp, record)
+    originalPayload = record["logging.googleapis.com/__tmp"]
+    if originalPayload == nil then
+        return 0, timestamp, record
+    end
+    
+    -- Remove original payload
+    record["logging.googleapis.com/__tmp"] = nil
+    record = merge(originalPayload, record)
+    return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows-2012/68d6a3a0e8edf37868e1bf94adc737f4.lua
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows-2012/68d6a3a0e8edf37868e1bf94adc737f4.lua
@@ -1,0 +1,38 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["message"]
+end)();
+local v = __field_0;
+if v == "LogParseErr" then v = "Ops Agent failed to parse logs, Code: LogParseErr, Documentation: https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/troubleshoot-find-info"
+elseif v == "LogPipelineErr" then v = "Ops Agent logging pipeline failed, Code: LogPipelineErr, Documentation: https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/troubleshoot-find-info"
+end
+(function(value)
+record["message"] = value
+end)(v)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows-2012/98b52408a7bd746aaf24acc193569c95.lua
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows-2012/98b52408a7bd746aaf24acc193569c95.lua
@@ -1,0 +1,17 @@
+
+function parser_nest(tag, timestamp, record)
+  local nestedRecord = {}
+  local parseKey = "TimeGenerated"
+  for k, v in pairs(record) do
+      if k ~= parseKey then
+          nestedRecord[k] = v
+      end
+  end
+
+  local result = {}
+  result[parseKey] = record[parseKey]
+  result["logging.googleapis.com/__tmp"] = nestedRecord
+
+  return 2, timestamp, result
+end
+

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows-2012/b4a0dead382dce7b4fe011d3f59fdb6d.lua
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows-2012/b4a0dead382dce7b4fe011d3f59fdb6d.lua
@@ -1,0 +1,17 @@
+
+function parser_nest(tag, timestamp, record)
+  local nestedRecord = {}
+  local parseKey = "message"
+  for k, v in pairs(record) do
+      if k ~= parseKey then
+          nestedRecord[k] = v
+      end
+  end
+
+  local result = {}
+  result[parseKey] = record[parseKey]
+  result["logging.googleapis.com/__tmp"] = nestedRecord
+
+  return 2, timestamp, result
+end
+

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows-2012/f261516bf0c22cc61bb3f5f741e83a3a.lua
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows-2012/f261516bf0c22cc61bb3f5f741e83a3a.lua
@@ -1,0 +1,42 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["agent.googleapis.com/log_file_path"]
+end)();
+local __field_1 = (function()
+if record["logging.googleapis.com/labels"] == nil
+then
+return nil
+end
+return record["logging.googleapis.com/labels"]["compute.googleapis.com/resource_name"]
+end)();
+local __field_2 = (function()
+return record["logging.googleapis.com/logName"]
+end)();
+(function(value)
+record["agent.googleapis.com/log_file_path"] = value
+end)(nil);
+local v = __field_0;
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/log_file_path"] = value
+end)(v)
+local v = __field_1;
+if v == nil then v = "" end;
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["compute.googleapis.com/resource_name"] = value
+end)(v)
+local v = __field_2;
+if v == nil then v = "windows_event_log" end;
+(function(value)
+record["logging.googleapis.com/logName"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows-2012/features.yaml
@@ -1,0 +1,8 @@
+- module: logging
+  feature: service:pipelines
+  key: default_pipeline_overridden
+  value: "false"
+- module: metrics
+  feature: service:pipelines
+  key: default_pipeline_overridden
+  value: "false"

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows-2012/fluent_bit_main.conf
@@ -1,0 +1,227 @@
+@SET buffers_dir=C:\ProgramData\Google\Cloud Operations\Ops Agent\run/buffers
+@SET logs_dir=C:\ProgramData\Google\Cloud Operations\Ops Agent\log
+
+[SERVICE]
+    Daemon                    off
+    Flush                     1
+    Log_Level                 debug
+    dns.resolver              legacy
+    storage.backlog.mem_limit 50M
+    storage.checksum          off
+    storage.max_chunks_up     128
+    storage.metrics           on
+    storage.sync              normal
+
+[INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 60
+    Scrape_On_Start True
+
+[INPUT]
+    Channels     System,Application,Security
+    DB           ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec 1
+    Name         winlog
+    Tag          default_pipeline.windows_event_log
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/logging-module.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-fluent-bit
+    storage.type      memory
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health
+    storage.type      memory
+
+[FILTER]
+    Match  default_pipeline.windows_event_log
+    Name   lua
+    call   parser_nest
+    script 98b52408a7bd746aaf24acc193569c95.lua
+
+[FILTER]
+    Key_Name     TimeGenerated
+    Match        default_pipeline.windows_event_log
+    Name         parser
+    Preserve_Key True
+    Reserve_Data True
+    Parser       default_pipeline.windows_event_log.timestamp_parser
+
+[FILTER]
+    Match  default_pipeline.windows_event_log
+    Name   lua
+    call   parser_merge_record
+    script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
+
+[FILTER]
+    Add       logging.googleapis.com/severity ERROR
+    Condition Key_Value_Equals EventType Error
+    Match     default_pipeline.windows_event_log
+    Name      modify
+
+[FILTER]
+    Add       logging.googleapis.com/severity INFO
+    Condition Key_Value_Equals EventType Information
+    Match     default_pipeline.windows_event_log
+    Name      modify
+
+[FILTER]
+    Add       logging.googleapis.com/severity WARNING
+    Condition Key_Value_Equals EventType Warning
+    Match     default_pipeline.windows_event_log
+    Name      modify
+
+[FILTER]
+    Add       logging.googleapis.com/severity NOTICE
+    Condition Key_Value_Equals EventType SuccessAudit
+    Match     default_pipeline.windows_event_log
+    Name      modify
+
+[FILTER]
+    Add       logging.googleapis.com/severity NOTICE
+    Condition Key_Value_Equals EventType FailureAudit
+    Match     default_pipeline.windows_event_log
+    Name      modify
+
+[FILTER]
+    Match  default_pipeline.windows_event_log
+    Name   lua
+    call   process
+    script f261516bf0c22cc61bb3f5f741e83a3a.lua
+
+[FILTER]
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   parser_nest
+    script b4a0dead382dce7b4fe011d3f59fdb6d.lua
+
+[FILTER]
+    Key_Name     message
+    Match        ops-agent-fluent-bit
+    Name         parser
+    Preserve_Key True
+    Reserve_Data True
+    Parser       ops-agent-fluent-bit.fluent-bit-self-log-regex-parsing
+
+[FILTER]
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   parser_merge_record
+    script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
+
+[FILTER]
+    Exclude severity DEBUG
+    Match   ops-agent-fluent-bit
+    Name    grep
+
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   parser_nest
+    script b4a0dead382dce7b4fe011d3f59fdb6d.lua
+
+[FILTER]
+    Key_Name     message
+    Match        ops-agent-health
+    Name         parser
+    Reserve_Data True
+    Parser       ops-agent-health.health-checks-json
+
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   parser_merge_record
+    script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
+
+[FILTER]
+    Match ops-agent-health
+    Name  grep
+    Regex severity INFO|ERROR|WARNING|DEBUG|info|error|warning|debug
+
+[FILTER]
+    Match ops-agent-fluent-bit
+    Name  rewrite_tag
+    Rule  message \[error\]\s\[lib\]\sbackend\sfailed ops-agent-health true
+
+[FILTER]
+    Name      modify
+    Match     ops-agent-health
+    Condition Key_value_matches message \[error\]\s\[lib\]\sbackend\sfailed
+    Set       message LogPipelineErr
+    Set       code LogPipelineErr
+
+[FILTER]
+    Match ops-agent-fluent-bit
+    Name  rewrite_tag
+    Rule  message \[error\]\s\[parser\]\scannot\sparse ops-agent-health true
+
+[FILTER]
+    Name      modify
+    Match     ops-agent-health
+    Condition Key_value_matches message \[error\]\s\[parser\]\scannot\sparse
+    Set       message LogParseErr
+    Set       code LogParseErr
+
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 68d6a3a0e8edf37868e1bf94adc737f4.lua
+
+[FILTER]
+    Match  ops-agent-*
+    Name   lua
+    call   process
+    script 4d6012ff003886818fb9b9285b4af962.lua
+
+[OUTPUT]
+    Match_Regex                   ^(default_pipeline\.windows_event_log)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      2G
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  20202

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows-2012/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows-2012/fluent_bit_parser.conf
@@ -1,0 +1,20 @@
+[PARSER]
+    Format      regex
+    Name        default_pipeline.windows_event_log.timestamp_parser
+    Regex       (?<timestamp>\d+-\d+-\d+ \d+:\d+:\d+ [+-]\d{4})
+    Time_Format %Y-%m-%d %H:%M:%S %z
+    Time_Key    timestamp
+
+[PARSER]
+    Format      regex
+    Name        ops-agent-fluent-bit.fluent-bit-self-log-regex-parsing
+    Regex       (?<message>\[[ ]*(?<time>\d+\/\d+\/\d+ \d+:\d+:\d+)] \[[ ]*(?<severity>[a-z]+)\].*)
+    Time_Format %Y/%m/%d %H:%M:%S
+    Time_Key    time
+    Types       severity:string
+
+[PARSER]
+    Format      json
+    Name        ops-agent-health.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows-2012/otel.yaml
@@ -1,0 +1,619 @@
+exporters:
+  googlecloud:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    retry_on_failure:
+      enabled: false
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+processors:
+  agentmetrics/hostmetrics_0:
+    blank_label_metrics:
+    - system.cpu.utilization
+  casttosum/iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
+  filter/default__pipeline_hostmetrics_0:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names: []
+  filter/default__pipeline_iis_0:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names: []
+  filter/default__pipeline_mssql_0:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names: []
+  filter/fluentbit_0:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+        - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
+        - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
+  filter/hostmetrics_1:
+    metrics:
+      exclude:
+        match_type: strict
+        metric_names:
+        - system.cpu.time
+        - system.network.dropped
+        - system.filesystem.inodes.usage
+        - system.paging.faults
+        - system.disk.operation_time
+  filter/otel_0:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+        - otelcol_process_uptime
+        - otelcol_process_memory_rss
+        - otelcol_grpc_io_client_completed_rpcs
+        - otelcol_googlecloudmonitoring_point_count
+  metricstransform/fluentbit_1:
+    transforms:
+    - action: update
+      include: fluentbit_uptime
+      new_name: agent/uptime
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: version
+        new_value: google-cloud-ops-agent-logging/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_proc_records_total
+      new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/hostmetrics_2:
+    transforms:
+    - action: update
+      include: system.cpu.time
+      new_name: cpu/usage_time
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: cpu
+        new_label: cpu_number
+      - action: update_label
+        label: state
+        new_label: cpu_state
+    - action: update
+      include: system.cpu.utilization
+      new_name: cpu/utilization
+      operations:
+      - action: aggregate_labels
+        aggregation_type: mean
+        label_set:
+        - state
+        - blank
+      - action: update_label
+        label: blank
+        new_label: cpu_number
+      - action: update_label
+        label: state
+        new_label: cpu_state
+    - action: update
+      include: system.cpu.load_average.1m
+      new_name: cpu/load_1m
+    - action: update
+      include: system.cpu.load_average.5m
+      new_name: cpu/load_5m
+    - action: update
+      include: system.cpu.load_average.15m
+      new_name: cpu/load_15m
+    - action: update
+      include: system.disk.read_io
+      new_name: disk/read_bytes_count
+    - action: update
+      include: system.disk.write_io
+      new_name: disk/write_bytes_count
+    - action: update
+      include: system.disk.operations
+      new_name: disk/operation_count
+    - action: update
+      include: system.disk.io_time
+      new_name: disk/io_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.weighted_io_time
+      new_name: disk/weighted_io_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.average_operation_time
+      new_name: disk/operation_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.pending_operations
+      new_name: disk/pending_operations
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.merged
+      new_name: disk/merged_operations
+    - action: update
+      include: system.filesystem.usage
+      new_name: disk/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: max
+        label_set:
+        - device
+        - state
+    - action: update
+      include: system.filesystem.utilization
+      new_name: disk/percent_used
+      operations:
+      - action: aggregate_labels
+        aggregation_type: max
+        label_set:
+        - device
+        - state
+    - action: update
+      include: system.memory.usage
+      new_name: memory/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_label_values
+        aggregated_values:
+        - slab_reclaimable
+        - slab_unreclaimable
+        aggregation_type: sum
+        label: state
+        new_value: slab
+    - action: update
+      include: system.memory.utilization
+      new_name: memory/percent_used
+      operations:
+      - action: aggregate_label_values
+        aggregated_values:
+        - slab_reclaimable
+        - slab_unreclaimable
+        aggregation_type: sum
+        label: state
+        new_value: slab
+    - action: update
+      include: system.network.io
+      new_name: interface/traffic
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.errors
+      new_name: interface/errors
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.packets
+      new_name: interface/packets
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.connections
+      new_name: network/tcp_connections
+      operations:
+      - action: toggle_scalar_data_type
+      - action: delete_label_value
+        label: protocol
+        label_value: udp
+      - action: update_label
+        label: state
+        new_label: tcp_state
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - tcp_state
+      - action: add_label
+        new_label: port
+        new_value: all
+    - action: update
+      include: system.processes.created
+      new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
+    - action: update
+      include: system.paging.usage
+      new_name: swap/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.paging.utilization
+      new_name: swap/percent_used
+    - action: insert
+      include: swap/percent_used
+      new_name: pagefile/percent_used
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - state
+    - action: update
+      include: system.paging.operations
+      new_name: swap/io
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - direction
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: in
+          value: page_in
+        - new_value: out
+          value: page_out
+    - action: update
+      include: process.cpu.time
+      new_name: processes/cpu_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1e+06
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+      - action: delete_label_value
+        label: state
+        label_value: wait
+      - action: update_label
+        label: state
+        new_label: user_or_syst
+      - action: update_label
+        label: user_or_syst
+        value_actions:
+        - new_value: syst
+          value: system
+    - action: update
+      include: process.disk.read_io
+      new_name: processes/disk/read_bytes_count
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.disk.write_io
+      new_name: processes/disk/write_bytes_count
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.memory.usage
+      new_name: processes/rss_usage
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.memory.virtual
+      new_name: processes/vm_usage
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.handles
+      new_name: processes/windows/handles
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/iis_0:
+    transforms:
+    - action: update
+      include: "\\Web Service(_Total)\\Current Connections"
+      new_name: iis/current_connections
+    - action: combine
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
+      match_type: regexp
+      new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
+      submatch_case: lower
+    - action: update
+      include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
+      new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
+    - action: combine
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
+      match_type: regexp
+      new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      submatch_case: lower
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/mssql_0:
+    transforms:
+    - action: update
+      include: "\\SQLServer:General Statistics(_Total)\\User Connections"
+      new_name: mssql/connections/user
+    - action: update
+      include: "\\SQLServer:Databases(_Total)\\Transactions/sec"
+      new_name: mssql/transaction_rate
+    - action: update
+      include: "\\SQLServer:Databases(_Total)\\Write Transactions/sec"
+      new_name: mssql/write_transaction_rate
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/otel_1:
+    transforms:
+    - action: update
+      include: otelcol_process_uptime
+      new_name: agent/uptime
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: version
+        new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
+    - action: update
+      include: otelcol_process_memory_rss
+      new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
+    - action: update
+      include: otelcol_grpc_io_client_completed_rpcs
+      new_name: agent/api_request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: grpc_client_status
+        new_label: state
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - state
+    - action: update
+      include: otelcol_googlecloudmonitoring_point_count
+      new_name: agent/monitoring/point_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  modifyscope/iis_3:
+    override_scope_name: agent.googleapis.com/iis
+    override_scope_version: "1.0"
+  modifyscope/mssql_1:
+    override_scope_name: agent.googleapis.com/mssql
+    override_scope_version: "1.0"
+  normalizesums/iis_2: {}
+  resourcedetection/_global_0:
+    detectors:
+    - gcp
+receivers:
+  hostmetrics/hostmetrics:
+    collection_interval: 60s
+    scrapers:
+      cpu: {}
+      disk: {}
+      filesystem: {}
+      load: {}
+      memory: {}
+      network: {}
+      paging: {}
+      process:
+        metrics:
+          process.handles:
+            enabled: true
+        mute_process_name_error: true
+      processes: {}
+  prometheus/fluentbit:
+    config:
+      scrape_configs:
+      - job_name: logging-collector
+        metrics_path: /metrics
+        scrape_interval: 1m
+        static_configs:
+        - targets:
+          - 0.0.0.0:20202
+  prometheus/otel:
+    config:
+      scrape_configs:
+      - job_name: otel-collector
+        scrape_interval: 1m
+        static_configs:
+        - targets:
+          - 0.0.0.0:20201
+  windowsperfcounters/iis:
+    collection_interval: 60s
+    perfcounters:
+    - counters:
+      - name: Current Connections
+      - name: Total Bytes Received
+      - name: Total Bytes Sent
+      - name: Total Connection Attempts (all instances)
+      - name: Total Delete Requests
+      - name: Total Get Requests
+      - name: Total Head Requests
+      - name: Total Options Requests
+      - name: Total Post Requests
+      - name: Total Put Requests
+      - name: Total Trace Requests
+      instances:
+      - _Total
+      object: Web Service
+  windowsperfcounters/mssql:
+    collection_interval: 60s
+    perfcounters:
+    - counters:
+      - name: User Connections
+      instances:
+      - _Total
+      object: SQLServer:General Statistics
+    - counters:
+      - name: Transactions/sec
+      - name: Write Transactions/sec
+      instances:
+      - _Total
+      object: SQLServer:Databases
+service:
+  pipelines:
+    metrics/default__pipeline_hostmetrics:
+      exporters:
+      - googlecloud
+      processors:
+      - agentmetrics/hostmetrics_0
+      - filter/hostmetrics_1
+      - metricstransform/hostmetrics_2
+      - filter/default__pipeline_hostmetrics_0
+      - resourcedetection/_global_0
+      receivers:
+      - hostmetrics/hostmetrics
+    metrics/default__pipeline_iis:
+      exporters:
+      - googlecloud
+      processors:
+      - metricstransform/iis_0
+      - casttosum/iis_1
+      - normalizesums/iis_2
+      - modifyscope/iis_3
+      - filter/default__pipeline_iis_0
+      - resourcedetection/_global_0
+      receivers:
+      - windowsperfcounters/iis
+    metrics/default__pipeline_mssql:
+      exporters:
+      - googlecloud
+      processors:
+      - metricstransform/mssql_0
+      - modifyscope/mssql_1
+      - filter/default__pipeline_mssql_0
+      - resourcedetection/_global_0
+      receivers:
+      - windowsperfcounters/mssql
+    metrics/fluentbit:
+      exporters:
+      - googlecloud
+      processors:
+      - filter/fluentbit_0
+      - metricstransform/fluentbit_1
+      - resourcedetection/_global_0
+      receivers:
+      - prometheus/fluentbit
+    metrics/otel:
+      exporters:
+      - googlecloud
+      processors:
+      - filter/otel_0
+      - metricstransform/otel_1
+      - resourcedetection/_global_0
+      receivers:
+      - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows/4d6012ff003886818fb9b9285b4af962.lua
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows/4d6012ff003886818fb9b9285b4af962.lua
@@ -1,0 +1,19 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["severity"]
+end)();
+(function(value)
+record["severity"] = value
+end)(nil);
+local v = __field_0;
+if v == "debug" then v = "DEBUG"
+elseif v == "error" then v = "ERROR"
+elseif v == "info" then v = "INFO"
+elseif v == "warn" then v = "WARNING"
+end
+(function(value)
+record["logging.googleapis.com/severity"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows/5fc5f42c16c9e1ab8292e3d42f74f3be.lua
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows/5fc5f42c16c9e1ab8292e3d42f74f3be.lua
@@ -1,0 +1,49 @@
+
+  function shallow_merge(record, parsedRecord)
+    -- If no exiting record exists
+    if (record == nil) then 
+        return parsedRecord
+    end
+    
+    for k, v in pairs(parsedRecord) do
+        record[k] = v
+    end
+
+    return record
+end
+
+function merge(record, parsedRecord)
+    -- If no exiting record exists
+    if record == nil then 
+        return parsedRecord
+    end
+    
+    -- Potentially overwrite or merge the original records.
+    for k, v in pairs(parsedRecord) do
+        -- If there is no conflict
+        if k == "logging.googleapis.com/logName" then 
+            -- Ignore the parsed payload since the logName is controlled
+            -- by the OpsAgent.
+        elseif k == "logging.googleapis.com/labels" then 
+            -- LogEntry.labels are basically a map[string]string and so only require a
+            -- shallow merge (one level deep merge).
+            record[k] = shallow_merge(record[k], v)
+        else
+            record[k] = v
+        end
+    end
+
+    return record
+end
+
+function parser_merge_record(tag, timestamp, record)
+    originalPayload = record["logging.googleapis.com/__tmp"]
+    if originalPayload == nil then
+        return 0, timestamp, record
+    end
+    
+    -- Remove original payload
+    record["logging.googleapis.com/__tmp"] = nil
+    record = merge(originalPayload, record)
+    return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows/68d6a3a0e8edf37868e1bf94adc737f4.lua
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows/68d6a3a0e8edf37868e1bf94adc737f4.lua
@@ -1,0 +1,38 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["message"]
+end)();
+local v = __field_0;
+if v == "LogParseErr" then v = "Ops Agent failed to parse logs, Code: LogParseErr, Documentation: https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/troubleshoot-find-info"
+elseif v == "LogPipelineErr" then v = "Ops Agent logging pipeline failed, Code: LogPipelineErr, Documentation: https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/troubleshoot-find-info"
+end
+(function(value)
+record["message"] = value
+end)(v)
+local v = "ops-agent";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentKind"] = value
+end)(v)
+local v = "latest";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/agentVersion"] = value
+end)(v)
+local v = "v1";
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/health/schemaVersion"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows/98b52408a7bd746aaf24acc193569c95.lua
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows/98b52408a7bd746aaf24acc193569c95.lua
@@ -1,0 +1,17 @@
+
+function parser_nest(tag, timestamp, record)
+  local nestedRecord = {}
+  local parseKey = "TimeGenerated"
+  for k, v in pairs(record) do
+      if k ~= parseKey then
+          nestedRecord[k] = v
+      end
+  end
+
+  local result = {}
+  result[parseKey] = record[parseKey]
+  result["logging.googleapis.com/__tmp"] = nestedRecord
+
+  return 2, timestamp, result
+end
+

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows/b4a0dead382dce7b4fe011d3f59fdb6d.lua
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows/b4a0dead382dce7b4fe011d3f59fdb6d.lua
@@ -1,0 +1,17 @@
+
+function parser_nest(tag, timestamp, record)
+  local nestedRecord = {}
+  local parseKey = "message"
+  for k, v in pairs(record) do
+      if k ~= parseKey then
+          nestedRecord[k] = v
+      end
+  end
+
+  local result = {}
+  result[parseKey] = record[parseKey]
+  result["logging.googleapis.com/__tmp"] = nestedRecord
+
+  return 2, timestamp, result
+end
+

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows/f261516bf0c22cc61bb3f5f741e83a3a.lua
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows/f261516bf0c22cc61bb3f5f741e83a3a.lua
@@ -1,0 +1,42 @@
+
+function process(tag, timestamp, record)
+local __field_0 = (function()
+return record["agent.googleapis.com/log_file_path"]
+end)();
+local __field_1 = (function()
+if record["logging.googleapis.com/labels"] == nil
+then
+return nil
+end
+return record["logging.googleapis.com/labels"]["compute.googleapis.com/resource_name"]
+end)();
+local __field_2 = (function()
+return record["logging.googleapis.com/logName"]
+end)();
+(function(value)
+record["agent.googleapis.com/log_file_path"] = value
+end)(nil);
+local v = __field_0;
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["agent.googleapis.com/log_file_path"] = value
+end)(v)
+local v = __field_1;
+if v == nil then v = "" end;
+(function(value)
+if record["logging.googleapis.com/labels"] == nil
+then
+record["logging.googleapis.com/labels"] = {}
+end
+record["logging.googleapis.com/labels"]["compute.googleapis.com/resource_name"] = value
+end)(v)
+local v = __field_2;
+if v == nil then v = "windows_event_log" end;
+(function(value)
+record["logging.googleapis.com/logName"] = value
+end)(v)
+return 2, timestamp, record
+end

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows/features.yaml
@@ -1,0 +1,8 @@
+- module: logging
+  feature: service:pipelines
+  key: default_pipeline_overridden
+  value: "false"
+- module: metrics
+  feature: service:pipelines
+  key: default_pipeline_overridden
+  value: "false"

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows/fluent_bit_main.conf
@@ -1,0 +1,227 @@
+@SET buffers_dir=C:\ProgramData\Google\Cloud Operations\Ops Agent\run/buffers
+@SET logs_dir=C:\ProgramData\Google\Cloud Operations\Ops Agent\log
+
+[SERVICE]
+    Daemon                    off
+    Flush                     1
+    Log_Level                 debug
+    dns.resolver              legacy
+    storage.backlog.mem_limit 50M
+    storage.checksum          off
+    storage.max_chunks_up     128
+    storage.metrics           on
+    storage.sync              normal
+
+[INPUT]
+    Name            fluentbit_metrics
+    Scrape_Interval 60
+    Scrape_On_Start True
+
+[INPUT]
+    Channels     System,Application,Security
+    DB           ${buffers_dir}/default_pipeline_windows_event_log
+    Interval_Sec 1
+    Name         winlog
+    Tag          default_pipeline.windows_event_log
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-fluent-bit
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/logging-module.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-fluent-bit
+    storage.type      memory
+
+[INPUT]
+    Buffer_Chunk_Size 512k
+    Buffer_Max_Size   2M
+    DB                ${buffers_dir}/ops-agent-health
+    DB.locking        true
+    Key               message
+    Mem_Buf_Limit     10M
+    Name              tail
+    Path              ${logs_dir}/health-checks.log
+    Read_from_Head    True
+    Rotate_Wait       30
+    Skip_Long_Lines   On
+    Tag               ops-agent-health
+    storage.type      memory
+
+[FILTER]
+    Match  default_pipeline.windows_event_log
+    Name   lua
+    call   parser_nest
+    script 98b52408a7bd746aaf24acc193569c95.lua
+
+[FILTER]
+    Key_Name     TimeGenerated
+    Match        default_pipeline.windows_event_log
+    Name         parser
+    Preserve_Key True
+    Reserve_Data True
+    Parser       default_pipeline.windows_event_log.timestamp_parser
+
+[FILTER]
+    Match  default_pipeline.windows_event_log
+    Name   lua
+    call   parser_merge_record
+    script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
+
+[FILTER]
+    Add       logging.googleapis.com/severity ERROR
+    Condition Key_Value_Equals EventType Error
+    Match     default_pipeline.windows_event_log
+    Name      modify
+
+[FILTER]
+    Add       logging.googleapis.com/severity INFO
+    Condition Key_Value_Equals EventType Information
+    Match     default_pipeline.windows_event_log
+    Name      modify
+
+[FILTER]
+    Add       logging.googleapis.com/severity WARNING
+    Condition Key_Value_Equals EventType Warning
+    Match     default_pipeline.windows_event_log
+    Name      modify
+
+[FILTER]
+    Add       logging.googleapis.com/severity NOTICE
+    Condition Key_Value_Equals EventType SuccessAudit
+    Match     default_pipeline.windows_event_log
+    Name      modify
+
+[FILTER]
+    Add       logging.googleapis.com/severity NOTICE
+    Condition Key_Value_Equals EventType FailureAudit
+    Match     default_pipeline.windows_event_log
+    Name      modify
+
+[FILTER]
+    Match  default_pipeline.windows_event_log
+    Name   lua
+    call   process
+    script f261516bf0c22cc61bb3f5f741e83a3a.lua
+
+[FILTER]
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   parser_nest
+    script b4a0dead382dce7b4fe011d3f59fdb6d.lua
+
+[FILTER]
+    Key_Name     message
+    Match        ops-agent-fluent-bit
+    Name         parser
+    Preserve_Key True
+    Reserve_Data True
+    Parser       ops-agent-fluent-bit.fluent-bit-self-log-regex-parsing
+
+[FILTER]
+    Match  ops-agent-fluent-bit
+    Name   lua
+    call   parser_merge_record
+    script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
+
+[FILTER]
+    Exclude severity DEBUG
+    Match   ops-agent-fluent-bit
+    Name    grep
+
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   parser_nest
+    script b4a0dead382dce7b4fe011d3f59fdb6d.lua
+
+[FILTER]
+    Key_Name     message
+    Match        ops-agent-health
+    Name         parser
+    Reserve_Data True
+    Parser       ops-agent-health.health-checks-json
+
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   parser_merge_record
+    script 5fc5f42c16c9e1ab8292e3d42f74f3be.lua
+
+[FILTER]
+    Match ops-agent-health
+    Name  grep
+    Regex severity INFO|ERROR|WARNING|DEBUG|info|error|warning|debug
+
+[FILTER]
+    Match ops-agent-fluent-bit
+    Name  rewrite_tag
+    Rule  message \[error\]\s\[lib\]\sbackend\sfailed ops-agent-health true
+
+[FILTER]
+    Name      modify
+    Match     ops-agent-health
+    Condition Key_value_matches message \[error\]\s\[lib\]\sbackend\sfailed
+    Set       message LogPipelineErr
+    Set       code LogPipelineErr
+
+[FILTER]
+    Match ops-agent-fluent-bit
+    Name  rewrite_tag
+    Rule  message \[error\]\s\[parser\]\scannot\sparse ops-agent-health true
+
+[FILTER]
+    Name      modify
+    Match     ops-agent-health
+    Condition Key_value_matches message \[error\]\s\[parser\]\scannot\sparse
+    Set       message LogParseErr
+    Set       code LogParseErr
+
+[FILTER]
+    Match  ops-agent-health
+    Name   lua
+    call   process
+    script 68d6a3a0e8edf37868e1bf94adc737f4.lua
+
+[FILTER]
+    Match  ops-agent-*
+    Name   lua
+    call   process
+    script 4d6012ff003886818fb9b9285b4af962.lua
+
+[OUTPUT]
+    Match_Regex                   ^(default_pipeline\.windows_event_log)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    storage.total_limit_size      2G
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match_Regex                   ^(ops-agent-fluent-bit|ops-agent-health)$
+    Name                          stackdriver
+    Retry_Limit                   3
+    http_request_key              logging.googleapis.com/httpRequest
+    net.connect_timeout_log_error False
+    resource                      gce_instance
+    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    tls                           On
+    tls.verify                    Off
+    workers                       8
+
+[OUTPUT]
+    Match *
+    Name  prometheus_exporter
+    host  0.0.0.0
+    port  20202

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows/fluent_bit_parser.conf
@@ -1,0 +1,20 @@
+[PARSER]
+    Format      regex
+    Name        default_pipeline.windows_event_log.timestamp_parser
+    Regex       (?<timestamp>\d+-\d+-\d+ \d+:\d+:\d+ [+-]\d{4})
+    Time_Format %Y-%m-%d %H:%M:%S %z
+    Time_Key    timestamp
+
+[PARSER]
+    Format      regex
+    Name        ops-agent-fluent-bit.fluent-bit-self-log-regex-parsing
+    Regex       (?<message>\[[ ]*(?<time>\d+\/\d+\/\d+ \d+:\d+:\d+)] \[[ ]*(?<severity>[a-z]+)\].*)
+    Time_Format %Y/%m/%d %H:%M:%S
+    Time_Key    time
+    Types       severity:string
+
+[PARSER]
+    Format      json
+    Name        ops-agent-health.health-checks-json
+    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Key    time

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/golden/windows/otel.yaml
@@ -1,0 +1,619 @@
+exporters:
+  googlecloud:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    retry_on_failure:
+      enabled: false
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+processors:
+  agentmetrics/hostmetrics_0:
+    blank_label_metrics:
+    - system.cpu.utilization
+  casttosum/iis_1:
+    metrics:
+    - agent.googleapis.com/iis/network/transferred_bytes_count
+    - agent.googleapis.com/iis/new_connection_count
+    - agent.googleapis.com/iis/request_count
+  filter/default__pipeline_hostmetrics_0:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names: []
+  filter/default__pipeline_iis_0:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names: []
+  filter/default__pipeline_mssql_0:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names: []
+  filter/fluentbit_0:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+        - fluentbit_uptime
+        - fluentbit_stackdriver_requests_total
+        - fluentbit_stackdriver_proc_records_total
+        - fluentbit_stackdriver_retried_records_total
+  filter/hostmetrics_1:
+    metrics:
+      exclude:
+        match_type: strict
+        metric_names:
+        - system.cpu.time
+        - system.network.dropped
+        - system.filesystem.inodes.usage
+        - system.paging.faults
+        - system.disk.operation_time
+  filter/otel_0:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+        - otelcol_process_uptime
+        - otelcol_process_memory_rss
+        - otelcol_grpc_io_client_completed_rpcs
+        - otelcol_googlecloudmonitoring_point_count
+  metricstransform/fluentbit_1:
+    transforms:
+    - action: update
+      include: fluentbit_uptime
+      new_name: agent/uptime
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: version
+        new_value: google-cloud-ops-agent-logging/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
+    - action: update
+      include: fluentbit_stackdriver_requests_total
+      new_name: agent/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_proc_records_total
+      new_name: agent/log_entry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: fluentbit_stackdriver_retried_records_total
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: response_code
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/hostmetrics_2:
+    transforms:
+    - action: update
+      include: system.cpu.time
+      new_name: cpu/usage_time
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: cpu
+        new_label: cpu_number
+      - action: update_label
+        label: state
+        new_label: cpu_state
+    - action: update
+      include: system.cpu.utilization
+      new_name: cpu/utilization
+      operations:
+      - action: aggregate_labels
+        aggregation_type: mean
+        label_set:
+        - state
+        - blank
+      - action: update_label
+        label: blank
+        new_label: cpu_number
+      - action: update_label
+        label: state
+        new_label: cpu_state
+    - action: update
+      include: system.cpu.load_average.1m
+      new_name: cpu/load_1m
+    - action: update
+      include: system.cpu.load_average.5m
+      new_name: cpu/load_5m
+    - action: update
+      include: system.cpu.load_average.15m
+      new_name: cpu/load_15m
+    - action: update
+      include: system.disk.read_io
+      new_name: disk/read_bytes_count
+    - action: update
+      include: system.disk.write_io
+      new_name: disk/write_bytes_count
+    - action: update
+      include: system.disk.operations
+      new_name: disk/operation_count
+    - action: update
+      include: system.disk.io_time
+      new_name: disk/io_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.weighted_io_time
+      new_name: disk/weighted_io_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.average_operation_time
+      new_name: disk/operation_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1000.0
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.pending_operations
+      new_name: disk/pending_operations
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.disk.merged
+      new_name: disk/merged_operations
+    - action: update
+      include: system.filesystem.usage
+      new_name: disk/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: max
+        label_set:
+        - device
+        - state
+    - action: update
+      include: system.filesystem.utilization
+      new_name: disk/percent_used
+      operations:
+      - action: aggregate_labels
+        aggregation_type: max
+        label_set:
+        - device
+        - state
+    - action: update
+      include: system.memory.usage
+      new_name: memory/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_label_values
+        aggregated_values:
+        - slab_reclaimable
+        - slab_unreclaimable
+        aggregation_type: sum
+        label: state
+        new_value: slab
+    - action: update
+      include: system.memory.utilization
+      new_name: memory/percent_used
+      operations:
+      - action: aggregate_label_values
+        aggregated_values:
+        - slab_reclaimable
+        - slab_unreclaimable
+        aggregation_type: sum
+        label: state
+        new_value: slab
+    - action: update
+      include: system.network.io
+      new_name: interface/traffic
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.errors
+      new_name: interface/errors
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.packets
+      new_name: interface/packets
+      operations:
+      - action: update_label
+        label: interface
+        new_label: device
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: rx
+          value: receive
+        - new_value: tx
+          value: transmit
+    - action: update
+      include: system.network.connections
+      new_name: network/tcp_connections
+      operations:
+      - action: toggle_scalar_data_type
+      - action: delete_label_value
+        label: protocol
+        label_value: udp
+      - action: update_label
+        label: state
+        new_label: tcp_state
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - tcp_state
+      - action: add_label
+        new_label: port
+        new_value: all
+    - action: update
+      include: system.processes.created
+      new_name: processes/fork_count
+    - action: update
+      include: system.processes.count
+      new_name: processes/count_by_state
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: status
+        new_label: state
+    - action: update
+      include: system.paging.usage
+      new_name: swap/bytes_used
+      operations:
+      - action: toggle_scalar_data_type
+    - action: update
+      include: system.paging.utilization
+      new_name: swap/percent_used
+    - action: insert
+      include: swap/percent_used
+      new_name: pagefile/percent_used
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - state
+    - action: update
+      include: system.paging.operations
+      new_name: swap/io
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - direction
+      - action: update_label
+        label: direction
+        value_actions:
+        - new_value: in
+          value: page_in
+        - new_value: out
+          value: page_out
+    - action: update
+      include: process.cpu.time
+      new_name: processes/cpu_time
+      operations:
+      - action: experimental_scale_value
+        experimental_scale: 1e+06
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+      - action: delete_label_value
+        label: state
+        label_value: wait
+      - action: update_label
+        label: state
+        new_label: user_or_syst
+      - action: update_label
+        label: user_or_syst
+        value_actions:
+        - new_value: syst
+          value: system
+    - action: update
+      include: process.disk.read_io
+      new_name: processes/disk/read_bytes_count
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.disk.write_io
+      new_name: processes/disk/write_bytes_count
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.memory.usage
+      new_name: processes/rss_usage
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.memory.virtual
+      new_name: processes/vm_usage
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: process.handles
+      new_name: processes/windows/handles
+      operations:
+      - action: add_label
+        new_label: process
+        new_value: all
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/iis_0:
+    transforms:
+    - action: update
+      include: "\\Web Service(_Total)\\Current Connections"
+      new_name: iis/current_connections
+    - action: combine
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total Bytes (?P<direction>.*)$$"
+      match_type: regexp
+      new_name: iis/network/transferred_bytes_count
+      operations:
+      - action: toggle_scalar_data_type
+      submatch_case: lower
+    - action: update
+      include: "\\Web Service(_Total)\\Total Connection Attempts (all instances)"
+      new_name: iis/new_connection_count
+      operations:
+      - action: toggle_scalar_data_type
+    - action: combine
+      include: "^\\\\Web Service\\(_Total\\)\\\\Total (?P<http_method>.*) Requests$$"
+      match_type: regexp
+      new_name: iis/request_count
+      operations:
+      - action: toggle_scalar_data_type
+      submatch_case: lower
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/mssql_0:
+    transforms:
+    - action: update
+      include: "\\SQLServer:General Statistics(_Total)\\User Connections"
+      new_name: mssql/connections/user
+    - action: update
+      include: "\\SQLServer:Databases(_Total)\\Transactions/sec"
+      new_name: mssql/transaction_rate
+    - action: update
+      include: "\\SQLServer:Databases(_Total)\\Write Transactions/sec"
+      new_name: mssql/write_transaction_rate
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  metricstransform/otel_1:
+    transforms:
+    - action: update
+      include: otelcol_process_uptime
+      new_name: agent/uptime
+      operations:
+      - action: toggle_scalar_data_type
+      - action: add_label
+        new_label: version
+        new_value: google-cloud-ops-agent-metrics/latest-build_distro
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
+    - action: update
+      include: otelcol_process_memory_rss
+      new_name: agent/memory_usage
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set: []
+    - action: update
+      include: otelcol_grpc_io_client_completed_rpcs
+      new_name: agent/api_request_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: update_label
+        label: grpc_client_status
+        new_label: state
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - state
+    - action: update
+      include: otelcol_googlecloudmonitoring_point_count
+      new_name: agent/monitoring/point_count
+      operations:
+      - action: toggle_scalar_data_type
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - status
+    - action: update
+      include: ^(.*)$$
+      match_type: regexp
+      new_name: agent.googleapis.com/$${1}
+  modifyscope/iis_3:
+    override_scope_name: agent.googleapis.com/iis
+    override_scope_version: "1.0"
+  modifyscope/mssql_1:
+    override_scope_name: agent.googleapis.com/mssql
+    override_scope_version: "1.0"
+  normalizesums/iis_2: {}
+  resourcedetection/_global_0:
+    detectors:
+    - gcp
+receivers:
+  hostmetrics/hostmetrics:
+    collection_interval: 60s
+    scrapers:
+      cpu: {}
+      disk: {}
+      filesystem: {}
+      load: {}
+      memory: {}
+      network: {}
+      paging: {}
+      process:
+        metrics:
+          process.handles:
+            enabled: true
+        mute_process_name_error: true
+      processes: {}
+  prometheus/fluentbit:
+    config:
+      scrape_configs:
+      - job_name: logging-collector
+        metrics_path: /metrics
+        scrape_interval: 1m
+        static_configs:
+        - targets:
+          - 0.0.0.0:20202
+  prometheus/otel:
+    config:
+      scrape_configs:
+      - job_name: otel-collector
+        scrape_interval: 1m
+        static_configs:
+        - targets:
+          - 0.0.0.0:20201
+  windowsperfcounters/iis:
+    collection_interval: 60s
+    perfcounters:
+    - counters:
+      - name: Current Connections
+      - name: Total Bytes Received
+      - name: Total Bytes Sent
+      - name: Total Connection Attempts (all instances)
+      - name: Total Delete Requests
+      - name: Total Get Requests
+      - name: Total Head Requests
+      - name: Total Options Requests
+      - name: Total Post Requests
+      - name: Total Put Requests
+      - name: Total Trace Requests
+      instances:
+      - _Total
+      object: Web Service
+  windowsperfcounters/mssql:
+    collection_interval: 60s
+    perfcounters:
+    - counters:
+      - name: User Connections
+      instances:
+      - _Total
+      object: SQLServer:General Statistics
+    - counters:
+      - name: Transactions/sec
+      - name: Write Transactions/sec
+      instances:
+      - _Total
+      object: SQLServer:Databases
+service:
+  pipelines:
+    metrics/default__pipeline_hostmetrics:
+      exporters:
+      - googlecloud
+      processors:
+      - agentmetrics/hostmetrics_0
+      - filter/hostmetrics_1
+      - metricstransform/hostmetrics_2
+      - filter/default__pipeline_hostmetrics_0
+      - resourcedetection/_global_0
+      receivers:
+      - hostmetrics/hostmetrics
+    metrics/default__pipeline_iis:
+      exporters:
+      - googlecloud
+      processors:
+      - metricstransform/iis_0
+      - casttosum/iis_1
+      - normalizesums/iis_2
+      - modifyscope/iis_3
+      - filter/default__pipeline_iis_0
+      - resourcedetection/_global_0
+      receivers:
+      - windowsperfcounters/iis
+    metrics/default__pipeline_mssql:
+      exporters:
+      - googlecloud
+      processors:
+      - metricstransform/mssql_0
+      - modifyscope/mssql_1
+      - filter/default__pipeline_mssql_0
+      - resourcedetection/_global_0
+      receivers:
+      - windowsperfcounters/mssql
+    metrics/fluentbit:
+      exporters:
+      - googlecloud
+      processors:
+      - filter/fluentbit_0
+      - metricstransform/fluentbit_1
+      - resourcedetection/_global_0
+      receivers:
+      - prometheus/fluentbit
+    metrics/otel:
+      exporters:
+      - googlecloud
+      processors:
+      - filter/otel_0
+      - metricstransform/otel_1
+      - resourcedetection/_global_0
+      receivers:
+      - prometheus/otel
+  telemetry:
+    metrics:
+      address: 0.0.0.0:20201

--- a/confgenerator/testdata/goldens/logging-service_log_level_debug/input.yaml
+++ b/confgenerator/testdata/goldens/logging-service_log_level_debug/input.yaml
@@ -1,0 +1,3 @@
+logging:
+  service:
+    log_level: debug

--- a/tasks.mak
+++ b/tasks.mak
@@ -72,6 +72,14 @@ test_confgenerator_update:
 test_metadata_update:
 	go test ./integration_test/metadata -update
 
+new_confgenerator_test:
+ifndef TEST_NAME
+	$(error "Please provide a TEST_NAME argument")
+endif
+	mkdir -p ./confgenerator/testdata/goldens/$(TEST_NAME) 
+	mkdir -p ./confgenerator/testdata/goldens/$(TEST_NAME)/golden
+	touch ./confgenerator/testdata/goldens/$(TEST_NAME)/input.yaml
+
 ############
 # Integration Tests
 ############


### PR DESCRIPTION
## Description
Currently, Fluent Bit self logs absolutely explode if you turn on debug logging. This PR will add a filter to drop `DEBUG` Fluent Bit logs when the logging level is set to `debug` in the Ops Agent config.

## Related issue
b/272779619

## How has this been tested?
Tested the generated config in my own environment to ensure debug logs weren't sent to Cloud Logging.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
