### PR TITLE
Disable PacApiConnErr check

### DIFF
--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -3805,7 +3805,7 @@ func TestLoggingSelfLogs(t *testing.T) {
 
 		// Waiting 10 minutes (subtracting current test runtime) after Ops Agent startup for
 		// "LogPingOpsAgent" to show. We can remove wait when feature b/319102785 is complete.
-		time.Sleep(10 * time.Minute - time.Now().Sub(start))
+		time.Sleep(10*time.Minute - time.Now().Sub(start))
 		queryPing := fmt.Sprintf(`severity="DEBUG" AND jsonPayload.code="LogPingOpsAgent" AND labels."agent.googleapis.com/health/agentKind"="ops-agent" AND labels."agent.googleapis.com/health/agentVersion"=~"^\d+\.\d+\.\d+.*$" AND labels."agent.googleapis.com/health/schemaVersion"="v1"`)
 		if err := gce.WaitForLog(ctx, logger.ToMainLog(), vm, "ops-agent-health", time.Hour, queryPing); err != nil {
 			t.Error(err)
@@ -4512,7 +4512,8 @@ func TestNetworkHealthCheck(t *testing.T) {
 
 		checkExpectedHealthCheckResult(t, cmdOut.Stdout, "Network", "FAIL", "LogApiConnErr")
 		checkExpectedHealthCheckResult(t, cmdOut.Stdout, "Network", "FAIL", "MonApiConnErr")
-		checkExpectedHealthCheckResult(t, cmdOut.Stdout, "Network", "WARNING", "PacApiConnErr")
+		// TODO(b/321220138): restore this once there's a more reliable endpoint.
+		// checkExpectedHealthCheckResult(t, cmdOut.Stdout, "Network", "WARNING", "PacApiConnErr")
 		checkExpectedHealthCheckResult(t, cmdOut.Stdout, "Network", "WARNING", "DLApiConnErr")
 		checkExpectedHealthCheckResult(t, cmdOut.Stdout, "Ports", "PASS", "")
 		checkExpectedHealthCheckResult(t, cmdOut.Stdout, "API", "FAIL", "MonApiConnErr")

--- a/internal/healthchecks/network_check.go
+++ b/internal/healthchecks/network_check.go
@@ -48,12 +48,13 @@ var (
 			successMessage:   "Request to the Monitoring API was successful.",
 			healthCheckError: MonApiConnErr,
 		},
-		{
-			name:             "Packages API",
-			url:              "https://packages.cloud.google.com",
-			successMessage:   "Request to packages.cloud.google.com was successful.",
-			healthCheckError: PacApiConnErr,
-		},
+		// TODO(b/321220138): restore this once there's a more reliable endpoint.
+		// {
+		// 	name:             "Packages API",
+		// 	url:              "https://packages.cloud.google.com",
+		// 	successMessage:   "Request to packages.cloud.google.com was successful.",
+		// 	healthCheckError: PacApiConnErr,
+		// },
 		{
 			name:             "dl.google.com",
 			url:              "https://dl.google.com",


### PR DESCRIPTION
## Description
The endpoint seems to return 404 if you request it too early during VM startup. Disable it for now until we figure out the root cause to unblock the integration tests.

## Related issue
b/321220138

## How has this been tested?
Will let presubmits run.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
  - [ ] This PR introduces user visible changes and we're leaving the documentation as-is for now because 1) users will still be running older versions of the agent that produce PacApiConnErr, and 2) we intend for this to be a brief, temporary change
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
