### PR TITLE
Internal: debuggging dockerfile cache misses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,10 +102,6 @@ RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
-# Debug why we get docker cache misses for release builds.
-RUN go install github.com/MShekow/directory-checksum@main
-RUN directory-checksum --max-depth=3 .
-
 FROM centos7-build-base AS centos7-build-otel
 WORKDIR /work
 # Download golang deps
@@ -165,6 +161,10 @@ FROM centos7-build-golang-base AS centos7-build
 WORKDIR /work
 COPY . /work
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
+
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
 WORKDIR /tmp/cache_run/golang
@@ -208,10 +208,6 @@ ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VER
 RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
-
-# Debug why we get docker cache misses for release builds.
-RUN go install github.com/MShekow/directory-checksum@main
-RUN directory-checksum --max-depth=3 .
 
 FROM centos8-build-base AS centos8-build-otel
 WORKDIR /work
@@ -272,6 +268,10 @@ FROM centos8-build-golang-base AS centos8-build
 WORKDIR /work
 COPY . /work
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
+
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
 WORKDIR /tmp/cache_run/golang
@@ -318,10 +318,6 @@ ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VER
 RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
-
-# Debug why we get docker cache misses for release builds.
-RUN go install github.com/MShekow/directory-checksum@main
-RUN directory-checksum --max-depth=3 .
 
 FROM rockylinux9-build-base AS rockylinux9-build-otel
 WORKDIR /work
@@ -382,6 +378,10 @@ FROM rockylinux9-build-golang-base AS rockylinux9-build
 WORKDIR /work
 COPY . /work
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
+
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
 WORKDIR /tmp/cache_run/golang
@@ -423,10 +423,6 @@ ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VER
 RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
-
-# Debug why we get docker cache misses for release builds.
-RUN go install github.com/MShekow/directory-checksum@main
-RUN directory-checksum --max-depth=3 .
 
 FROM bookworm-build-base AS bookworm-build-otel
 WORKDIR /work
@@ -487,6 +483,10 @@ FROM bookworm-build-golang-base AS bookworm-build
 WORKDIR /work
 COPY . /work
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
+
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
 WORKDIR /tmp/cache_run/golang
@@ -528,10 +528,6 @@ ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VER
 RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
-
-# Debug why we get docker cache misses for release builds.
-RUN go install github.com/MShekow/directory-checksum@main
-RUN directory-checksum --max-depth=3 .
 
 FROM bullseye-build-base AS bullseye-build-otel
 WORKDIR /work
@@ -592,6 +588,10 @@ FROM bullseye-build-golang-base AS bullseye-build
 WORKDIR /work
 COPY . /work
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
+
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
 WORKDIR /tmp/cache_run/golang
@@ -635,10 +635,6 @@ ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VER
 RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
-
-# Debug why we get docker cache misses for release builds.
-RUN go install github.com/MShekow/directory-checksum@main
-RUN directory-checksum --max-depth=3 .
 
 FROM buster-build-base AS buster-build-otel
 WORKDIR /work
@@ -698,6 +694,10 @@ RUN ./agent_wrapper.sh /work/cache/
 FROM buster-build-golang-base AS buster-build
 WORKDIR /work
 COPY . /work
+
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
 
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
@@ -760,10 +760,6 @@ RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
-# Debug why we get docker cache misses for release builds.
-RUN go install github.com/MShekow/directory-checksum@main
-RUN directory-checksum --max-depth=3 .
-
 FROM sles12-build-base AS sles12-build-otel
 WORKDIR /work
 # Download golang deps
@@ -823,6 +819,10 @@ FROM sles12-build-golang-base AS sles12-build
 WORKDIR /work
 COPY . /work
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
+
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
 WORKDIR /tmp/cache_run/golang
@@ -869,10 +869,6 @@ ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VER
 RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
-
-# Debug why we get docker cache misses for release builds.
-RUN go install github.com/MShekow/directory-checksum@main
-RUN directory-checksum --max-depth=3 .
 
 FROM sles15-build-base AS sles15-build-otel
 WORKDIR /work
@@ -933,6 +929,10 @@ FROM sles15-build-golang-base AS sles15-build
 WORKDIR /work
 COPY . /work
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
+
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
 WORKDIR /tmp/cache_run/golang
