### PR TITLE
simulacra: Fix logger usage in Simulacra.

### DIFF
--- a/cmd/simulacra/simulacra.go
+++ b/cmd/simulacra/simulacra.go
@@ -147,7 +147,7 @@ func installApps(ctx context.Context, vm *gce.VM, logger *logging.DirectoryLogge
 		if scriptContent, err := os.ReadFile(filepath.Join(installPath, "applications", app, folder, "install")); err == nil {
 			logger.ToMainLog().Printf("Installing %s to VM", app)
 			log.Default().Printf("Installing %s to VM", app)
-			if _, err := gce.RunScriptRemotely(ctx, logger, vm, string(scriptContent), nil, make(map[string]string)); err != nil {
+			if _, err := gce.RunScriptRemotely(ctx, logger.ToMainLog(), vm, string(scriptContent), nil, make(map[string]string)); err != nil {
 				return fmt.Errorf("Failed to install app %s %v", app, err)
 			}
 			logger.ToMainLog().Printf("Done Installing %s", app)
@@ -332,7 +332,7 @@ func runCustomScripts(ctx context.Context, vm *gce.VM, logger *logging.Directory
 
 		logger.ToMainLog().Printf("Running script from %s", script.Path)
 		log.Default().Printf("Running script from %s", script.Path)
-		if _, err := gce.RunScriptRemotely(ctx, logger, vm, string(scriptContent), script.Args, make(map[string]string)); err != nil {
+		if _, err := gce.RunScriptRemotely(ctx, logger.ToMainLog(), vm, string(scriptContent), script.Args, make(map[string]string)); err != nil {
 			return fmt.Errorf("Script with path %s failed to run %v", script.Path, err)
 		}
 		logger.ToMainLog().Printf("Done Running Script from  %s", script.Path)


### PR DESCRIPTION
## Description
After https://github.com/GoogleCloudPlatform/ops-agent/pull/1501 there is a need to update how `logger` is used in simulacra.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
