### PR TITLE
Cherry Pick 8179 and 8002 into 2.1.9

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "submodules/fluent-bit"]
 	path = submodules/fluent-bit
-	url = ../../fluent/fluent-bit.git
+	url = ../../avilevy18/fluent-bit.git
+	branch = avilevy-ops-agent-release-2.44.0
 [submodule "submodules/opentelemetry-java-contrib"]
 	path = submodules/opentelemetry-java-contrib
 	url = ../../open-telemetry/opentelemetry-java-contrib.git


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Changing Fluent-bit to custom version that cherry-picks `#8179` and `#8002` into the 2.1.9 tree.
## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->
[b/313902315](http://b/313902315)

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->
Integration tests and E2E tests
## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
