### PR TITLE
Testing: SLES - GCloud SDK update needs sudo

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1524,7 +1524,7 @@ INSTALL_DIR="$(readlink --canonicalize .)"
 ` + installFromTarball + `
 
 # Upgrade to the latest version
-${INSTALL_DIR}/google-cloud-sdk/bin/gcloud components update --quiet
+sudo ${INSTALL_DIR}/google-cloud-sdk/bin/gcloud components update --quiet
 
 sudo ln -s ${INSTALL_DIR}/google-cloud-sdk/bin/gsutil /usr/bin/gsutil 
 `
@@ -1555,7 +1555,7 @@ export CLOUDSDK_PYTHON=/usr/bin/python3.11
 ` + installFromTarball + `
 
 # Upgrade to the latest version
-CLOUDSDK_PYTHON=/usr/bin/python3.11 ${INSTALL_DIR}/google-cloud-sdk/bin/gcloud components update --quiet
+sudo CLOUDSDK_PYTHON=/usr/bin/python3.11 ${INSTALL_DIR}/google-cloud-sdk/bin/gcloud components update --quiet
 
 # Make a "gsutil" bash script in /usr/bin that runs the copy of gsutil that
 # was installed into $INSTALL_DIR with CLOUDSDK_PYTHON set.


### PR DESCRIPTION
## Description
For SLES 12 and 15, we download a versioned (453.0.0) tarball, and try to upgrade to the latest version to keep in sync with other platforms. 
There is a new version of the SDK available today (454.0.0) and when call `gcloud components update`, the command failed because it requires sudo to actually apply the update. 

## Related issue
[b/308605793](http://b/308605793)

## How has this been tested?
Integration tests to pass on SLES 12 and 15. 

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
