### PR TITLE
Update integration tests for SLES15 SP5

### DIFF
--- a/integration_test/third_party_apps_data/applications/cassandra/sles/install
+++ b/integration_test/third_party_apps_data/applications/cassandra/sles/install
@@ -14,7 +14,7 @@ sudo zypper -n refresh
 
 # SLES 15 SP5 has moved Java 8 to a legacy module
 if [[ "${SUSE_VERSION}" == 15 ]]; then
-  sudo SUSEConnect --product sle-module-legacy/15.5/x86_64
+  sudo SUSEConnect --product sle-module-legacy/15.5/$(uname -m)
 fi
 
 sudo zypper -n install java-1_8_0-openjdk java-1_8_0-openjdk-devel

--- a/integration_test/third_party_apps_data/applications/cassandra/sles/install
+++ b/integration_test/third_party_apps_data/applications/cassandra/sles/install
@@ -12,6 +12,11 @@ if [[ "${ID}" == opensuse-leap && "${VERSION_ID}" == 15.[01] ]]; then
 fi
 sudo zypper -n refresh
 
+# SLES 15 SP5 has moved Java 8 to a legacy module
+if [[ "${SUSE_VERSION}" == 15 ]]; then
+  sudo SUSEConnect --product sle-module-legacy/15.5/x86_64
+fi
+
 sudo zypper -n install java-1_8_0-openjdk java-1_8_0-openjdk-devel
 
 # There is no official or even semi-official zypper package for cassandra

--- a/integration_test/third_party_apps_data/applications/couchbase/sles/install
+++ b/integration_test/third_party_apps_data/applications/couchbase/sles/install
@@ -1,5 +1,12 @@
 set -e 
 
+source /etc/os-release
+SUSE_VERSION="${VERSION_ID%%.*}"
+
+# SLES 15 SP5 has moved Java 8 to a legacy module
+if [[ "${SUSE_VERSION}" == 15 ]]; then
+  sudo SUSEConnect --product sle-module-legacy/15.5/x86_64
+fi
 
 if [[ "$(uname -m)" == aarch64 ]]; then
   sudo zypper install -y curl bzip2 net-tools

--- a/integration_test/third_party_apps_data/applications/couchbase/sles/install
+++ b/integration_test/third_party_apps_data/applications/couchbase/sles/install
@@ -5,7 +5,7 @@ SUSE_VERSION="${VERSION_ID%%.*}"
 
 # SLES 15 SP5 has moved Java 8 to a legacy module
 if [[ "${SUSE_VERSION}" == 15 ]]; then
-  sudo SUSEConnect --product sle-module-legacy/15.5/x86_64
+  sudo SUSEConnect --product sle-module-legacy/15.5/$(uname -m)
 fi
 
 if [[ "$(uname -m)" == aarch64 ]]; then

--- a/integration_test/third_party_apps_data/applications/jvm/sles/install
+++ b/integration_test/third_party_apps_data/applications/jvm/sles/install
@@ -16,6 +16,10 @@ if [[ "$(uname -m)" == aarch64 ]]; then
   # GCP arm64 machines ship with Java 11 vs Java 8 support
   sudo zypper -n install java-11-openjdk java-11-openjdk-devel
 else
+  # SLES 15 SP5 has moved Java 8 to a legacy module
+  if [[ "${SUSE_VERSION}" == 15 ]]; then
+    sudo SUSEConnect --product sle-module-legacy/15.5/x86_64
+  fi
   sudo zypper -n install java-1_8_0-openjdk java-1_8_0-openjdk-devel
 fi
 

--- a/integration_test/third_party_apps_data/applications/jvm/sles/install
+++ b/integration_test/third_party_apps_data/applications/jvm/sles/install
@@ -18,7 +18,7 @@ if [[ "$(uname -m)" == aarch64 ]]; then
 else
   # SLES 15 SP5 has moved Java 8 to a legacy module
   if [[ "${SUSE_VERSION}" == 15 ]]; then
-    sudo SUSEConnect --product sle-module-legacy/15.5/x86_64
+    sudo SUSEConnect --product sle-module-legacy/15.5/$(uname -m)
   fi
   sudo zypper -n install java-1_8_0-openjdk java-1_8_0-openjdk-devel
 fi

--- a/integration_test/third_party_apps_data/applications/mongodb3.6/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/mongodb3.6/metadata.yaml
@@ -42,6 +42,7 @@ platforms_to_skip:
   - debian-11-arm64
   - debian-12
   - debian-12-arm64
+  - sles-15
   - sles-15-arm64
 supported_app_version: ["2.6", "3.0+", "4.0+", "5.0"]
 expected_metrics:

