### PR TITLE
Testing: Fix issue with building gpu drivers on rl8

### DIFF
--- a/integration_test/third_party_apps_data/applications/dcgm/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/dcgm/centos_rhel/install
@@ -35,7 +35,7 @@ case $DEVICE_CODE in
         ;;
 esac
 
-echo "Installing NVIDIA CUDA $CUDA_VERSION with driver $DRIVER_VERSION"
+echo "Installing NVIDIA Data Center driver $DRIVER_VERSION"
 curl -fSsl -O https://us.download.nvidia.com/tesla/$DRIVER_VERSION/NVIDIA-Linux-x86_64-$DRIVER_VERSION.run
 sudo bash ./NVIDIA-Linux-x86_64-$DRIVER_VERSION.run --silent
 

--- a/integration_test/third_party_apps_data/applications/dcgm/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/dcgm/centos_rhel/install
@@ -31,7 +31,7 @@ case $DEVICE_CODE in
         ;;
     *)
         # Installing latest version of NVIDIA CUDA and driver
-        DRIVER_VERSION=535.104.05
+        DRIVER_VERSION=535.129.03
         ;;
 esac
 

--- a/integration_test/third_party_apps_data/applications/nvml/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/nvml/centos_rhel/install
@@ -46,8 +46,8 @@ echo "Installing NVIDIA Data Center driver $DRIVER_VERSION"
 curl -fSsl -O https://us.download.nvidia.com/tesla/$DRIVER_VERSION/NVIDIA-Linux-x86_64-$DRIVER_VERSION.run
 sudo bash ./NVIDIA-Linux-x86_64-$DRIVER_VERSION.run --silent
 # Install the CUDA toolkit only, so that the CUDA toolkit uses the Data Center driver installed in the previous step
-# See https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html for CUDA and driver compatibility 
-echo "Installing CUDA Toolkit $CUDA_VERSION from CUDA installer cuda_${CUDA_VERSION}_${CUDA_BUNDLED_DRIVER_VERSION}_linux.run."
+# See https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/ for CUDA and driver compatibility
+echo "Installing CUDA Toolkit $CUDA_VERSION from CUDA installer with bundled driver $CUDA_BUNDLED_DRIVER_VERSION"
 curl -fSsl -O https://developer.download.nvidia.com/compute/cuda/$CUDA_VERSION/local_installers/cuda_${CUDA_VERSION}_${CUDA_BUNDLED_DRIVER_VERSION}_linux.run
 sudo sh cuda_${CUDA_VERSION}_${CUDA_BUNDLED_DRIVER_VERSION}_linux.run --toolkit --silent
 

--- a/integration_test/third_party_apps_data/applications/nvml/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/nvml/centos_rhel/install
@@ -42,11 +42,12 @@ case $DEVICE_CODE in
         ;;
 esac
 
-echo "Installing NVIDIA CUDA $CUDA_VERSION with driver $DRIVER_VERSION"
+echo "Installing NVIDIA Data Center driver $DRIVER_VERSION"
 curl -fSsl -O https://us.download.nvidia.com/tesla/$DRIVER_VERSION/NVIDIA-Linux-x86_64-$DRIVER_VERSION.run
 sudo bash ./NVIDIA-Linux-x86_64-$DRIVER_VERSION.run --silent
 # Install the CUDA toolkit only, so that the CUDA toolkit uses the Data Center driver installed in the previous step
 # See https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html for CUDA and driver compatibility 
+echo "Installing CUDA Toolkit $CUDA_VERSION from CUDA installer cuda_${CUDA_VERSION}_${CUDA_BUNDLED_DRIVER_VERSION}_linux.run."
 curl -fSsl -O https://developer.download.nvidia.com/compute/cuda/$CUDA_VERSION/local_installers/cuda_${CUDA_VERSION}_${CUDA_BUNDLED_DRIVER_VERSION}_linux.run
 sudo sh cuda_${CUDA_VERSION}_${CUDA_BUNDLED_DRIVER_VERSION}_linux.run --toolkit --silent
 

