### PR TITLE
Add Kokoro build configs for new distro noble_x86_64

### DIFF
--- a/kokoro/config/build/presubmit/noble_x86_64.gcl
+++ b/kokoro/config/build/presubmit/noble_x86_64.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'noble'
+      PKGFORMAT = 'deb'
+    }
+  }
+}

--- a/kokoro/config/test/ops_agent/presubmit/noble_x86_64.gcl
+++ b/kokoro/config/test/ops_agent/presubmit/noble_x86_64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    environment {
+      TARGET = 'noble_x86_64'
+      ARCH = 'x86_64'
+    }
+  }
+}

--- a/kokoro/config/test/ops_agent/release/noble_x86_64.gcl
+++ b/kokoro/config/test/ops_agent/release/noble_x86_64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    environment {
+      TARGET = 'noble_x86_64'
+      ARCH = 'x86_64'
+    }
+  }
+}

--- a/kokoro/config/test/third_party_apps/presubmit/noble_x86_64.gcl
+++ b/kokoro/config/test/third_party_apps/presubmit/noble_x86_64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    environment {
+      TARGET = 'noble_x86_64'
+      ARCH = 'x86_64'
+    }
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/noble_x86_64.gcl
+++ b/kokoro/config/test/third_party_apps/release/noble_x86_64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    environment {
+      TARGET = 'noble_x86_64'
+      ARCH = 'x86_64'
+    }
+  }
+}

--- a/project.yaml
+++ b/project.yaml
@@ -1,4 +1,14 @@
 targets:
+  noble:
+    package_extension:
+      deb
+    architectures:
+      x86_64:
+        test_distros:
+          representative:
+          - ubuntu-os-cloud:ubuntu-2404-lts-amd64
+          exhaustive:
+          - ubuntu-os-cloud:ubuntu-minimal-2404-lts-amd64
   bookworm:
     package_extension:
       deb


### PR DESCRIPTION
## Description
Add Kokoro build configs for new distro noble_x86_64

Followup to : https://github.com/GoogleCloudPlatform/ops-agent/pull/1691
Tested in : https://github.com/GoogleCloudPlatform/ops-agent/pull/1705

## Related issue
b/332569979

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
