### PR TITLE
Internal: Move ZONES logic into go_test

### DIFF
--- a/kokoro/config/test/common.gcl
+++ b/kokoro/config/test/common.gcl
@@ -1,31 +1,5 @@
 import '../utils/functions.gcl' as functions
 
-local _zones_for_arch = {
-  // Note: if we ever need to change regions, we will need to set up a new
-  // Cloud Router and Cloud NAT gateway for that region. This is because
-  // we use --no-address on Kokoro, because of b/169084857.
-  // The new Cloud NAT gateway must have "Minimum ports per VM instance"
-  // set to 512 as per this article:
-  // https://cloud.google.com/knowledge/kb/sles-unable-to-fetch-updates-when-behind-cloud-nat-000004450
-  x86_64 = join([
-    'us-central1-a=3',
-    'us-central1-b=3',
-    'us-central1-c=3',
-    'us-central1-f=3',
-    'us-east1-b=2',
-    'us-east1-c=2',
-    'us-east1-d=2',
-  ], ',')
-
-  // T2A machines are only available on us-central1-{a,b,f}.
-  // See warning above about changing regions.
-  aarch64 = join([
-    'us-central1-a',
-    'us-central1-b',
-    'us-central1-f',
-  ], ',')
-}
-
 template config common = {
   params = {
     platforms = external
@@ -38,8 +12,6 @@ template config common = {
 
     environment = {
       PROJECT = 'stackdriver-test-143416'
-      ZONES = _zones_for_arch.get(arch, 'invalid_zone')
-
       PLATFORMS = cond(platforms != [], join(platforms, ','), null)
     }
   }

--- a/kokoro/config/test/common.gcl
+++ b/kokoro/config/test/common.gcl
@@ -11,6 +11,7 @@ template config common = {
     artifacts = []
 
     environment = {
+      ARCH = arch
       PROJECT = 'stackdriver-test-143416'
       PLATFORMS = cond(platforms != [], join(platforms, ','), null)
     }

--- a/kokoro/config/test/soak/common.gcl
+++ b/kokoro/config/test/soak/common.gcl
@@ -9,5 +9,9 @@ template config soak_test = common.go_test {
     build_file = 'unified_agents/kokoro/scripts/test/start_soak_test.sh'
 
     test_suite = null
+
+    environment {
+      ZONES = 'us-central1-a'
+    }
   }
 }

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -66,11 +66,14 @@ else:
 
 # A helper function for joining a bash array.
 # Ex. join_by , a b c -> a,b,c
-function join_by {
-  local d=${1-} f=${2-}
-  if shift 2; then
-    printf %s "$f" "${@/#/$d}"
-  fi
+function join_by() {
+  delim="$1"
+  for (( i = 2; i <= $#; i++)); do
+    printf "${!i}"  # The ith positional argument
+    if [[ $i -ne $# ]]; then
+      printf "${delim}"
+    fi
+  done
 }
 
 function set_platforms() {
@@ -124,7 +127,7 @@ function set_platforms() {
 # https://cloud.google.com/knowledge/kb/sles-unable-to-fetch-updates-when-behind-cloud-nat-000004450
 function set_zones() {
   if [[ "${ARCH:-}" == "x86_64" ]]; then
-    zones=(
+    zone_list=(
       us-central1-a=3
       us-central1-b=3
       us-central1-c=3
@@ -136,17 +139,18 @@ function set_zones() {
   # T2A machines are only available on us-central1-{a,b,f}.
   # See warning above about changing regions.
   elif [[ "${ARCH:-}" == "aarch64" ]]; then
-    zones=(
+    zone_list=(
       us-central1-a
       us-central1-b
       us-central1-f
     )
   else
-    zones=(
+    zone_list=(
       invalid_zone
     )
   fi
-  export ZONES="$(join_by , ${zones[@]})"
+  zones=$(join_by , "${zone_list[@]}")
+  export ZONES=$zones
 }
 
 set_platforms


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
When running tests from Louhi, it is too late to change the zones as-is. By moving the zone setting logic into go_test.sh. It should work for Louhi as well.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
