### PR TITLE
Add Kokoro build configs for new distro mantic_x86_64

### DIFF
--- a/kokoro/config/build/presubmit/mantic_x86_64.gcl
+++ b/kokoro/config/build/presubmit/mantic_x86_64.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'mantic'
+      PKGFORMAT = 'deb'
+    }
+  }
+}

--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -13,6 +13,15 @@ local template _distro {
 }
 
 // DEB Linux distros. (Do not modify this comment.)
+mantic_x86_64 = _distro {
+  release = [
+      'ubuntu-2310-amd64',
+      'ubuntu-minimal-2310-amd64',
+  ]
+  presubmit = [
+      'ubuntu-minimal-2310-amd64',
+  ]
+}
 bookworm_x86_64 = _distro {
   release = [
       'debian-12',

--- a/kokoro/config/test/ops_agent/mantic_x86_64.gcl
+++ b/kokoro/config/test/ops_agent/mantic_x86_64.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.mantic_x86_64.presubmit
+    arch = 'x86_64'
+  }
+}

--- a/kokoro/config/test/ops_agent/release/mantic_x86_64.gcl
+++ b/kokoro/config/test/ops_agent/release/mantic_x86_64.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.mantic_x86_64.release
+    arch = 'x86_64'
+  }
+}

--- a/kokoro/config/test/third_party_apps/mantic_x86_64.gcl
+++ b/kokoro/config/test/third_party_apps/mantic_x86_64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = [
+      'ubuntu-2310-amd64',
+    ]
+    arch = 'x86_64'
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/mantic_x86_64.gcl
+++ b/kokoro/config/test/third_party_apps/release/mantic_x86_64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = [
+      'ubuntu-2310-amd64',
+    ]
+    arch = 'x86_64'
+  }
+}


### PR DESCRIPTION
## Description
Autogenerated PR for adding support in Kokoro for Ubuntu 23.10 Mantic x86_64. 

## Related issue
b/304832107

## How has this been tested?
N/A

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [x] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
