### PR TITLE
Update activemq version used in integration tests

### DIFF
--- a/integration_test/third_party_apps_data/applications/activemq/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/activemq/centos_rhel/install
@@ -6,7 +6,7 @@ sudo yum install -y \
 # https://github.com/GoogleCloudPlatform/ops-agent/blob/master/integration_test/README.md#vendored-dependencies
 curl -L -o \
     activemq.tar.gz \
-    https://storage.googleapis.com/ops-agents-public-buckets-vendored-deps/mirrored-content/archive.apache.org/dist/activemq/5.16.3/apache-activemq-5.16.3-bin.tar.gz
+    https://storage.googleapis.com/ops-agents-public-buckets-vendored-deps/mirrored-content/archive.apache.org/dist/activemq/5.16.7/apache-activemq-5.16.7-bin.tar.gz
 
 sudo mkdir /opt/activemq
 sudo tar -xf \

--- a/integration_test/third_party_apps_data/applications/activemq/sles/install
+++ b/integration_test/third_party_apps_data/applications/activemq/sles/install
@@ -6,7 +6,7 @@ sudo zypper install -y \
 # https://github.com/GoogleCloudPlatform/ops-agent/blob/master/integration_test/README.md#vendored-dependencies
 curl -L -o \
     activemq.tar.gz \
-    https://storage.googleapis.com/ops-agents-public-buckets-vendored-deps/mirrored-content/archive.apache.org/dist/activemq/5.16.3/apache-activemq-5.16.3-bin.tar.gz
+    https://storage.googleapis.com/ops-agents-public-buckets-vendored-deps/mirrored-content/archive.apache.org/dist/activemq/5.16.7/apache-activemq-5.16.7-bin.tar.gz
 
 sudo mkdir /opt/activemq
 sudo tar -xf \


### PR DESCRIPTION
## Description
Updating activeMQ for integration test to version not affected by CVE https://nvd.nist.gov/vuln/detail/CVE-2023-46604

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
