### PR TITLE
Replace deprecated rhel-8-2-sap-ha image by a newer one.

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -36,7 +36,7 @@ AGENT_PACKAGES_IN_GCS, for details see README.md.
 
 	PROJECT=dev_project \
 	ZONES=us-central1-b \
-	PLATFORMS=debian-cloud:debian-10,rocky-linux-cloud:rocky-linux-8,rhel-sap-cloud:rhel-8-2-sap-ha,suse-cloud:sles-15,ubuntu-os-cloud:ubuntu-2004-lts,windows-cloud:windows-2016,windows-cloud:windows-2019 \
+	PLATFORMS=debian-cloud:debian-10,rocky-linux-cloud:rocky-linux-8,rhel-sap-cloud:rhel-8-8-sap-ha,suse-cloud:sles-15,ubuntu-os-cloud:ubuntu-2004-lts,windows-cloud:windows-2016,windows-cloud:windows-2019 \
 	go test -v ops_agent_test.go \
 	  -test.parallel=1000 \
 	  -tags=integration_test \

--- a/project.yaml
+++ b/project.yaml
@@ -56,9 +56,9 @@ targets:
           - rocky-linux-cloud:rocky-linux-8
           exhaustive:
           - rhel-cloud:rhel-8
-          - rhel-sap-cloud:rhel-8-2-sap-ha
           - rhel-sap-cloud:rhel-8-4-sap-ha
           - rhel-sap-cloud:rhel-8-6-sap-ha
+          - rhel-sap-cloud:rhel-8-8-sap-ha
   focal:
     package_extension:
       deb


### PR DESCRIPTION
## Description
Replace deprecated `rhel-8-2-sap-ha` image family by `rhel-8-8-sap-ha`. The `rhel-8-2-sap-ha` image family was deprecated by GCE.

## Related issue
[b/338588266](http://b/338588266)

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [x] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
