### PR TITLE
Internal: use gotestsum in go_test.sh

### DIFF
--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -212,8 +212,10 @@ if [[ "${SHORT:-false}" == "true" ]]; then
   args+=( "-test.short" )
 fi
 
+go install gotest.tools/gotestsum@latest
+
 TEST_UNDECLARED_OUTPUTS_DIR="${LOGS_DIR}" \
-  go test -v "${TEST_SUITE_NAME}.go" \
+  gotestsum --rerun-fails -v "${TEST_SUITE_NAME}.go" \
   "${args[@]}" \
   2>&1 \
   | tee "${STDERR_STDOUT_FILE}"

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -215,7 +215,7 @@ fi
 go install gotest.tools/gotestsum@latest
 
 TEST_UNDECLARED_OUTPUTS_DIR="${LOGS_DIR}" \
-  gotestsum --rerun-fails --format=standard-verbose "${TEST_SUITE_NAME}.go" \
+  gotestsum --rerun-fails -- -v "${TEST_SUITE_NAME}.go" \
   "${args[@]}" \
   2>&1 \
   | tee "${STDERR_STDOUT_FILE}"

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -207,11 +207,9 @@ if [[ "${SHORT:-false}" == "true" ]]; then
   args+=( "-test.short" )
 fi
 
-# "${GOTESTSUM_ARGS:-}"
-
 TEST_UNDECLARED_OUTPUTS_DIR="${LOGS_DIR}" \
   gotestsum \
-  --rerun-fails \
+  "${GOTESTSUM_ARGS:-}" \
   --packages=./"${TEST_SUITE_NAME}.go" \
   --junitfile "${LOGS_DIR}/sponge_log.xml" \
   -- -v  \

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -211,7 +211,7 @@ go install gotest.tools/gotestsum@latest
 
 TEST_UNDECLARED_OUTPUTS_DIR="${LOGS_DIR}" \
   gotestsum --rerun-fails \
-  --packages="${TEST_SUITE_NAME}.go" \
+  --packages=./"${TEST_SUITE_NAME}.go" \
   --junitfile "${LOGS_DIR}/sponge_log.xml" \
   -- -v  \
   "${args[@]}" \

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -215,7 +215,7 @@ fi
 go install gotest.tools/gotestsum@latest
 
 TEST_UNDECLARED_OUTPUTS_DIR="${LOGS_DIR}" \
-  gotestsum --rerun-fails -v "${TEST_SUITE_NAME}.go" \
+  gotestsum --rerun-fails -- -v "${TEST_SUITE_NAME}.go" \
   "${args[@]}" \
   2>&1 \
   | tee "${STDERR_STDOUT_FILE}"

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -209,10 +209,9 @@ fi
 
 TEST_UNDECLARED_OUTPUTS_DIR="${LOGS_DIR}" \
   gotestsum \
-  "${GOTESTSUM_ARGS:-}" \
   --packages=./"${TEST_SUITE_NAME}.go" \
-  --junitfile "${LOGS_DIR}/sponge_log.xml" \
-  -- -v  \
-  "${args[@]}" \
+  --format=standard-verbose \
+  --junitfile="${LOGS_DIR}/sponge_log.xml" \
+  -- "${args[@]}" \
   2>&1 \
   | tee "${STDERR_STDOUT_FILE}"

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -215,7 +215,7 @@ fi
 go install gotest.tools/gotestsum@latest
 
 TEST_UNDECLARED_OUTPUTS_DIR="${LOGS_DIR}" \
-  gotestsum --rerun-fails -- -v "${TEST_SUITE_NAME}.go" \
+  gotestsum --rerun-fails --format=standard-verbose "${TEST_SUITE_NAME}.go" \
   "${args[@]}" \
   2>&1 \
   | tee "${STDERR_STDOUT_FILE}"

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -193,11 +193,6 @@ if [[ "${TEST_SUITE_NAME}" == "os_config_test" ]]; then
 fi
 
 STDERR_STDOUT_FILE="${KOKORO_ARTIFACTS_DIR}/test_stderr_stdout.txt"
-function produce_xml() {
-  cat "${STDERR_STDOUT_FILE}" | "$(go env GOPATH)/bin/go-junit-report" > "${LOGS_DIR}/sponge_log.xml"
-}
-# Always run produce_xml on exit, whether the test passes or fails.
-trap produce_xml EXIT
 
 # Boost the max number of open files from 1024 to 1 million.
 ulimit -n 1000000
@@ -215,7 +210,10 @@ fi
 go install gotest.tools/gotestsum@latest
 
 TEST_UNDECLARED_OUTPUTS_DIR="${LOGS_DIR}" \
-  gotestsum --rerun-fails --packages="${TEST_SUITE_NAME}.go" -- -v  \
+  gotestsum --rerun-fails \
+  --packages="${TEST_SUITE_NAME}.go" \
+  --junitfile "${LOGS_DIR}/sponge_log.xml" \
+  -- -v  \
   "${args[@]}" \
   2>&1 \
   | tee "${STDERR_STDOUT_FILE}"

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -207,10 +207,11 @@ if [[ "${SHORT:-false}" == "true" ]]; then
   args+=( "-test.short" )
 fi
 
-go install gotest.tools/gotestsum@latest
+# "${GOTESTSUM_ARGS:-}"
 
 TEST_UNDECLARED_OUTPUTS_DIR="${LOGS_DIR}" \
-  gotestsum --rerun-fails \
+  gotestsum \
+  --rerun-fails \
   --packages=./"${TEST_SUITE_NAME}.go" \
   --junitfile "${LOGS_DIR}/sponge_log.xml" \
   -- -v  \

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -215,7 +215,7 @@ fi
 go install gotest.tools/gotestsum@latest
 
 TEST_UNDECLARED_OUTPUTS_DIR="${LOGS_DIR}" \
-  gotestsum --rerun-fails -- -v "${TEST_SUITE_NAME}.go" \
+  gotestsum --rerun-fails --packages="${TEST_SUITE_NAME}.go" -- -v  \
   "${args[@]}" \
   2>&1 \
   | tee "${STDERR_STDOUT_FILE}"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

`gotestsum` is a [wrapper](https://github.com/gotestyourself/gotestsum) for `go test`.

We can rerun flaky tests easily with the `--rerun-fails`, which should significantly speed up our release builds where we currently rerun the entire suite (saving quota too!).

This also means we no longer need `go-junit-report`, as `gotestsum` provides identical functionality. This may let us upgrade our version of go we use in our test runner.

## Related issue
https://github.com/GoogleCloudPlatform/ops-agent/pull/1644

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
