### PR TITLE
Remove rhel-8-1-sap-ha

### DIFF
--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -596,11 +596,11 @@ func isRetriableInstallError(platform string, err error) bool {
 		strings.Contains(err.Error(), "context deadline exceeded") {
 		return true // See b/197127877 for history.
 	}
-	if platform == "rhel-8-1-sap-ha" &&
+	if strings.HasPrefix(platform, "rhel-8-") && strings.HasSuffix(platform, "-sap-ha") &&
 		strings.Contains(err.Error(), "Could not refresh the google-cloud-ops-agent yum repositories") {
 		return true // See b/174039270 for history.
 	}
-	if platform == "rhel-8-1-sap-ha" &&
+	if strings.HasPrefix(platform, "rhel-8-") && strings.HasSuffix(platform, "-sap-ha") &&
 		strings.Contains(err.Error(), "Failed to download metadata for repo 'rhui-rhel-8-") {
 		return true // This happens when the RHEL servers are down. See b/189950957.
 	}
@@ -638,7 +638,7 @@ func RunInstallFuncWithRetry(ctx context.Context, logger *log.Logger, vm *gce.VM
 	shouldRetry := func(err error) bool { return isRetriableInstallError(vm.Platform, err) }
 	installWithRecovery := func() error {
 		err := installFunc()
-		if err != nil && shouldRetry(err) && vm.Platform == "rhel-8-1-sap-ha" {
+		if err != nil && shouldRetry(err) && strings.HasPrefix(vm.Platform, "rhel-8-") && strings.HasSuffix(vm.Platform, "-sap-ha") {
 			logger.Println("attempting recovery steps from https://access.redhat.com/discussions/4656371 so that subsequent attempts are more likely to succeed... see b/189950957")
 			gce.RunRemotely(ctx, logger, vm, "", "sudo dnf clean all && sudo rm -r /var/cache/dnf && sudo dnf upgrade")
 		}

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -36,7 +36,7 @@ AGENT_PACKAGES_IN_GCS, for details see README.md.
 
 	PROJECT=dev_project \
 	ZONES=us-central1-b \
-	PLATFORMS=debian-10,centos-8,rhel-8-1-sap-ha,sles-15,ubuntu-2004-lts,windows-2016,windows-2019 \
+	PLATFORMS=debian-10,centos-8,rhel-8-2-sap-ha,sles-15,ubuntu-2004-lts,windows-2016,windows-2019 \
 	go test -v ops_agent_test.go \
 	  -test.parallel=1000 \
 	  -tags=integration_test \

--- a/kokoro/config/test/image_lists.gcl
+++ b/kokoro/config/test/image_lists.gcl
@@ -118,7 +118,6 @@ centos8_x86_64 = _distro {
   release = [
     // RHEL.
     'rhel-8',
-    'rhel-8-1-sap-ha',
     'rhel-8-2-sap-ha',
     'rhel-8-4-sap-ha',
     'rhel-8-6-sap-ha',


### PR DESCRIPTION
## Description
rhel-8-1-sap-ha is deprecated.

## Related issue
[b/315990795](http://b/315990795)

## How has this been tested?
Will let presubmits run, and then will try a release test afterwards.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [x] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
