### PR TITLE
Testing: space out logging/metrics retries more

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -158,11 +158,11 @@ const (
 	SuggestedTimeout = 2 * time.Hour
 
 	// QueryMaxAttempts is the default number of retries when calling WaitForLog and WaitForMetricSeries.
-	// Retries are spaced by 5 seconds, so 80 retries denotes 6 minutes 40 seconds total.
-	QueryMaxAttempts              = 80 // 6 minutes 40 seconds total.
-	queryMaxAttemptsMetricMissing = 5  // 25 seconds total.
-	queryMaxAttemptsLogMissing    = 5  // 25 seconds total.
-	queryBackoffDuration          = 5 * time.Second
+	// Retries are spaced by 10 seconds, so 40 retries denotes 6 minutes 40 seconds total.
+	QueryMaxAttempts              = 40 // 6 minutes 40 seconds total.
+	queryMaxAttemptsMetricMissing = 5  // 50 seconds total.
+	queryMaxAttemptsLogMissing    = 5  // 50 seconds total.
+	queryBackoffDuration          = 10 * time.Second
 
 	// traceQueryDerate is the number of backoff durations to wait before retrying a trace query.
 	// Cloud Trace quota is incredibly low, and each call to ListTraces uses 25 quota tokens.


### PR DESCRIPTION
## Description
This increases the polling interval from 5 to 10 seconds, to avoid using up limited quota for querying the logging and monitoring APIs. Example flake: https://source.cloud.google.com/results/invocations/0a29a952-4284-4f1c-a93e-ea14252a714f

We are wasting a lot of that quota on queries that simply haven't appeared yet. Spacing it out more should help.

## Related issue
flake

## How has this been tested?
automated tests only

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
