### PR TITLE
Testing: Temporary fix of gpu driver for Rocky Linux 8/9

### DIFF
--- a/integration_test/third_party_apps_data/applications/dcgm/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/dcgm/centos_rhel/install
@@ -1,7 +1,30 @@
 set -e
 source /etc/os-release
 KERNEL_VERSION=`uname -r`
-sudo yum install -y kernel-devel-${KERNEL_VERSION} pciutils gcc make wget yum-utils 
+
+# sudo yum install -y kernel-devel-${KERNEL_VERSION} pciutils gcc make wget yum-utils 
+# TODO(b/312455563): Temporary fix for Rocky Linux 9.2/8.8; uncomment the above line and remove this following section once the image has been updated to Rocky Linux 9.3/8.9
+sudo yum install -y pciutils gcc make wget yum-utils
+if ! sudo yum install -y kernel-devel-${KERNEL_VERSION}; then 
+    sudo yum install -y kernel-devel  # Install the latest kernel dev package first to bring in the dependencies, before switching to 9.2 vault repo
+    if [[ $ID == rocky && "${VERSION_ID}" == 9.2 ]]; then
+        sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever$rltype,baseurl=https://dl.rockylinux.org/vault/rocky/9.2/AppStream/x86_64/os/,g' /etc/yum.repos.d/rocky.repo
+    elif [[ $ID == rocky && "${VERSION_ID}" == 8.8 ]]; then
+        # Right now the Rocky Linux 8.8 packages are still in the main repo, and the vault repo is returning 403;
+        # It can move to the vault repo (archive repo) anytime and then the main repo will become unaccessable.
+        VAULT_STATUS=`curl -s -o /dev/null -w "%{http_code}" https://dl.rockylinux.org/vault/rocky/8.8/BaseOS/x86_64/os/`
+        if [[ $VAULT_STATUS == 403 ]]; then
+            sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever,baseurl=https://download.rockylinux.org/pub/rocky/8.8/BaseOS/x86_64/os,g' /etc/yum.repos.d/Rocky-BaseOS.repo
+        else
+            sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever,baseurl=https://dl.rockylinux.org/vault/rocky/8.8/BaseOS/x86_64/os/,g' /etc/yum.repos.d/Rocky-BaseOS.repo
+        fi
+    fi
+    sudo yum clean all 
+    sudo yum --showduplicates list available kernel-devel
+    sudo yum install -y kernel-devel-${KERNEL_VERSION}
+fi
+# End of the temporary fix
+
 
 # Install the driver the same way as the nvml app 
 # Prefer to install from the package manager since it is normally faster and has

--- a/integration_test/third_party_apps_data/applications/dcgm/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/dcgm/centos_rhel/install
@@ -8,16 +8,9 @@ sudo yum install -y pciutils gcc make wget yum-utils
 if ! sudo yum install -y kernel-devel-${KERNEL_VERSION}; then 
     sudo yum install -y kernel-devel  # Install the latest kernel dev package first to bring in the dependencies, before switching to 9.2 vault repo
     if [[ $ID == rocky && "${VERSION_ID}" == 9.2 ]]; then
-        sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever$rltype,baseurl=https://dl.rockylinux.org/vault/rocky/9.2/AppStream/x86_64/os/,g' /etc/yum.repos.d/rocky.repo
+        sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever$rltype,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=x86_64\&repo=AppStream-9.2,g' /etc/yum.repos.d/rocky.repo
     elif [[ $ID == rocky && "${VERSION_ID}" == 8.8 ]]; then
-        # Right now the Rocky Linux 8.8 packages are still in the main repo, and the vault repo is returning 403;
-        # It can move to the vault repo (archive repo) anytime and then the main repo will become unaccessable.
-        VAULT_STATUS=`curl -s -o /dev/null -w "%{http_code}" https://dl.rockylinux.org/vault/rocky/8.8/BaseOS/x86_64/os/`
-        if [[ $VAULT_STATUS == 403 ]]; then
-            sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever,baseurl=https://download.rockylinux.org/pub/rocky/8.8/BaseOS/x86_64/os,g' /etc/yum.repos.d/Rocky-BaseOS.repo
-        else
-            sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever,baseurl=https://dl.rockylinux.org/vault/rocky/8.8/BaseOS/x86_64/os/,g' /etc/yum.repos.d/Rocky-BaseOS.repo
-        fi
+        sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=x86_64\&repo=BaseOS-8.8,g' /etc/yum.repos.d/Rocky-BaseOS.repo
     fi
     sudo yum clean all 
     sudo yum --showduplicates list available kernel-devel

