### PR TITLE
Add test coverage for preserving fields with parse_json

### DIFF
--- a/transformation_test/testdata/ops_agent_test-TestProcessorOrder/input.log
+++ b/transformation_test/testdata/ops_agent_test-TestProcessorOrder/input.log
@@ -1,1 +1,1 @@
-{"log":"{\"level\":\"info\",\"message\":\"start\"}\n","time":"2009-11-10T23:00:00.000001+0000"}
+{"log":"{\"level\":\"info\",\"message\":\"start\",\"overwritten\":\"yes\"}\n","time":"2009-11-10T23:00:00.000001+0000","preserved":"yes","overwritten":"no"}

--- a/transformation_test/testdata/ops_agent_test-TestProcessorOrder/output_fluentbit.yaml
+++ b/transformation_test/testdata/ops_agent_test-TestProcessorOrder/output_fluentbit.yaml
@@ -2,6 +2,8 @@
   - jsonPayload:
       level: info
       message: start
+      overwritten: "yes"
+      preserved: "yes"
     logName: projects/my-project/logs/transformation_test
     timestamp: 2009-11-10T23:00:00.000001000Z
   partialSuccess: true

--- a/transformation_test/testdata/ops_agent_test-TestProcessorOrder/output_otel.yaml
+++ b/transformation_test/testdata/ops_agent_test-TestProcessorOrder/output_otel.yaml
@@ -2,6 +2,7 @@
   - jsonPayload:
       level: info
       message: start
+      overwritten: "yes"
     logName: projects/my-project/logs/my-log-name
     resource:
       labels:


### PR DESCRIPTION
## Description
Add test coverage for preserving fields with parse_json.

## Related issue
https://github.com/GoogleCloudPlatform/ops-agent/issues/650

## How has this been tested?
One integration test passed locally, will let presubmits run.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