@@ -974,10 +974,6 @@ ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VER
 RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
-
-# Debug why we get docker cache misses for release builds.
-RUN go install github.com/MShekow/directory-checksum@main
-RUN directory-checksum --max-depth=3 .
 
 FROM focal-build-base AS focal-build-otel
 WORKDIR /work
@@ -1038,6 +1034,10 @@ FROM focal-build-golang-base AS focal-build
 WORKDIR /work
 COPY . /work
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
+
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
 WORKDIR /tmp/cache_run/golang
@@ -1079,10 +1079,6 @@ ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VER
 RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
-
-# Debug why we get docker cache misses for release builds.
-RUN go install github.com/MShekow/directory-checksum@main
-RUN directory-checksum --max-depth=3 .
 
 FROM jammy-build-base AS jammy-build-otel
 WORKDIR /work
@@ -1143,6 +1139,10 @@ FROM jammy-build-golang-base AS jammy-build
 WORKDIR /work
 COPY . /work
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
+
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
 WORKDIR /tmp/cache_run/golang
@@ -1184,10 +1184,6 @@ ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VER
 RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
-
-# Debug why we get docker cache misses for release builds.
-RUN go install github.com/MShekow/directory-checksum@main
-RUN directory-checksum --max-depth=3 .
 
 FROM lunar-build-base AS lunar-build-otel
 WORKDIR /work
@@ -1248,6 +1244,10 @@ FROM lunar-build-golang-base AS lunar-build
 WORKDIR /work
 COPY . /work
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
+
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
 WORKDIR /tmp/cache_run/golang
@@ -1289,10 +1289,6 @@ ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VER
 RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
-
-# Debug why we get docker cache misses for release builds.
-RUN go install github.com/MShekow/directory-checksum@main
-RUN directory-checksum --max-depth=3 .
 
 FROM mantic-build-base AS mantic-build-otel
 WORKDIR /work
@@ -1352,6 +1348,10 @@ RUN ./agent_wrapper.sh /work/cache/
 FROM mantic-build-golang-base AS mantic-build
 WORKDIR /work
 COPY . /work
+
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
 
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,9 @@ RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN directory-checksum --max-depth=3 .
 
 FROM centos7-build-base AS centos7-build-otel
 WORKDIR /work
@@ -180,6 +183,7 @@ FROM scratch AS centos7
 COPY --from=centos7-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-centos-7.tgz
 COPY --from=centos7-build /google-cloud-ops-agent*.rpm /
 
+
 # ======================================
 # Build Ops Agent for centos-8 
 # ======================================
@@ -205,6 +209,9 @@ RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN directory-checksum --max-depth=3 .
 
 FROM centos8-build-base AS centos8-build-otel
 WORKDIR /work
@@ -283,6 +290,7 @@ FROM scratch AS centos8
 COPY --from=centos8-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-centos-8.tgz
 COPY --from=centos8-build /google-cloud-ops-agent*.rpm /
 
+
 # ======================================
 # Build Ops Agent for rockylinux-9 
 # ======================================
@@ -311,6 +319,9 @@ RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN directory-checksum --max-depth=3 .
 
 FROM rockylinux9-build-base AS rockylinux9-build-otel
 WORKDIR /work
@@ -389,6 +400,7 @@ FROM scratch AS rockylinux9
 COPY --from=rockylinux9-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-rockylinux-9.tgz
 COPY --from=rockylinux9-build /google-cloud-ops-agent*.rpm /
 
+
 # ======================================
 # Build Ops Agent for debian-bookworm 
 # ======================================
@@ -412,6 +424,9 @@ RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN directory-checksum --max-depth=3 .
 
 FROM bookworm-build-base AS bookworm-build-otel
 WORKDIR /work
@@ -490,6 +505,7 @@ FROM scratch AS bookworm
 COPY --from=bookworm-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-debian-bookworm.tgz
 COPY --from=bookworm-build /google-cloud-ops-agent*.deb /
 
+
 # ======================================
 # Build Ops Agent for debian-bullseye 
 # ======================================
@@ -513,6 +529,9 @@ RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN directory-checksum --max-depth=3 .
 
 FROM bullseye-build-base AS bullseye-build-otel
 WORKDIR /work