--- a/integration_test/third_party_apps_data/applications/dcgm/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/dcgm/centos_rhel/install
@@ -3,14 +3,14 @@ source /etc/os-release
 KERNEL_VERSION=`uname -r`
 
 # sudo yum install -y kernel-devel-${KERNEL_VERSION} pciutils gcc make wget yum-utils 
-# TODO(b/312455563): Temporary fix for Rocky Linux 9.2/8.8; uncomment the above line and remove this following section once the image has been updated to Rocky Linux 9.3/8.9
+# TODO(b/312949832): Temporary fix for Rocky Linux 9.2/8.8; uncomment the above line and remove this following section once the image has been updated to Rocky Linux 9.3/8.9
 sudo yum install -y pciutils gcc make wget yum-utils
 if ! sudo yum install -y kernel-devel-${KERNEL_VERSION}; then 
-    sudo yum install -y kernel-devel  # Install the latest kernel dev package first to bring in the dependencies, before switching to 9.2 vault repo
+    sudo yum install -y kernel-devel  # Install the latest kernel dev package first to bring in the dependencies, before switching to 9.2 repo
     if [[ $ID == rocky && "${VERSION_ID}" == 9.2 ]]; then
-        sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever$rltype,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=x86_64\&repo=AppStream-9.2,g' /etc/yum.repos.d/rocky.repo
+        sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever$rltype,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch\&repo=AppStream-9.2,g' /etc/yum.repos.d/rocky.repo
     elif [[ $ID == rocky && "${VERSION_ID}" == 8.8 ]]; then
-        sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=x86_64\&repo=BaseOS-8.8,g' /etc/yum.repos.d/Rocky-BaseOS.repo
+        sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch\&repo=BaseOS-8.8,g' /etc/yum.repos.d/Rocky-BaseOS.repo
     fi
     sudo yum clean all 
     sudo yum --showduplicates list available kernel-devel

--- a/integration_test/third_party_apps_data/applications/nvml/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/nvml/centos_rhel/install
@@ -2,15 +2,15 @@ set -e
 KERNEL_VERSION=`uname -r`
 
 # sudo yum install -y kernel-devel-${KERNEL_VERSION} pciutils gcc make wget yum-utils 
-# TODO(b/312455563): Temporary fix for Rocky Linux 9.2/8.8; uncomment the above line and remove this following section once the image has been updated to Rocky Linux 9.3/8.9
+# TODO(b/312949832): Temporary fix for Rocky Linux 9.2/8.8; uncomment the above line and remove this following section once the image has been updated to Rocky Linux 9.3/8.9
 source /etc/os-release
 sudo yum install -y pciutils gcc make wget yum-utils
 if ! sudo yum install -y kernel-devel-${KERNEL_VERSION}; then 
-    sudo yum install -y kernel-devel  # Install the latest kernel dev package first to bring in the dependencies, before switching to 9.2 vault repo
+    sudo yum install -y kernel-devel  # Install the latest kernel dev package first to bring in the dependencies, before switching to 9.2 repo
     if [[ $ID == rocky && "${VERSION_ID}" == 9.2 ]]; then
-        sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever$rltype,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=x86_64\&repo=AppStream-9.2,g' /etc/yum.repos.d/rocky.repo
+        sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever$rltype,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch\&repo=AppStream-9.2,g' /etc/yum.repos.d/rocky.repo
     elif [[ $ID == rocky && "${VERSION_ID}" == 8.8 ]]; then
-        sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=x86_64\&repo=BaseOS-8.8,g' /etc/yum.repos.d/Rocky-BaseOS.repo
+        sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch\&repo=BaseOS-8.8,g' /etc/yum.repos.d/Rocky-BaseOS.repo
     fi
     sudo yum clean all 
     sudo yum --showduplicates list available kernel-devel

--- a/integration_test/third_party_apps_data/applications/nvml/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/nvml/centos_rhel/install
@@ -8,16 +8,9 @@ sudo yum install -y pciutils gcc make wget yum-utils
 if ! sudo yum install -y kernel-devel-${KERNEL_VERSION}; then 
     sudo yum install -y kernel-devel  # Install the latest kernel dev package first to bring in the dependencies, before switching to 9.2 vault repo
     if [[ $ID == rocky && "${VERSION_ID}" == 9.2 ]]; then
-        sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever$rltype,baseurl=https://dl.rockylinux.org/vault/rocky/9.2/AppStream/x86_64/os/,g' /etc/yum.repos.d/rocky.repo
+        sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever$rltype,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=x86_64\&repo=AppStream-9.2,g' /etc/yum.repos.d/rocky.repo
     elif [[ $ID == rocky && "${VERSION_ID}" == 8.8 ]]; then
