### PR TITLE
Internal: update go_test.Dockerfile

### DIFF
--- a/kokoro/scripts/test/go_test.Dockerfile
+++ b/kokoro/scripts/test/go_test.Dockerfile
@@ -1,6 +1,6 @@
 # To edit this file, follow these instructions: go/sdi-integ-test#updating-the-test-runner-container.
 
-FROM golang:1.19-bullseye
+FROM golang:1.22-bullseye
 
 RUN curl -sSL https://sdk.cloud.google.com | bash
 
@@ -8,8 +8,6 @@ ENV PATH $PATH:/root/google-cloud-sdk/bin
 
 # Needed for --max-run-duration, see b/227348032.
 RUN gcloud components install beta
-
-RUN go install -v github.com/jstemmer/go-junit-report/v2@latest
 
 RUN go install gotest.tools/gotestsum@latest
 


### PR DESCRIPTION
## Description

1. Upgrade to go 1.22
2. remove now-unnecessary dependency on `go-junit-report`

## Related issue
none, cleanup

## How has this been tested?
Tested locally

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
