### PR TITLE
Internal: Make the instructions banner more noticeable

### DIFF
--- a/cloudbuild/new-distro-detector/run.sh
+++ b/cloudbuild/new-distro-detector/run.sh
@@ -42,7 +42,15 @@ gsutil -q cp "${LAST_KNOWN_LIST}" - \
 # If there is a difference, print the diff, and...
 if ! diff known_families.txt current_families.txt; then
   # Print instructions for handling the error.
-  echo 'See go/sdi-new-distro-detector#handling-errors for instructions on handling this error.'
+  # Set +x temporarily so that the banner is only printed once.
+  set +x
+  echo '
+    ####################################################
+    #  See go/sdi-new-distro-detector#handling-errors  #
+    #  for instructions on handling this error.        #
+    ####################################################
+  '
+  set -x
   # Upload the current list to the GCS bucket so that the next run passes.
   gsutil -q cp current_families.txt "${LAST_KNOWN_LIST}"
   # Report an error, which will result in a bug being filed.


### PR DESCRIPTION
## Description
This is to aid people in finding the instructions buried in the logs, and to make it easier to write instructions.

## Related issue
b/305026436

## How has this been tested?
Not triggered by any automated test. I ran similar snippets of code on my workstation and found some bugs that way.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
