### PR TITLE
kokoro: Use `Codename` instead of `KokoroCodename` in .gcl templates.

### DIFF
--- a/kokoro/config/test/ops_agent/presubmit/template.gcl.tmpl
+++ b/kokoro/config/test/ops_agent/presubmit/template.gcl.tmpl
@@ -3,7 +3,7 @@ import 'common.gcl' as common
 config build = common.ops_agent_test {
   params {
     environment {
-      TARGET = '{{.KokoroCodename}}'
+      TARGET = '{{.Codename}}'
       ARCH = '{{.Arch}}'
     }
   }

--- a/kokoro/config/test/ops_agent/release/template.gcl.tmpl
+++ b/kokoro/config/test/ops_agent/release/template.gcl.tmpl
@@ -3,7 +3,7 @@ import 'common.gcl' as common
 config build = common.ops_agent_test {
   params {
     environment {
-      TARGET = '{{.KokoroCodename}}'
+      TARGET = '{{.Codename}}'
       ARCH = '{{.Arch}}'
     }
   }

--- a/kokoro/config/test/third_party_apps/presubmit/template.gcl.tmpl
+++ b/kokoro/config/test/third_party_apps/presubmit/template.gcl.tmpl
@@ -3,7 +3,7 @@ import 'common.gcl' as common
 config build = common.third_party_apps_test {
   params {
     environment {
-      TARGET = '{{.KokoroCodename}}'
+      TARGET = '{{.Codename}}'
       ARCH = '{{.Arch}}'
     }
   }

--- a/kokoro/config/test/third_party_apps/release/template.gcl.tmpl
+++ b/kokoro/config/test/third_party_apps/release/template.gcl.tmpl
@@ -3,7 +3,7 @@ import 'common.gcl' as common
 config build = common.third_party_apps_test {
   params {
     environment {
-      TARGET = '{{.KokoroCodename}}'
+      TARGET = '{{.Codename}}'
       ARCH = '{{.Arch}}'
     }
   }


### PR DESCRIPTION
## Description
Use `Codename` instead of `KokoroCodename` in .gcl templates to access correctly `project.yaml`.

## Related issue
[b/332569979](http://b/332569979)

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
