### PR TITLE
Add public url to DCGM metadata.yaml to enable the integration

### DIFF
--- a/integration_test/third_party_apps_data/applications/dcgm/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/dcgm/metadata.yaml
@@ -113,3 +113,4 @@ configuration_options:
           description: The DCGM service endpoint specified as 'hostname:port'
 minimum_supported_agent_version:
   metrics: 2.38.0
+public_url: https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party-nvidia


### PR DESCRIPTION
## Description
Add `public_url` to DCGM metadata so that the DCGM integration can be marked as GA. 

## Related issue
b/270716923

## How has this been tested?
N/A

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
