### PR TITLE
Testing: use ImageSpec in gce_testing_test.go

### DIFF
--- a/integration_test/gce/gce_testing_test.go
+++ b/integration_test/gce/gce_testing_test.go
@@ -57,7 +57,7 @@ func SetupLoggerAndVM(t *testing.T, platform string) (context.Context, *logging.
 
 	logger := gce.SetupLogger(t)
 	logger.ToMainLog().Println("Calling SetupVM(). For details, see VM_initialization.txt.")
-	vm := gce.SetupVM(ctx, t, logger.ToFile("VM_initialization.txt"), gce.VMOptions{Platform: platform, MachineType: agents.RecommendedMachineType(platform)})
+	vm := gce.SetupVM(ctx, t, logger.ToFile("VM_initialization.txt"), gce.VMOptions{ImageSpec: platform, MachineType: agents.RecommendedMachineType(platform)})
 	logger.ToMainLog().Printf("VM is ready: %#v", vm)
 	return ctx, logger, vm
 }


### PR DESCRIPTION
## Description
This was one place that uses the old-style `Platform` but should use `ImageSpec` like everything else.

## Related issue
b/330177642

## How has this been tested?
Run manually on my cloudtop

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
