### PR TITLE
confgenerator: sanitize metadata values in the gce_resource detector

### DIFF
--- a/confgenerator/confgenerator_test.go
+++ b/confgenerator/confgenerator_test.go
@@ -69,7 +69,7 @@ var (
 		InstanceName:  "test-instance-name",
 		Tags:          "test-tag",
 		MachineType:   "test-machine-type",
-		Metadata:      map[string]string{"test-key": "test-value", "test-escape": "${foo:bar}"},
+		Metadata:      map[string]string{"test-key": "test-value", "test-escape": "$foo", "test-escape-parentheses": "${foo:bar}"},
 		Label:         map[string]string{"test-label-key": "test-label-value"},
 		InterfaceIPv4: map[string]string{"test-interface": "test-interface-ipv4"},
 	}

--- a/confgenerator/resourcedetector/gce_detector.go
+++ b/confgenerator/resourcedetector/gce_detector.go
@@ -150,7 +150,12 @@ func (r GCEResource) PrometheusStyleMetadata() map[string]string {
 	prefix := "__meta_gce_"
 	for k, v := range r.Metadata {
 		sanitizedKey := "metadata_" + strutil.SanitizeLabelName(k)
-		metaLabels[prefix+sanitizedKey] = strings.ReplaceAll(v, "$", "$$")
+		// Once https://github.com/open-telemetry/opentelemetry-collector/issues/9204
+		// is fixed, this will no longer be needed.
+		sanitizedVal := strings.ReplaceAll(v, "${", "_{")
+		sanitizedVal = strings.ReplaceAll(sanitizedVal, "$", "$$")
+		metaLabels[prefix+sanitizedKey] = sanitizedVal
+
 	}
 
 	// Labels are not available using the GCE metadata API.

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux-gpu/otel.yaml
@@ -525,7 +525,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux/otel.yaml
@@ -494,7 +494,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/otel.yaml
@@ -569,7 +569,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/otel.yaml
@@ -569,7 +569,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux-gpu/otel.yaml
@@ -528,7 +528,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux/otel.yaml
@@ -497,7 +497,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows-2012/otel.yaml
@@ -572,7 +572,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows/otel.yaml
@@ -572,7 +572,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux-gpu/otel.yaml
@@ -518,7 +518,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip
@@ -577,7 +578,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux/otel.yaml
@@ -487,7 +487,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip
@@ -546,7 +547,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/otel.yaml
@@ -562,7 +562,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip
@@ -621,7 +622,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/otel.yaml
@@ -562,7 +562,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip
@@ -621,7 +622,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux-gpu/otel.yaml
@@ -525,7 +525,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux/otel.yaml
@@ -494,7 +494,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/otel.yaml
@@ -569,7 +569,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/otel.yaml
@@ -569,7 +569,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux-gpu/otel.yaml
@@ -525,7 +525,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux/otel.yaml
@@ -494,7 +494,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/otel.yaml
@@ -569,7 +569,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/otel.yaml
@@ -569,7 +569,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux-gpu/otel.yaml
@@ -518,7 +518,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux/otel.yaml
@@ -487,7 +487,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/otel.yaml
@@ -562,7 +562,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/otel.yaml
@@ -562,7 +562,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux-gpu/otel.yaml
@@ -579,7 +579,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux/otel.yaml
@@ -548,7 +548,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/otel.yaml
@@ -623,7 +623,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/otel.yaml
@@ -623,7 +623,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux-gpu/otel.yaml
@@ -525,7 +525,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux/otel.yaml
@@ -494,7 +494,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows-2012/otel.yaml
@@ -569,7 +569,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows/otel.yaml
@@ -569,7 +569,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux-gpu/otel.yaml
@@ -523,7 +523,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux/otel.yaml
@@ -492,7 +492,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/otel.yaml
@@ -567,7 +567,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/otel.yaml
@@ -567,7 +567,8 @@ receivers:
             __meta_gce_instance_name: test-instance-name
             __meta_gce_interface_ipv4_nictest_interface: test-interface-ipv4
             __meta_gce_machine_type: test-machine-type
-            __meta_gce_metadata_test_escape: $${foo:bar}
+            __meta_gce_metadata_test_escape: $$foo
+            __meta_gce_metadata_test_escape_parentheses: _{foo:bar}
             __meta_gce_metadata_test_key: test-value
             __meta_gce_network: test-network
             __meta_gce_private_ip: test-private-ip

--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -2643,6 +2643,61 @@ func TestPrometheusMetrics(t *testing.T) {
 	})
 }
 
+func TestPrometheusMetricsWithMetadata(t *testing.T) {
+	t.Parallel()
+	gce.RunForEachPlatform(t, func(t *testing.T, platform string) {
+		t.Parallel()
+		metadataKey, metadataValue := "test", "${test:value}"
+		escapedMetadataValue := "_{test:value}"
+		ctx, logger, vm := agents.CommonSetupWithExtraCreateArgumentsAndMetadata(t, platform, nil, map[string]string{
+			metadataKey: metadataValue,
+		})
+
+		promConfig := fmt.Sprintf(`metrics:
+  receivers:
+    prometheus:
+      type: prometheus
+      config:
+        scrape_configs:
+          - job_name: 'prometheus'
+            scrape_interval: 10s
+            static_configs:
+              - targets: ['localhost:20202']
+            relabel_configs:
+              - source_labels: [__meta_gce_metadata_%s]
+                regex: '(.+)'
+                replacement: '${1}'
+                target_label: %s
+  service:
+    pipelines:
+      prometheus_pipeline:
+        receivers:
+          - prometheus
+`, metadataKey, metadataKey)
+
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, promConfig); err != nil {
+			t.Fatal(err)
+		}
+
+		// Wait long enough for the data to percolate through the backends
+		// under normal circumstances. Based on some experiments, 2 minutes
+		// is normal; wait a bit longer to be on the safe side.
+		time.Sleep(3 * time.Minute)
+
+		existingMetric := "prometheus.googleapis.com/fluentbit_uptime/counter"
+		window := time.Minute
+		metric, err := gce.WaitForMetric(ctx, logger.ToMainLog(), vm, existingMetric, window, nil, true)
+		if err != nil {
+			t.Fatal(fmt.Errorf("failed to find metric %q in VM %q: %w", existingMetric, vm.Name, err))
+		}
+
+		metricLabels := metric.Metric.Labels
+		if metricLabels[metadataKey] != escapedMetadataValue {
+			t.Errorf("metric %q has VM metadata %q set to %q instead of %q", existingMetric, metadataKey, metricLabels[metadataKey], escapedMetadataValue)
+		}
+	})
+}
+
 // Test the Counter and Gauge metric types using a JSON Prometheus exporter
 // The JSON exporter will connect to a http server that serve static JSON files
 func TestPrometheusMetricsWithJSONExporter(t *testing.T) {
@@ -3763,7 +3818,6 @@ func TestLoggingDataprocAttributes(t *testing.T) {
 		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, ""); err != nil {
 			t.Fatal(err)
 		}
-
 
 		if err := writeToSystemLog(ctx, logger.ToMainLog(), vm, "123456789"); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION

## Description
This change sanitizes the metadata values so strings of the form `${...:...}` are not expanded in the OTel configs.

## Related issue
b/311724243
Resolves https://github.com/GoogleCloudPlatform/ops-agent/issues/1517.

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
