### PR TITLE
Testing: Remove stdin argument from RunRemotely

### DIFF
--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -183,12 +183,12 @@ func RunOpsAgentDiagnostics(ctx context.Context, logger *logging.DirectoryLogger
 	// hang, so give them a shorter timeout to avoid hanging the whole test.
 	metricsCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	gce.RunRemotely(metricsCtx, logger.ToFile("fluent_bit_metrics.txt"), vm, "", "sudo curl -s localhost:20202/metrics")
-	gce.RunRemotely(metricsCtx, logger.ToFile("otel_metrics.txt"), vm, "", "sudo curl -s localhost:20201/metrics")
+	gce.RunRemotely(metricsCtx, logger.ToFile("fluent_bit_metrics.txt"), vm, "sudo curl -s localhost:20202/metrics")
+	gce.RunRemotely(metricsCtx, logger.ToFile("otel_metrics.txt"), vm, "sudo curl -s localhost:20201/metrics")
 
-	gce.RunRemotely(ctx, logger.ToFile("systemctl_status_for_ops_agent.txt"), vm, "", "sudo systemctl status google-cloud-ops-agent*")
+	gce.RunRemotely(ctx, logger.ToFile("systemctl_status_for_ops_agent.txt"), vm, "sudo systemctl status google-cloud-ops-agent*")
 
-	gce.RunRemotely(ctx, logger.ToFile("journalctl_output.txt"), vm, "", "sudo journalctl -xe")
+	gce.RunRemotely(ctx, logger.ToFile("journalctl_output.txt"), vm, "sudo journalctl -xe")
 
 	for _, log := range []string{
 		gce.SyslogLocation(vm.Platform),
@@ -201,21 +201,21 @@ func RunOpsAgentDiagnostics(ctx context.Context, logger *logging.DirectoryLogger
 		"/run/google-cloud-ops-agent-opentelemetry-collector/otel.yaml",
 	} {
 		_, basename := path.Split(log)
-		gce.RunRemotely(ctx, logger.ToFile(basename+txtSuffix), vm, "", "sudo cat "+log)
+		gce.RunRemotely(ctx, logger.ToFile(basename+txtSuffix), vm, "sudo cat "+log)
 	}
 }
 
 func runOpsAgentDiagnosticsWindows(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.VM) {
-	gce.RunRemotely(ctx, logger.ToFile("windows_System_log.txt"), vm, "", "Get-WinEvent -LogName System | Format-Table -AutoSize -Wrap")
+	gce.RunRemotely(ctx, logger.ToFile("windows_System_log.txt"), vm, "Get-WinEvent -LogName System | Format-Table -AutoSize -Wrap")
 
-	gce.RunRemotely(ctx, logger.ToFile("Get-Service_output.txt"), vm, "", "Get-Service google-cloud-ops-agent* | Format-Table -AutoSize -Wrap")
+	gce.RunRemotely(ctx, logger.ToFile("Get-Service_output.txt"), vm, "Get-Service google-cloud-ops-agent* | Format-Table -AutoSize -Wrap")
 
-	gce.RunRemotely(ctx, logger.ToFile("ops_agent_logs.txt"), vm, "", "Get-WinEvent -FilterHashtable @{ Logname='Application'; ProviderName='google-cloud-ops-agent' } | Format-Table -AutoSize -Wrap")
-	gce.RunRemotely(ctx, logger.ToFile("ops_agent_diagnostics_logs.txt"), vm, "", "Get-WinEvent -FilterHashtable @{ Logname='Application'; ProviderName='google-cloud-ops-agent-diagnostics' } | Format-Table -AutoSize -Wrap")
-	gce.RunRemotely(ctx, logger.ToFile("open_telemetry_agent_logs.txt"), vm, "", "Get-WinEvent -FilterHashtable @{ Logname='Application'; ProviderName='google-cloud-ops-agent-opentelemetry-collector' } | Format-Table -AutoSize -Wrap")
+	gce.RunRemotely(ctx, logger.ToFile("ops_agent_logs.txt"), vm, "Get-WinEvent -FilterHashtable @{ Logname='Application'; ProviderName='google-cloud-ops-agent' } | Format-Table -AutoSize -Wrap")
+	gce.RunRemotely(ctx, logger.ToFile("ops_agent_diagnostics_logs.txt"), vm, "Get-WinEvent -FilterHashtable @{ Logname='Application'; ProviderName='google-cloud-ops-agent-diagnostics' } | Format-Table -AutoSize -Wrap")
+	gce.RunRemotely(ctx, logger.ToFile("open_telemetry_agent_logs.txt"), vm, "Get-WinEvent -FilterHashtable @{ Logname='Application'; ProviderName='google-cloud-ops-agent-opentelemetry-collector' } | Format-Table -AutoSize -Wrap")
 	// Fluent-Bit has not implemented exporting logs to the Windows event log yet.
-	gce.RunRemotely(ctx, logger.ToFile("fluent_bit_agent_logs.txt"), vm, "", fmt.Sprintf("Get-Content -Path '%s' -Raw", `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\logging-module.log`))
-	gce.RunRemotely(ctx, logger.ToFile("health-checks.txt"), vm, "", fmt.Sprintf("Get-Content -Path '%s' -Raw", `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\health-checks.log`))
+	gce.RunRemotely(ctx, logger.ToFile("fluent_bit_agent_logs.txt"), vm, fmt.Sprintf("Get-Content -Path '%s' -Raw", `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\logging-module.log`))
+	gce.RunRemotely(ctx, logger.ToFile("health-checks.txt"), vm, fmt.Sprintf("Get-Content -Path '%s' -Raw", `C:\ProgramData\Google\Cloud Operations\Ops Agent\log\health-checks.log`))
 
 	for _, conf := range []string{
 		`C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml`,
@@ -225,7 +225,7 @@ func runOpsAgentDiagnosticsWindows(ctx context.Context, logger *logging.Director
 	} {
 		pathParts := strings.Split(conf, `\`)
 		basename := pathParts[len(pathParts)-1]
-		gce.RunRemotely(ctx, logger.ToFile(basename+txtSuffix), vm, "", fmt.Sprintf("Get-Content -Path '%s' -Raw", conf))
+		gce.RunRemotely(ctx, logger.ToFile(basename+txtSuffix), vm, fmt.Sprintf("Get-Content -Path '%s' -Raw", conf))
 	}
 }
 
@@ -266,7 +266,7 @@ func CheckServicesRunning(ctx context.Context, logger *log.Logger, vm *gce.VM, s
 	var err error
 	for _, service := range services {
 		if gce.IsWindows(vm.Platform) {
-			output, statusErr := gce.RunRemotely(ctx, logger, vm, "", fmt.Sprintf("(Get-Service -Name '%s').Status", service.ServiceName))
+			output, statusErr := gce.RunRemotely(ctx, logger, vm, fmt.Sprintf("(Get-Service -Name '%s').Status", service.ServiceName))
 			if statusErr != nil {
 				err = multierr.Append(err, fmt.Errorf("no service named %q could be found: %v", service.ServiceName, statusErr))
 				continue
@@ -278,7 +278,7 @@ func CheckServicesRunning(ctx context.Context, logger *log.Logger, vm *gce.VM, s
 			}
 			continue
 		}
-		if _, statusErr := gce.RunRemotely(ctx, logger, vm, "", fmt.Sprintf("sudo service %s status", service.ServiceName)); statusErr != nil {
+		if _, statusErr := gce.RunRemotely(ctx, logger, vm, fmt.Sprintf("sudo service %s status", service.ServiceName)); statusErr != nil {
 			err = multierr.Append(err, fmt.Errorf("RunRemotely(): status of %s was not OK. error was: %v", service.ServiceName, statusErr))
 		}
 	}
@@ -317,7 +317,7 @@ func CheckServicesNotRunning(ctx context.Context, logger *log.Logger, vm *gce.VM
 			// We currently only see case #1, but let's permit case #2 as well.
 			// The following command should output nothing, or maybe just a blank
 			// line, in either case.
-			output, err := gce.RunRemotely(ctx, logger, vm, "", fmt.Sprintf("Get-Service | Where-Object {$_.Name -eq '%s' -and $_.Status -eq 'Running'}", service.ServiceName))
+			output, err := gce.RunRemotely(ctx, logger, vm, fmt.Sprintf("Get-Service | Where-Object {$_.Name -eq '%s' -and $_.Status -eq 'Running'}", service.ServiceName))
 			if err != nil {
 				return fmt.Errorf("CheckServicesNotRunning(): error looking up running services named %v: %v", service.ServiceName, err)
 			}
@@ -329,7 +329,7 @@ func CheckServicesNotRunning(ctx context.Context, logger *log.Logger, vm *gce.VM
 		if service.ServiceName == "google-fluentd" {
 			continue // TODO(b/159817885): Assert that google-fluentd is not running.
 		}
-		if _, err := gce.RunRemotely(ctx, logger, vm, "", fmt.Sprintf("! sudo service %s status", service.ServiceName)); err != nil {
+		if _, err := gce.RunRemotely(ctx, logger, vm, fmt.Sprintf("! sudo service %s status", service.ServiceName)); err != nil {
 			return fmt.Errorf("CheckServicesNotRunning(): command could not be run or status of %s was unexpectedly OK. err: %v", service.ServiceName, err)
 		}
 	}
@@ -340,7 +340,7 @@ func CheckServicesNotRunning(ctx context.Context, logger *log.Logger, vm *gce.VM
 func tryInstallPackages(ctx context.Context, logger *log.Logger, vm *gce.VM, pkgs []string) error {
 	pkgsString := strings.Join(pkgs, " ")
 	if gce.IsWindows(vm.Platform) {
-		_, err := gce.RunRemotely(ctx, logger, vm, "", fmt.Sprintf("googet -noconfirm install %s", pkgsString))
+		_, err := gce.RunRemotely(ctx, logger, vm, fmt.Sprintf("googet -noconfirm install %s", pkgsString))
 		return err
 	}
 	cmd := ""
@@ -356,7 +356,7 @@ func tryInstallPackages(ctx context.Context, logger *log.Logger, vm *gce.VM, pkg
 	} else {
 		return fmt.Errorf("tryInstallPackages() doesn't support platform %q", vm.Platform)
 	}
-	_, err := gce.RunRemotely(ctx, logger, vm, "", cmd)
+	_, err := gce.RunRemotely(ctx, logger, vm, cmd)
 	return err
 }
 
@@ -375,7 +375,7 @@ func InstallPackages(ctx context.Context, logger *log.Logger, vm *gce.VM, pkgs [
 func UninstallPackages(ctx context.Context, logger *log.Logger, vm *gce.VM, pkgs []string) error {
 	pkgsString := strings.Join(pkgs, " ")
 	if gce.IsWindows(vm.Platform) {
-		if _, err := gce.RunRemotely(ctx, logger, vm, "", fmt.Sprintf("googet -noconfirm remove %s", pkgsString)); err != nil {
+		if _, err := gce.RunRemotely(ctx, logger, vm, fmt.Sprintf("googet -noconfirm remove %s", pkgsString)); err != nil {
 			return fmt.Errorf("could not uninstall %s. err: %v", pkgsString, err)
 		}
 		return nil
@@ -393,7 +393,7 @@ func UninstallPackages(ctx context.Context, logger *log.Logger, vm *gce.VM, pkgs
 	} else {
 		return fmt.Errorf("UninstallPackages() doesn't support platform %q", vm.Platform)
 	}
-	if _, err := gce.RunRemotely(ctx, logger, vm, "", cmd); err != nil {
+	if _, err := gce.RunRemotely(ctx, logger, vm, cmd); err != nil {
 		return fmt.Errorf("could not uninstall %s. err: %v", pkgsString, err)
 	}
 	return nil
@@ -406,7 +406,7 @@ func checkPackages(ctx context.Context, logger *log.Logger, vm *gce.VM, pkgs []s
 		errPrefix = "not "
 	}
 	if gce.IsWindows(vm.Platform) {
-		output, err := gce.RunRemotely(ctx, logger, vm, "", "googet installed")
+		output, err := gce.RunRemotely(ctx, logger, vm, "googet installed")
 		if err != nil {
 			return err
 		}
@@ -445,7 +445,7 @@ func checkPackages(ctx context.Context, logger *log.Logger, vm *gce.VM, pkgs []s
 		} else {
 			return fmt.Errorf("checkPackages() does not support platform: %s", vm.Platform)
 		}
-		if _, err := gce.RunRemotely(ctx, logger, vm, "", cmd); err != nil {
+		if _, err := gce.RunRemotely(ctx, logger, vm, cmd); err != nil {
 			return fmt.Errorf("command could not be run or %q was unexpectedly %sinstalled. err: %v", pkg, errPrefix, err)
 		}
 	}
@@ -500,7 +500,7 @@ func StripTildeSuffix(version string) string {
 }
 
 func fetchPackageVersionWindows(ctx context.Context, logger *log.Logger, vm *gce.VM, pkg string) (semver.Version, error) {
-	output, err := gce.RunRemotely(ctx, logger, vm, "", "googet installed -info "+pkg)
+	output, err := gce.RunRemotely(ctx, logger, vm, "googet installed -info "+pkg)
 	if err != nil {
 		return semver.Version{}, err
 	}
@@ -544,7 +544,7 @@ func fetchPackageVersion(ctx context.Context, logger *log.Logger, vm *gce.VM, pk
 		if IsRPMBased(vm.Platform) {
 			cmd = `rpm --query --queryformat=%\{VERSION} ` + pkg
 		}
-		output, err := gce.RunRemotely(ctx, logger, vm, "", cmd)
+		output, err := gce.RunRemotely(ctx, logger, vm, cmd)
 		if err != nil {
 			return err
 		}
@@ -640,7 +640,7 @@ func RunInstallFuncWithRetry(ctx context.Context, logger *log.Logger, vm *gce.VM
 		err := installFunc()
 		if err != nil && shouldRetry(err) && strings.HasPrefix(vm.Platform, "rhel-8-") && strings.HasSuffix(vm.Platform, "-sap-ha") {
 			logger.Println("attempting recovery steps from https://access.redhat.com/discussions/4656371 so that subsequent attempts are more likely to succeed... see b/189950957")
-			gce.RunRemotely(ctx, logger, vm, "", "sudo dnf clean all && sudo rm -r /var/cache/dnf && sudo dnf upgrade")
+			gce.RunRemotely(ctx, logger, vm, "sudo dnf clean all && sudo rm -r /var/cache/dnf && sudo dnf upgrade")
 		}
 		if err != nil && !shouldRetry(err) {
 			err = backoff.Permanent(err)
@@ -659,7 +659,7 @@ func InstallStandaloneWindowsLoggingAgent(ctx context.Context, logger *log.Logge
 	// The command needed to be adjusted to work in a non-GUI context.
 	cmd := `(New-Object Net.WebClient).DownloadFile("https://dl.google.com/cloudagents/windows/StackdriverLogging-v1-16.exe", "${env:UserProfile}\StackdriverLogging-v1-16.exe")
 		Start-Process -FilePath "${env:UserProfile}\StackdriverLogging-v1-16.exe" -ArgumentList "/S" -Wait -NoNewWindow`
-	_, err := gce.RunRemotely(ctx, logger, vm, "", cmd)
+	_, err := gce.RunRemotely(ctx, logger, vm, cmd)
 	return err
 }
 
@@ -670,7 +670,7 @@ func InstallStandaloneWindowsMonitoringAgent(ctx context.Context, logger *log.Lo
 	// The command needed to be adjusted to work in a non-GUI context.
 	cmd := `(New-Object Net.WebClient).DownloadFile("https://repo.stackdriver.com/windows/StackdriverMonitoring-GCM-46.exe", "${env:UserProfile}\StackdriverMonitoring-GCM-46.exe")
 		Start-Process -FilePath "${env:UserProfile}\StackdriverMonitoring-GCM-46.exe" -ArgumentList "/S" -Wait -NoNewWindow`
-	_, err := gce.RunRemotely(ctx, logger, vm, "", cmd)
+	_, err := gce.RunRemotely(ctx, logger, vm, cmd)
 	return err
 }
 
@@ -760,13 +760,13 @@ func InstallOpsAgent(ctx context.Context, logger *log.Logger, vm *gce.VM, locati
 		// (https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/installation)
 		// and keeping them in sync is encouraged so that we are testing the
 		// same commands that our customers are running.
-		if _, err := gce.RunRemotely(ctx, logger, vm, "", `(New-Object Net.WebClient).DownloadFile("https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.ps1", "${env:UserProfile}\add-google-cloud-ops-agent-repo.ps1")`); err != nil {
+		if _, err := gce.RunRemotely(ctx, logger, vm, `(New-Object Net.WebClient).DownloadFile("https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.ps1", "${env:UserProfile}\add-google-cloud-ops-agent-repo.ps1")`); err != nil {
 			return fmt.Errorf("InstallOpsAgent() failed to download repo script: %w", err)
 		}
 		runScript := func() error {
 			scriptCmd := fmt.Sprintf(`%s
 & "${env:UserProfile}\add-google-cloud-ops-agent-repo.ps1" -AlsoInstall`, windowsEnvironment(preservedEnvironment))
-			_, err := gce.RunRemotely(ctx, logger, vm, "", scriptCmd)
+			_, err := gce.RunRemotely(ctx, logger, vm, scriptCmd)
 			return err
 		}
 		// TODO: b/202526819 - Remove retries once the script does retries internally.
@@ -777,13 +777,13 @@ func InstallOpsAgent(ctx context.Context, logger *log.Logger, vm *gce.VM, locati
 	}
 
 	if _, err := gce.RunRemotely(ctx,
-		logger, vm, "", "curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh"); err != nil {
+		logger, vm, "curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh"); err != nil {
 		return fmt.Errorf("InstallOpsAgent() failed to download repo script: %w", err)
 	}
 
 	runInstallScript := func() error {
 		envVars := linuxEnvironment(preservedEnvironment)
-		_, err := gce.RunRemotely(ctx, logger, vm, "", "sudo "+envVars+" bash -x add-google-cloud-ops-agent-repo.sh --also-install")
+		_, err := gce.RunRemotely(ctx, logger, vm, "sudo "+envVars+" bash -x add-google-cloud-ops-agent-repo.sh --also-install")
 		return err
 	}
 	if err := RunInstallFuncWithRetry(ctx, logger, vm, runInstallScript); err != nil {
@@ -799,7 +799,7 @@ func SetupOpsAgent(ctx context.Context, logger *log.Logger, vm *gce.VM, config s
 
 // restartOpsAgent restarts the Ops Agent and waits for it to become available.
 func restartOpsAgent(ctx context.Context, logger *log.Logger, vm *gce.VM) error {
-	if _, err := gce.RunRemotely(ctx, logger, vm, "", restartOpsAgentForPlatform(vm.Platform)); err != nil {
+	if _, err := gce.RunRemotely(ctx, logger, vm, restartOpsAgentForPlatform(vm.Platform)); err != nil {
 		return fmt.Errorf("restartOpsAgent() failed to restart ops agent: %v", err)
 	}
 	// Give agents time to shut down. Fluent-Bit's default shutdown grace period
@@ -889,24 +889,24 @@ func InstallPackageFromGCS(ctx context.Context, logger *log.Logger, vm *gce.VM, 
 	if gce.IsWindows(vm.Platform) {
 		return installWindowsPackageFromGCS(ctx, logger, vm, gcsPath)
 	}
-	if _, err := gce.RunRemotely(ctx, logger, vm, "", "mkdir -p /tmp/agentUpload"); err != nil {
+	if _, err := gce.RunRemotely(ctx, logger, vm, "mkdir -p /tmp/agentUpload"); err != nil {
 		return err
 	}
 	if err := gce.InstallGsutilIfNeeded(ctx, logger, vm); err != nil {
 		return err
 	}
-	if _, err := gce.RunRemotely(ctx, logger, vm, "", "sudo gsutil cp -r "+gcsPath+"/* /tmp/agentUpload"); err != nil {
+	if _, err := gce.RunRemotely(ctx, logger, vm, "sudo gsutil cp -r "+gcsPath+"/* /tmp/agentUpload"); err != nil {
 		return fmt.Errorf("error copying down agent package from GCS: %v", err)
 	}
 	// Print the contents of /tmp/agentUpload into the logs.
-	if _, err := gce.RunRemotely(ctx, logger, vm, "", "ls /tmp/agentUpload"); err != nil {
+	if _, err := gce.RunRemotely(ctx, logger, vm, "ls /tmp/agentUpload"); err != nil {
 		return err
 	}
-	if _, err := gce.RunRemotely(ctx, logger, vm, "", "rm /tmp/agentUpload/*dbgsym* || echo nothing to delete"); err != nil {
+	if _, err := gce.RunRemotely(ctx, logger, vm, "rm /tmp/agentUpload/*dbgsym* || echo nothing to delete"); err != nil {
 		return err
 	}
 	if IsRPMBased(vm.Platform) {
-		if _, err := gce.RunRemotely(ctx, logger, vm, "", "sudo rpm --upgrade -v --force /tmp/agentUpload/*"); err != nil {
+		if _, err := gce.RunRemotely(ctx, logger, vm, "sudo rpm --upgrade -v --force /tmp/agentUpload/*"); err != nil {
 			return fmt.Errorf("error installing agent from .rpm file: %v", err)
 		}
 		return nil
@@ -916,7 +916,7 @@ func InstallPackageFromGCS(ctx context.Context, logger *log.Logger, vm *gce.VM, 
 	// 1. install stable package from Rapture
 	// 2. install just-built package from GCS
 	// Nor do I know why apt considers that sequence to be a downgrade.
-	if _, err := gce.RunRemotely(ctx, logger, vm, "", "sudo apt install --allow-downgrades --yes --verbose-versions /tmp/agentUpload/*"); err != nil {
+	if _, err := gce.RunRemotely(ctx, logger, vm, "sudo apt install --allow-downgrades --yes --verbose-versions /tmp/agentUpload/*"); err != nil {
 		return fmt.Errorf("error installing agent from .deb file: %v", err)
 	}
 	return nil
@@ -924,13 +924,13 @@ func InstallPackageFromGCS(ctx context.Context, logger *log.Logger, vm *gce.VM, 
 
 // Installs the agent package from GCS (see packagesInGCS) onto the given Windows VM.
 func installWindowsPackageFromGCS(ctx context.Context, logger *log.Logger, vm *gce.VM, gcsPath string) error {
-	if _, err := gce.RunRemotely(ctx, logger, vm, "", "New-Item -ItemType directory -Path C:\\agentUpload"); err != nil {
+	if _, err := gce.RunRemotely(ctx, logger, vm, "New-Item -ItemType directory -Path C:\\agentUpload"); err != nil {
 		return err
 	}
-	if _, err := gce.RunRemotely(ctx, logger, vm, "", fmt.Sprintf("gsutil cp -r %s/*.goo C:\\agentUpload", gcsPath)); err != nil {
+	if _, err := gce.RunRemotely(ctx, logger, vm, fmt.Sprintf("gsutil cp -r %s/*.goo C:\\agentUpload", gcsPath)); err != nil {
 		return fmt.Errorf("error copying down agent package from GCS: %v", err)
 	}
-	if _, err := gce.RunRemotely(ctx, logger, vm, "", "googet -noconfirm -verbose install -reinstall (Get-ChildItem C:\\agentUpload\\*.goo | Select-Object -Expand FullName)"); err != nil {
+	if _, err := gce.RunRemotely(ctx, logger, vm, "googet -noconfirm -verbose install -reinstall (Get-ChildItem C:\\agentUpload\\*.goo | Select-Object -Expand FullName)"); err != nil {
 		return fmt.Errorf("error installing agent from .goo file: %v", err)
 	}
 	return nil

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -966,7 +966,7 @@ func RunScriptRemotely(ctx context.Context, logger *log.Logger, vm *VM, scriptCo
 	// one to put scriptContents into a file and another to execute the script.
 	//
 	// To test changes to this command, please run gce_testing_test.go (manually).
-	return RunRemotelyStdin(ctx, logger, vm, scriptContents, "cat - > "+scriptPath+" && sudo "+envVarMapToBashPrefix(env)+"bash -x "+scriptPath+" "+flagsStr)
+	return RunRemotelyStdin(ctx, logger, vm, strings.NewReader(scriptContents), "cat - > "+scriptPath+" && sudo "+envVarMapToBashPrefix(env)+"bash -x "+scriptPath+" "+flagsStr)
 }
 
 // MapToCommaSeparatedList converts a map of key-value pairs into a form that

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -815,14 +815,11 @@ func wrapPowershellCommand(command string) (string, error) {
 //
 // 'command' is what to run on the machine. Example: "cat /tmp/foo; echo hello"
 // For extremely long commands, use RunScriptRemotely instead.
-// 'stdin' is what to supply to the command on stdin. It is usually "".
-// TODO: Remove the stdin parameter. Any callsite that needs to pass
-// data over standard input should use RunRemotelyStdin.
 //
 // When making changes to this function, please test them by running
 // gce_testing_test.go (manually).
-func RunRemotely(ctx context.Context, logger *log.Logger, vm *VM, stdin string, command string) (_ CommandOutput, err error) {
-	return RunRemotelyStdin(ctx, logger, vm, strings.NewReader(stdin), command)
+func RunRemotely(ctx context.Context, logger *log.Logger, vm *VM, command string) (_ CommandOutput, err error) {
+	return RunRemotelyStdin(ctx, logger, vm, nil, command)
 }
 
 // RunRemotelyStdin is just like RunRemotely but it accepts an io.Reader
@@ -892,14 +889,14 @@ func UploadContent(ctx context.Context, logger *log.Logger, vm *VM, content io.R
 	}()
 
 	if IsWindows(vm.Platform) {
-		_, err = RunRemotely(ctx, logger, vm, "", fmt.Sprintf(`Read-GcsObject -Force -Bucket "%s" -ObjectName "%s" -OutFile "%s"`, object.BucketName(), object.ObjectName(), remotePath))
+		_, err = RunRemotely(ctx, logger, vm, fmt.Sprintf(`Read-GcsObject -Force -Bucket "%s" -ObjectName "%s" -OutFile "%s"`, object.BucketName(), object.ObjectName(), remotePath))
 		return err
 	}
 	if err := InstallGsutilIfNeeded(ctx, logger, vm); err != nil {
 		return err
 	}
 	objectPath := fmt.Sprintf("gs://%s/%s", object.BucketName(), object.ObjectName())
-	_, err = RunRemotely(ctx, logger, vm, "", fmt.Sprintf("sudo gsutil cp '%s' '%s'", objectPath, remotePath))
+	_, err = RunRemotely(ctx, logger, vm, fmt.Sprintf("sudo gsutil cp '%s' '%s'", objectPath, remotePath))
 	return err
 }
 
@@ -956,7 +953,7 @@ func RunScriptRemotely(ctx context.Context, logger *log.Logger, vm *VM, scriptCo
 		// script seems to work around this completely.
 		//
 		// To test changes to this command, please run gce_testing_test.go (manually).
-		return RunRemotely(ctx, logger, vm, "", envVarMapToPowershellPrefix(env)+"powershell -File "+scriptPath+" "+flagsStr)
+		return RunRemotely(ctx, logger, vm, envVarMapToPowershellPrefix(env)+"powershell -File "+scriptPath+" "+flagsStr)
 	}
 	scriptPath := uuid.NewString() + ".sh"
 	// Write the script contents to <UUID>.sh, then tell bash to execute it with -x
@@ -969,7 +966,7 @@ func RunScriptRemotely(ctx context.Context, logger *log.Logger, vm *VM, scriptCo
 	// one to put scriptContents into a file and another to execute the script.
 	//
 	// To test changes to this command, please run gce_testing_test.go (manually).
-	return RunRemotely(ctx, logger, vm, scriptContents, "cat - > "+scriptPath+" && sudo "+envVarMapToBashPrefix(env)+"bash -x "+scriptPath+" "+flagsStr)
+	return RunRemotelyStdin(ctx, logger, vm, scriptContents, "cat - > "+scriptPath+" && sudo "+envVarMapToBashPrefix(env)+"bash -x "+scriptPath+" "+flagsStr)
 }
 
 // MapToCommaSeparatedList converts a map of key-value pairs into a form that
@@ -998,11 +995,11 @@ const (
 func prepareSLES(ctx context.Context, logger *log.Logger, vm *VM) error {
 	backoffPolicy := backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(5*time.Second), 5), ctx) // 5 attempts.
 	err := backoff.Retry(func() error {
-		_, err := RunRemotely(ctx, logger, vm, "", "sudo /usr/sbin/registercloudguest --force")
+		_, err := RunRemotely(ctx, logger, vm, "sudo /usr/sbin/registercloudguest --force")
 		return err
 	}, backoffPolicy)
 	if err != nil {
-		RunRemotely(ctx, logger, vm, "", "sudo cat /var/log/cloudregister")
+		RunRemotely(ctx, logger, vm, "sudo cat /var/log/cloudregister")
 		return fmt.Errorf("error running registercloudguest: %v", err)
 	}
 
@@ -1014,11 +1011,11 @@ func prepareSLES(ctx context.Context, logger *log.Logger, vm *VM) error {
 		// timezone-java was selected arbitrarily as a package that:
 		// a) can be installed from the default repos, and
 		// b) isn't installed already.
-		_, zypperErr := RunRemotely(ctx, logger, vm, "", "sudo zypper --non-interactive --gpg-auto-import-keys refresh && sudo zypper --non-interactive install timezone-java")
+		_, zypperErr := RunRemotely(ctx, logger, vm, "sudo zypper --non-interactive --gpg-auto-import-keys refresh && sudo zypper --non-interactive install timezone-java")
 		return zypperErr
 	}, backoffPolicy)
 	if err != nil {
-		RunRemotely(ctx, logger, vm, "", "sudo cat /var/log/zypper.log")
+		RunRemotely(ctx, logger, vm, "sudo cat /var/log/zypper.log")
 	}
 	return err
 }
@@ -1271,7 +1268,7 @@ func attemptCreateInstance(ctx context.Context, logger *log.Logger, options VMOp
 	if IsSUSE(vm.Platform) {
 		// Set download.max_silent_tries to 5 (by default, it is commented out in
 		// the config file). This should help with issues like b/211003972.
-		if _, err := RunRemotely(ctx, logger, vm, "", "sudo sed -i -E 's/.*download.max_silent_tries.*/download.max_silent_tries = 5/g' /etc/zypp/zypp.conf"); err != nil {
+		if _, err := RunRemotely(ctx, logger, vm, "sudo sed -i -E 's/.*download.max_silent_tries.*/download.max_silent_tries = 5/g' /etc/zypp/zypp.conf"); err != nil {
 			return nil, fmt.Errorf("attemptCreateInstance() failed to configure retries in zypp.conf: %v", err)
 		}
 	}
@@ -1285,7 +1282,7 @@ func attemptCreateInstance(ctx context.Context, logger *log.Logger, options VMOp
 	if IsSUSE(vm.Platform) {
 		// Set ZYPP_LOCK_TIMEOUT so tests that use zypper don't randomly fail
 		// because some background process happened to be using zypper at the same time.
-		if _, err := RunRemotely(ctx, logger, vm, "", `echo 'ZYPP_LOCK_TIMEOUT=300' | sudo tee -a /etc/environment`); err != nil {
+		if _, err := RunRemotely(ctx, logger, vm, `echo 'ZYPP_LOCK_TIMEOUT=300' | sudo tee -a /etc/environment`); err != nil {
 			return nil, err
 		}
 	}
@@ -1293,7 +1290,7 @@ func attemptCreateInstance(ctx context.Context, logger *log.Logger, options VMOp
 	// Removing flaky rhel-7 repositories due to b/265341502
 	if isRHEL7SAPHA(vm.Platform) {
 		if _, err := RunRemotely(ctx,
-			logger, vm, "", `sudo yum -y --disablerepo=rhui-rhel*-7-* install yum-utils && sudo yum-config-manager --disable "rhui-rhel*-7-*"`); err != nil {
+			logger, vm, `sudo yum -y --disablerepo=rhui-rhel*-7-* install yum-utils && sudo yum-config-manager --disable "rhui-rhel*-7-*"`); err != nil {
 			return nil, fmt.Errorf("disabling flaky repos failed : %w", err)
 		}
 	}
@@ -1397,7 +1394,7 @@ func SetEnvironmentVariables(ctx context.Context, logger *log.Logger, vm *VM, en
 		for key, value := range envVariables {
 			envVariableCmd := fmt.Sprintf(`setx %s "%s" /M`, key, value)
 			logger.Println("envVariableCmd " + envVariableCmd)
-			if _, err := RunRemotely(ctx, logger, vm, "", envVariableCmd); err != nil {
+			if _, err := RunRemotely(ctx, logger, vm, envVariableCmd); err != nil {
 				return err
 			}
 		}
@@ -1417,13 +1414,13 @@ func SetEnvironmentVariables(ctx context.Context, logger *log.Logger, vm *VM, en
 	} {
 		dir := fmt.Sprintf("/etc/systemd/system/%s.service.d", service)
 		cmd := fmt.Sprintf(`sudo mkdir -p %s && echo -e '%s' | sudo tee %s/override.conf`, dir, override, dir)
-		if _, err := RunRemotely(ctx, logger, vm, "", cmd); err != nil {
+		if _, err := RunRemotely(ctx, logger, vm, cmd); err != nil {
 			return err
 		}
 	}
 	// Reload the systemd daemon to pick up the new settings edited in the previous command
 	daemonReload := "sudo systemctl daemon-reload"
-	_, err := RunRemotely(ctx, logger, vm, "", daemonReload)
+	_, err := RunRemotely(ctx, logger, vm, daemonReload)
 	return err
 }
 
@@ -1541,7 +1538,7 @@ func InstallGsutilIfNeeded(ctx context.Context, logger *log.Logger, vm *VM) erro
 	if IsWindows(vm.Platform) {
 		return nil
 	}
-	if _, err := RunRemotely(ctx, logger, vm, "", "sudo gsutil --version"); err == nil {
+	if _, err := RunRemotely(ctx, logger, vm, "sudo gsutil --version"); err == nil {
 		// Success, no need to install gsutil.
 		return nil
 	}
@@ -1620,7 +1617,7 @@ sudo chmod a+x /usr/bin/gsutil
 `
 	}
 
-	_, err := RunRemotely(ctx, logger, vm, "", installCmd)
+	_, err := RunRemotely(ctx, logger, vm, installCmd)
 	return err
 }
 
@@ -1743,7 +1740,7 @@ func waitForStartWindows(ctx context.Context, logger *log.Logger, vm *VM) error 
 		attempt++
 		ctx, cancel := context.WithTimeout(ctx, vmInitPokeSSHTimeout)
 		defer cancel()
-		output, err := RunRemotely(ctx, logger, vm, "", "'foo'")
+		output, err := RunRemotely(ctx, logger, vm, "'foo'")
 		logger.Printf("Printing 'foo' finished with err=%v, attempt #%d\noutput: %v",
 			err, attempt, output)
 		return err
@@ -1779,7 +1776,7 @@ func waitForStartLinux(ctx context.Context, logger *log.Logger, vm *VM) error {
 	isStartupDone := func() error {
 		ctx, cancel := context.WithTimeout(ctx, vmInitPokeSSHTimeout)
 		defer cancel()
-		output, err := RunRemotely(ctx, logger, vm, "", "systemctl is-system-running")
+		output, err := RunRemotely(ctx, logger, vm, "systemctl is-system-running")
 
 		// There are a few cases for what is-system-running returns:
 		// https://www.freedesktop.org/software/systemd/man/systemctl.html#is-system-running
@@ -1793,7 +1790,7 @@ func waitForStartLinux(ctx context.Context, logger *log.Logger, vm *VM) error {
 			// to run the test. There are various unnecessary services that could be
 			// failing, see b/185473981 and b/185182238 for some examples.
 			// But let's at least print out which services failed into the logs.
-			RunRemotely(ctx, logger, vm, "", "systemctl --failed")
+			RunRemotely(ctx, logger, vm, "systemctl --failed")
 			return nil
 		}
 		// There are several reasons this could be failing, but usually if we get
@@ -1813,7 +1810,7 @@ func waitForStartLinux(ctx context.Context, logger *log.Logger, vm *VM) error {
 		// TODO(b/259122953): wait until sudo is ready
 		backoffPolicy := backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(slesStartupSudoDelay), slesStartupSudoMaxAttempts), ctx)
 		err := backoff.Retry(func() error {
-			_, err := RunRemotely(ctx, logger, vm, "", "sudo ls /root")
+			_, err := RunRemotely(ctx, logger, vm, "sudo ls /root")
 			return err
 		}, backoffPolicy)
 		if err != nil {

--- a/integration_test/gce/gce_testing_test.go
+++ b/integration_test/gce/gce_testing_test.go
@@ -304,7 +304,7 @@ echo hello`,
 }
 
 // testRunRemotelyHelper runs all the given test cases on the given VM, checking
-// that RunRemotely and RunScriptRemotely report all expected errors and that
+// that RunRemotelyStdin and RunScriptRemotely report all expected errors and that
 // standard out/error are as expected.
 func testRunRemotelyHelper(ctx context.Context, t *testing.T, logger *log.Logger, vm *gce.VM, testCases []testCase) {
 	runners := []struct {

--- a/integration_test/soak_test/cmd/launcher/main.go
+++ b/integration_test/soak_test/cmd/launcher/main.go
@@ -87,7 +87,7 @@ func main() {
 // Pause updates for 35 days to avoid reboots (b/297357060) using:
 // https://stackoverflow.com/a/64862952/1188632
 func pauseWindowsUpdates(ctx context.Context, logger *log.Logger, vm *gce.VM) (gce.CommandOutput, error) {
-	return gce.RunRemotely(ctx, logger, vm, "", `
+	return gce.RunRemotely(ctx, logger, vm, `
 $ErrorActionPreference = 'Stop'
 
 $now = Get-Date
@@ -191,7 +191,7 @@ $pythonInstallDir = "$env:SystemDrive\Python"
 $pythonPath = "$pythonInstallDir\python.exe"
 Start-Process "$tempDir\$pythonInstallerName" -Wait -ArgumentList "/quiet TargetDir=$pythonInstallDir InstallAllUsers=1"
 `
-		if _, err := gce.RunRemotely(ctx, logger, vm, "", installPython); err != nil {
+		if _, err := gce.RunRemotely(ctx, logger, vm, installPython); err != nil {
 			return fmt.Errorf("Could not install Python: %w", err)
 		}
 	} else {
@@ -219,7 +219,7 @@ Start-Process "$tempDir\$pythonInstallerName" -Wait -ArgumentList "/quiet Target
   &> %v &
 `, logGeneratorPath, logSizeInBytes, logRate, logPath, debugLogPath)
 	}
-	if _, err := gce.RunRemotely(ctx, logger, vm, "", startLogGenerator); err != nil {
+	if _, err := gce.RunRemotely(ctx, logger, vm, startLogGenerator); err != nil {
 		return err
 	}
 
@@ -228,7 +228,7 @@ Start-Process "$tempDir\$pythonInstallerName" -Wait -ArgumentList "/quiet Target
 	if !gce.IsWindows(vm.Platform) {
 		time.Sleep(5 * time.Second)
 
-		if _, err := gce.RunRemotely(ctx, logger, vm, "", "cat "+debugLogPath); err != nil {
+		if _, err := gce.RunRemotely(ctx, logger, vm, "cat "+debugLogPath); err != nil {
 			return err
 		}
 	}

--- a/integration_test/third_party_apps_test.go
+++ b/integration_test/third_party_apps_test.go
@@ -94,7 +94,7 @@ func assertFilePresence(ctx context.Context, logger *log.Logger, vm *gce.VM, fil
 		fileQuery = fmt.Sprintf(`sudo test -f %s`, filePath)
 	}
 
-	out, err := gce.RunRemotely(ctx, logger, vm, "", fileQuery)
+	out, err := gce.RunRemotely(ctx, logger, vm, fileQuery)
 	if err != nil {
 		return fmt.Errorf("error accessing backup file: %v", err)
 	}
@@ -556,7 +556,7 @@ func runSingleTest(ctx context.Context, logger *logging.DirectoryLogger, vm *gce
 		// Gets us around problematic prompts for user input.
 		installEnv["DEBIAN_FRONTEND"] = "noninteractive"
 		// Configures sudo to keep the value of DEBIAN_FRONTEND that we set.
-		if _, err := gce.RunRemotely(ctx, logger.ToMainLog(), vm, "", `echo 'Defaults env_keep += "DEBIAN_FRONTEND"' | sudo tee -a /etc/sudoers`); err != nil {
+		if _, err := gce.RunRemotely(ctx, logger.ToMainLog(), vm, `echo 'Defaults env_keep += "DEBIAN_FRONTEND"' | sudo tee -a /etc/sudoers`); err != nil {
 			return nonRetryable, err
 		}
 	}


### PR DESCRIPTION
## Description
Just a cleanup. Callers that wish to pass in stdin should use RunRemotelyStdin.

The intent is to submit this around the same time as cl/623244681.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
