### PR TITLE
Internal: Flag to include `exhaustive` distro list

### DIFF
--- a/kokoro/config/test/ops_agent/release/common.gcl
+++ b/kokoro/config/test/ops_agent/release/common.gcl
@@ -7,6 +7,7 @@ template config ops_agent_test = common.ops_agent_test {
       TRANSFERS_BUCKET = 'stackdriver-test-143416-file-transfers'
       SERVICE_EMAIL =
           'build-and-test@stackdriver-test-143416.iam.gserviceaccount.com'
+      ADD_EXHAUSTIVE_DISTROS = '1'
     }
   }
 }

--- a/kokoro/config/test/ops_agent/release/common.gcl
+++ b/kokoro/config/test/ops_agent/release/common.gcl
@@ -7,7 +7,7 @@ template config ops_agent_test = common.ops_agent_test {
       TRANSFERS_BUCKET = 'stackdriver-test-143416-file-transfers'
       SERVICE_EMAIL =
           'build-and-test@stackdriver-test-143416.iam.gserviceaccount.com'
-      ADD_EXHAUSTIVE_DISTROS = '1'
+      TEST_EXHAUSTIVE_DISTROS = '1'
     }
   }
 }

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -96,7 +96,7 @@ function set_platforms() {
   local platforms
   platforms=$(yaml project.yaml "['targets']['${TARGET}']['architectures']['${ARCH}']['test_distros']['representative']")
   # If not a presubmit job, add the exhaustive list of test distros.
-  if [[ ! "${KOKORO_ROOT_JOB_TYPE:-$KOKORO_JOB_TYPE}" =~ ^PRESUBMIT_ ]] && [[ "${_SKIP_EXHAUSTIVE_DISTROS:-}" != "1" ]]; then
+  if [[ ! "${KOKORO_ROOT_JOB_TYPE:-$KOKORO_JOB_TYPE}" =~ ^PRESUBMIT_ ]] && [[ "${SKIP_EXHAUSTIVE_DISTROS:-}" != "1" ]]; then
     # ['test_distros']['exhaustive'] is an optional field.
     platforms=${platforms},$(yaml project.yaml "['targets']['${TARGET}']['architectures']['${ARCH}']['test_distros']['exhaustive']") || true
   fi

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -96,9 +96,10 @@ function set_platforms() {
   local platforms
   platforms=$(yaml project.yaml "['targets']['${TARGET}']['architectures']['${ARCH}']['test_distros']['representative']")
   # If not a presubmit job, add the exhaustive list of test distros.
-  if [[ ! "${KOKORO_ROOT_JOB_TYPE:-$KOKORO_JOB_TYPE}" =~ ^PRESUBMIT_ ]] && [[ "${SKIP_EXHAUSTIVE_DISTROS:-}" != "1" ]]; then
+  if [[ "${ADD_EXHAUSTIVE_DISTROS:-}" == "1" ]]; then
     # ['test_distros']['exhaustive'] is an optional field.
-    platforms=${platforms},$(yaml project.yaml "['targets']['${TARGET}']['architectures']['${ARCH}']['test_distros']['exhaustive']") || true
+    exhaustive_platforms=$(yaml project.yaml "['targets']['${TARGET}']['architectures']['${ARCH}']['test_distros']['exhaustive']") || break
+    platforms="${platforms},${exhaustive_platforms}"
   fi
   PLATFORMS="${platforms}"
   export PLATFORMS

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -96,7 +96,7 @@ function set_platforms() {
   local platforms
   platforms=$(yaml project.yaml "['targets']['${TARGET}']['architectures']['${ARCH}']['test_distros']['representative']")
   # If not a presubmit job, add the exhaustive list of test distros.
-  if ! [[ "${KOKORO_ROOT_JOB_TYPE:-$KOKORO_JOB_TYPE}" =~ ^PRESUBMIT_ ]]; then
+  if [[ ! "${KOKORO_ROOT_JOB_TYPE:-$KOKORO_JOB_TYPE}" =~ ^PRESUBMIT_ ]] && [[ "${_SKIP_EXHAUSTIVE_DISTROS:-}" != "1" ]]; then
     # ['test_distros']['exhaustive'] is an optional field.
     platforms=${platforms},$(yaml project.yaml "['targets']['${TARGET}']['architectures']['${ARCH}']['test_distros']['exhaustive']") || true
   fi

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -98,7 +98,10 @@ function set_platforms() {
   # If not a presubmit job, add the exhaustive list of test distros.
   if [[ "${TEST_EXHAUSTIVE_DISTROS:-}" == "1" ]]; then
     # ['test_distros']['exhaustive'] is an optional field.
-    exhaustive_platforms=$(yaml project.yaml "['targets']['${TARGET}']['architectures']['${ARCH}']['test_distros']['exhaustive']") && platforms="${platforms},${exhaustive_platforms}"
+    exhaustive_platforms=$(yaml project.yaml "['targets']['${TARGET}']['architectures']['${ARCH}']['test_distros']['exhaustive']") || true
+    if [[ -n "${exhaustive_platforms:-}" ]]; then
+      platforms="${platforms},${exhaustive_platforms}"
+    fi
   fi
   PLATFORMS="${platforms}"
   export PLATFORMS

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -96,7 +96,7 @@ function set_platforms() {
   local platforms
   platforms=$(yaml project.yaml "['targets']['${TARGET}']['architectures']['${ARCH}']['test_distros']['representative']")
   # If not a presubmit job, add the exhaustive list of test distros.
-  if [[ "${ADD_EXHAUSTIVE_DISTROS:-}" == "1" ]]; then
+  if [[ "${TEST_EXHAUSTIVE_DISTROS:-}" == "1" ]]; then
     # ['test_distros']['exhaustive'] is an optional field.
     exhaustive_platforms=$(yaml project.yaml "['targets']['${TARGET}']['architectures']['${ARCH}']['test_distros']['exhaustive']") || break
     platforms="${platforms},${exhaustive_platforms}"

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -98,8 +98,7 @@ function set_platforms() {
   # If not a presubmit job, add the exhaustive list of test distros.
   if [[ "${TEST_EXHAUSTIVE_DISTROS:-}" == "1" ]]; then
     # ['test_distros']['exhaustive'] is an optional field.
-    exhaustive_platforms=$(yaml project.yaml "['targets']['${TARGET}']['architectures']['${ARCH}']['test_distros']['exhaustive']") || break
-    platforms="${platforms},${exhaustive_platforms}"
+    exhaustive_platforms=$(yaml project.yaml "['targets']['${TARGET}']['architectures']['${ARCH}']['test_distros']['exhaustive']") && platforms="${platforms},${exhaustive_platforms}"
   fi
   PLATFORMS="${platforms}"
   export PLATFORMS


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

We need a way to manually control when we want to just test against "representative" distros.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
