### PR TITLE
healthchecks: Handle `no such host` from `Network Check` and show `MetaApiConnErr` as `WARNING`.

### DIFF
--- a/internal/healthchecks/error.go
+++ b/internal/healthchecks/error.go
@@ -98,7 +98,7 @@ var (
 		Message:      "Request to GCE Metadata server failed",
 		Action:       "Check your internet connection and firewall rules.",
 		ResourceLink: "https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/troubleshoot-run-ingest#network-issues",
-		IsFatal:      true,
+		IsFatal:      false,
 	}
 	LogApiScopeErr = HealthCheckError{
 		Code:         "LogApiScopeErr",


### PR DESCRIPTION
When verifying connection to endpoints during `Network Check` execution (see [network_check.go](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/internal/healthchecks/network_check.go#L37-L73)), if the endpoint doesn't exist it shows the following error (see https://github.com/GoogleCloudPlatform/ops-agent/issues/1630) :
```
[Network Check] Result: ERROR, Detail: Get "http://metadata.google.internal/": dial tcp *:
```



This PR does the following changes : 
- Handle `no such host` from `Network Check` and present `FAILURE` (log and monitoring api endpoints) or `WARNING` (not required endpoints for Ops Agent execution) when appropiate.
- Show `MetaApiConnErr` as `WARNING` (not fatal error).

## Description
<!--- Describe your changes in detail. -->

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
