### PR TITLE
Fix debian 10 test for rabbitmq

### DIFF
--- a/integration_test/third_party_apps_data/applications/rabbitmq/debian_ubuntu/install
+++ b/integration_test/third_party_apps_data/applications/rabbitmq/debian_ubuntu/install
@@ -44,7 +44,14 @@ curl -s \
     sudo bash
 
 sudo apt-get update
-sudo apt-get install -y rabbitmq-server
+
+if [[ "${VERSION_ID}" == 10 ]]; then
+  # Versions starting at 3.13 require Erlang 26 which is difficult/impossible to install
+  # on debian 10, so we need to pin the version of rabbitmq-server
+  sudo apt-get install -y rabbitmq-server=3.12.13-1
+else
+  sudo apt-get install -y rabbitmq-server
+fi
 
 sudo systemctl daemon-reload
 sudo systemctl enable rabbitmq-server


### PR DESCRIPTION
## Description
The following error has popped up in integration tests, appears that new versions of rabbitmq are difficult to install on debian 10.

```
Running apt-get update... done.
        
        The repository is setup! You can now install packages.
        + sudo apt-get update
        Hit:1 https://packages.cloud.google.com/apt google-compute-engine-buster-stable InRelease
        Hit:2 https://packages.cloud.google.com/apt cloud-sdk-buster InRelease
        Hit:3 https://deb.debian.org/debian buster InRelease
        Hit:4 https://deb.debian.org/debian-security buster/updates InRelease
        Hit:6 https://deb.debian.org/debian buster-updates InRelease
        Hit:7 http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu bionic InRelease
        Hit:8 https://deb.debian.org/debian buster-backports InRelease
        Hit:5 https://packagecloud.io/rabbitmq/rabbitmq-server/debian buster InRelease
        Reading package lists...
        + sudo apt-get install -y rabbitmq-server
        ...
        The following packages have unmet dependencies:
         rabbitmq-server : Depends: erlang-base (>= 1:26.0) but 1:25.3.2.2-1rmq1ppa1~ubuntu18.04.1 is to be installed or
                                    erlang-base-hipe (>= 1:26.0) but it is not going to be installed or
                                    esl-erlang (>= 1:26.0) but it is not installable
                           Depends: erlang-crypto (>= 1:26.0) but 1:25.3.2.2-1rmq1ppa1~ubuntu18.04.1 is to be installed or
                                    esl-erlang (>= 1:26.0) but it is not installable
                           Depends: erlang-eldap (>= 1:26.0) but 1:25.3.2.2-1rmq1ppa1~ubuntu18.04.1 is to be installed or
                                    esl-erlang (>= 1:26.0) but it is not installable
                           Depends: erlang-inets (>= 1:26.0) but 1:25.3.2.2-1rmq1ppa1~ubuntu18.04.1 is to be installed or
                                    esl-erlang (>= 1:26.0) but it is not installable
                           Depends: erlang-mnesia (>= 1:26.0) but 1:25.3.2.2-1rmq1ppa1~ubuntu18.04.1 is to be installed or
                                    esl-erlang (>= 1:26.0) but it is not installable
                           Depends: erlang-os-mon (>= 1:26.0) but 1:25.3.2.2-1rmq1ppa1~ubuntu18.04.1 is to be installed or
                                    esl-erlang (>= 1:26.0) but it is not installable
                           Depends: erlang-parsetools (>= 1:26.0) but 1:25.3.2.2-1rmq1ppa1~ubuntu18.04.1 is to be installed or
                                    esl-erlang (>= 1:26.0) but it is not installable
                           Depends: erlang-public-key (>= 1:26.0) but 1:25.3.2.2-1rmq1ppa1~ubuntu18.04.1 is to be installed or
        E: Unable to correct problems, you have held broken packages.
                                    esl-erlang (>= 1:26.0) but it is not installable
                           Depends: erlang-runtime-tools (>= 1:26.0) but 1:25.3.2.2-1rmq1ppa1~ubuntu18.04.1 is to be installed or
                                    esl-erlang (>= 1:26.0) but it is not installable
                           Depends: erlang-ssl (>= 1:26.0) but 1:25.3.2.2-1rmq1ppa1~ubuntu18.04.1 is to be installed or
                                    esl-erlang (>= 1:26.0) but it is not installable
                           Depends: erlang-syntax-tools (>= 1:26.0) but 1:25.3.2.2-1rmq1ppa1~ubuntu18.04.1 is to be installed or
                                    esl-erlang (>= 1:26.0) but it is not installable
                           Depends: erlang-tools (>= 1:26.0) but 1:25.3.2.2-1rmq1ppa1~ubuntu18.04.1 is to be installed or
                                    esl-erlang (>= 1:26.0) but it is not installable
                           Depends: erlang-xmerl (>= 1:26.0) but 1:25.3.2.2-1rmq1ppa1~ubuntu18.04.1 is to be installed or
                                    esl-erlang (>= 1:26.0) but it is not installable
```


## How has this been tested?
To be tested in kokoro. Validated that the install command works in a deb10 image.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
