### PR TITLE
Internal: Install gotestsum from ':main' tag

### DIFF
--- a/kokoro/scripts/test/go_test.Dockerfile
+++ b/kokoro/scripts/test/go_test.Dockerfile
@@ -9,7 +9,7 @@ ENV PATH $PATH:/root/google-cloud-sdk/bin
 # Needed for --max-run-duration, see b/227348032.
 RUN gcloud components install beta
 
-RUN go install gotest.tools/gotestsum@latest
+RUN go install gotest.tools/gotestsum@main
 
 RUN apt-get update
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

A [bug](https://github.com/gotestyourself/gotestsum/pull/382) in `gotestsum` causes reruns with flags to fail in their latest release, but has been fixed at head. Switching our `gotestsum` version to adopt this fix.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