--- a/integration_test/third_party_apps_data/applications/postgresql/sles/install
+++ b/integration_test/third_party_apps_data/applications/postgresql/sles/install
@@ -8,6 +8,7 @@ if [[ "${SUSE_VERSION}" == 12 ]]; then
   sudo zypper --non-interactive --no-gpg-checks ref
   sudo zypper --no-gpg-checks in -y postgresql14-server=14.1-3.3.1 postgresql14-contrib=14.1-3.3.1 postgresql14-libs=14.1-1PGDG.sles12 postgresql14=14.1-3.3.1
 elif [[ "${SUSE_VERSION}" == 15 ]]; then
+  sudo zypper addrepo https://download.postgresql.org/pub/repos/zypp/repo/pgdg-sles-15-pg14.repo
   sudo zypper --non-interactive --no-gpg-checks ref
   sudo zypper --no-gpg-checks in -y postgresql14-server postgresql14-contrib postgresql14
 fi

--- a/integration_test/third_party_apps_data/applications/postgresql/sles/install
+++ b/integration_test/third_party_apps_data/applications/postgresql/sles/install
@@ -26,7 +26,7 @@ sudo service $SERVICE_NAME restart
 
 sudo su postgres -c "psql postgres -c \"ALTER ROLE postgres WITH PASSWORD 'abc123';\""
 
-sudo sh -c 'echo "host    all             all             127.0.0.1/32            scram-sha-256" > $DATA_DIR/pg_hba.conf'
-sudo sh -c 'echo "host    all             all             ::1/128                 scram-sha-256" >> $DATA_DIR/pg_hba.conf'
+sudo sh -c 'echo "host    all             all             127.0.0.1/32            scram-sha-256" > '"$DATA_DIR"'/pg_hba.conf'
+sudo sh -c 'echo "host    all             all             ::1/128                 scram-sha-256" >> '"$DATA_DIR"'/pg_hba.conf'
 
 sudo service $SERVICE_NAME restart

--- a/integration_test/third_party_apps_data/applications/postgresql/sles/install
+++ b/integration_test/third_party_apps_data/applications/postgresql/sles/install
@@ -3,6 +3,9 @@ set -e
 source /etc/os-release
 SUSE_VERSION="${VERSION_ID%%.*}"
 
+SERVICE_NAME="postgresql"
+DATA_DIR="/var/lib/pgsql/data"
+
 if [[ "${SUSE_VERSION}" == 12 ]]; then
   sudo zypper addrepo https://download.postgresql.org/pub/repos/zypp/repo/pgdg-sles-12-pg14.repo
   sudo zypper --non-interactive --no-gpg-checks ref
@@ -11,14 +14,19 @@ elif [[ "${SUSE_VERSION}" == 15 ]]; then
   sudo zypper addrepo https://download.postgresql.org/pub/repos/zypp/repo/pgdg-sles-15-pg14.repo
   sudo zypper --non-interactive --no-gpg-checks ref
   sudo zypper --no-gpg-checks in -y postgresql14-server postgresql14-contrib postgresql14
+
+  SERVICE_NAME="postgresql-14"
+  DATA_DIR="/var/lib/pgsql/14/data"
+
+  sudo /usr/pgsql-14/bin/postgresql-14-setup initdb
 fi
 
-sudo systemctl enable postgresql
-sudo service postgresql restart
+sudo systemctl enable $SERVICE_NAME
+sudo service $SERVICE_NAME restart
 
 sudo su postgres -c "psql postgres -c \"ALTER ROLE postgres WITH PASSWORD 'abc123';\""
 
-sudo sh -c 'echo "host    all             all             127.0.0.1/32            scram-sha-256" > /var/lib/pgsql/data/pg_hba.conf'
-sudo sh -c 'echo "host    all             all             ::1/128                 scram-sha-256" >> /var/lib/pgsql/data/pg_hba.conf'
+sudo sh -c 'echo "host    all             all             127.0.0.1/32            scram-sha-256" > $DATA_DIR/pg_hba.conf'
+sudo sh -c 'echo "host    all             all             ::1/128                 scram-sha-256" >> $DATA_DIR/pg_hba.conf'
 
-sudo service postgresql restart
+sudo service $SERVICE_NAME restart


### PR DESCRIPTION
## Description
With the removal of SP4, certain integration tests no longer pass. This should resolve that.

## Related issue
b/266416507
https://github.com/GoogleCloudPlatform/ops-agent/pull/1561

## How has this been tested?
Tested fixes on a GCP VM, require validation in kokoro.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