@@ -591,6 +610,7 @@ FROM scratch AS bullseye
 COPY --from=bullseye-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-debian-bullseye.tgz
 COPY --from=bullseye-build /google-cloud-ops-agent*.deb /
 
+
 # ======================================
 # Build Ops Agent for debian-buster 
 # ======================================
@@ -616,6 +636,9 @@ RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN directory-checksum --max-depth=3 .
 
 FROM buster-build-base AS buster-build-otel
 WORKDIR /work
@@ -694,6 +717,7 @@ FROM scratch AS buster
 COPY --from=buster-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-debian-buster.tgz
 COPY --from=buster-build /google-cloud-ops-agent*.deb /
 
+
 # ======================================
 # Build Ops Agent for sles-12 
 # ======================================
@@ -736,6 +760,9 @@ RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN directory-checksum --max-depth=3 .
 
 FROM sles12-build-base AS sles12-build-otel
 WORKDIR /work
@@ -814,6 +841,7 @@ FROM scratch AS sles12
 COPY --from=sles12-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-sles-12.tgz
 COPY --from=sles12-build /google-cloud-ops-agent*.rpm /
 
+
 # ======================================
 # Build Ops Agent for sles-15 
 # ======================================
@@ -842,6 +870,9 @@ RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN directory-checksum --max-depth=3 .
 
 FROM sles15-build-base AS sles15-build-otel
 WORKDIR /work
@@ -920,6 +951,7 @@ FROM scratch AS sles15
 COPY --from=sles15-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-sles-15.tgz
 COPY --from=sles15-build /google-cloud-ops-agent*.rpm /
 
+
 # ======================================
 # Build Ops Agent for ubuntu-focal 
 # ======================================
@@ -943,6 +975,9 @@ RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN directory-checksum --max-depth=3 .
 
 FROM focal-build-base AS focal-build-otel
 WORKDIR /work
@@ -1021,6 +1056,7 @@ FROM scratch AS focal
 COPY --from=focal-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-focal.tgz
 COPY --from=focal-build /google-cloud-ops-agent*.deb /
 
+
 # ======================================
 # Build Ops Agent for ubuntu-jammy 
 # ======================================
@@ -1044,6 +1080,9 @@ RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN directory-checksum --max-depth=3 .
 
 FROM jammy-build-base AS jammy-build-otel
 WORKDIR /work
@@ -1122,6 +1161,7 @@ FROM scratch AS jammy
 COPY --from=jammy-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-jammy.tgz
 COPY --from=jammy-build /google-cloud-ops-agent*.deb /
 
+
 # ======================================
 # Build Ops Agent for ubuntu-lunar 
 # ======================================
@@ -1145,6 +1185,9 @@ RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN directory-checksum --max-depth=3 .
 
 FROM lunar-build-base AS lunar-build-otel
 WORKDIR /work
@@ -1223,6 +1266,7 @@ FROM scratch AS lunar
 COPY --from=lunar-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-lunar.tgz
 COPY --from=lunar-build /google-cloud-ops-agent*.deb /
 
+
 # ======================================
 # Build Ops Agent for ubuntu-mantic 
 # ======================================
@@ -1246,6 +1290,9 @@ RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN directory-checksum --max-depth=3 .
 
 FROM mantic-build-base AS mantic-build-otel
 WORKDIR /work
@@ -1323,6 +1370,7 @@ RUN ./pkg/deb/build.sh
 FROM scratch AS mantic
 COPY --from=mantic-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-mantic.tgz
 COPY --from=mantic-build /google-cloud-ops-agent*.deb /
