### PR TITLE
Fix TestExcludeLogsHasOperator

### DIFF
--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -1156,12 +1156,9 @@ func TestExcludeLogsHasOperator(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		line := `{"field":"string containing pattern"}` + "\n"
-		excludedLine := `{"field":"other"}` + "\n"
-		if err := gce.UploadContent(ctx, logger.ToMainLog(), vm, strings.NewReader(line), file1); err != nil {
-			t.Fatalf("error uploading log: %v", err)
-		}
-		if err := gce.UploadContent(ctx, logger.ToMainLog(), vm, strings.NewReader(excludedLine), file1); err != nil {
+		logContents := `{"field":"string containing pattern"}` + "\n"
+		logContents += `{"field":"other"}` + "\n"
+		if err := gce.UploadContent(ctx, logger.ToMainLog(), vm, strings.NewReader(logContents), file1); err != nil {
 			t.Fatalf("error uploading log: %v", err)
 		}
 


### PR DESCRIPTION
## Description
Previous version was clobbering the first log line with the second file upload. It's sufficient to include both lines in the same upload/file.

## Related issue
N/A

## How has this been tested?
Passed when invoked manually, will let the presubmits run too.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
