### PR TITLE
Fixes Ubuntu 2310 Mantic tests

### DIFF
--- a/integration_test/third_party_apps_data/applications/aerospike/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/aerospike/metadata.yaml
@@ -136,4 +136,6 @@ platforms_to_skip:
   - rocky-linux-9
   - rocky-linux-9-arm64
   - ubuntu-2304-amd64
+  - ubuntu-2310-amd64
+  - ubuntu-2310-arm64
 public_url: https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/aerospike

--- a/integration_test/third_party_apps_data/applications/couchbase/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/couchbase/metadata.yaml
@@ -204,4 +204,6 @@ platforms_to_skip:
   - debian-11-arm64
   - debian-12
   - ubuntu-2304-amd64
+  - ubuntu-2310-amd64
+  - ubuntu-2310-arm64
 public_url: https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/couchbase

--- a/integration_test/third_party_apps_data/applications/couchdb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/couchdb/metadata.yaml
@@ -35,6 +35,8 @@ platforms_to_skip:
   - rocky-linux-9
   - rocky-linux-9-arm64
   - ubuntu-2304-amd64
+  - ubuntu-2310-amd64
+  - ubuntu-2310-arm64
   - debian-12
 supported_app_version: ["2.3+", "3.1+"]
 expected_metrics:

--- a/integration_test/third_party_apps_data/applications/mariadb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mariadb/metadata.yaml
@@ -146,6 +146,9 @@ expected_metrics:
     monitored_resource: gce_instance
     labels:
       operation: deleted|inserted|read|updated
+    unavailable_on:
+      - ubuntu-2310-amd64
+      - ubuntu-2310-arm64
   - type: workload.googleapis.com/mysql.sorts
     value_type: INT64
     kind: CUMULATIVE

--- a/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
@@ -29,6 +29,8 @@ supported_operating_systems: linux
 platforms_to_skip:
   # mongodb is not currently supported on various distros.
   - ubuntu-2304-amd64
+  - ubuntu-2310-amd64
+  - ubuntu-2310-arm64
   - debian-12
   - sles-15-arm64
 supported_app_version: ["2.6", "3.0+", "4.0+", "5.0", "6.0"]

--- a/integration_test/third_party_apps_data/applications/mongodb3.6/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mongodb3.6/metadata.yaml
@@ -35,6 +35,8 @@ platforms_to_skip:
   - ubuntu-2204-lts
   - ubuntu-2204-lts-arm64
   - ubuntu-2304-amd64
+  - ubuntu-2310-amd64
+  - ubuntu-2310-arm64
   - debian-10
   - debian-11
   - debian-11-arm64

--- a/integration_test/third_party_apps_data/applications/mysql5.7/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mysql5.7/metadata.yaml
@@ -47,6 +47,8 @@ platforms_to_skip:
   - ubuntu-2204-lts
   - ubuntu-2204-lts-arm64
   - ubuntu-2304-amd64
+  - ubuntu-2310-amd64
+  - ubuntu-2310-arm64
 supported_app_version: ["8.0", "5.7"]
 expected_metrics:
   - type: workload.googleapis.com/mysql.buffer_pool_data_pages

--- a/integration_test/third_party_apps_data/applications/oracledb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/oracledb/metadata.yaml
@@ -58,6 +58,8 @@ platforms_to_skip:
   - ubuntu-2204-lts
   - ubuntu-2204-lts-arm64
   - ubuntu-2304-amd64
+  - ubuntu-2310-amd64
+  - ubuntu-2310-arm64
   - sles-12
   - sles-15
   - sles-15-arm64

--- a/integration_test/third_party_apps_data/applications/postgresql/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/postgresql/metadata.yaml
@@ -34,6 +34,9 @@ platforms_to_skip:
   - rocky-linux-9
   - rocky-linux-9-arm64
   - sles-15-arm64
+  # mantic not yet supported, but should revisit this in the future
+  - ubuntu-2310-amd64
+  - ubuntu-2310-arm64
 supported_app_version: ["10.18+"]
 expected_metrics:
   - kind: GAUGE

--- a/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
@@ -31,6 +31,8 @@ platforms_to_skip:
   - debian-12
   - sles-12
   - ubuntu-2304-amd64
+  - ubuntu-2310-amd64
+  - ubuntu-2310-arm64
 supported_app_version: ["3.8", "3.9"]
 expected_metrics:
   - type: workload.googleapis.com/rabbitmq.consumer.count

--- a/integration_test/third_party_apps_data/applications/vault/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/vault/metadata.yaml
@@ -61,8 +61,10 @@ configure_integration: |-
   ```
 supported_operating_systems: linux
 platforms_to_skip:
-  # Vault is not supported on Ubuntu 23.04
+  # Vault is not supported on various distros.
   - ubuntu-2304-amd64
+  - ubuntu-2310-amd64
+  - ubuntu-2310-arm64
 supported_app_version: ["1.6+"]
 expected_metrics:
   - type: workload.googleapis.com/vault.core.request.count


### PR DESCRIPTION
## Description
3rd party tests passing under Bullseye (hacked to run Mantic amd64 and arm64).
<img width="936" alt="image" src="https://github.com/GoogleCloudPlatform/ops-agent/assets/12396806/314d0cd1-2ce3-4600-8a01-9a406b5c6a31">


## Related issue
[b/304832107](http://b/304832107)

## How has this been tested?
NA

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
