### PR TITLE
Testing: Set TimeToLive in gce_testing_test.go

### DIFF
--- a/integration_test/gce/gce_testing_test.go
+++ b/integration_test/gce/gce_testing_test.go
@@ -60,7 +60,7 @@ func SetupLoggerAndVM(t *testing.T, platform string) (context.Context, *logging.
 	logger := gce.SetupLogger(t)
 	options := gce.VMOptions{
 		ImageSpec: platform,
-		TimeToLive: "3h",
+		TimeToLive: "1h",
 		MachineType: agents.RecommendedMachineType(platform),
 	}
 	logger.ToMainLog().Println("Calling SetupVM(). For details, see VM_initialization.txt.")

--- a/integration_test/gce/gce_testing_test.go
+++ b/integration_test/gce/gce_testing_test.go
@@ -58,8 +58,13 @@ func SetupLoggerAndVM(t *testing.T, platform string) (context.Context, *logging.
 	t.Cleanup(cancel)
 
 	logger := gce.SetupLogger(t)
+	options := gce.VMOptions{
+		ImageSpec: platform,
+		TimeToLive: "3h",
+		MachineType: agents.RecommendedMachineType(platform),
+	}
 	logger.ToMainLog().Println("Calling SetupVM(). For details, see VM_initialization.txt.")
-	vm := gce.SetupVM(ctx, t, logger.ToFile("VM_initialization.txt"), gce.VMOptions{ImageSpec: platform, MachineType: agents.RecommendedMachineType(platform)})
+	vm := gce.SetupVM(ctx, t, logger.ToFile("VM_initialization.txt"), options)
 	logger.ToMainLog().Printf("VM is ready: %#v", vm)
 	return ctx, logger, vm
 }


### PR DESCRIPTION
## Description
gce_testing_test.go was not setting TimeToLive, leading to some leaked VM instances.

## Related issue
cleanup

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
