### PR TITLE
Testing: add tests for UploadContent

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -287,10 +287,10 @@ func (f *logClientFactory) new(project string) (*logadmin.Client, error) {
 
 // VM represents an individual virtual machine.
 type VM struct {
-	Name        string
-	Project     string
-	Network     string
-	Platform    string
+	Name     string
+	Project  string
+	Network  string
+	Platform string
 	// The VMOptions.ImageSpec used to create the VM.
 	ImageSpec   string
 	Zone        string
@@ -821,6 +821,8 @@ func RunRemotelyStdin(ctx context.Context, logger *log.Logger, vm *VM, stdin io.
 // given permission to read from that bucket. This was accomplished by adding
 // the "Compute Engine default service account" for PROJECT as
 // a "Storage Object Viewer" and "Storage Object Creator" on the bucket.
+//
+// When making changes to this function, please run gce_testing_test.go (manually).
 func UploadContent(ctx context.Context, logger *log.Logger, vm *VM, content io.Reader, remotePath string) (err error) {
 	defer func() {
 		if err != nil {
@@ -1072,7 +1074,7 @@ func constructImageSpec(options *VMOptions) {
 
 // parseImageSpec looks for the ImageSpec field in VMOptions and sets
 // ImageProject/Image/Platform accordingly.
-func parseImageSpec(options *VMOptions) (error) {
+func parseImageSpec(options *VMOptions) error {
 	if options.ImageSpec == "" {
 		constructImageSpec(options)
 		return nil
@@ -1083,9 +1085,9 @@ func parseImageSpec(options *VMOptions) (error) {
 	}
 
 	delim := ""
-	if strings.Contains(options.ImageSpec, ":"){
+	if strings.Contains(options.ImageSpec, ":") {
 		delim = ":"
-	} else if strings.Contains(options.ImageSpec, "="){
+	} else if strings.Contains(options.ImageSpec, "=") {
 		delim = "="
 	} else {
 		return fmt.Errorf("could not parse options.ImageSpec from struct: %+v", options)
@@ -1094,11 +1096,11 @@ func parseImageSpec(options *VMOptions) (error) {
 	s := strings.Split(options.ImageSpec, delim)
 	options.ImageProject = s[0]
 
-	switch delim  {
-		case ":":
-			options.Platform = s[1]
-		case "=":
-			options.Image = s[1]
+	switch delim {
+	case ":":
+		options.Platform = s[1]
+	case "=":
+		options.Image = s[1]
 	}
 
 	return nil
@@ -1338,7 +1340,7 @@ func CreateInstance(origCtx context.Context, logger *log.Logger, options VMOptio
 			strings.Contains(err.Error(), "currently unavailable") ||
 			// This error is a consequence of running gcloud concurrently, which is actually
 			// unsupported. In the absence of a better fix, just retry such errors.
-		        strings.Contains(err.Error(), "database is locked") ||
+			strings.Contains(err.Error(), "database is locked") ||
 			// windows-*-core instances sometimes fail to be ssh-able: b/305721001
 			(IsWindowsCore(options.Platform) && strings.Contains(err.Error(), windowsStartupFailedMessage)) ||
 			// SLES instances sometimes fail to be ssh-able: b/186426190

--- a/integration_test/gce/gce_testing_test.go
+++ b/integration_test/gce/gce_testing_test.go
@@ -392,8 +392,8 @@ func TestRunRemotely(t *testing.T) {
 
 // eachByte returns a byte slice with each byte represented once in it.
 func eachByte() []byte {
-	result := make([]byte, 128)
-	for i := 0; i < 128; i++ {
+	result := make([]byte, 256)
+	for i := 0; i < 256; i++ {
 		result[i] = byte(i)
 	}
 	return result

--- a/integration_test/gce/gce_testing_test.go
+++ b/integration_test/gce/gce_testing_test.go
@@ -306,7 +306,7 @@ echo hello`,
 }
 
 // testRunRemotelyHelper runs all the given test cases on the given VM, checking
-// that RunRemotely and RunScriptRemotely report all expected errors and that
+// that RunRemotelyStdin and RunScriptRemotely report all expected errors and that
 // standard out/error are as expected.
 func testRunRemotelyHelper(ctx context.Context, t *testing.T, logger *log.Logger, vm *gce.VM, testCases []testCase) {
 	runners := []struct {


### PR DESCRIPTION
## Description
These tests are split off from https://github.com/GoogleCloudPlatform/ops-agent/pull/1637 and https://github.com/GoogleCloudPlatform/ops-agent/pull/1640, where they were very useful as I was attempting to revamp `UploadContent`. Those PRs may never see the light of day, especially https://github.com/GoogleCloudPlatform/ops-agent/pull/1640, so I figured I'd split off this PR containing the tests only.

## Related issue
cleanup

## How has this been tested?
Ran gce_testing_test.go manually over various distros.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
