### PR TITLE
Revert DNS workaround

### DIFF
--- a/kokoro/scripts/build/build_package.ps1
+++ b/kokoro/scripts/build/build_package.ps1
@@ -50,14 +50,10 @@ PACKAGE_VERSION,$env:PKG_VERSION
 Invoke-Program git submodule update --init
 $artifact_registry='us-docker.pkg.dev'
 Invoke-Program docker-credential-gcr configure-docker --registries="$artifact_registry"
-
-# TODO(b/300141768): fix DNS properly
-Invoke-Program docker network create --driver nat -o com.docker.network.windowsshim.dnsservers="8.8.8.8" natdnsworkaround
-
 $arch = Invoke-Program docker info --format '{{.Architecture}}'
 $cache_location="${artifact_registry}/stackdriver-test-143416/google-cloud-ops-agent-build-cache/ops-agent-cache:windows-${arch}"
 Invoke-Program docker pull $cache_location
-Invoke-Program docker build --network natdnsworkaround --cache-from="${cache_location}" -t $tag -f './Dockerfile.windows' .
+Invoke-Program docker build --cache-from="${cache_location}" -t $tag -f './Dockerfile.windows' .
 Invoke-Program docker create --name $name $tag
 Invoke-Program docker cp "${name}:/work/out" $env:KOKORO_ARTIFACTS_DIR
 


### PR DESCRIPTION
## Description
The underlying DNS issue in the ltsc2019 image has been resolved.

Reverts #1417.

## Related issue
[b/300141768](http://b/300141768)

## How has this been tested?
Confirmed manually that the original DNS issue no longer occurs with the latest ltsc2019 image. Will let the presubmits run.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
