### PR TITLE
Add Kokoro build configs for new distro bookworm_aarch64

### DIFF
--- a/kokoro/config/build/presubmit/bookworm_aarch64.gcl
+++ b/kokoro/config/build/presubmit/bookworm_aarch64.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'bookworm'
+      PKGFORMAT = 'deb'
+    }
+  }
+}

--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -13,6 +13,14 @@ local template _distro {
 }
 
 // DEB Linux distros. (Do not modify this comment.)
+bookworm_aarch64 = _distro {
+  release = [
+      'debian-12-arm64',
+  ]
+  presubmit = [
+      'debian-12-arm64',
+  ]
+}
 mantic_x86_64 = _distro {
   release = [
       'ubuntu-2310-amd64',

--- a/kokoro/config/test/ops_agent/bookworm_aarch64.gcl
+++ b/kokoro/config/test/ops_agent/bookworm_aarch64.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.bookworm_aarch64.presubmit
+    arch = 'aarch64'
+  }
+}

--- a/kokoro/config/test/ops_agent/release/bookworm_aarch64.gcl
+++ b/kokoro/config/test/ops_agent/release/bookworm_aarch64.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+import '../../image_lists.gcl' as image_lists
+
+config build = common.ops_agent_test {
+  params {
+    platforms = image_lists.bookworm_aarch64.release
+    arch = 'aarch64'
+  }
+}

--- a/kokoro/config/test/third_party_apps/bookworm_aarch64.gcl
+++ b/kokoro/config/test/third_party_apps/bookworm_aarch64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = [
+      'debian-12-arm64',
+    ]
+    arch = 'aarch64'
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/bookworm_aarch64.gcl
+++ b/kokoro/config/test/third_party_apps/release/bookworm_aarch64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    platforms = [
+      'debian-12-arm64',
+    ]
+    arch = 'aarch64'
+  }
+}


### PR DESCRIPTION
## Description
```
CODENAME="bookworm" \
DISPLAY_NAME="Debian 12 Bookworm AArch64" \
PKGFORMAT="deb" \
REPO_IDENTIFIER="bookworm" \
RELEASE_TEST_PLATFORMS="debian-12-arm64" \
PRESUBMIT_TEST_PLATFORMS="debian-12-arm64" \
THIRD_PARTY_TEST_PLATFORMS="debian-12-arm64" \
ARCH="aarch64" \
  go run /google/src/files/head/depot/google3/cloud/monitoring/agents/tools/new_gce_distro/make_ops_agent_changes.go
```

## Related issue
b/292099395

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
