### PR TITLE
Internal: safely check for vars set in go_test

### DIFF
--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -66,22 +66,22 @@ else:
 
 function set_platforms() {
   # if PLATFORMS is defined, do nothing
-  if [[ -n "${PLATFORMS}" ]]; then
+  if [[ -n "${PLATFORMS:-}" ]]; then
     return 0
   fi
   # if _LOUHI_TAG_NAME is defined, set TARGET and ARCH env vars by parsing it.
   # Example value: louhi/2.46.0/shortref/windows/x86_64/start
-  if [[ -n "${_LOUHI_TAG_NAME}" ]]; then
+  if [[ -n "${_LOUHI_TAG_NAME:-}" ]]; then
     TARGET="$(echo -n "${_LOUHI_TAG_NAME}" | cut --delimiter="/" --fields=4)"
     ARCH="$(echo -n "${_LOUHI_TAG_NAME}" | cut --delimiter="/" --fields=5)"
   fi
   # if TARGET is not set, return an error
-  if [[ -z "${TARGET}" ]]; then
+  if [[ -z "${TARGET:-}" ]]; then
     echo "At least one of TARGET/PLATFORMS must be set." 1>&2
     return 1
   fi
   # if ARCH is not set, return an error
-  if [[ -z "${ARCH}" ]]; then
+  if [[ -z "${ARCH:-}" ]]; then
     echo "If TARGET is set, ARCH must be as well." 1>&2
     return 1
   fi


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Because -u is set, checking for the vars in this change errors with "unbound variable". We can fix this by giving them a default value.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
