### PR TITLE
confgenerator: Add self logs sampling cases.

### DIFF
--- a/confgenerator/self_logs.go
+++ b/confgenerator/self_logs.go
@@ -143,6 +143,21 @@ var selfLogTranslationList = []selfLogTranslationEntry{
 		message:    fmt.Sprintf("Ops Agent failed to parse logs, Code: LogParseErr, Documentation: %s", troubleshootFindInfoURL),
 		code:       "LogParseErr",
 	},
+	{
+		regexMatch: `\[ warn\].*\serror\sparsing\slog\smessage\swith\sparser.*`,
+		message:    fmt.Sprintf("Ops Agent failed to parse logs, Code: LogParseErr, Documentation: %s", troubleshootFindInfoURL),
+		code:       "LogParseErr",
+	},
+	{
+		regexMatch: `\[error\].*\sparsers\sreturned\san\serror.*`,
+		message:    fmt.Sprintf("Ops Agent failed to parse logs, Code: LogParseErr, Documentation: %s", troubleshootFindInfoURL),
+		code:       "LogParseErr",
+	},
+	{
+		regexMatch: `\[error\].*\sNo\ssuch\sfile\sor\sdirectory.*`,
+		message:    fmt.Sprintf("Ops Agent not found path or directory, Code: LogPathNotFound, Documentation: %s", troubleshootFindInfoURL),
+		code:       "LogPathNotFound",
+	},
 }
 
 func generateSelfLogsSamplingComponents(ctx context.Context) []fluentbit.Component {

--- a/confgenerator/self_logs.go
+++ b/confgenerator/self_logs.go
@@ -155,8 +155,13 @@ var selfLogTranslationList = []selfLogTranslationEntry{
 	},
 	{
 		regexMatch: `\[error\].*\sNo\ssuch\sfile\sor\sdirectory.*`,
-		message:    fmt.Sprintf("Ops Agent not found path or directory, Code: LogPathNotFound, Documentation: %s", troubleshootFindInfoURL),
-		code:       "LogPathNotFound",
+		message:    fmt.Sprintf("Ops Agent path or directory not found, Code: LogPathNotFound, Documentation: %s", troubleshootFindInfoURL),
+		code:       "LogPathNotFoundErr",
+	},
+	{
+		regexMatch: `\[error\] \[in_winlog\] cannot read '.*' (6)`,
+		message:    fmt.Sprintf("Ops Agent windows event log failure, Code: LogWinEventLogErr, Documentation: %s", troubleshootFindInfoURL),
+		code:       "LogWinEventLogErr",
 	},
 }
 

--- a/confgenerator/self_logs.go
+++ b/confgenerator/self_logs.go
@@ -159,6 +159,11 @@ var selfLogTranslationList = []selfLogTranslationEntry{
 		code:       "LogPathNotFoundErr",
 	},
 	{
+		regexMatch: `\[error\].*read\serror,\scheck\spermissions:.*`,
+		message:    fmt.Sprintf("Ops Agent log read error, Code: LogPathNotFound, Documentation: %s", troubleshootFindInfoURL),
+		code:       "LogReadPermissionsErr",
+	},
+	{
 		regexMatch: `\[error\] \[in_winlog\] cannot read '.*' (6)`,
 		message:    fmt.Sprintf("Ops Agent windows event log failure, Code: LogWinEventLogErr, Documentation: %s", troubleshootFindInfoURL),
 		code:       "LogWinEventLogErr",


### PR DESCRIPTION
## Description
This PR adds filters to sample specific logs fluent-bit self-logs and transform them into `ops-agent-health` logs, following the Structured Ops Agent Health Logs format(https://github.com/GoogleCloudPlatform/ops-agent/pull/1290). The following fluent-bit logs will be sampled :

Code : `LogParseErr`, Match : `[ warn] * error parsing log message with parser *`,
Code : `LogParseErr`, Match : `[error] * parsers returned an error *`,
Code : `LogPathNotFoundErr`, Match : `[error] * No such file or directory *`
Code : `LogWinEventLogErr`, Match : `[error] [in_winlog] cannot read '*' (6)`

This is similar to the previous PR https://github.com/GoogleCloudPlatform/ops-agent/pull/1300 .

## Related issue
b/303073892

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
