### PR TITLE
Testing: Stop populating stderr_stdout.txt

### DIFF
--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -192,8 +192,6 @@ if [[ "${TEST_SUITE_NAME}" == "os_config_test" ]]; then
   export GCLOUD_TO_TEST
 fi
 
-STDERR_STDOUT_FILE="${KOKORO_ARTIFACTS_DIR}/test_stderr_stdout.txt"
-
 # Boost the max number of open files from 1024 to 1 million.
 ulimit -n 1000000
 
@@ -212,6 +210,4 @@ TEST_UNDECLARED_OUTPUTS_DIR="${LOGS_DIR}" \
   --packages=./"${TEST_SUITE_NAME}.go" \
   --format=standard-verbose \
   --junitfile="${LOGS_DIR}/sponge_log.xml" \
-  -- "${args[@]}" \
-  2>&1 \
-  | tee "${STDERR_STDOUT_FILE}"
+  -- "${args[@]}"


### PR DESCRIPTION
## Description
PR https://github.com/GoogleCloudPlatform/ops-agent/pull/1641 removed the place where we were using `test_stderr_stdout.txt`, so this PR just cleans up the now-unnecessary file.

## Related issue
none, cleanup

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
