### PR TITLE
Remove mentions of the deprecated sles-15-sp1-sap image.

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -332,7 +332,7 @@ func imageProject(family string) (string, error) {
 		return "opensuse-cloud", nil
 	case "sles":
 		// There are a few different cases:
-		// "sles-15" and "sles-15-sp1-sap".
+		// "sles-15" and "sles-15-sp*-sap".
 		if strings.Contains(family, "-sap") {
 			return "suse-sap-cloud", nil
 		}

--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -155,7 +155,7 @@ sles12_x86_64 = _distro {
 sles15_x86_64 = _distro {
   release = [
     'sles-15',
-    'sles-15-sp1-sap',
+    'sles-15-sp2-sap',
     'sles-15-sp5-sap',
     'opensuse-leap',
     'opensuse-leap-15-4',


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
`sles-15-sp1-sap` has been deprecated, and is now causing test failures.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->
[b/315687625](http://b/315687625)

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->
Removes an image from testing.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
