### PR TITLE
Remove references to Windows 2012 R2 (now EOL).

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -36,7 +36,7 @@ AGENT_PACKAGES_IN_GCS, for details see README.md.
 
 	PROJECT=dev_project \
 	ZONES=us-central1-b \
-	PLATFORMS=debian-10,centos-8,rhel-8-1-sap-ha,sles-15,ubuntu-2004-lts,windows-2012-r2,windows-2019 \
+	PLATFORMS=debian-10,centos-8,rhel-8-1-sap-ha,sles-15,ubuntu-2004-lts,windows-2016,windows-2019 \
 	go test -v ops_agent_test.go \
 	  -test.parallel=1000 \
 	  -tags=integration_test \

--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -147,8 +147,6 @@ sles15_aarch64 = _distro {
 // Windows distros.
 windows_x86_64 = _distro {
   release = [
-    'windows-2012-r2',
-    'windows-2012-r2-core',
     'windows-2016',
     'windows-2016-core',
     'windows-2019',
@@ -157,7 +155,7 @@ windows_x86_64 = _distro {
     'windows-2022-core',
   ]
   presubmit = [
-    'windows-2012-r2',
+    'windows-2016-core',
     // TODO(martijnvs): Switch this to windows-20h2-core.
     'windows-2019',
   ]

--- a/kokoro/config/test/third_party_apps/release/windows_x86_64.gcl
+++ b/kokoro/config/test/third_party_apps/release/windows_x86_64.gcl
@@ -3,10 +3,9 @@ import 'common.gcl' as common
 config build = common.third_party_apps_test {
   params {
     platforms = [
-      'windows-2012-r2',
       'windows-2019',
       'sql-std-2019-win-2019',
-      'windows-2022', 
+      'windows-2022',
       'sql-std-2022-win-2022',
     ]
   }

--- a/kokoro/config/test/third_party_apps/windows_x86_64.gcl
+++ b/kokoro/config/test/third_party_apps/windows_x86_64.gcl
@@ -3,7 +3,7 @@ import 'common.gcl' as common
 config build = common.third_party_apps_test {
   params {
     platforms = [
-      'windows-2012-r2',
+      'windows-2019',
       'sql-std-2019-win-2019',
     ]
   }


### PR DESCRIPTION
## Description
Windows 2012 R2 is now EOL: https://cloud.google.com/compute/docs/instances/windows/end-of-support.

## Related issue
[b/304820684](http://b/304820684)

## How has this been tested?
Automated tests should take care of this.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
