### PR TITLE
Support referencing the `trace` and `spanId` fields

### DIFF
--- a/confgenerator/filter/internal/ast/ast.go
+++ b/confgenerator/filter/internal/ast/ast.go
@@ -46,6 +46,8 @@ type Target []string
 var logEntryRootValueMapToFluentBit = map[string]string{
 	"severity": "logging.googleapis.com/severity",
 	"logName":  "logging.googleapis.com/logName",
+	"trace":    "logging.googleapis.com/trace",
+	"spanId":   "logging.googleapis.com/spanId",
 }
 
 var logEntryRootStructMapToFluentBit = map[string]string{

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux-gpu/b2a99eb6e203ad763668e018eef9e96a.lua
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux-gpu/b2a99eb6e203ad763668e018eef9e96a.lua
@@ -1,0 +1,11 @@
+
+function process(tag, timestamp, record)
+local match = ((function(v) if v == nil then return false end return (string.lower(tostring(v)) == string.lower("foo")) end)((function()
+return record["logging.googleapis.com/trace"]
+end)()));
+
+  if match then
+    return -1, 0, 0
+  end
+  return 2, 0, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux-gpu/features.yaml
@@ -182,3 +182,19 @@
   feature: processors:exclude_logs
   key: "[20].match_any.__length"
   value: "1"
+- module: logging
+  feature: processors:exclude_logs
+  key: "[21].enabled"
+  value: "true"
+- module: logging
+  feature: processors:exclude_logs
+  key: "[21].match_any.__length"
+  value: "1"
+- module: logging
+  feature: processors:exclude_logs
+  key: "[22].enabled"
+  value: "true"
+- module: logging
+  feature: processors:exclude_logs
+  key: "[22].match_any.__length"
+  value: "1"

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux-gpu/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux-gpu/fluent_bit_main.conf
@@ -243,6 +243,37 @@
     Match  p1.sample_logs
     Name   lua
     call   process
+    script b2a99eb6e203ad763668e018eef9e96a.lua
+
+[FILTER]
+    Match      p1.sample_logs
+    Name       nest
+    Nest_under record
+    Operation  nest
+    Wildcard   *
+
+[FILTER]
+    Condition Key_value_matches $record['logging.googleapis.com/spanId'] foo
+    Match     p1.sample_logs
+    Name      modify
+    Set       __match_0_0 1
+
+[FILTER]
+    Match        p1.sample_logs
+    Name         nest
+    Nested_under record
+    Operation    lift
+
+[FILTER]
+    Match  p1.sample_logs
+    Name   lua
+    call   process
+    script 67770d56918933c3ea3dd6ec983c21bd.lua
+
+[FILTER]
+    Match  p1.sample_logs
+    Name   lua
+    call   process
     script 14bd6ae40aaa341d71fcdaa1bffa3e93.lua
 
 [FILTER]

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/b2a99eb6e203ad763668e018eef9e96a.lua
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/b2a99eb6e203ad763668e018eef9e96a.lua
@@ -1,0 +1,11 @@
+
+function process(tag, timestamp, record)
+local match = ((function(v) if v == nil then return false end return (string.lower(tostring(v)) == string.lower("foo")) end)((function()
+return record["logging.googleapis.com/trace"]
+end)()));
+
+  if match then
+    return -1, 0, 0
+  end
+  return 2, 0, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/features.yaml
@@ -182,3 +182,19 @@
   feature: processors:exclude_logs
   key: "[20].match_any.__length"
   value: "1"
+- module: logging
+  feature: processors:exclude_logs
+  key: "[21].enabled"
+  value: "true"
+- module: logging
+  feature: processors:exclude_logs
+  key: "[21].match_any.__length"
+  value: "1"
+- module: logging
+  feature: processors:exclude_logs
+  key: "[22].enabled"
+  value: "true"
+- module: logging
+  feature: processors:exclude_logs
+  key: "[22].match_any.__length"
+  value: "1"

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/fluent_bit_main.conf
@@ -243,6 +243,37 @@
     Match  p1.sample_logs
     Name   lua
     call   process
+    script b2a99eb6e203ad763668e018eef9e96a.lua
+
+[FILTER]
+    Match      p1.sample_logs
+    Name       nest
+    Nest_under record
+    Operation  nest
+    Wildcard   *
+
+[FILTER]
+    Condition Key_value_matches $record['logging.googleapis.com/spanId'] foo
+    Match     p1.sample_logs
+    Name      modify
+    Set       __match_0_0 1
+
+[FILTER]
+    Match        p1.sample_logs
+    Name         nest
+    Nested_under record
+    Operation    lift
+
+[FILTER]
+    Match  p1.sample_logs
+    Name   lua
+    call   process
+    script 67770d56918933c3ea3dd6ec983c21bd.lua
+
+[FILTER]
+    Match  p1.sample_logs
+    Name   lua
+    call   process
     script 14bd6ae40aaa341d71fcdaa1bffa3e93.lua
 
 [FILTER]

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/b2a99eb6e203ad763668e018eef9e96a.lua
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/b2a99eb6e203ad763668e018eef9e96a.lua
@@ -1,0 +1,11 @@
+
+function process(tag, timestamp, record)
+local match = ((function(v) if v == nil then return false end return (string.lower(tostring(v)) == string.lower("foo")) end)((function()
+return record["logging.googleapis.com/trace"]
+end)()));
+
+  if match then
+    return -1, 0, 0
+  end
+  return 2, 0, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/features.yaml
@@ -182,3 +182,19 @@
   feature: processors:exclude_logs
   key: "[20].match_any.__length"
   value: "1"
+- module: logging
+  feature: processors:exclude_logs
+  key: "[21].enabled"
+  value: "true"
+- module: logging
+  feature: processors:exclude_logs
+  key: "[21].match_any.__length"
+  value: "1"
+- module: logging
+  feature: processors:exclude_logs
+  key: "[22].enabled"
+  value: "true"
+- module: logging
+  feature: processors:exclude_logs
+  key: "[22].match_any.__length"
+  value: "1"

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/fluent_bit_main.conf
@@ -285,6 +285,37 @@
     Match  p1.sample_logs
     Name   lua
     call   process
+    script b2a99eb6e203ad763668e018eef9e96a.lua
+
+[FILTER]
+    Match      p1.sample_logs
+    Name       nest
+    Nest_under record
+    Operation  nest
+    Wildcard   *
+
+[FILTER]
+    Condition Key_value_matches $record['logging.googleapis.com/spanId'] foo
+    Match     p1.sample_logs
+    Name      modify
+    Set       __match_0_0 1
+
+[FILTER]
+    Match        p1.sample_logs
+    Name         nest
+    Nested_under record
+    Operation    lift
+
+[FILTER]
+    Match  p1.sample_logs
+    Name   lua
+    call   process
+    script 67770d56918933c3ea3dd6ec983c21bd.lua
+
+[FILTER]
+    Match  p1.sample_logs
+    Name   lua
+    call   process
     script 14bd6ae40aaa341d71fcdaa1bffa3e93.lua
 
 [FILTER]

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/b2a99eb6e203ad763668e018eef9e96a.lua
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/b2a99eb6e203ad763668e018eef9e96a.lua
@@ -1,0 +1,11 @@
+
+function process(tag, timestamp, record)
+local match = ((function(v) if v == nil then return false end return (string.lower(tostring(v)) == string.lower("foo")) end)((function()
+return record["logging.googleapis.com/trace"]
+end)()));
+
+  if match then
+    return -1, 0, 0
+  end
+  return 2, 0, record
+end

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/features.yaml
@@ -182,3 +182,19 @@
   feature: processors:exclude_logs
   key: "[20].match_any.__length"
   value: "1"
+- module: logging
+  feature: processors:exclude_logs
+  key: "[21].enabled"
+  value: "true"
+- module: logging
+  feature: processors:exclude_logs
+  key: "[21].match_any.__length"
+  value: "1"
+- module: logging
+  feature: processors:exclude_logs
+  key: "[22].enabled"
+  value: "true"
+- module: logging
+  feature: processors:exclude_logs
+  key: "[22].match_any.__length"
+  value: "1"

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/fluent_bit_main.conf
@@ -285,6 +285,37 @@
     Match  p1.sample_logs
     Name   lua
     call   process
+    script b2a99eb6e203ad763668e018eef9e96a.lua
+
+[FILTER]
+    Match      p1.sample_logs
+    Name       nest
+    Nest_under record
+    Operation  nest
+    Wildcard   *
+
+[FILTER]
+    Condition Key_value_matches $record['logging.googleapis.com/spanId'] foo
+    Match     p1.sample_logs
+    Name      modify
+    Set       __match_0_0 1
+
+[FILTER]
+    Match        p1.sample_logs
+    Name         nest
+    Nested_under record
+    Operation    lift
+
+[FILTER]
+    Match  p1.sample_logs
+    Name   lua
+    call   process
+    script 67770d56918933c3ea3dd6ec983c21bd.lua
+
+[FILTER]
+    Match  p1.sample_logs
+    Name   lua
+    call   process
     script 14bd6ae40aaa341d71fcdaa1bffa3e93.lua
 
 [FILTER]

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/input.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/input.yaml
@@ -39,6 +39,12 @@ logging:
     special_httpRequest:
       type: exclude_logs
       match_any: ['httpRequest.method =~ "GET"']
+    special_trace:
+      type: exclude_logs
+      match_any: ['trace = "foo"']
+    special_spanId:
+      type: exclude_logs
+      match_any: ['spanId =~ "foo"']
     nested_tabs:
       type: exclude_logs
       match_any: ['jsonPayload."aa	bb" = foo']
@@ -99,6 +105,8 @@ logging:
         - special_severity
         - special_jsonPayload
         - special_httpRequest
+        - special_trace
+        - special_spanId
         - nested_tabs
         - nested_symbols
         - nested_escaped

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux-gpu/298c35a0f243b492883d4a987c1e203a.lua
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux-gpu/298c35a0f243b492883d4a987c1e203a.lua
@@ -38,11 +38,17 @@ end)();
 local __field_10 = (function()
 return record["level"]
 end)();