+
 
 FROM scratch
 COPY --from=centos7 /* /

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,7 @@ RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
+
 FROM centos7-build-base AS centos7-build-otel
 WORKDIR /work
 # Download golang deps
@@ -163,7 +164,7 @@ COPY . /work
 
 # Debug why we get docker cache misses for release builds.
 RUN go install github.com/MShekow/directory-checksum@main
-RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work
 
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
@@ -208,6 +209,7 @@ ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VER
 RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
+
 
 FROM centos8-build-base AS centos8-build-otel
 WORKDIR /work
@@ -270,7 +272,7 @@ COPY . /work
 
 # Debug why we get docker cache misses for release builds.
 RUN go install github.com/MShekow/directory-checksum@main
-RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work
 
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
@@ -318,6 +320,7 @@ ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VER
 RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
+
 
 FROM rockylinux9-build-base AS rockylinux9-build-otel
 WORKDIR /work
@@ -380,7 +383,7 @@ COPY . /work
 
 # Debug why we get docker cache misses for release builds.
 RUN go install github.com/MShekow/directory-checksum@main
-RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work
 
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
@@ -423,6 +426,7 @@ ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VER
 RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
+
 
 FROM bookworm-build-base AS bookworm-build-otel
 WORKDIR /work
@@ -485,7 +489,7 @@ COPY . /work
 
 # Debug why we get docker cache misses for release builds.
 RUN go install github.com/MShekow/directory-checksum@main
-RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work
 
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
@@ -528,6 +532,7 @@ ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VER
 RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
+
 
 FROM bullseye-build-base AS bullseye-build-otel
 WORKDIR /work
@@ -590,7 +595,7 @@ COPY . /work
 
 # Debug why we get docker cache misses for release builds.
 RUN go install github.com/MShekow/directory-checksum@main
-RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work
 
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
@@ -635,6 +640,7 @@ ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VER
 RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
+
 
 FROM buster-build-base AS buster-build-otel
 WORKDIR /work
@@ -697,7 +703,7 @@ COPY . /work
 
 # Debug why we get docker cache misses for release builds.
 RUN go install github.com/MShekow/directory-checksum@main
-RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work
 
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
@@ -760,6 +766,7 @@ RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
+
 FROM sles12-build-base AS sles12-build-otel
 WORKDIR /work
 # Download golang deps
@@ -821,7 +828,7 @@ COPY . /work
 
 # Debug why we get docker cache misses for release builds.
 RUN go install github.com/MShekow/directory-checksum@main
-RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work
 
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
@@ -869,6 +876,7 @@ ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VER
 RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
+
 
 FROM sles15-build-base AS sles15-build-otel
 WORKDIR /work
@@ -931,7 +939,7 @@ COPY . /work
 
 # Debug why we get docker cache misses for release builds.
 RUN go install github.com/MShekow/directory-checksum@main
-RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work
 
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
@@ -974,6 +982,7 @@ ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VER
 RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
+
 
 FROM focal-build-base AS focal-build-otel
 WORKDIR /work
@@ -1036,7 +1045,7 @@ COPY . /work
 
 # Debug why we get docker cache misses for release builds.
 RUN go install github.com/MShekow/directory-checksum@main
-RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work
 
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
@@ -1079,6 +1088,7 @@ ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VER
 RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
+
 
 FROM jammy-build-base AS jammy-build-otel
 WORKDIR /work
@@ -1141,7 +1151,7 @@ COPY . /work
 
 # Debug why we get docker cache misses for release builds.
 RUN go install github.com/MShekow/directory-checksum@main
-RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work
 
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
@@ -1184,6 +1194,7 @@ ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VER
 RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
+
 
 FROM lunar-build-base AS lunar-build-otel
 WORKDIR /work
@@ -1246,7 +1257,7 @@ COPY . /work
 
 # Debug why we get docker cache misses for release builds.
 RUN go install github.com/MShekow/directory-checksum@main
-RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work
 
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
@@ -1289,6 +1300,7 @@ ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VER
 RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
+
 
 FROM mantic-build-base AS mantic-build-otel
 WORKDIR /work
@@ -1351,7 +1363,7 @@ COPY . /work
 
 # Debug why we get docker cache misses for release builds.
 RUN go install github.com/MShekow/directory-checksum@main
-RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work
 
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -102,7 +102,7 @@ WORKDIR /work/submodules/fluent-bit/build
 
 # Debug why we get docker cache misses for release builds.
 RUN go install github.com/MShekow/directory-checksum@main
-RUN "${HOME}/go/bin/directory-checksum" --max-depth=3 /work
+RUN (go env GOPATH)+"/directory-checksum" --max-depth=3 /work
 RUN asdf
 
 RUN cmake -G "'Visual Studio 16 2019'" -DCMAKE_BUILD_TYPE=RELWITHDEBINFO -DFLB_OUT_KINESIS_STREAMS=OFF ../;

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -102,7 +102,8 @@ WORKDIR /work/submodules/fluent-bit/build
 
 # Debug why we get docker cache misses for release builds.
 RUN go install github.com/MShekow/directory-checksum@main
-RUN $HOME/go/bin/directory-checksum --max-depth=3 /work
+RUN "${HOME}/go/bin/directory-checksum" --max-depth=3 /work
+RUN asdf
 
 RUN cmake -G "'Visual Studio 16 2019'" -DCMAKE_BUILD_TYPE=RELWITHDEBINFO -DFLB_OUT_KINESIS_STREAMS=OFF ../;
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -92,6 +92,10 @@ RUN Start-Process msiexec.exe `
 WORKDIR /goget
 RUN go install github.com/google/googet/v2/goopack@latest;
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN directory-checksum --max-depth=3 .
+
 ###############################################################################
 # Build fluent-bit
 ###############################################################################

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -100,11 +100,6 @@ COPY submodules/fluent-bit /work/submodules/fluent-bit
 
 WORKDIR /work/submodules/fluent-bit/build
 
-# Debug why we get docker cache misses for release builds.
-RUN go install github.com/MShekow/directory-checksum@main
-RUN (go env GOPATH)+"/directory-checksum" --max-depth=3 /work
-RUN asdf
-
 RUN cmake -G "'Visual Studio 16 2019'" -DCMAKE_BUILD_TYPE=RELWITHDEBINFO -DFLB_OUT_KINESIS_STREAMS=OFF ../;
 
 RUN cmake --build . --config Release; `

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -92,10 +92,6 @@ RUN Start-Process msiexec.exe `
 WORKDIR /goget
 RUN go install github.com/google/googet/v2/goopack@latest;
 
-# Debug why we get docker cache misses for release builds.
-RUN go install github.com/MShekow/directory-checksum@main
-RUN directory-checksum --max-depth=3 .
-
 ###############################################################################
 # Build fluent-bit
 ###############################################################################
@@ -103,6 +99,10 @@ RUN directory-checksum --max-depth=3 .
 COPY submodules/fluent-bit /work/submodules/fluent-bit
 
 WORKDIR /work/submodules/fluent-bit/build
+
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN $HOME/go/bin/directory-checksum --max-depth=3 /work
 
 RUN cmake -G "'Visual Studio 16 2019'" -DCMAKE_BUILD_TYPE=RELWITHDEBINFO -DFLB_OUT_KINESIS_STREAMS=OFF ../;
 

--- a/dockerfiles/template
+++ b/dockerfiles/template
@@ -17,6 +17,7 @@ RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
+
 FROM {target_name}-build-base AS {target_name}-build-otel
 WORKDIR /work
 # Download golang deps
@@ -78,7 +79,7 @@ COPY . /work
 
 # Debug why we get docker cache misses for release builds.
 RUN go install github.com/MShekow/directory-checksum@main
-RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work
 
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang

--- a/dockerfiles/template
+++ b/dockerfiles/template
@@ -17,10 +17,6 @@ RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
-# Debug why we get docker cache misses for release builds.
-RUN go install github.com/MShekow/directory-checksum@main
-RUN directory-checksum --max-depth=3 .
-
 FROM {target_name}-build-base AS {target_name}-build-otel
 WORKDIR /work
 # Download golang deps
@@ -79,6 +75,10 @@ RUN ./agent_wrapper.sh /work/cache/
 FROM {target_name}-build-golang-base AS {target_name}-build
 WORKDIR /work
 COPY . /work
+
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN ${HOME}/go/bin/directory-checksum --max-depth=3 /work && exit 1
 
 # Run the build script once to build the ops agent engine to a cache
 RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang

--- a/dockerfiles/template
+++ b/dockerfiles/template
@@ -17,6 +17,9 @@ RUN set -xe; \
     tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
 ENV PATH="${PATH}:/usr/local/go/bin"
 
+# Debug why we get docker cache misses for release builds.
+RUN go install github.com/MShekow/directory-checksum@main
+RUN directory-checksum --max-depth=3 .
 
 FROM {target_name}-build-base AS {target_name}-build-otel
 WORKDIR /work


### PR DESCRIPTION
## Description
During the build, dump a filesystem checksum view that should show us what things are different for github builds vs git-on-borg builds. 

For more on the tool being installed, see https://github.com/MShekow/directory-checksum/tree/main?tab=readme-ov-file#directory-checksum.

## Related issue
b/318538879

## How has this been tested?
automated presubmits

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
