### PR TITLE
Update Go build version to `1.20.8`.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ARG CMAKE_VERSION=3.25.2
 ARG OPENJDK_MAJOR_VERSION=17
 ARG OPENJDK_FULL_VERSION=17.0.8
 ARG OPENJDK_VERSION_SUFFIX=7
-ARG GO_VERSION=1.21.1
+ARG GO_VERSION=1.20.8
 
 # Manually prepare a recent enough version of CMake.
 # This should be used on platforms where the default package manager

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -77,10 +77,10 @@ RUN Expand-Archive /local/win_flex_bison.zip -Destination /WinFlexBison; `
 #
 # Install Golang
 #
-ADD https://go.dev/dl/go1.21.1.windows-amd64.msi /local/go1.21.1.windows-amd64.msi
+ADD https://go.dev/dl/go1.20.8.windows-amd64.msi /local/go1.20.8.windows-amd64.msi
 
 RUN Start-Process msiexec.exe `
-    -ArgumentList '/i C:\local\go1.21.1.windows-amd64.msi ', '/quiet ', `
+    -ArgumentList '/i C:\local\go1.20.8.windows-amd64.msi ', '/quiet ', `
     '/norestart ', 'ALLUSERS=1,INSTALLDIR=C:\Go' -NoNewWindow -Wait;
 
 #

--- a/dockerfiles/template-header
+++ b/dockerfiles/template-header
@@ -24,7 +24,7 @@ ARG CMAKE_VERSION=3.25.2
 ARG OPENJDK_MAJOR_VERSION=17
 ARG OPENJDK_FULL_VERSION=17.0.8
 ARG OPENJDK_VERSION_SUFFIX=7
-ARG GO_VERSION=1.21.1
+ARG GO_VERSION=1.20.8
 
 # Manually prepare a recent enough version of CMake.
 # This should be used on platforms where the default package manager

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/ops-agent
 
-go 1.21
+go 1.20
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3


### PR DESCRIPTION
## Description
The current Go 1.21 version when building the opentelemetry `nvmlreceiver` causes a crash when linking the nvml library. Related `go-nvml` issue https://github.com/NVIDIA/go-nvml/issues/36.

## Related issue
b/301431546

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
