### PR TITLE
Add aerospike test coverage for debian-12 and rocky-linux-9

### DIFF
--- a/integration_test/third_party_apps_data/applications/aerospike/metadata.yaml
+++ b/integration_test/third_party_apps_data/applications/aerospike/metadata.yaml
@@ -130,13 +130,8 @@ minimum_supported_agent_version:
   logging: 2.23.0
 supported_operating_systems: linux
 platforms_to_skip:
-  # Unable to install Aerospike on various distros.
-  - debian-12
-  - debian-12-arm64
-  - sles-12
-  - rocky-linux-9
-  - rocky-linux-9-arm64
-  - ubuntu-2304-amd64
-  - ubuntu-2310-amd64
-  - ubuntu-2310-arm64
+  - sles-12  # Not supported by Aerospike.
+  - ubuntu-2304-amd64  # Not supported by Aerospike.
+  - ubuntu-2310-amd64  # Not supported by Aerospike.
+  - ubuntu-2310-arm64  # Not supported by Aerospike.
 public_url: https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/aerospike


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
