### PR TITLE
Internal: Remove action that sends coverage info to coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,9 @@ jobs:
         cache: true
     - run: |
         go install golang.org/x/tools/cmd/goimports@latest
-        go install github.com/mattn/goveralls@latest
     - if: ${{ runner.os == 'Linux' }}
       run: if [ $(goimports -l .) ]; then goimports -d .; echo 'Failed the goimports format check. Please format the code using "goimports -w ."'; exit 1; fi
     - run: go test -mod=mod -coverpkg="./..." -coverprofile=covprofile ./...
-    - env:
-        COVERALLS_TOKEN: ${{ secrets.github_token }}
-      run: goveralls -coverprofile=covprofile -service=github -ignore="confgenerator/filter/internal/generated/*/*"
     - id: 'set-coverage-vars'
       if: ${{ runner.os == 'Linux' && github.event_name == 'push' && github.repository == 'GoogleCloudPlatform/ops-agent' && github.ref == 'refs/heads/master' }}
       name: 'Set Coverage Env Vars'


### PR DESCRIPTION
## Description
Remove the step in the actions that send the code coverage info to coveralls. 

## Related issue


## How has this been tested?


## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
