### PR TITLE
Testing: allow "not found" when deleting VMs

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1444,6 +1444,10 @@ func DeleteInstance(logger *log.Logger, vm *VM) error {
 				"--zone=" + vm.Zone,
 				vm.Name,
 			})
+		// TODO: comment, also double check logic
+		if err != nil && strings.Contains(err.Error(), "not found") && attempt > 1 {
+			return nil
+		}
 		// GCE sometimes responds with 502 or 503 errors. Retry these errors
 		// (and other 50x errors for good measure), by returning them directly.
 		if err != nil && strings.Contains(err.Error(), "Error 50") {

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1436,7 +1436,9 @@ func DeleteInstance(logger *log.Logger, vm *VM) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 	backoffPolicy := backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(30*time.Second), 10), ctx)
+	attempt := 0
 	tryDelete := func() error {
+		attempt++
 		_, err := RunGcloud(ctx, logger, "",
 			[]string{
 				"compute", "instances", "delete",
@@ -1444,20 +1446,23 @@ func DeleteInstance(logger *log.Logger, vm *VM) error {
 				"--zone=" + vm.Zone,
 				vm.Name,
 			})
-		// TODO: comment, also double check logic
-		if err != nil && strings.Contains(err.Error(), "not found") && attempt > 1 {
+		if err == nil {
 			return nil
 		}
 		// GCE sometimes responds with 502 or 503 errors. Retry these errors
 		// (and other 50x errors for good measure), by returning them directly.
-		if err != nil && strings.Contains(err.Error(), "Error 50") {
+		if strings.Contains(err.Error(), "Error 50") {
 			return err
 		}
-		// Wrap other errors in backoff.Permanent() to avoid retrying those.
-		if err != nil {
-			return backoff.Permanent(err)
+		// "not found" can happen when a previous attempt actually did delete
+		// the VM but there was some communication problem along the way.
+		// Consider that a successful deletion. Only do this when there has
+		// been a previous attempt.
+		if strings.Contains(err.Error(), "not found") && attempt > 1 {
+			return nil
 		}
-		return nil
+		// Wrap other errors in backoff.Permanent() to avoid retrying those.
+		return backoff.Permanent(err)
 	}
 	err := backoff.Retry(tryDelete, backoffPolicy)
 	if err == nil {


### PR DESCRIPTION
## Description
Avoid flakes like https://source.cloud.google.com/results/invocations/78ac4601-e8f9-4f7d-a00e-3c1bbc126a97 that look like this:

```
2024/03/14 16:04:28 Running command: gcloud [compute instances delete --project=stackdriver-test-143416 --zone=us-central1-a github-test-20240314-1fde4-fa627d2a-f1f6-4331-87c6-f70db158fffe]
2024/03/14 16:05:10 exit code: 1
2024/03/14 16:05:10 stdout+stderr: ERROR: (gcloud.compute.instances.delete) Could not fetch resource:
  <title>Error 502 (Server Error)!!1</title>
 [snip]

2024/03/14 16:05:40 Running command: gcloud [compute instances delete --project=stackdriver-test-143416 --zone=us-central1-a github-test-20240314-1fde4-fa627d2a-f1f6-4331-87c6-f70db158fffe]
2024/03/14 16:05:41 exit code: 1
2024/03/14 16:05:41 stdout+stderr: ERROR: (gcloud.compute.instances.delete) Could not fetch resource:
 - The resource 'projects/stackdriver-test-143416/zones/us-central1-a/instances/github-test-20240314-1fde4-fa627d2a-f1f6-4331-87c6-f70db158fffe' was not found
```

Note that a previous attempt hit a 502 error (which is retried) but the VM did end up getting deleted. :/  This new logic will declare success in cases like that.

## Related issue
flake

## How has this been tested?
automated tests only

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