-        # Right now the Rocky Linux 8.8 packages are still in the main repo, and the vault repo is returning 403;
-        # It can move to the vault repo (archive repo) anytime and then the main repo will become unaccessable.
-        VAULT_STATUS=`curl -s -o /dev/null -w "%{http_code}" https://dl.rockylinux.org/vault/rocky/8.8/BaseOS/x86_64/os/`
-        if [[ $VAULT_STATUS == 403 ]]; then
-            sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever,baseurl=https://download.rockylinux.org/pub/rocky/8.8/BaseOS/x86_64/os,g' /etc/yum.repos.d/Rocky-BaseOS.repo
-        else
-            sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever,baseurl=https://dl.rockylinux.org/vault/rocky/8.8/BaseOS/x86_64/os/,g' /etc/yum.repos.d/Rocky-BaseOS.repo
-        fi
+        sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=x86_64\&repo=BaseOS-8.8,g' /etc/yum.repos.d/Rocky-BaseOS.repo
     fi
     sudo yum clean all 
     sudo yum --showduplicates list available kernel-devel

--- a/integration_test/third_party_apps_data/applications/nvml/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/nvml/centos_rhel/install
@@ -3,6 +3,7 @@ KERNEL_VERSION=`uname -r`
 
 # sudo yum install -y kernel-devel-${KERNEL_VERSION} pciutils gcc make wget yum-utils 
 # TODO(b/312455563): Temporary fix for Rocky Linux 9.2/8.8; uncomment the above line and remove this following section once the image has been updated to Rocky Linux 9.3/8.9
+source /etc/os-release
 sudo yum install -y pciutils gcc make wget yum-utils
 if ! sudo yum install -y kernel-devel-${KERNEL_VERSION}; then 
     sudo yum install -y kernel-devel  # Install the latest kernel dev package first to bring in the dependencies, before switching to 9.2 vault repo

--- a/integration_test/third_party_apps_data/applications/nvml/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/nvml/centos_rhel/install
@@ -1,6 +1,28 @@
 set -e
 KERNEL_VERSION=`uname -r`
-sudo yum install -y kernel-devel-${KERNEL_VERSION} pciutils gcc make wget yum-utils 
+
+# sudo yum install -y kernel-devel-${KERNEL_VERSION} pciutils gcc make wget yum-utils 
+# TODO(b/312455563): Temporary fix for Rocky Linux 9.2/8.8; uncomment the above line and remove this following section once the image has been updated to Rocky Linux 9.3/8.9
+sudo yum install -y pciutils gcc make wget yum-utils
+if ! sudo yum install -y kernel-devel-${KERNEL_VERSION}; then 
+    sudo yum install -y kernel-devel  # Install the latest kernel dev package first to bring in the dependencies, before switching to 9.2 vault repo
+    if [[ $ID == rocky && "${VERSION_ID}" == 9.2 ]]; then
+        sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever$rltype,baseurl=https://dl.rockylinux.org/vault/rocky/9.2/AppStream/x86_64/os/,g' /etc/yum.repos.d/rocky.repo
+    elif [[ $ID == rocky && "${VERSION_ID}" == 8.8 ]]; then
+        # Right now the Rocky Linux 8.8 packages are still in the main repo, and the vault repo is returning 403;
+        # It can move to the vault repo (archive repo) anytime and then the main repo will become unaccessable.
+        VAULT_STATUS=`curl -s -o /dev/null -w "%{http_code}" https://dl.rockylinux.org/vault/rocky/8.8/BaseOS/x86_64/os/`
+        if [[ $VAULT_STATUS == 403 ]]; then
+            sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever,baseurl=https://download.rockylinux.org/pub/rocky/8.8/BaseOS/x86_64/os,g' /etc/yum.repos.d/Rocky-BaseOS.repo
+        else
+            sudo sed -i 's,mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever,baseurl=https://dl.rockylinux.org/vault/rocky/8.8/BaseOS/x86_64/os/,g' /etc/yum.repos.d/Rocky-BaseOS.repo
+        fi
+    fi
+    sudo yum clean all 
+    sudo yum --showduplicates list available kernel-devel
+    sudo yum install -y kernel-devel-${KERNEL_VERSION}
+fi
+# End of the temporary fix
 
 # Install CUDA and driver together, since the `exercise` script needs to run a 
 # CUDA sample app to generating GPU process metrics


### PR DESCRIPTION
## Description
The NVML and DCGM integration tests are failing on Rocky Linux 8 and 9: with Rocky Linux 9.3 and 8.9 released, the current GCE images can no longer install the matching `kernel-devel` packages. 

The fix here is to override the system repos to use the repo of the matching release version. The fix should be removed once new images become available; the fix only targets 9.2 and 8.8 images so should not break the tests when new images are available. 

## Related issue
[b/312455563](http://b/312455563)

## How has this been tested?
Integration tests passing on RL 8/9 for NVML/DCGM. 

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
