### PR TITLE
Testing: SLES 15 GPU tests: Pin the driver to a working version on SLES 15

### DIFF
--- a/integration_test/third_party_apps_data/applications/dcgm/sles/install
+++ b/integration_test/third_party_apps_data/applications/dcgm/sles/install
@@ -24,6 +24,7 @@ case $DEVICE_CODE in
         ;;
     *)
         echo "Installing latest version of NVIDIA CUDA and driver"
+        # TODO(b/328095390): Remove the temporary fix and use the metapackage without version (i.e., cuda). 
         sudo zypper --non-interactive install -y cuda-drivers-545
         ;;
 esac

--- a/integration_test/third_party_apps_data/applications/dcgm/sles/install
+++ b/integration_test/third_party_apps_data/applications/dcgm/sles/install
@@ -24,7 +24,7 @@ case $DEVICE_CODE in
         ;;
     *)
         echo "Installing latest version of NVIDIA CUDA and driver"
-        sudo zypper --non-interactive install -y cuda
+        sudo zypper --non-interactive install -y cuda-drivers-545
         ;;
 esac
 

--- a/integration_test/third_party_apps_data/applications/nvml/sles/install
+++ b/integration_test/third_party_apps_data/applications/nvml/sles/install
@@ -24,6 +24,7 @@ case $DEVICE_CODE in
         echo "Installing latest version of NVIDIA CUDA and driver"
         sudo zypper --non-interactive ar http://developer.download.nvidia.com/compute/cuda/repos/${DISTRIBUTION}/x86_64/cuda-${DISTRIBUTION}.repo
         sudo zypper --gpg-auto-import-keys --non-interactive refresh
+        # TODO(b/328095390): Remove the temporary fix and use the metapackage without version (i.e., cuda). 
         sudo zypper --non-interactive install -y cuda-drivers-545 cuda-toolkit-12-3 cuda
         ;;
 esac

--- a/integration_test/third_party_apps_data/applications/nvml/sles/install
+++ b/integration_test/third_party_apps_data/applications/nvml/sles/install
@@ -24,7 +24,7 @@ case $DEVICE_CODE in
         echo "Installing latest version of NVIDIA CUDA and driver"
         sudo zypper --non-interactive ar http://developer.download.nvidia.com/compute/cuda/repos/${DISTRIBUTION}/x86_64/cuda-${DISTRIBUTION}.repo
         sudo zypper --gpg-auto-import-keys --non-interactive refresh
-        sudo zypper --non-interactive install -y cuda
+        sudo zypper --non-interactive install -y cuda-drivers-545 cuda-toolkit-12-3 cuda
         ;;
 esac
 


### PR DESCRIPTION
## Description
On SLES 15 pin the Nvidia driver to a previously working version 545. This is a temporary fix, and we can remove this once the new version's matching CUDA toolkit 12.4 becomes available and work properly on SLES 15 [b/328095390](http://b/328095390). 

## Related issue
[b/326942566](http://b/326942566)

## How has this been tested?
GPU tests are passing on SLES 15. 

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
