### PR TITLE
Testing: fix install command to stop dropping errors

### DIFF
--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -749,7 +749,7 @@ func InstallOpsAgent(ctx context.Context, logger *log.Logger, vm *gce.VM, locati
 	}
 
 	preservedEnvironment := map[string]string{
-		"REPO_SUFFIX":              "asdf",
+		"REPO_SUFFIX":              location.repoSuffix,
 		"REPO_CODENAME":            location.repoCodename,
 		"ARTIFACT_REGISTRY_PROJECT":             location.artifactRegistryProject,
 		"ARTIFACT_REGISTRY_REGION": location.artifactRegistryRegion,
@@ -766,9 +766,9 @@ func InstallOpsAgent(ctx context.Context, logger *log.Logger, vm *gce.VM, locati
 			return err
 		}
 		if err := RunInstallFuncWithRetry(ctx, logger, vm, runScript); err != nil {
-			return fmt.Errorf("yay, InstallOpsAgent() failed to run repo script: %w", err)
+			return fmt.Errorf("InstallOpsAgent() failed to run repo script: %w", err)
 		}
-		return fmt.Errorf("failed to produce error when an error was expected! %s", "err")
+		return nil
 	}
 
 	if _, err := gce.RunRemotely(ctx,

--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -761,7 +761,7 @@ func InstallOpsAgent(ctx context.Context, logger *log.Logger, vm *gce.VM, locati
 		}
 		runScript := func() error {
 			scriptCmd := fmt.Sprintf(`%s
-& ${env:UserProfile}\add-google-cloud-ops-agent-repo.ps1 -AlsoInstall`, windowsEnvironment(preservedEnvironment))
+& "${env:UserProfile}\add-google-cloud-ops-agent-repo.ps1" -AlsoInstall`, windowsEnvironment(preservedEnvironment))
 			_, err := gce.RunRemotely(ctx, logger, vm, "", scriptCmd)
 			return err
 		}

--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -761,7 +761,7 @@ func InstallOpsAgent(ctx context.Context, logger *log.Logger, vm *gce.VM, locati
 		}
 		runScript := func() error {
 			scriptCmd := fmt.Sprintf(`%s
-Invoke-Expression "${env:UserProfile}\add-google-cloud-ops-agent-repo.ps1 -AlsoInstall"`, windowsEnvironment(preservedEnvironment))
+& ${env:UserProfile}\add-google-cloud-ops-agent-repo.ps1 -AlsoInstall`, windowsEnvironment(preservedEnvironment))
 			_, err := gce.RunRemotely(ctx, logger, vm, "", scriptCmd)
 			return err
 		}

--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -756,6 +756,10 @@ func InstallOpsAgent(ctx context.Context, logger *log.Logger, vm *gce.VM, locati
 	}
 
 	if gce.IsWindows(vm.Platform) {
+		// Note that these commands match the ones from our public install docs
+		// (https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/installation)
+		// and keeping them in sync is encouraged so that we are testing the
+		// same commands that our customers are running.
 		if _, err := gce.RunRemotely(ctx, logger, vm, "", `(New-Object Net.WebClient).DownloadFile("https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.ps1", "${env:UserProfile}\add-google-cloud-ops-agent-repo.ps1")`); err != nil {
 			return fmt.Errorf("InstallOpsAgent() failed to download repo script: %w", err)
 		}
@@ -765,6 +769,7 @@ func InstallOpsAgent(ctx context.Context, logger *log.Logger, vm *gce.VM, locati
 			_, err := gce.RunRemotely(ctx, logger, vm, "", scriptCmd)
 			return err
 		}
+		// TODO: b/202526819 - Remove retries once the script does retries internally.
 		if err := RunInstallFuncWithRetry(ctx, logger, vm, runScript); err != nil {
 			return fmt.Errorf("InstallOpsAgent() failed to run repo script: %w", err)
 		}

--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -749,7 +749,7 @@ func InstallOpsAgent(ctx context.Context, logger *log.Logger, vm *gce.VM, locati
 	}
 
 	preservedEnvironment := map[string]string{
-		"REPO_SUFFIX":              location.repoSuffix,
+		"REPO_SUFFIX":              "asdf",
 		"REPO_CODENAME":            location.repoCodename,
 		"ARTIFACT_REGISTRY_PROJECT":             location.artifactRegistryProject,
 		"ARTIFACT_REGISTRY_REGION": location.artifactRegistryRegion,
@@ -766,9 +766,9 @@ Invoke-Expression "${env:UserProfile}\add-google-cloud-ops-agent-repo.ps1 -AlsoI
 			return err
 		}
 		if err := RunInstallFuncWithRetry(ctx, logger, vm, runScript); err != nil {
-			return fmt.Errorf("InstallOpsAgent() failed to run repo script: %w", err)
+			return fmt.Errorf("yay, InstallOpsAgent() failed to run repo script: %w", err)
 		}
-		return nil
+		return fmt.Errorf("failed to produce error when an error was expected! %s", "err")
 	}
 
 	if _, err := gce.RunRemotely(ctx,

--- a/kokoro/scripts/build/build_package.sh
+++ b/kokoro/scripts/build/build_package.sh
@@ -25,6 +25,8 @@ set -e
 set -x
 set -o pipefail
 
+exit 7
+
 RESULT_DIR=${RESULT_DIR:-"${KOKORO_ARTIFACTS_DIR}/result"}
 export RESULT_DIR
 

--- a/kokoro/scripts/build/build_package.sh
+++ b/kokoro/scripts/build/build_package.sh
@@ -25,8 +25,6 @@ set -e
 set -x
 set -o pipefail
 
-exit 7
-
 RESULT_DIR=${RESULT_DIR:-"${KOKORO_ARTIFACTS_DIR}/result"}
 export RESULT_DIR
 


### PR DESCRIPTION
## Description
See b/326084619#comment3 and b/326247071 for full description, but in short, Invoke-Expression hides certain errors (e.g. the script running `exit 1`). This should fix that, so that errors when installing the ops agent will be noticed by the tests and report an error. This will greatly aid in debugging install failures (no need to be puzzled and dive into `main_log.txt`).

## Related issue
b/326084619

## How has this been tested?
b/326084619#comment3 discusses this.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
