### PR TITLE
Internal: Step 1 of renaming configs `arm64`->`aarch64`

### DIFF
--- a/kokoro/config/build/presubmit/bullseye_aarch64.gcl
+++ b/kokoro/config/build/presubmit/bullseye_aarch64.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'bullseye'
+      PKGFORMAT = 'deb'
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/focal_aarch64.gcl
+++ b/kokoro/config/build/presubmit/focal_aarch64.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'focal'
+      PKGFORMAT = 'deb'
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/rockylinux9_aarch64.gcl
+++ b/kokoro/config/build/presubmit/rockylinux9_aarch64.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'rockylinux9'
+      PKGFORMAT = 'rpm'
+    }
+  }
+}

--- a/kokoro/config/test/common.gcl
+++ b/kokoro/config/test/common.gcl
@@ -19,6 +19,14 @@ local _zones_for_arch = {
 
   // T2A machines are only available on us-central1-{a,b,f}.
   // See warning above about changing regions.
+  aarch64 = join([
+    'us-central1-a',
+    'us-central1-b',
+    'us-central1-f',
+  ], ',')
+
+  // TODO: b/288442211 - Remove this once everything is switched over to using
+  // "aarch64".
   arm64 = join([
     'us-central1-a',
     'us-central1-b',

--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -38,7 +38,7 @@ bullseye = _distro {
   release = ['debian-11']
   presubmit = ['debian-11']
 }
-bullseye_arm64 = _distro {
+bullseye_aarch64 = _distro {
   release = ['debian-11-arm64']
   presubmit = ['debian-11-arm64']
 }
@@ -49,7 +49,7 @@ focal = _distro {
   ]
   presubmit = ['ubuntu-minimal-2004-lts']
 }
-focal_arm64 = _distro {
+focal_aarch64 = _distro {
   release = [
       'ubuntu-2004-lts-arm64',
       'ubuntu-minimal-2004-lts-arm64',
@@ -98,7 +98,7 @@ rockylinux9 = _distro {
   ]
   presubmit = ['rocky-linux-9']
 }
-rockylinux9_arm64 = _distro {
+rockylinux9_aarch64 = _distro {
   release = [
     // RHEL.
     'rhel-9-arm64',
@@ -143,3 +143,10 @@ windows = _distro {
     'windows-2019',
   ]
 }
+
+// TODO: b/288442211: Remove these old aliases once everything is switched over
+// to <distro>_aarch64.
+bullseye_arm64 = bullseye_aarch64
+focal_arm64 = focal_aarch64
+rockylinux9_arm64 = rockylinux9_aarch64
+

--- a/kokoro/config/test/ops_agent/bullseye_aarch64.gcl
+++ b/kokoro/config/test/ops_agent/bullseye_aarch64.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.bullseye_aarch64.presubmit
+    arch = 'aarch64'
+  }
+}

--- a/kokoro/config/test/ops_agent/focal_aarch64.gcl
+++ b/kokoro/config/test/ops_agent/focal_aarch64.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.focal_aarch64.presubmit
+    arch = 'aarch64'
+  }
+}

--- a/kokoro/config/test/ops_agent/release/bullseye_aarch64.gcl
+++ b/kokoro/config/test/ops_agent/release/bullseye_aarch64.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.bullseye_aarch64.release
+    arch = 'aarch64'
+  }
+}

--- a/kokoro/config/test/ops_agent/release/focal_aarch64.gcl
+++ b/kokoro/config/test/ops_agent/release/focal_aarch64.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.focal_aarch64.release
+    arch = 'aarch64'
+  }
+}

--- a/kokoro/config/test/ops_agent/release/rockylinux9_aarch64.gcl
+++ b/kokoro/config/test/ops_agent/release/rockylinux9_aarch64.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.rockylinux9_aarch64.release
+    arch = 'aarch64'
+  }
+}

--- a/kokoro/config/test/ops_agent/rockylinux9_aarch64.gcl
+++ b/kokoro/config/test/ops_agent/rockylinux9_aarch64.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.rockylinux9_aarch64.presubmit
+    arch = 'aarch64'
+  }
+}

--- a/kokoro/config/test/third_party_apps/bullseye_aarch64.gcl
+++ b/kokoro/config/test/third_party_apps/bullseye_aarch64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['debian-11-arm64']
+    arch = 'aarch64'
+  }
+}

--- a/kokoro/config/test/third_party_apps/focal_aarch64.gcl
+++ b/kokoro/config/test/third_party_apps/focal_aarch64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = [
+      'ubuntu-2004-lts-arm64',
+    ]
+    arch = 'aarch64'
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/bullseye_aarch64.gcl
+++ b/kokoro/config/test/third_party_apps/release/bullseye_aarch64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['debian-11-arm64']
+    arch = 'aarch64'
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/focal_aarch64.gcl
+++ b/kokoro/config/test/third_party_apps/release/focal_aarch64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = [
+      'ubuntu-2004-lts-arm64',
+    ]
+    arch = 'aarch64'
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/rockylinux9_aarch64.gcl
+++ b/kokoro/config/test/third_party_apps/release/rockylinux9_aarch64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['rocky-linux-9-arm64']
+    arch = 'aarch64'
+  }
+}

--- a/kokoro/config/test/third_party_apps/rockylinux9_aarch64.gcl
+++ b/kokoro/config/test/third_party_apps/rockylinux9_aarch64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['rocky-linux-9-arm64']
+    arch = 'aarch64'
+  }
+}


### PR DESCRIPTION
## Description
Standardizing on `aarch64` for config names.

## Related issue
b/288442211

## How has this been tested?
Nothing should be triggering this yet.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
