### PR TITLE
Internal: Pass gotestsum_args via env vars

### DIFF
--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -197,23 +197,28 @@ STDERR_STDOUT_FILE="${KOKORO_ARTIFACTS_DIR}/test_stderr_stdout.txt"
 # Boost the max number of open files from 1024 to 1 million.
 ulimit -n 1000000
 
+# Set up some command line flags for "gotestsum".
+gotestsum_args=(
+  --packages=./"${TEST_SUITE_NAME}.go"
+  --format=standard-verbose
+  --junitfile="${LOGS_DIR}/sponge_log.xml"
+)
+if [[ -n "${GOTESTSUM_RERUN_FAILS:-}" ]]; then
+  go_test_args+=( "--rerun-rails=${GOTESTSUM_RERUN_FAILS}" )
+fi
+
 # Set up some command line flags for "go test".
-args=(
+go_test_args=(
   -test.parallel=1000
   -tags=integration_test
   -timeout=3h
 )
 if [[ "${SHORT:-false}" == "true" ]]; then
-  args+=( "-test.short" )
+  go_test_args+=( "-test.short" )
 fi
 
- # GOTESTSUM_ARGS is intentionally unquoted
 TEST_UNDECLARED_OUTPUTS_DIR="${LOGS_DIR}" \
-  gotestsum \
-  ${GOTESTSUM_ARGS:-} \
-  --packages=./"${TEST_SUITE_NAME}.go" \
-  --format=standard-verbose \
-  --junitfile="${LOGS_DIR}/sponge_log.xml" \
-  -- "${args[@]}" \
+  gotestsum "${gotestsum_args[@]}" \
+  -- "${go_test_args[@]}" \
   2>&1 \
   | tee "${STDERR_STDOUT_FILE}"

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -207,8 +207,6 @@ if [[ "${SHORT:-false}" == "true" ]]; then
   args+=( "-test.short" )
 fi
 
-GOTESTSUM_ARGS='--rerun-fails --rerun-fails-max-failures=5'
-
  # GOTESTSUM_ARGS is intentionally unquoted
 TEST_UNDECLARED_OUTPUTS_DIR="${LOGS_DIR}" \
   gotestsum \

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -207,6 +207,8 @@ if [[ "${SHORT:-false}" == "true" ]]; then
   args+=( "-test.short" )
 fi
 
+GOTESTSUM_ARGS='--rerun-fails --rerun-fails-max-failures=5'
+
  # GOTESTSUM_ARGS is intentionally unquoted
 TEST_UNDECLARED_OUTPUTS_DIR="${LOGS_DIR}" \
   gotestsum \

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -207,9 +207,10 @@ if [[ "${SHORT:-false}" == "true" ]]; then
   args+=( "-test.short" )
 fi
 
+ # GOTESTSUM_ARGS is intentionally unquoted
 TEST_UNDECLARED_OUTPUTS_DIR="${LOGS_DIR}" \
   gotestsum \
-  ${GOTESTSUM_ARGS:-} \ # intentionally unquoted
+  ${GOTESTSUM_ARGS:-} \
   --packages=./"${TEST_SUITE_NAME}.go" \
   --format=standard-verbose \
   --junitfile="${LOGS_DIR}/sponge_log.xml" \

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -204,7 +204,7 @@ gotestsum_args=(
   --junitfile="${LOGS_DIR}/sponge_log.xml"
 )
 if [[ -n "${GOTESTSUM_RERUN_FAILS:-}" ]]; then
-  go_test_args+=( "--rerun-rails=${GOTESTSUM_RERUN_FAILS}" )
+  go_test_args+=( "--rerun-fails=${GOTESTSUM_RERUN_FAILS}" )
 fi
 
 # Set up some command line flags for "go test".

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -208,7 +208,7 @@ if [[ "${SHORT:-false}" == "true" ]]; then
 fi
 
 TEST_UNDECLARED_OUTPUTS_DIR="${LOGS_DIR}" \
-  gotestsum \
+  gotestsum ${GOTESTSUM_ARGS} \
   --packages=./"${TEST_SUITE_NAME}.go" \
   --format=standard-verbose \
   --junitfile="${LOGS_DIR}/sponge_log.xml" \

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -208,7 +208,8 @@ if [[ "${SHORT:-false}" == "true" ]]; then
 fi
 
 TEST_UNDECLARED_OUTPUTS_DIR="${LOGS_DIR}" \
-  gotestsum ${GOTESTSUM_ARGS} \
+  gotestsum \
+  ${GOTESTSUM_ARGS} \ # intentionally unquoted
   --packages=./"${TEST_SUITE_NAME}.go" \
   --format=standard-verbose \
   --junitfile="${LOGS_DIR}/sponge_log.xml" \

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -209,7 +209,7 @@ fi
 
 TEST_UNDECLARED_OUTPUTS_DIR="${LOGS_DIR}" \
   gotestsum \
-  ${GOTESTSUM_ARGS} \ # intentionally unquoted
+  ${GOTESTSUM_ARGS:-} \ # intentionally unquoted
   --packages=./"${TEST_SUITE_NAME}.go" \
   --format=standard-verbose \
   --junitfile="${LOGS_DIR}/sponge_log.xml" \


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

For passing in flags such as `--rerun-fails`

## Related issue
[b/329867231](http://b/329867231)

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
