### PR TITLE
Testing: Fix DCGM install script

### DIFF
--- a/integration_test/third_party_apps_data/applications/dcgm/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/dcgm/debian_ubuntu/install
@@ -44,5 +44,5 @@ sudo apt-get install -y datacenter-gpu-manager
 sudo systemctl --now enable nvidia-dcgm
 
 # check if DCGM service is running
-# This is for debugging the test only - ignore return code
+# This command is only used for informational/debugging output.
 dcgmi discovery --list || true

--- a/integration_test/third_party_apps_data/applications/dcgm/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/dcgm/debian_ubuntu/install
@@ -43,5 +43,6 @@ sudo apt-get update
 sudo apt-get install -y datacenter-gpu-manager
 sudo systemctl --now enable nvidia-dcgm
 
-# check DCGM service running and load profiling module
-dcgmi discovery --list
+# check if DCGM service is running
+# This is for debugging the test only - ignore return code
+dcgmi discovery --list || true


### PR DESCRIPTION
## Description
On Debian 11 with the new DCGM 3.3, the `dcgmi discovery -l` will fail to get CPU info which we don't need. Ignore the return code of the command in the installation script.  

## Related issue
[b/309148533](http://b/309148533)

## How has this been tested?
Integration test for DCGM passed on Debian 11. 

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
