### PR TITLE
Add missing t.Parallel to speed up tests

### DIFF
--- a/integration_test/ops_agent_test.go
+++ b/integration_test/ops_agent_test.go
@@ -4728,6 +4728,7 @@ func TestNoNvmlOtelReceiverWithoutGpu(t *testing.T) {
 func TestPartialSuccess(t *testing.T) {
 	t.Parallel()
 	gce.RunForEachPlatform(t, func(t *testing.T, platform string) {
+ 		t.Parallel()
 		ctx, logger, vm := setupMainLogAndVM(t, platform)
 		logPath := logPathForPlatform(vm.Platform)
 		config := fmt.Sprintf(`logging:


### PR DESCRIPTION
## Description
Corey noticed tests were slow, and after some digging I found:

```
--- PASS: TestPartialSuccess (3231.11s)
    --- PASS: TestPartialSuccess/windows-2016-core (441.91s)
    --- PASS: TestPartialSuccess/sql-std-2019-win-2019 (488.53s)
    --- PASS: TestPartialSuccess/windows-2022 (494.28s)
    --- PASS: TestPartialSuccess/windows-2016 (532.98s)
    --- PASS: TestPartialSuccess/windows-2019 (455.43s)
    --- PASS: TestPartialSuccess/windows-2019-core (412.52s)
    --- PASS: TestPartialSuccess/windows-2022-core (405.47s)
```

This normally looks different (a tiny number after the test name, `TestPartialSuccess` in this case) and indicates that the tests were running in series, not in parallel. Easy fix.

## Related issue
None

## How has this been tested?
automated tests should be enough.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
