### PR TITLE
Testing: revert to label-based cleanup due to hangs/OOMs

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1085,7 +1085,7 @@ func addFrameworkLabels(inputLabels map[string]string, timeToLive string) (map[s
 
 	parsedTTL, err := time.ParseDuration(timeToLive)
 	if err != nil {
-		return fmt.Errorf("Could not parse TTL duration %q: %w", timeToLive, err)
+		return nil, fmt.Errorf("Could not parse TTL duration %q: %w", timeToLive, err)
 	}
 
 	labelsCopy := map[string]string{


### PR DESCRIPTION
## Description
Partially reverts https://github.com/GoogleCloudPlatform/ops-agent/pull/1574 due to some errors we see in release builds.

I decided to keep `VMOptions.TimeToLive` and just implement it the old way instead of the hardcoded 180 minutes for two reasons:

1.  It's a better end state to have the TTL configurable
2. Keeping `TimeToLive` means I don't have to roll back a changelist in Piper.

## Related issue
b/227348032

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
