### PR TITLE
Set PLATFORMS to empty list in generic test config

### DIFF
--- a/kokoro/config/test/common.gcl
+++ b/kokoro/config/test/common.gcl
@@ -28,7 +28,7 @@ local _zones_for_arch = {
 
 template config common = {
   params = {
-    platforms = null
+    platforms = external
     build_file = external
 
     // This is only used for determining the value of ZONES.

--- a/kokoro/config/test/common.gcl
+++ b/kokoro/config/test/common.gcl
@@ -28,7 +28,7 @@ local _zones_for_arch = {
 
 template config common = {
   params = {
-    platforms = external
+    platforms = null
     build_file = external
 
     // This is only used for determining the value of ZONES.

--- a/kokoro/config/test/ops_agent/release.gcl
+++ b/kokoro/config/test/ops_agent/release.gcl
@@ -1,6 +1,5 @@
 import 'common.gcl' as common
 
-
 config build = common.ops_agent_test {
   params {
     platforms = []

--- a/kokoro/config/test/ops_agent/release.gcl
+++ b/kokoro/config/test/ops_agent/release.gcl
@@ -2,8 +2,6 @@ import 'common.gcl' as common
 
 config build = common.ops_agent_test {
   params {
-    platforms = ''
-
     environment {
       // The release builds run as a different service account.
       TRANSFERS_BUCKET = 'stackdriver-test-143416-file-transfers'

--- a/kokoro/config/test/ops_agent/release.gcl
+++ b/kokoro/config/test/ops_agent/release.gcl
@@ -1,9 +1,10 @@
 import 'common.gcl' as common
 
-platforms = []
 
 config build = common.ops_agent_test {
   params {
+    platforms = []
+
     environment {
       // The release builds run as a different service account.
       TRANSFERS_BUCKET = 'stackdriver-test-143416-file-transfers'

--- a/kokoro/config/test/ops_agent/release.gcl
+++ b/kokoro/config/test/ops_agent/release.gcl
@@ -1,5 +1,7 @@
 import 'common.gcl' as common
 
+platforms = []
+
 config build = common.ops_agent_test {
   params {
     environment {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
