### PR TITLE
Testing: Remove K80 from the GPU tests

### DIFF
--- a/integration_test/third_party_apps_test/applications/dcgm/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/dcgm/debian_ubuntu/install
@@ -9,31 +9,16 @@ sudo apt install -y linux-headers-${KERNEL_VERSION} software-properties-common p
 # Prefer to install from the package manager since it is normally faster and has
 # less errors on installation; fallback to the runfile method if the package 
 # manager's package is not working or not compitible with the GPU model
-DEVICE_CODE=$(lspci -n | grep -Po '10de:[\w\d]{4}')
 DISTRIBUTION=$(echo $ID$VERSION_ID | sed -e 's/\.//g')
 # Need to add the keyring for installing CUDA and DCGM
 wget --no-verbose https://developer.download.nvidia.com/compute/cuda/repos/${DISTRIBUTION}/x86_64/cuda-keyring_1.0-1_all.deb
 sudo dpkg -i cuda-keyring_1.0-1_all.deb
-case $DEVICE_CODE in
-    10de:102d)
-        # Install a specific version for NVIDIA Tesla K80, R470 is the last supported version
-        DRIVER_VERSION=470.82.01
-        CUDA_VERSION=11.4.4
-        echo "Installing NVIDIA CUDA $CUDA_VERSION with driver $DRIVER_VERSION"
-        curl -fSsl -O https://us.download.nvidia.com/tesla/$DRIVER_VERSION/NVIDIA-Linux-x86_64-$DRIVER_VERSION.run
-        sudo bash ./NVIDIA-Linux-x86_64-$DRIVER_VERSION.run --silent
-        wget --no-verbose https://developer.download.nvidia.com/compute/cuda/$CUDA_VERSION/local_installers/cuda_${CUDA_VERSION}_${DRIVER_VERSION}_linux.run
-        sudo sh cuda_${CUDA_VERSION}_${DRIVER_VERSION}_linux.run --toolkit --silent
-        ;;
-    *)
-        echo "Installing latest version of NVIDIA CUDA and driver"
-        if [[ $ID == debian ]]; then
-            sudo add-apt-repository contrib
-        fi
-        sudo apt update
-        sudo apt -y install cuda 
-        ;;
-esac
+echo "Installing latest version of NVIDIA CUDA and driver"
+if [[ $ID == debian ]]; then
+    sudo add-apt-repository contrib
+fi
+sudo apt update
+sudo apt -y install cuda 
 
 # check NVIDIA driver installation succeeded
 nvidia-smi

--- a/integration_test/third_party_apps_test/applications/dcgm/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/dcgm/metadata.yaml
@@ -23,7 +23,7 @@ configure_integration: |-
   You must install DCGM and run the DCGM daemon service. 
 supported_operating_systems: linux
 supported_app_version: ["3.1"]
-gpu_platforms: # p4, k80, p100 don't emit DCGM profiling metrics
+gpu_platforms: # p4, p100 don't emit DCGM profiling metrics
   - model: a100
     platforms:
       - ubuntu-os-cloud:ubuntu-2004-lts

