### PR TITLE
Internal: Swap `minimal` distros into `exhaustive` test distros.

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -66,15 +66,15 @@ targets:
       x86_64:
         test_distros:
           representative:
-          - ubuntu-minimal-2004-lts
-          exhaustive:
           - ubuntu-2004-lts
+          exhaustive:
+          - ubuntu-minimal-2004-lts
       aarch64:
         test_distros:
           representative:
-          - ubuntu-minimal-2004-lts-arm64
-          exhaustive:
           - ubuntu-2004-lts-arm64
+          exhaustive:
+          - ubuntu-minimal-2004-lts-arm64
   jammy:
     package_extension:
       deb
@@ -82,15 +82,15 @@ targets:
       x86_64:
         test_distros:
           representative:
-          - ubuntu-minimal-2204-lts
-          exhaustive:
           - ubuntu-2204-lts
+          exhaustive:
+          - ubuntu-minimal-2204-lts
       aarch64:
         test_distros:
           representative:
-          - ubuntu-minimal-2204-lts-arm64
-          exhaustive:
           - ubuntu-2204-lts-arm64
+          exhaustive:
+          - ubuntu-minimal-2204-lts-arm64
   mantic:
     package_extension:
       deb
@@ -98,15 +98,15 @@ targets:
       x86_64:
         test_distros:
           representative:
-          - ubuntu-minimal-2310-amd64
-          exhaustive:
           - ubuntu-2310-amd64
+          exhaustive:
+          - ubuntu-minimal-2310-amd64
       aarch64:
         test_distros:
           representative:
-          - ubuntu-minimal-2310-arm64
-          exhaustive:
           - ubuntu-2310-arm64
+          exhaustive:
+          - ubuntu-minimal-2310-arm64
   rockylinux9:
     package_extension:
       rpm


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This is correcting an incorrect configuration.

Several 3P tests fail on "minimal" versions of distros.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
