### PR TITLE
Testing: workaround for `buster-backports` issue with GCE image

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1290,6 +1290,13 @@ func attemptCreateInstance(ctx context.Context, logger *log.Logger, options VMOp
 		}
 	}
 
+	// See b/334918531.
+	if strings.Contains(vm.Platform, "debian-10") {
+		if _, err := RunRemotely(ctx, logger, vm, "sudo sed -i 's#https://deb.debian.org/debian buster-backports#https://archive.debian.org/debian buster-backports#' /etc/apt/sources.list"); err != nil {
+			return nil, fmt.Errorf("attemptCreateInstance() failed to reconfigure buster-backports: %v", err)
+		}
+	}
+
 	return vm, nil
 }
 


### PR DESCRIPTION
## Description
See b/334918531. This PR switches the repos that ship with `debian-10` to use `archive.debian.org` instead, which should hold us over until debian 10 reaches EOL in June.

## Related issue
b/334918531

## How has this been tested?
gce_testing_test.go run manually on my cloudtop.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
