### PR TITLE
Testing: unpin sles-15 version to fix most failing tests

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1028,8 +1028,6 @@ func prepareSLES(ctx context.Context, logger *log.Logger, vm *VM) error {
 var (
 	overriddenImageFamilies = map[string]string{
 		"opensuse-leap-15-4": "opensuse-leap-15-4-v20230603-x86-64",
-		// TODO(b/288286057): remove this override once the 3P app tests are working with newer images.
-		"sles-15": "sles-15-sp4-v20230322-x86-64",
 	}
 )
 


### PR DESCRIPTION
## Description
Currently all sles-15 tests are failing, including unrelated ones such as ops_agent_test and install_scripts_test (which is currently in Piper). This change should get those tests passing, which will provide me with a much better signal for [go/sdi-rapture-migration-testing-plan#heading=h.sfviohmrqgaa](https://goto.google.com/sdi-rapture-migration-testing-plan#heading=h.sfviohmrqgaa)

## Related issue
b/266416507

## How has this been tested?
ops_agent_test should start passing, and parts of third_party_apps_test should start passing, while other parts will fail for different reasons.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
