### PR TITLE
Testing: Simplify RunScriptRemotely on Linux

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -788,13 +788,12 @@ func wrapPowershellCommand(command string) (string, error) {
 
 // RunRemotely runs a command on the provided VM.
 // The command should be a shell command if the VM is Linux, or powershell if the VM is Windows.
-// Returns the combined stdout+stderr as a string, plus an error if there was
+// Returns the stdout and stderr as strings, plus an error if there was
 // a problem.
 //
 // 'command' is what to run on the machine. Example: "cat /tmp/foo; echo hello"
 // For extremely long commands, use RunScriptRemotely instead.
 // 'stdin' is what to supply to the command on stdin. It is usually "".
-// TODO: Remove the stdin parameter, because it is hardly used.
 func RunRemotely(ctx context.Context, logger *log.Logger, vm *VM, stdin string, command string) (_ CommandOutput, err error) {
 	logger.Printf("Running command remotely: %v", command)
 	defer func() {

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -922,12 +922,10 @@ func RunScriptRemotely(ctx context.Context, logger *logging.DirectoryLogger, vm 
 		// script seems to work around this completely.
 		return RunRemotely(ctx, logger.ToMainLog(), vm, "", envVarMapToPowershellPrefix(env)+"powershell -File "+scriptPath+" "+flagsStr)
 	}
-	scriptPath := uuid.NewString() + ".sh"
-	// Write the script contents to <UUID>.sh, then tell bash to execute it with -x
-	// to print each line as it runs.
-	// Use a UUID for the script name in case RunScriptRemotely is being called
-	// concurrently on the same VM.
-	return RunRemotely(ctx, logger.ToMainLog(), vm, scriptContents, "cat - > "+scriptPath+" && sudo "+envVarMapToBashPrefix(env)+"bash -x "+scriptPath+" "+flagsStr)
+	// Tell bash to run the contents of stdin (-s), executing it with -x
+	// to print each line as it runs. Everything after "--" is passed as arguments
+	// to the script.
+	return RunRemotely(ctx, logger.ToMainLog(), vm, scriptContents, "sudo "+envVarMapToBashPrefix(env)+"bash -x -s -- "+flagsStr)
 }
 
 // MapToCommaSeparatedList converts a map of key-value pairs into a form that


### PR DESCRIPTION
TODO: consider automated or manual tests for RunRemotely/RunScriptRemotely.

Simplify RunScriptRemotely on Linux by making it go directly from stdin to bash instead of needing to take a side journey to `<UUID>.sh` along the way.

Just something I noticed when considering other cleanups to this function.

## Description
<!--- Describe your changes in detail. -->

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
