### PR TITLE
A single kokoro build config for ops agent tests

### DIFF
--- a/kokoro/config/test/ops_agent/release.gcl
+++ b/kokoro/config/test/ops_agent/release.gcl
@@ -12,7 +12,7 @@ _parse_distro = lambda tag: {
 config build = common.ops_agent_test {
   params {
     local _distro_arch = _parse_distro(params.environment._LOUHI_TAG_NAME)
-    platforms = image_lists.get(_distro_arch.distro + '_' + _distro_arch.arch).release
+    platforms = image_lists.get(_distro_arch.distro + '_' + _distro_arch.arch, 'invalid_distro').release
     arch = _distro_arch.arch
 
     environment {

--- a/kokoro/config/test/ops_agent/release.gcl
+++ b/kokoro/config/test/ops_agent/release.gcl
@@ -1,0 +1,26 @@
+import 'common.gcl' as common
+import '../image_lists.gcl' as image_lists
+
+_parse_distro = lambda tag: {
+  parts = split(tag, '/')
+  ret = {
+    distro = parts[3]
+    arch = parts[4]
+  }
+}.ret
+
+config build = common.ops_agent_test {
+  params {
+    local _distro_arch = _parse_distro(params.environment._LOUHI_TRIGGER_TAG)
+    platforms = image_lists.get(_distro_arch.distro + '_' + distro_arch.arch).release
+    arch = _distro_arch.arch
+
+    // stuff from common.gcl
+    environment {
+      // The release builds run as a different service account.
+      TRANSFERS_BUCKET = 'stackdriver-test-143416-file-transfers'
+      SERVICE_EMAIL =
+          'build-and-test@stackdriver-test-143416.iam.gserviceaccount.com'
+    }
+  }
+}

--- a/kokoro/config/test/ops_agent/release.gcl
+++ b/kokoro/config/test/ops_agent/release.gcl
@@ -11,11 +11,10 @@ _parse_distro = lambda tag: {
 
 config build = common.ops_agent_test {
   params {
-    local _distro_arch = _parse_distro(params.environment._LOUHI_TRIGGER_TAG)
+    local _distro_arch = _parse_distro(params.environment._LOUHI_TAG_NAME)
     platforms = image_lists.get(_distro_arch.distro + '_' + distro_arch.arch).release
     arch = _distro_arch.arch
 
-    // stuff from common.gcl
     environment {
       // The release builds run as a different service account.
       TRANSFERS_BUCKET = 'stackdriver-test-143416-file-transfers'

--- a/kokoro/config/test/ops_agent/release.gcl
+++ b/kokoro/config/test/ops_agent/release.gcl
@@ -12,7 +12,7 @@ _parse_distro = lambda tag: {
 config build = common.ops_agent_test {
   params {
     local _distro_arch = _parse_distro(params.environment._LOUHI_TAG_NAME)
-    platforms = image_lists.get(_distro_arch.distro + '_' + distro_arch.arch).release
+    platforms = image_lists.get(_distro_arch.distro + '_' + _distro_arch.arch).release
     arch = _distro_arch.arch
 
     environment {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
For now, this is Louhi-only

Once verified, we can replace our per-platform/arch boilerplate kokoro configs with a single one.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
