### PR TITLE
Add ARM build configurations for sles15

### DIFF
--- a/kokoro/config/build/presubmit/sles15_aarch64.gcl
+++ b/kokoro/config/build/presubmit/sles15_aarch64.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'sles15'
+      PKGFORMAT = 'rpm'
+    }
+  }
+}

--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -136,6 +136,13 @@ sles15_x86_64 = _distro {
   ]
   presubmit = ['sles-15']
 }
+sles15_aarch64 = _distro {
+  release = [
+    'sles-15-arm64',
+    'opensuse-leap-arm64',
+  ]
+  presubmit = ['sles-15-arm64']
+}
 
 // Windows distros.
 windows_x86_64 = _distro {

--- a/kokoro/config/test/ops_agent/release/sles15_aarch64.gcl
+++ b/kokoro/config/test/ops_agent/release/sles15_aarch64.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.sles15_aarch64.release
+    arch = 'aarch64'
+  }
+}

--- a/kokoro/config/test/ops_agent/sles15_aarch64.gcl
+++ b/kokoro/config/test/ops_agent/sles15_aarch64.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.sles15_aarch64.presubmit
+    arch = 'aarch64'
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/sles15_aarch64.gcl
+++ b/kokoro/config/test/third_party_apps/release/sles15_aarch64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['sles-15-arm64']
+    arch = 'aarch64'
+  }
+}

--- a/kokoro/config/test/third_party_apps/sles15_aarch64.gcl
+++ b/kokoro/config/test/third_party_apps/sles15_aarch64.gcl
@@ -1,0 +1,8 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = ['sles-15-arm64']
+    arch = 'aarch64'
+  }
+}


### PR DESCRIPTION
## Description
Add ARM build configurations for sles15

## Related issue

## How has this been tested?
For now, let the existing non-ARM GitHub presubmits run and not break. There is a google3 counterpart to this PR that still needs to be done after this is merged.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

