### PR TITLE
Testing: Retry "database is locked" flakes

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1344,6 +1344,9 @@ func CreateInstance(origCtx context.Context, logger *log.Logger, options VMOptio
 			strings.Contains(err.Error(), "Internal error") ||
 			// Instance creation can also fail due to service unavailability.
 			strings.Contains(err.Error(), "currently unavailable") ||
+			// This error is a consequence of running gcloud concurrently, which is actually
+			// unsupported. In the absence of a better fix, just retry such errors.
+		        strings.Contains(err.Error(), "database is locked") ||
 			// windows-*-core instances sometimes fail to be ssh-able: b/305721001
 			(IsWindowsCore(options.Platform) && strings.Contains(err.Error(), windowsStartupFailedMessage)) ||
 			// SLES instances sometimes fail to be ssh-able: b/186426190


### PR DESCRIPTION
## Description
Most of the flakes that I see now look like `gcloud crashed (OperationalError): database is locked` when trying to create a VM. We can just retry those. Ideally gcloud would support running concurrently and do things like block on the database lock instead of crashing, but for now it doesn't support that officially (although we do it a LOT and it mostly works). Semi-ideally we could maybe isolate separate gcloud instances from each other by configuring them to run against separate databases/homedirs/whatever. I haven't looked into that very much, but it seems like a pain and might have a performance penalty if it's always regenerating its database or whatever. Another possible fix is to stop using gcloud, but that is a huge change with many implications.

Full error:
```
SetupVM() error creating instance: Command failed: [gcloud beta compute instances create github-test-20240319-84276-49a5a294-ff1e-422f-89e7-6cd98240b380 --project=stackdriver-test-143416 --zone=us-central1-b --machine-type=t2a-standard-2 --image-project=debian-cloud --image-family=debian-11-arm64 --image-family-scope=global --network=default --format=json --metadata=enable-oslogin=false,ssh-keys=test_user:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC+xLM2Ud7lFwWHY+svelHKzxzjg4rVAUNr+TtDdiK7TVw2mYVAkaTbSlDnyWHhevzNB5QTxgIWC+cE6FbiwUUs2oi4GSGUWvCAr6UOp45HlUkf1ym/orYxGQAtaOTwXmlTvEPn3zwk04mmd/9suH8Rj79G2cMPEG+JWYgrqhXbCR8FUIQyq9odAZBeNplE694qzaSL+fgMPI0mj8lXMRAHWVTy+OSGEDMeoI1fCdkgICXbqZDhrwk+1sKVmQkwd6HKll2ndzOR7RkADoBJCsssvkOT5NQdX5h3Hum/gsEjr0rBGKn26TllDwe/YVmPjGv8ltN0HoLHNdPOOXpAJzTBK99z6zp5sZ3rjC7XGcF+5uVqbrtBHEmozZMuwijc714zGWdEr3+ezT2BHEm5Osm3OIO9i5briOjxjw3gC1XA6fTPV7EV06Y4hh+xGG5vskfFtQNoJJAi3Nit3ym0uuUsV+fy7fsWc3SOBD+pG9r+8nPVoE9ksD0BwizIf9bHQYs= test_user
        ,serial-port-logging-enable=true --labels=kokoro_build_id=6b5b1491-3c8f-4ef8-8a67-e62e73bcef05 --service-account=[build-and-test-external@stackdriver-test-143416.iam.gserviceaccount.com](mailto:build-and-test-external@stackdriver-test-143416.iam.gserviceaccount.com) --no-address --max-run-duration=3h --instance-termination-action=DELETE --provisioning-model=STANDARD]
        exit status 1
        stdout+stderr: ERROR: gcloud crashed (OperationalError): database is locked
        
        If you would like to report this issue, please run the following command:
          gcloud feedback
        
        To check gcloud for common problems, please run the following command:
          gcloud info --run-diagnostics
```

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
