### PR TITLE
Fixes or skips Debian 12 Aarch64 Tests

### DIFF
--- a/integration_test/third_party_apps_data/applications/aerospike/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/aerospike/metadata.yaml
@@ -132,6 +132,7 @@ supported_operating_systems: linux
 platforms_to_skip:
   # Unable to install Aerospike on various distros.
   - debian-12
+  - debian-12-arm64
   - sles-12
   - rocky-linux-9
   - rocky-linux-9-arm64

--- a/integration_test/third_party_apps_data/applications/cassandra/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/cassandra/metadata.yaml
@@ -53,6 +53,7 @@ platforms_to_skip:
   - sles-15 # QueryLog() failed: cassandra_system not found, exhausted retries; QueryLog() failed: cassandra_debug not found, exhausted retries; QueryLog() failed: cassandra_gc not found, exhausted retries
   - sles-15-arm64
   - debian-12 # QueryLog() failed: cassandra_system not found, exhausted retries; QueryLog() failed: cassandra_debug not found, exhausted retries; QueryLog() failed: cassandra_gc not found, exhausted retries
+  - debian-12-arm64 # QueryLog() failed: cassandra_system not found, exhausted retries; QueryLog() failed: cassandra_debug not found, exhausted retries; QueryLog() failed: cassandra_gc not found, exhausted retries
   - ubuntu-2004-lts # GPG error [...] the public key is not available: NO_PUBKEY AA8E81B4331F7F50 NO_PUBKEY 112695A0E562B32A
   - ubuntu-2204-lts # GPG error [...] the public key is not available: NO_PUBKEY AA8E81B4331F7F50 NO_PUBKEY 112695A0E562B32A
 supported_app_version: ["3.11", "4.0"]

--- a/integration_test/third_party_apps_data/applications/couchdb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/couchdb/metadata.yaml
@@ -38,6 +38,7 @@ platforms_to_skip:
   - ubuntu-2310-amd64
   - ubuntu-2310-arm64
   - debian-12
+  - debian-12-arm64
 supported_app_version: ["2.3+", "3.1+"]
 expected_metrics:
   - type: workload.googleapis.com/couchdb.average_request_time

--- a/integration_test/third_party_apps_data/applications/flink/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/flink/metadata.yaml
@@ -21,6 +21,7 @@ description: |-
 platforms_to_skip:
   # Flink only supports Java 11, which has no installation candidate for Debian 12
   - debian-12
+  - debian-12-arm64
 supported_app_version: ["1.12.5", "1.13.6", "1.14.4"]
 configure_integration: ""
 expected_metrics:

--- a/integration_test/third_party_apps_data/applications/hbase/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/hbase/metadata.yaml
@@ -47,6 +47,7 @@ minimum_supported_agent_version:
 platforms_to_skip:
   # Hbase only supports Java 11, which has no installation candidate for Debian 12
   - debian-12
+  - debian-12-arm64
 supported_operating_systems: linux
 supported_app_version: ["1.7.x", "2.3.x", "2.4.x"]
 expected_metrics:

--- a/integration_test/third_party_apps_data/applications/mariadb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mariadb/metadata.yaml
@@ -149,6 +149,7 @@ expected_metrics:
     unavailable_on:
       - ubuntu-2310-amd64
       - ubuntu-2310-arm64
+      - debian-12-arm64
   - type: workload.googleapis.com/mysql.sorts
     value_type: INT64
     kind: CUMULATIVE

--- a/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mongodb/metadata.yaml
@@ -32,6 +32,7 @@ platforms_to_skip:
   - ubuntu-2310-amd64
   - ubuntu-2310-arm64
   - debian-12
+  - debian-12-arm64
   - sles-15-arm64
 supported_app_version: ["2.6", "3.0+", "4.0+", "5.0", "6.0"]
 expected_metrics:

--- a/integration_test/third_party_apps_data/applications/mongodb3.6/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mongodb3.6/metadata.yaml
@@ -41,6 +41,7 @@ platforms_to_skip:
   - debian-11
   - debian-11-arm64
   - debian-12
+  - debian-12-arm64
   - sles-15-arm64
 supported_app_version: ["2.6", "3.0+", "4.0+", "5.0"]
 expected_metrics:

--- a/integration_test/third_party_apps_data/applications/mysql/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mysql/metadata.yaml
@@ -39,6 +39,7 @@ platforms_to_skip:
   # MySQL is not currently supported on various distros.
   - debian-11-arm64
   - debian-12
+  - debian-12-arm64
   - sles-15-arm64
 supported_app_version: ["8.0", "5.7"]
 expected_metrics:

--- a/integration_test/third_party_apps_data/applications/mysql5.7/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mysql5.7/metadata.yaml
@@ -42,6 +42,7 @@ platforms_to_skip:
   - debian-11
   - debian-11-arm64
   - debian-12
+  - debian-12-arm64
   - ubuntu-2004-lts
   - ubuntu-2004-lts-arm64
   - ubuntu-2204-lts

--- a/integration_test/third_party_apps_data/applications/oracledb/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/oracledb/metadata.yaml
@@ -53,6 +53,7 @@ platforms_to_skip:
   - debian-11
   - debian-11-arm64
   - debian-12
+  - debian-12-arm64
   - ubuntu-2004-lts
   - ubuntu-2004-lts-arm64
   - ubuntu-2204-lts

--- a/integration_test/third_party_apps_data/applications/rabbitmq/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/rabbitmq/debian_ubuntu/install
@@ -30,6 +30,9 @@ case $VERSION_ID in
   11)
     echo "deb http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/rabbitmq.list
     ;;
+  12)
+    echo "deb http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu jammy main" | sudo tee /etc/apt/sources.list.d/rabbitmq.list
+    ;;
   *)
     echo -n "unknown version"
     exit 1

--- a/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/rabbitmq/metadata.yaml
@@ -28,7 +28,6 @@ minimum_supported_agent_version:
 supported_operating_systems: linux
 platforms_to_skip:
   # RabbitMQ is not supported on various distros.
-  - debian-12
   - sles-12
   - ubuntu-2304-amd64
   - ubuntu-2310-amd64


### PR DESCRIPTION
## Description
Fixes or skips Debian 12 Aarch64 tests. Here are all tests passing with the Bullseye overwrite hack in place
<img width="936" alt="image" src="https://github.com/GoogleCloudPlatform/ops-agent/assets/12396806/5c8d8556-9a2f-4352-8528-9dc56af0d627">

Hack has since been removed.

## Related issue
NA

## How has this been tested?
NA

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