+local __field_12 = (function()
+return record["trace"]
+end)();
 local omit7 = (function(v) if v == nil then return false end return (string.lower(tostring(v)) == string.lower("-")) end)((function()
 return record["omitted"]
 end)());
 (function(value)
 record["move_source"] = value
+end)(nil);
+(function(value)
+record["trace"] = value
 end)(nil);
 local v = __field_0;
 (function(value)
@@ -118,6 +124,14 @@ elseif v == "W" then v = "WARNING"
 end
 (function(value)
 record["logging.googleapis.com/severity"] = value
+end)(v)
+local v = "spanValue";
+(function(value)
+record["logging.googleapis.com/spanId"] = value
+end)(v)
+local v = __field_12;
+(function(value)
+record["logging.googleapis.com/trace"] = value
 end)(v)
 return 2, timestamp, record
 end

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux-gpu/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux-gpu/fluent_bit_main.conf
@@ -87,7 +87,7 @@
     Match  p1.sample_logs
     Name   lua
     call   process
-    script de7636ee3df1619cbc56390c3de1a1b0.lua
+    script 298c35a0f243b492883d4a987c1e203a.lua
 
 [FILTER]
     Match  p1.sample_logs

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux/298c35a0f243b492883d4a987c1e203a.lua
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux/298c35a0f243b492883d4a987c1e203a.lua
@@ -38,11 +38,17 @@ end)();
 local __field_10 = (function()
 return record["level"]
 end)();
