### PR TITLE
Testing: Install drivers for K80 without causing vm to reboot

### DIFF
--- a/integration_test/third_party_apps_data/applications/dcgm/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/dcgm/debian_ubuntu/install
@@ -9,7 +9,7 @@ DEVICE_CODE=$(lspci -n | grep -Po '10de:[\w\d]{4}')
 case $DEVICE_CODE in
     10de:102d)
         # Install a specific version for NVIDIA Tesla K80
-        DRIVER_VERSION=460.106.00
+        DRIVER_VERSION=470.82.01
         ;;
     *)
         DRIVER_VERSION=525.60.13

--- a/integration_test/third_party_apps_data/applications/nvml/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/nvml/debian_ubuntu/install
@@ -10,12 +10,12 @@ DEVICE_CODE=$(lspci -n | grep -Po '10de:[\w\d]{4}')
 case $DEVICE_CODE in
     10de:102d)
         # Install a specific version for NVIDIA Tesla K80, R470 is the last supported version
-        echo "Installing NVIDIA CUDA 11.2.1 with driver 460.32.03"
-        curl https://raw.githubusercontent.com/GoogleCloudPlatform/compute-gpu-installation/main/linux/install_gpu_driver.py --output install_gpu_driver.py
-        sudo python3 install_gpu_driver.py
-        wget --no-verbose https://developer.download.nvidia.com/compute/cuda/11.2.1/local_installers/cuda_11.2.1_460.32.03_linux.run
-        sudo sh cuda_11.2.1_460.32.03_linux.run --toolkit --silent
-        sudo apt install -y libcublas10
+        DRIVER_VERSION=470.82.01
+        echo "Installing NVIDIA CUDA 11.2.1 with driver $DRIVER_VERSION"
+        curl -fSsl -O https://us.download.nvidia.com/tesla/$DRIVER_VERSION/NVIDIA-Linux-x86_64-$DRIVER_VERSION.run
+        sudo bash ./NVIDIA-Linux-x86_64-$DRIVER_VERSION.run --silent
+        wget --no-verbose https://developer.download.nvidia.com/compute/cuda/11.4.4/local_installers/cuda_11.4.4_${DRIVER_VERSION}_linux.run
+        sudo sh cuda_11.4.4_${DRIVER_VERSION}_linux.run --toolkit --silent
         ;;
     *)
         echo "Installing latest version of NVIDIA CUDA and driver"

--- a/integration_test/third_party_apps_data/applications/nvml/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/nvml/debian_ubuntu/install
@@ -5,17 +5,18 @@ sudo apt update
 kernel_version=`uname -r`
 sudo apt install -y linux-headers-${kernel_version} software-properties-common pciutils gcc make dkms wget
 
-# Install CUDA and driver together, since the `exercise` script needs CUDA to compile the application to generating GPU process metrics
+# Install CUDA and driver together, since the `exercise` script needs to run a CUDA sample app to generating GPU process metrics
 DEVICE_CODE=$(lspci -n | grep -Po '10de:[\w\d]{4}')
 case $DEVICE_CODE in
     10de:102d)
         # Install a specific version for NVIDIA Tesla K80, R470 is the last supported version
         DRIVER_VERSION=470.82.01
-        echo "Installing NVIDIA CUDA 11.2.1 with driver $DRIVER_VERSION"
+        CUDA_VERSION=11.4.4
+        echo "Installing NVIDIA CUDA $CUDA_VERSION with driver $DRIVER_VERSION"
         curl -fSsl -O https://us.download.nvidia.com/tesla/$DRIVER_VERSION/NVIDIA-Linux-x86_64-$DRIVER_VERSION.run
         sudo bash ./NVIDIA-Linux-x86_64-$DRIVER_VERSION.run --silent
-        wget --no-verbose https://developer.download.nvidia.com/compute/cuda/11.4.4/local_installers/cuda_11.4.4_${DRIVER_VERSION}_linux.run
-        sudo sh cuda_11.4.4_${DRIVER_VERSION}_linux.run --toolkit --silent
+        wget --no-verbose https://developer.download.nvidia.com/compute/cuda/$CUDA_VERSION/local_installers/cuda_${CUDA_VERSION}_${DRIVER_VERSION}_linux.run
+        sudo sh cuda_${CUDA_VERSION}_${DRIVER_VERSION}_linux.run --toolkit --silent
         ;;
     *)
         echo "Installing latest version of NVIDIA CUDA and driver"


### PR DESCRIPTION
## Description
The GPU driver installation script will cause the testing vm to reboot and fail the test. Now updating the install script to install the driver directly from NVIDIA to get around the issue. 

## Related issue
b/303701077

## How has this been tested?
Checked to make sure K80 NVML test is passing now. 

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
