### PR TITLE
Testing: Update Cassandra install script to get the correct GPG key

### DIFF
--- a/integration_test/third_party_apps_data/applications/cassandra/centos_rhel/install
+++ b/integration_test/third_party_apps_data/applications/cassandra/centos_rhel/install
@@ -13,7 +13,7 @@ name=Apache Cassandra
 baseurl=https://redhat.cassandra.apache.org/41x/
 gpgcheck=1
 repo_gpgcheck=1
-gpgkey=https://www.apache.org/dist/cassandra/KEYS
+gpgkey=https://downloads.apache.org/cassandra/KEYS
 EOF
 
 sudo mv cassandra.repo /etc/yum.repos.d/cassandra.repo


### PR DESCRIPTION
## Description
Follow https://cassandra.apache.org/doc/stable/cassandra/getting_started/installing.html#installing-the-rpm-packages to update the `install` script for Cassandra. 

## Related issue
[b/318674589](http://b/318674589)

## How has this been tested?
Cassandra tests passing on Rocky Linux 8/9. 

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
