### PR TITLE
Testing: Simplify UploadContent on linux

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -868,7 +868,7 @@ func UploadContent(ctx context.Context, logger *log.Logger, vm *VM, content io.R
 		// Pass the content in on stdin and tell "cp" to copy it to the file.
 		// This is to avoid having to quote the content correctly for the shell.
 		// Use "sudo" in case elevated privileges are necessary.
-		_, err = RunRemotelyStdin(ctx, logger, vm, content, fmt.Sprintf("sudo cp /dev/stdin '%s'", remotePath, remotePath))
+		_, err = RunRemotelyStdin(ctx, logger, vm, content, fmt.Sprintf("sudo cp /dev/stdin '%s'", remotePath))
 		return err
 	}
 

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -857,7 +857,7 @@ func RunRemotelyStdin(ctx context.Context, logger *log.Logger, vm *VM, stdin io.
 // UploadContent takes an io.Reader and uploads its contents as a file to a
 // given path on the given VM.
 //
-// In order for this function to work, the currently active application default
+// When used for a Windows VM, the currently active application default
 // credentials (GOOGLE_APPLICATION_CREDENTIALS) need to be able to upload to
 // fileTransferBucket, and also the role running on the remote VM needs to be
 // given permission to read from that bucket. This was accomplished by adding
@@ -865,6 +865,9 @@ func RunRemotelyStdin(ctx context.Context, logger *log.Logger, vm *VM, stdin io.
 // a "Storage Object Viewer" and "Storage Object Creator" on the bucket.
 func UploadContent(ctx context.Context, logger *log.Logger, vm *VM, content io.Reader, remotePath string) (err error) {
 	if !IsWindows(vm.Platform) {
+		if _, err := RunRemotely(ctx, logger, vm, fmt.Sprintf(`sudo mkdir -p "$(dirname '%s')"`, remotePath)); err != nil {
+			return err
+		}
 		// Pass the content in on stdin and tell "tee" to write it to the file.
 		// This is to avoid having to quote the content correctly for the shell.
 		// Use "sudo" to write to the file in case elevated privileges are necessary.

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -868,7 +868,7 @@ func UploadContent(ctx context.Context, logger *log.Logger, vm *VM, content io.R
 		// Pass the content in on stdin and tell "cp" to copy it to the file.
 		// This is to avoid having to quote the content correctly for the shell.
 		// Use "sudo" in case elevated privileges are necessary.
-		_, err = RunRemotelyStdin(ctx, logger, vm, content, fmt.Sprintf(`sudo mkdir -p "$(dirname '%s')" && sudo cp /dev/stdin '%s'`, remotePath, remotePath))
+		_, err = RunRemotelyStdin(ctx, logger, vm, content, fmt.Sprintf("sudo cp /dev/stdin '%s'", remotePath, remotePath))
 		return err
 	}
 

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -865,13 +865,10 @@ func RunRemotelyStdin(ctx context.Context, logger *log.Logger, vm *VM, stdin io.
 // a "Storage Object Viewer" and "Storage Object Creator" on the bucket.
 func UploadContent(ctx context.Context, logger *log.Logger, vm *VM, content io.Reader, remotePath string) (err error) {
 	if !IsWindows(vm.Platform) {
-		if _, err := RunRemotely(ctx, logger, vm, fmt.Sprintf(`sudo mkdir -p "$(dirname '%s')"`, remotePath)); err != nil {
-			return err
-		}
-		// Pass the content in on stdin and tell "tee" to write it to the file.
+		// Pass the content in on stdin and tell "cp" to copy it to the file.
 		// This is to avoid having to quote the content correctly for the shell.
-		// Use "sudo" to write to the file in case elevated privileges are necessary.
-		_, err = RunRemotelyStdin(ctx, logger, vm, content, fmt.Sprintf("sudo tee '%s' > /dev/null", remotePath))
+		// Use "sudo" in case elevated privileges are necessary.
+		_, err = RunRemotelyStdin(ctx, logger, vm, content, fmt.Sprintf(`sudo mkdir -p "$(dirname '%s')" && sudo cp /dev/stdin '%s'`, remotePath, remotePath))
 		return err
 	}
 

--- a/integration_test/gce/gce_testing_test.go
+++ b/integration_test/gce/gce_testing_test.go
@@ -34,7 +34,9 @@ package gce_test
 import (
 	"bytes"
 	"context"
+	"crypto/md5"
 	"crypto/rand"
+	"fmt"
 	"io"
 	"log"
 	"os"

--- a/integration_test/gce/gce_testing_test.go
+++ b/integration_test/gce/gce_testing_test.go
@@ -410,7 +410,7 @@ func calculateRemoteMD5(ctx context.Context, logger *log.Logger, vm *gce.VM, pat
 		return strings.ToLower(strings.TrimSpace(output.Stdout)), nil
 	}
 
-	output, err := gce.RunRemotely(ctx, logger, vm, "", fmt.Sprintf("set -o pipefail; md5sum '%s' | cut --field 1 --delimiter ' '", path))
+	output, err := gce.RunRemotely(ctx, logger, vm, "", fmt.Sprintf("set -o pipefail; sudo md5sum '%s' | cut --field 1 --delimiter ' '", path))
 	if err != nil {
 		return "", err
 	}
@@ -431,7 +431,6 @@ func TestUploadContent(t *testing.T) {
 			randomBytes(t, 100_000_000),
 		}
 		// Chosen to be platform agnostic, and as a bonus, requires sudo on Linux.
-		// TODO: Test a file location that requires Administrator access on Windows.
 		path := "/test_upload_content"
 		for _, data := range cases {
 			if err := gce.UploadContent(ctx, logger.ToMainLog(), vm, bytes.NewReader(data), path); err != nil {


### PR DESCRIPTION
## Description

This PR is effectively undoing cl/378416757, because `RunRemotelyStdin` has been fixed (https://github.com/GoogleCloudPlatform/ops-agent/pull/1636) to handle large stdin values.

This PR also adds some tests for `UploadContent`, including a test that failed prior to https://github.com/GoogleCloudPlatform/ops-agent/pull/1636 (but passes now).

This PR also changes the contract of `UploadContent` to no longer automatically create enclosing directories; instead the burden of doing that has been moved to the caller. Only one callsite needed to be fixed, though that required implementing a new function `makeParentDirectory` in `ops_agent_test.go`.

The net effect of this PR is that:

- `UploadContent` doesn't depend on InstallGsutilIfNeeded anymore
- `UploadContent` doesn't use GCS or `TRANSFERS_BUCKET` on linux anymore
- `InstallGsutilIfNeeded` can move out of the core gce_testing.go library into the agents library, the only place that it is still used.

## Related issue
cleanup

## How has this been tested?
automated tests passed, plus I ran `gce_testing_test.go` manually, also passing.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
