### PR TITLE
Testing: retry all 50x errors when deleting VMs

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1446,9 +1446,9 @@ func DeleteInstance(logger *log.Logger, vm *VM) error {
 				"--zone=" + vm.Zone,
 				vm.Name,
 			})
-		// GCE sometimes responds with "The service is currently unavailable".
-		// Retry these errors, by returning them directly.
-		if err != nil && strings.Contains(err.Error(), "unavailable") {
+		// GCE sometimes responds with 502 or 503 errors. Retry these errors
+		// (and other 50x errors for good measure), by returning them directly.
+		if err != nil && strings.Contains(err.Error(), "Error 50") {
 			return err
 		}
 		// Wrap other errors in backoff.Permanent() to avoid retrying those.


### PR DESCRIPTION
## Description

I've seen this flake about 5 times, time to fix it.

Example flake that this should fix: https://source.cloud.google.com/results/invocations/b85a211b-c755-4af2-839e-0d7bf46db0c1

The error message was:
```
<title>Error 502 (Server Error)!!1</title>
 [snip]
          <p><b>502.</b> <ins>That’s an error.</ins>
          <p>The server encountered a temporary error and could not complete your request.<p>Please try again in 30 seconds.  <ins>That’s all we know.</ins>
```

## Related issue
no bug, flake

## How has this been tested?
automated tests should be enough.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