--- a/integration_test/third_party_apps_data/applications/nvml/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/nvml/centos_rhel/install
@@ -32,16 +32,17 @@ case $DEVICE_CODE in
         ;;
     *)
         # Installing latest version of NVIDIA CUDA and driver
-        DRIVER_VERSION=535.104.05
+        DRIVER_VERSION=535.129.03
         CUDA_VERSION=12.2.2
+        CUDA_BUNDLED_DRIVER_VERSION=535.104.05
         ;;
 esac
 
 echo "Installing NVIDIA CUDA $CUDA_VERSION with driver $DRIVER_VERSION"
 curl -fSsl -O https://us.download.nvidia.com/tesla/$DRIVER_VERSION/NVIDIA-Linux-x86_64-$DRIVER_VERSION.run
 sudo bash ./NVIDIA-Linux-x86_64-$DRIVER_VERSION.run --silent
-wget --no-verbose https://developer.download.nvidia.com/compute/cuda/$CUDA_VERSION/local_installers/cuda_${CUDA_VERSION}_${DRIVER_VERSION}_linux.run
-sudo sh cuda_${CUDA_VERSION}_${DRIVER_VERSION}_linux.run --toolkit --silent
+curl -fSsl -O https://developer.download.nvidia.com/compute/cuda/$CUDA_VERSION/local_installers/cuda_${CUDA_VERSION}_${CUDA_BUNDLED_DRIVER_VERSION}_linux.run
+sudo sh cuda_${CUDA_VERSION}_${CUDA_BUNDLED_DRIVER_VERSION}_linux.run --toolkit --silent
 
 # check NVIDIA driver installation succeeded
 nvidia-smi

--- a/integration_test/third_party_apps_data/applications/nvml/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/nvml/centos_rhel/install
@@ -32,6 +32,10 @@ case $DEVICE_CODE in
         ;;
     *)
         # Installing latest version of NVIDIA CUDA and driver
+        # Data Center/Tesla drivers and CUDA are released on different schedules;
+        # normally we install the matching versions of driver and CUDA 
+        # ($DRIVER_VERSION == $CUDA_BUNDLED_DRIVER_VERSION); due to https://github.com/NVIDIA/open-gpu-kernel-modules/issues/550
+        # we install a newer version of the driver
         DRIVER_VERSION=535.129.03
         CUDA_VERSION=12.2.2
         CUDA_BUNDLED_DRIVER_VERSION=535.104.05
@@ -41,6 +45,8 @@ esac
 echo "Installing NVIDIA CUDA $CUDA_VERSION with driver $DRIVER_VERSION"
 curl -fSsl -O https://us.download.nvidia.com/tesla/$DRIVER_VERSION/NVIDIA-Linux-x86_64-$DRIVER_VERSION.run
 sudo bash ./NVIDIA-Linux-x86_64-$DRIVER_VERSION.run --silent
+# Install the CUDA toolkit only, so that the CUDA toolkit uses the Data Center driver installed in the previous step
+# See https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html for CUDA and driver compatibility 
 curl -fSsl -O https://developer.download.nvidia.com/compute/cuda/$CUDA_VERSION/local_installers/cuda_${CUDA_VERSION}_${CUDA_BUNDLED_DRIVER_VERSION}_linux.run
 sudo sh cuda_${CUDA_VERSION}_${CUDA_BUNDLED_DRIVER_VERSION}_linux.run --toolkit --silent
 


### PR DESCRIPTION
## Description
The NVIDIA driver installation is failing on RL8 due to https://github.com/NVIDIA/open-gpu-kernel-modules/issues/550. Update the script to install a newer version of the data center driver. 

## Related issue
[b/316154675](http://b/316154675)

## How has this been tested?
NVML and DCGM tests pass on RL8 and other platforms. 

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