--- a/integration_test/third_party_apps_test/applications/dcgm/sles/install
+++ b/integration_test/third_party_apps_test/applications/dcgm/sles/install
@@ -6,27 +6,12 @@ sudo zypper --non-interactive install -y kernel-default-devel=$(uname -r | sed '
 # Prefer to install from the package manager since it is normally faster and has
 # less errors on installation; fallback to the runfile method if the package 
 # manager's package is not working or not compitible with the GPU model
-DEVICE_CODE=$(/sbin/lspci -n | grep -Po '10de:[\w\d]{4}')
 DISTRIBUTION=$(. /etc/os-release;echo $ID$VERSION_ID | sed -e 's/\.[0-9]//')
 # Need to add the repo for installing CUDA and DCGM
 sudo zypper --non-interactive ar http://developer.download.nvidia.com/compute/cuda/repos/${DISTRIBUTION}/x86_64/cuda-${DISTRIBUTION}.repo
 sudo zypper --gpg-auto-import-keys --non-interactive refresh
-case $DEVICE_CODE in
-    10de:102d)
-        # Install a specific version for NVIDIA Tesla K80, R470 is the last supported version
-        DRIVER_VERSION=470.82.01
-        CUDA_VERSION=11.4.4
-        echo "Installing NVIDIA CUDA $CUDA_VERSION with driver $DRIVER_VERSION"
-        curl -fSsl -O https://us.download.nvidia.com/tesla/$DRIVER_VERSION/NVIDIA-Linux-x86_64-$DRIVER_VERSION.run
-        sudo bash ./NVIDIA-Linux-x86_64-$DRIVER_VERSION.run --silent
-        wget --no-verbose https://developer.download.nvidia.com/compute/cuda/$CUDA_VERSION/local_installers/cuda_${CUDA_VERSION}_${DRIVER_VERSION}_linux.run
-        sudo sh cuda_${CUDA_VERSION}_${DRIVER_VERSION}_linux.run --toolkit --silent
-        ;;
-    *)
-        echo "Installing latest version of NVIDIA CUDA and driver"
-        sudo zypper --non-interactive install -y cuda
-        ;;
-esac
+echo "Installing latest version of NVIDIA CUDA and driver"
+sudo zypper --non-interactive install -y cuda
 
 # check NVIDIA driver installation succeeded
 nvidia-smi

--- a/integration_test/third_party_apps_test/applications/nvml/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/nvml/debian_ubuntu/install
@@ -10,30 +10,15 @@ sudo apt install -y linux-headers-${KERNEL_VERSION} software-properties-common p
 # Prefer to install from the package manager since it is normally faster and has
 # less errors on installation; fallback to the runfile method if the package 
 # manager's package is not working or not compitible with the GPU model
-DEVICE_CODE=$(lspci -n | grep -Po '10de:[\w\d]{4}')
 DISTRIBUTION=$(echo $ID$VERSION_ID | sed -e 's/\.//g')
-case $DEVICE_CODE in
-    10de:102d)
-        # Install a specific version for NVIDIA Tesla K80, R470 is the last supported version
-        DRIVER_VERSION=470.82.01
-        CUDA_VERSION=11.4.4
-        echo "Installing NVIDIA CUDA $CUDA_VERSION with driver $DRIVER_VERSION"
-        curl -fSsl -O https://us.download.nvidia.com/tesla/$DRIVER_VERSION/NVIDIA-Linux-x86_64-$DRIVER_VERSION.run
-        sudo bash ./NVIDIA-Linux-x86_64-$DRIVER_VERSION.run --silent
-        wget --no-verbose https://developer.download.nvidia.com/compute/cuda/$CUDA_VERSION/local_installers/cuda_${CUDA_VERSION}_${DRIVER_VERSION}_linux.run
-        sudo sh cuda_${CUDA_VERSION}_${DRIVER_VERSION}_linux.run --toolkit --silent
-        ;;
-    *)
-        echo "Installing latest version of NVIDIA CUDA and driver"
-        wget --no-verbose https://developer.download.nvidia.com/compute/cuda/repos/${DISTRIBUTION}/x86_64/cuda-keyring_1.0-1_all.deb
-        sudo dpkg -i cuda-keyring_1.0-1_all.deb
-        if [[ $ID == debian ]]; then
-            sudo add-apt-repository contrib
-        fi
-        sudo apt update
-        sudo apt -y install cuda 
-        ;;
-esac
+echo "Installing latest version of NVIDIA CUDA and driver"
+wget --no-verbose https://developer.download.nvidia.com/compute/cuda/repos/${DISTRIBUTION}/x86_64/cuda-keyring_1.0-1_all.deb
+sudo dpkg -i cuda-keyring_1.0-1_all.deb
+if [[ $ID == debian ]]; then
+    sudo add-apt-repository contrib
+fi
+sudo apt update
+sudo apt -y install cuda 
 
 # check NVIDIA driver installation succeeded
 nvidia-smi

--- a/integration_test/third_party_apps_test/applications/nvml/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/nvml/metadata.yaml
@@ -39,9 +39,6 @@ gpu_platforms:
   - model: p100
     platforms:
       - ubuntu-os-cloud:ubuntu-2004-lts
-  - model: k80
-    platforms:
-      - ubuntu-os-cloud:ubuntu-2004-lts
   - model: l4
     platforms:
       - centos-cloud:centos-7

