### PR TITLE
Internal: windows release builds use a separate cache

### DIFF
--- a/kokoro/scripts/build/build_package.ps1
+++ b/kokoro/scripts/build/build_package.ps1
@@ -52,13 +52,13 @@ $artifact_registry='us-docker.pkg.dev'
 Invoke-Program docker-credential-gcr configure-docker --registries="$artifact_registry"
 $arch = Invoke-Program docker info --format '{{.Architecture}}'
 $suffix = ''
-###if ($env:KOKORO_JOB_TYPE -eq 'RELEASE') {
+if ($env:KOKORO_JOB_TYPE -eq 'RELEASE') {
   # There's some difference between release builds and other kinds of builds
   # that makes release builds slow unless they use a separate cache. See b/318538879.
   $suffix = '-release'
-###}
+}
 $cache_location="${artifact_registry}/stackdriver-test-143416/google-cloud-ops-agent-build-cache/ops-agent-cache:windows-${arch}${suffix}"
-###Invoke-Program docker pull $cache_location
+Invoke-Program docker pull $cache_location
 Invoke-Program docker build --cache-from="${cache_location}" -t $tag -f './Dockerfile.windows' .
 Invoke-Program docker create --name $name $tag
 Invoke-Program docker cp "${name}:/work/out" $env:KOKORO_ARTIFACTS_DIR
@@ -68,10 +68,10 @@ Invoke-Program docker cp "${name}:/work/out" $env:KOKORO_ARTIFACTS_DIR
 # write to any kind of cache, for example a per-PR cache, because the
 # push takes a few minutes and adds little value over just using the continuous
 # build's cache.
-###if ($env:KOKORO_ROOT_JOB_TYPE -eq 'CONTINUOUS_INTEGRATION') {
+if ($env:KOKORO_ROOT_JOB_TYPE -eq 'CONTINUOUS_INTEGRATION') {
   Invoke-Program docker image tag $tag $cache_location
   Invoke-Program docker push $cache_location
-###}
+}
 
 # Copy the .goo file from $env:KOKORO_ARTIFACTS_DIR/out to $env:KOKORO_ARTIFACTS_DIR/result.
 # The .goo file is the installable package that is distributed to customers.


### PR DESCRIPTION
## Description
Workaround for b/318538879: tell release builds to use a separate cache.

I ran this script once with various parts commented out to establish the first `-release` cache entry.

## Related issue
b/318538879

## How has this been tested?


## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