+local __field_12 = (function()
+return record["trace"]
+end)();
 local omit7 = (function(v) if v == nil then return false end return (string.lower(tostring(v)) == string.lower("-")) end)((function()
 return record["omitted"]
 end)());
 (function(value)
 record["move_source"] = value
+end)(nil);
+(function(value)
+record["trace"] = value
 end)(nil);
 local v = __field_0;
 (function(value)
@@ -118,6 +124,14 @@ elseif v == "W" then v = "WARNING"
 end
 (function(value)
 record["logging.googleapis.com/severity"] = value
+end)(v)
+local v = "spanValue";
+(function(value)
+record["logging.googleapis.com/spanId"] = value
+end)(v)
+local v = __field_12;
+(function(value)
+record["logging.googleapis.com/trace"] = value
 end)(v)
 return 2, timestamp, record
 end

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux/fluent_bit_main.conf
@@ -87,7 +87,7 @@
     Match  p1.sample_logs
     Name   lua
     call   process
-    script de7636ee3df1619cbc56390c3de1a1b0.lua
+    script 298c35a0f243b492883d4a987c1e203a.lua
 
 [FILTER]
     Match  p1.sample_logs

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/298c35a0f243b492883d4a987c1e203a.lua
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/298c35a0f243b492883d4a987c1e203a.lua
@@ -38,11 +38,17 @@ end)();
 local __field_10 = (function()
 return record["level"]
 end)();