--- a/integration_test/third_party_apps_test/applications/nvml/sles/install
+++ b/integration_test/third_party_apps_test/applications/nvml/sles/install
@@ -7,26 +7,11 @@ sudo zypper --non-interactive install -y kernel-default-devel=$(uname -r | sed '
 # Prefer to install from the package manager since it is normally faster and has
 # less errors on installation; fallback to the runfile method if the package 
 # manager's package is not working or not compitible with the GPU model
-DEVICE_CODE=$(/sbin/lspci -n | grep -Po '10de:[\w\d]{4}')
 DISTRIBUTION=$(. /etc/os-release;echo $ID$VERSION_ID | sed -e 's/\.[0-9]//')
-case $DEVICE_CODE in
-    10de:102d)
-        # Install a specific version for NVIDIA Tesla K80, R470 is the last supported version
-        DRIVER_VERSION=470.82.01
-        CUDA_VERSION=11.4.4
-        echo "Installing NVIDIA CUDA $CUDA_VERSION with driver $DRIVER_VERSION"
-        curl -fSsl -O https://us.download.nvidia.com/tesla/$DRIVER_VERSION/NVIDIA-Linux-x86_64-$DRIVER_VERSION.run
-        sudo bash ./NVIDIA-Linux-x86_64-$DRIVER_VERSION.run --silent
-        wget --no-verbose https://developer.download.nvidia.com/compute/cuda/$CUDA_VERSION/local_installers/cuda_${CUDA_VERSION}_${DRIVER_VERSION}_linux.run
-        sudo sh cuda_${CUDA_VERSION}_${DRIVER_VERSION}_linux.run --toolkit --silent
-        ;;
-    *)
-        echo "Installing latest version of NVIDIA CUDA and driver"
-        sudo zypper --non-interactive ar http://developer.download.nvidia.com/compute/cuda/repos/${DISTRIBUTION}/x86_64/cuda-${DISTRIBUTION}.repo
-        sudo zypper --gpg-auto-import-keys --non-interactive refresh
-        sudo zypper --non-interactive install -y cuda
-        ;;
-esac
+echo "Installing latest version of NVIDIA CUDA and driver"
+sudo zypper --non-interactive ar http://developer.download.nvidia.com/compute/cuda/repos/${DISTRIBUTION}/x86_64/cuda-${DISTRIBUTION}.repo
+sudo zypper --gpg-auto-import-keys --non-interactive refresh
+sudo zypper --non-interactive install -y cuda
 
 # check NVIDIA driver installation succeeded
 nvidia-smi

--- a/integration_test/third_party_apps_test/main_test.go
+++ b/integration_test/third_party_apps_test/main_test.go
@@ -811,7 +811,7 @@ type test struct {
 }
 
 var defaultPlatforms = map[string]bool{
-	"debian-cloud:debian-10":    true,
+	"debian-cloud:debian-10":     true,
 	"windows-cloud:windows-2019": true,
 }
 
@@ -856,12 +856,6 @@ var gpuModels = map[string]accelerator{
 		machineType:   "n1-standard-2",
 		availableZone: "us-central1-c",
 	},
-	"k80": {
-		model:         "k80",
-		fullName:      "nvidia-tesla-k80",
-		machineType:   "n1-standard-2",
-		availableZone: "us-central1-a",
-	},
 	"l4": {
 		model:         "l4",
 		fullName:      "nvidia-l4",
@@ -872,7 +866,7 @@ var gpuModels = map[string]accelerator{
 
 const (
 	SAPHANAImageSpec = "stackdriver-test-143416:sles-15-sp4-sap-saphana"
-	SAPHANAApp      = "saphana"
+	SAPHANAApp       = "saphana"
 
 	OracleDBApp  = "oracledb"
 	AerospikeApp = "aerospike"


### PR DESCRIPTION
## Description
Remove NVIDIA K80 GPU model from the GPU tests. 

All NVIDIA PCI devices use vendor id 0x10de. `10de:102d` is the unique device ID for NVIDIA K80. 

## Related issue
[b/339704007](http://b/339704007)
[b/339826922](http://b/339826922)

## How has this been tested?
Focal was the only platform running K80 tests. Verified that the tests are not longer run for Focal. 

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
