### PR TITLE
Update golang version used in TestOTLPMetricsGMP test

### DIFF
--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -2676,7 +2676,7 @@ func TestPrometheusMetricsWithJSONExporter(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := buildGoBinary(ctx, logger, vm, serviceFiles[0].remote, "/opt/go-http-server/"); err != nil {
+		if err := buildGoBinary(ctx, logger, vm, filesToUpload[0].remote, "/opt/go-http-server/"); err != nil {
 			t.Fatal(err)
 		}
 

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -2676,6 +2676,10 @@ func TestPrometheusMetricsWithJSONExporter(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		if err := buildGoBinary(ctx, logger, vm, serviceFiles[0].remote, "/opt/go-http-server/"); err != nil {
+			t.Fatal(err)
+		}
+
 		// Run the setup script to run the http server and the JSON exporter
 		setupScript, err := testdataDir.ReadFile(path.Join(prometheusTestdata, "setup_json_exporter.sh"))
 		if err != nil {

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -3884,7 +3884,7 @@ func unmarshalResource(in string) (*resourcedetector.GCEResource, error) {
 // the PATH before calling `go` as goPath
 func installGolang(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.VM) error {
 	// TODO: use runtime.Version() to extract the go version
-	goVersion := "1.19"
+	goVersion := "1.20"
 	goArch := "amd64"
 	if gce.IsARM(vm.Platform) {
 		goArch = "arm64"

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -2676,6 +2676,10 @@ func TestPrometheusMetricsWithJSONExporter(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		if err := buildGoBinary(ctx, logger, vm, filesToUpload[0].remote, "/opt/go-http-server/"); err != nil {
+			t.Fatal(err)
+		}
+
 		// Run the setup script to run the http server and the JSON exporter
 		setupScript, err := testdataDir.ReadFile(path.Join(prometheusTestdata, "setup_json_exporter.sh"))
 		if err != nil {
@@ -3192,6 +3196,13 @@ func TestPrometheusSummaryMetrics(t *testing.T) {
 	testPrometheusMetrics(t, config, testChecks)
 }
 
+func buildGoBinary(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.VM, source, dest string) error {
+	installCmd := fmt.Sprintf(`
+               /usr/local/go/bin/go build -o %s/ %s`, dest, source)
+	_, err := gce.RunScriptRemotely(ctx, logger, vm, installCmd, nil, nil)
+	return err
+}
+
 // testPrometheusMetrics tests different Prometheus metric types using static
 // testing files. The files will contain metrics in the right format and hosted
 // by a simple HTTP server so that the agent can scrape the metrics
@@ -3227,8 +3238,13 @@ func testPrometheusMetrics(t *testing.T, opsAgentConfig string, testChecks []moc
 			t.Fatal(err)
 		}
 
-		// 2. Setup the golang and start the go http server
+		// 2. Setup the golang
 		if err := installGolang(ctx, logger, vm); err != nil {
+			t.Fatal(err)
+		}
+
+		// 3. Build the http server
+		if err := buildGoBinary(ctx, logger, vm, serviceFiles[0].remote, remoteWorkDir); err != nil {
 			t.Fatal(err)
 		}
 

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -3249,7 +3249,9 @@ func testPrometheusMetrics(t *testing.T, opsAgentConfig string, testChecks []moc
 		}
 
 		// 4. Start the go http server
-		setupScript := `sudo systemctl daemon-reload
+		setupScript := `
+			sudo chcon -t bin_t /opt/go-http-server/http_server
+			sudo systemctl daemon-reload
 			sudo systemctl enable http-server-for-prometheus-test
 			sudo systemctl restart http-server-for-prometheus-test`
 		setupOut, err := gce.RunScriptRemotely(ctx, logger, vm, string(setupScript), nil, nil)
@@ -3257,6 +3259,7 @@ func testPrometheusMetrics(t *testing.T, opsAgentConfig string, testChecks []moc
 			t.Fatalf("failed to start the http server in VM via systemctl with err: %v, stderr: %s", err, setupOut.Stderr)
 		}
 		// Wait until the http server is ready
+
 		time.Sleep(15 * time.Second)
 		liveCheckOut, liveCheckErr := gce.RunRemotely(ctx, logger.ToMainLog(), vm, "", `curl "http://localhost:8000/data"`)
 		if liveCheckErr != nil || strings.Contains(liveCheckOut.Stderr, "Connection refused") {

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -3192,6 +3192,13 @@ func TestPrometheusSummaryMetrics(t *testing.T) {
 	testPrometheusMetrics(t, config, testChecks)
 }
 
+func buildGoBinary(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.VM, source, dest string) error {
+	installCmd := fmt.Sprintf(`
+		/usr/local/go/bin/go build -o %s/ %s`, dest, source)
+	_, err := gce.RunScriptRemotely(ctx, logger, vm, installCmd, nil, nil)
+	return err
+}
+
 // testPrometheusMetrics tests different Prometheus metric types using static
 // testing files. The files will contain metrics in the right format and hosted
 // by a simple HTTP server so that the agent can scrape the metrics
@@ -3227,10 +3234,17 @@ func testPrometheusMetrics(t *testing.T, opsAgentConfig string, testChecks []moc
 			t.Fatal(err)
 		}
 
-		// 2. Setup the golang and start the go http server
+		// 2. Setup the golang
 		if err := installGolang(ctx, logger, vm); err != nil {
 			t.Fatal(err)
 		}
+
+		// 3. Build the http server
+		if err := buildGoBinary(ctx, logger, vm, serviceFiles[0].remote, remoteWorkDir); err != nil {
+			t.Fatal(err)
+		}
+
+		// 4. Start the go http server
 		setupScript := `sudo systemctl daemon-reload
 			sudo systemctl enable http-server-for-prometheus-test
 			sudo systemctl restart http-server-for-prometheus-test`
@@ -3239,7 +3253,7 @@ func testPrometheusMetrics(t *testing.T, opsAgentConfig string, testChecks []moc
 			t.Fatalf("failed to start the http server in VM via systemctl with err: %v, stderr: %s", err, setupOut.Stderr)
 		}
 		// Wait until the http server is ready
-		time.Sleep(5 * time.Second)
+		time.Sleep(15 * time.Second)
 		liveCheckOut, liveCheckErr := gce.RunRemotely(ctx, logger.ToMainLog(), vm, "", `curl "http://localhost:8000/data"`)
 		if liveCheckErr != nil || strings.Contains(liveCheckOut.Stderr, "Connection refused") {
 			t.Fatalf("Http server failed to start with stdout %s and stderr %s", liveCheckOut.Stdout, liveCheckOut.Stderr)

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -3227,14 +3227,14 @@ func testPrometheusMetrics(t *testing.T, opsAgentConfig string, testChecks []moc
 			t.Fatal(err)
 		}
 
-		// 2. Setup the golang
+		// 2. Setup the golang and start the go http server
 		if err := installGolang(ctx, logger, vm); err != nil {
 			t.Fatal(err)
 		}
 
 		// 4. Start the go http server
 		setupScript := `sudo systemctl daemon-reload
-			sudo systemctl enable http-server-for-prometheus-tes
+			sudo systemctl enable http-server-for-prometheus-test
 			sudo systemctl restart http-server-for-prometheus-test`
 		setupOut, err := gce.RunScriptRemotely(ctx, logger, vm, string(setupScript), nil, nil)
 		if err != nil {

--- a/integration_test/testdata/prometheus/http-server-for-prometheus-test.service
+++ b/integration_test/testdata/prometheus/http-server-for-prometheus-test.service
@@ -20,7 +20,7 @@ After=network.target
 [Service]
 Type=exec
 User=root
-ExecStart=/usr/local/go/bin/go run /opt/go-http-server/http_server.go -port=8000 -dir=/opt/go-http-server/
+ExecStart=/opt/go-http-server/http_server -port=8000 -dir=/opt/go-http-server/
 Restart=on-abnormal
 
 [Install]

--- a/integration_test/testdata/prometheus/http-server-for-prometheus-test.service
+++ b/integration_test/testdata/prometheus/http-server-for-prometheus-test.service
@@ -14,8 +14,8 @@
 
 [Unit]
 Description=Http Server for Prometheus Test
-Requires=network.target 
-After=network.target 
+Requires=network.target
+After=network.target
 
 [Service]
 Type=exec

--- a/integration_test/testdata/prometheus/http-server-for-prometheus-test.service
+++ b/integration_test/testdata/prometheus/http-server-for-prometheus-test.service
@@ -20,7 +20,7 @@ After=network.target
 [Service]
 Type=exec
 User=root
-ExecStart=/opt/go-http-server/http_server -port=8000 -dir=/opt/go-http-server/
+ExecStart=go run /opt/go-http-server/http_server.go -port=8000 -dir=/opt/go-http-server/
 Restart=on-abnormal
 
 [Install]

--- a/integration_test/testdata/prometheus/http-server-for-prometheus-test.service
+++ b/integration_test/testdata/prometheus/http-server-for-prometheus-test.service
@@ -20,7 +20,7 @@ After=network.target
 [Service]
 Type=exec
 User=root
-ExecStart=go run /opt/go-http-server/http_server.go -port=8000 -dir=/opt/go-http-server/
+ExecStart=/usr/local/go/bin/go run /opt/go-http-server/http_server.go -port=8000 -dir=/opt/go-http-server/
 Restart=on-abnormal
 
 [Install]


### PR DESCRIPTION
## Description
Integration test is failing because of operator now available. Updating golang version to fix it.

## Related issue
b/310621875

## How has this been tested?
Failing test is now passing

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