+local __field_12 = (function()
+return record["trace"]
+end)();
 local omit7 = (function(v) if v == nil then return false end return (string.lower(tostring(v)) == string.lower("-")) end)((function()
 return record["omitted"]
 end)());
 (function(value)
 record["move_source"] = value
+end)(nil);
+(function(value)
+record["trace"] = value
 end)(nil);
 local v = __field_0;
 (function(value)
@@ -118,6 +124,14 @@ elseif v == "W" then v = "WARNING"
 end
 (function(value)
 record["logging.googleapis.com/severity"] = value
+end)(v)
+local v = "spanValue";
+(function(value)
+record["logging.googleapis.com/spanId"] = value
+end)(v)
+local v = __field_12;
+(function(value)
+record["logging.googleapis.com/trace"] = value
 end)(v)
 return 2, timestamp, record
 end

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/fluent_bit_main.conf
@@ -129,7 +129,7 @@
     Match  p1.sample_logs
     Name   lua
     call   process
-    script de7636ee3df1619cbc56390c3de1a1b0.lua
+    script 298c35a0f243b492883d4a987c1e203a.lua
 
 [FILTER]
     Match  p1.sample_logs

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/298c35a0f243b492883d4a987c1e203a.lua
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/298c35a0f243b492883d4a987c1e203a.lua
@@ -38,11 +38,17 @@ end)();
 local __field_10 = (function()
 return record["level"]
 end)();
+local __field_12 = (function()
+return record["trace"]
+end)();
 local omit7 = (function(v) if v == nil then return false end return (string.lower(tostring(v)) == string.lower("-")) end)((function()
 return record["omitted"]
 end)());
 (function(value)
 record["move_source"] = value
+end)(nil);
+(function(value)
+record["trace"] = value
 end)(nil);
 local v = __field_0;
 (function(value)
@@ -118,6 +124,14 @@ elseif v == "W" then v = "WARNING"
 end
 (function(value)
 record["logging.googleapis.com/severity"] = value
+end)(v)
+local v = "spanValue";
+(function(value)
+record["logging.googleapis.com/spanId"] = value
+end)(v)
+local v = __field_12;
+(function(value)
+record["logging.googleapis.com/trace"] = value
 end)(v)
 return 2, timestamp, record
 end

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/fluent_bit_main.conf
@@ -129,7 +129,7 @@
     Match  p1.sample_logs
     Name   lua
     call   process
-    script de7636ee3df1619cbc56390c3de1a1b0.lua
+    script 298c35a0f243b492883d4a987c1e203a.lua
 
 [FILTER]
     Match  p1.sample_logs

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/input.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/input.yaml
@@ -48,6 +48,10 @@ logging:
         jsonPayload.omitted:
           omit_if: jsonPayload.omitted = "-"
         jsonPayload.untouched:
+        spanId:
+          static_value: spanValue
+        trace:
+          move_from: jsonPayload.trace
   service:
     pipelines:
       p1:

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -921,6 +921,63 @@ func TestHTTPRequestLog(t *testing.T) {
 	})
 }
 
