### PR TITLE
Internal: alter problematic `export`s

### DIFF
--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -72,8 +72,8 @@ function set_platforms() {
   # if _LOUHI_TAG_NAME is defined, set TARGET and ARCH env vars by parsing it.
   # Example value: louhi/2.46.0/shortref/windows/x86_64/start
   if [[ -n "${_LOUHI_TAG_NAME:-}" ]]; then
-    export TARGET="$(echo -n "${_LOUHI_TAG_NAME}" | cut --delimiter="/" --fields=4)"
-    export ARCH="$(echo -n "${_LOUHI_TAG_NAME}" | cut --delimiter="/" --fields=5)"
+    TARGET="$(echo -n "${_LOUHI_TAG_NAME}" | cut --delimiter="/" --fields=4)"
+    ARCH="$(echo -n "${_LOUHI_TAG_NAME}" | cut --delimiter="/" --fields=5)"
   fi
   # if TARGET is not set, return an error
   if [[ -z "${TARGET:-}" ]]; then
@@ -93,7 +93,8 @@ function set_platforms() {
     # ['test_distros']['exhaustive'] is an optional field.
     platforms=${platforms},$(yaml project.yaml "['targets']['${TARGET}']['architectures']['${ARCH}']['test_distros']['exhaustive']") || true
   fi
-  export PLATFORMS="${platforms}"
+  PLATFORMS="${platforms}"
+  export PLATFORMS
 }
 
 set_platforms


### PR DESCRIPTION
## Description

https://www.shellcheck.net/wiki/SC2155 describes the issue with previous PR (https://github.com/GoogleCloudPlatform/ops-agent/pull/1601), but basically it's preferred (and pointed out by linters) to do `export FOO` separately from assigining it a value.

In the case of `TARGET` and `ARCH`, the `export` wasn't needed anyway, so I removed it, and in the case of `PLATFORMS` it just got moved to a separate line.

## Related issue


## How has this been tested?
automated tests should be enough.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