+func TestLogEntrySpecialFields(t *testing.T) {
+	t.Parallel()
+	gce.RunForEachPlatform(t, func(t *testing.T, platform string) {
+		t.Parallel()
+		ctx, logger, vm := agents.CommonSetup(t, platform)
+		file1 := fmt.Sprintf("%s_1", logPathForPlatform(vm.Platform))
+		configStr := `
+logging:
+  receivers:
+    f1:
+      type: files
+      include_paths:
+        - %s
+  processors:
+    json:
+      type: parse_json
+  service:
+    pipelines:
+      p1:
+        receivers:
+          - f1
+        processors:
+          - json
+`
+		config := fmt.Sprintf(configStr, file1)
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
+			t.Fatal(err)
+		}
+
+		// httpRequest field is tested by TestHTTPRequestLog(); covers the rest
+		// of the specfial fields here
+		line := `{"logging.googleapis.com/severity": "WARNING", ` +
+			`"logging.googleapis.com/labels": {"label1":"value1", "label2":"value2"}, ` +
+			`"logging.googleapis.com/operation": {"id": "id", "producer": "producer", "first": true, "last": true}, ` +
+			`"logging.googleapis.com/sourceLocation": {"file": "file", "line": "1", "function": "function"}, ` +
+			`"logging.googleapis.com/trace":"trace", ` +
+			`"logging.googleapis.com/spanId":"spanId", ` +
+			`"normal_field": "value"}` + "\n"
+		if err := gce.UploadContent(ctx, logger.ToMainLog(), vm, strings.NewReader(line), file1); err != nil {
+			t.Fatalf("error uploading log: %v", err)
+		}
+
+		// Expect to see the log with the special fields to be placed to the top
+		// level of the LogEntry and the rest to jsonPayload
+		if err := gce.WaitForLog(ctx, logger.ToMainLog(), vm, "f1", time.Hour,
+			`severity="WARNING" AND `+
+				`labels.label1="value1" AND labels.label2="value2" AND `+
+				`operation.id="id" AND operation.producer="producer" AND operation.first=true AND operation.last=true AND `+
+				`sourceLocation.file="file" AND sourceLocation.line="1" AND sourceLocation.function="function" AND `+
+				`trace="trace" AND `+
+				`spanId="spanId" AND `+
+				`jsonPayload.normal_field="value"`); err != nil {
+			t.Error(err)
+		}
+	})
+}
+
 func TestInvalidConfig(t *testing.T) {
 	t.Parallel()
 	gce.RunForEachPlatform(t, func(t *testing.T, platform string) {
@@ -1285,6 +1342,100 @@ func TestExcludeLogsParseJsonOrder(t *testing.T) {
 	})
 }
 
+func TestExcludeLogsModifyFieldsOrder(t *testing.T) {
+	t.Parallel()
+	gce.RunForEachPlatform(t, func(t *testing.T, platform string) {
+		t.Parallel()
+		ctx, logger, vm := agents.CommonSetup(t, platform)
+		file1 := fmt.Sprintf("%s_1", logPathForPlatform(vm.Platform))
+		file2 := fmt.Sprintf("%s_2", logPathForPlatform(vm.Platform))
+		file3 := fmt.Sprintf("%s_3", logPathForPlatform(vm.Platform))
+
+		// This exclude_logs processor operates on a non-default field which is
+		// present if and only if the log is structured accordingly.
+		// The intended mechanism for inputting structured logs from a file is
+		// to use a parse_json processor, and the processor will automatically
+		// recongnize special fields for the LogEntry and place them at the top
+		// level and can be used by the exclude_logs processor to filter logs.
+		// (pipeline p1)
+		// For top level fields that set by modify_fields, since processors
+		// operate in the order in which they're written, the expectation is
+		// that if a modify_fields processor comes before the exclude_logs
+		// processor then the log is excluded. (pipeline p2)
+		// Conversely, if a modify_fields processor comes after the exclude_logs
+		// processor then the log is not excluded. (pipeline p3)
+		config := fmt.Sprintf(`logging:
+  receivers:
+    f1:
+      type: files
+      include_paths:
+      - %s
+    f2:
+      type: files
+      include_paths:
+      - %s
+    f3:
+      type: files
+      include_paths:
+      - %s
+  processors:
+    exclude_trace:
+      type: exclude_logs
+      match_any:
+      - trace =~ "value1"
+    exclude_span_id:
+      type: exclude_logs
+      match_any:
+      - spanId =~ "value2"
+    modify:
+      type: modify_fields
+      fields:
+        trace:
+          move_from: jsonPayload.none
+          default_value: value1
+    json:
+      type: parse_json
+  service:
+    pipelines:
+      p1:
+        receivers: [f1]
+        processors: [json, exclude_span_id]
+      p2:
+        receivers: [f2]
+        processors: [json, modify, exclude_trace]
+      p3:
+        receivers: [f3]
+        processors: [json, exclude_trace, modify]
+`, file1, file2, file3)
+
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
+			t.Fatal(err)
+		}
+
+		line := `{"logging.googleapis.com/spanId":"value2", "query_field": "value"}` + "\n"
+		for _, file := range []string{file1, file2, file3} {
+			if err := gce.UploadContent(ctx, logger.ToMainLog(), vm, strings.NewReader(line), file); err != nil {
+				t.Fatalf("error uploading log: %v", err)
+			}
+		}
+
+		// Expect to see the log included in p3 but not p1 and p2.
+		if err := gce.WaitForLog(ctx, logger.ToMainLog(), vm, "f3", time.Hour, `jsonPayload.query_field="value"`); err != nil {
+			t.Error(err)
+		}
+		// Give the excluded log some time to show up.
+		time.Sleep(60 * time.Second)
+		for _, name := range []string{"f1", "f2"} {
+			_, err := gce.QueryLog(ctx, logger.ToMainLog(), vm, name, time.Hour, `jsonPayload.query_field="value"`, 5)
+			if err == nil {
+				t.Error("expected log to be excluded but was included")
+			} else if !strings.Contains(err.Error(), "not found, exhausted retries") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		}
+	})
+}
+
 func TestModifyFields(t *testing.T) {
 	t.Parallel()
 	gce.RunForEachPlatform(t, func(t *testing.T, platform string) {
@@ -1331,6 +1482,10 @@ func TestModifyFields(t *testing.T) {
         jsonPayload.omitted:
           static_value: broken
           omit_if: jsonPayload.field = "value"
+        trace:
+          move_from: jsonPayload.trace
+        spanId:
+          copy_from: jsonPayload.spanId
     json:
       type: parse_json
   exporters:
@@ -1348,13 +1503,13 @@ func TestModifyFields(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		line := `{"field":"value", "default_present":"original", "logging.googleapis.com/labels": {"label1":"value"}}` + "\n"
+		line := `{"field":"value", "default_present":"original", "logging.googleapis.com/labels": {"label1":"value"}, "trace":"trace_value", "spanId": "span_id_value"}` + "\n"
 		if err := gce.UploadContent(ctx, logger.ToMainLog(), vm, strings.NewReader(line), file1); err != nil {
 			t.Fatalf("error uploading log: %v", err)
 		}
 
 		// Expect to see the log with the modifications applied
-		if err := gce.WaitForLog(ctx, logger.ToMainLog(), vm, "f1", time.Hour, `jsonPayload.field2="value" AND labels.static="hello world" AND labels.label2="value" AND NOT labels.label1:* AND labels."my.cool.service/foo"="value" AND severity="WARNING" AND NOT jsonPayload.field:* AND jsonPayload.default_present="original" AND jsonPayload.default_absent="default" AND jsonPayload.integer > 5 AND jsonPayload.float > 5 AND jsonPayload.mapped_field="new_value" AND (NOT jsonPayload.omitted = "broken")`); err != nil {
+		if err := gce.WaitForLog(ctx, logger.ToMainLog(), vm, "f1", time.Hour, `jsonPayload.field2="value" AND labels.static="hello world" AND labels.label2="value" AND NOT labels.label1:* AND labels."my.cool.service/foo"="value" AND severity="WARNING" AND NOT jsonPayload.field:* AND jsonPayload.default_present="original" AND jsonPayload.default_absent="default" AND jsonPayload.integer > 5 AND jsonPayload.float > 5 AND jsonPayload.mapped_field="new_value" AND (NOT jsonPayload.omitted = "broken") AND trace = "trace_value" AND NOT jsonPayload.trace:* AND spanId = "span_id_value" AND jsonPayload.spanId = "span_id_value"`); err != nil {
 			t.Error(err)
 		}
 	})


### PR DESCRIPTION
## Description
Add support to set, modify, and filter by `trace` and `spanId` fields in LogEntry:
- Both can be set via `logging.googleapis.com/*` if ingested as structured log (e.g., from a `parse_json` processor);
- The fields can be used in `modify_fields` processors;
- The fields can be referred in `exclude_logs` processors; 

## Related issue
[b/308132501](http://b/308132501)
#1483 
#459

## How has this been tested?
1. Modified `TestModifyFields` to cover `modify_fields` usage of the new fields;
2. Added `TestLogEntrySpecialFields` to verify the special fields are handled correctly;
3. Added `TestExcludeLogsModifyFieldsOrder` to cover `exclude_logs` usage, and the processors are executed in the correct order.
4. Unit tests updated. 

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [x] This PR introduces user visible changes and the corresponding documentation change has been made. (doc CL prepared)
- Minor version bump
  - [ ] This PR introduces no new features.
  - [x] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
