### PR TITLE
Testing: Update no gpu test to check otel config

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -877,7 +877,7 @@ func RetrieveContent(ctx context.Context, logger *log.Logger, vm *VM, remotePath
 		out, err := RunRemotely(ctx, logger, vm, fmt.Sprintf("Get-Content -Path '%s' -Raw", remotePath))
 		return out.Stdout, err
 	}
-	out, err := RunRemotely(ctx, logger, vm, fmt.Sprintf("sudo cat "+remotePath))
+	out, err := RunRemotely(ctx, logger, vm, "sudo cat "+remotePath)
 	return out.Stdout, err
 }
 

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -294,9 +294,9 @@ type OS struct {
 
 // VM represents an individual virtual machine.
 type VM struct {
-	Name     string
-	Project  string
-	Network  string
+	Name    string
+	Project string
+	Network string
 	// The VMOptions.ImageSpec used to create the VM.
 	ImageSpec   string
 	OS          OS
@@ -868,6 +868,17 @@ func UploadContent(ctx context.Context, logger *log.Logger, vm *VM, content io.R
 	objectPath := fmt.Sprintf("gs://%s/%s", object.BucketName(), object.ObjectName())
 	_, err = RunRemotely(ctx, logger, vm, fmt.Sprintf("sudo gsutil cp '%s' '%s'", objectPath, remotePath))
 	return err
+}
+
+// RetrieveContent retrieves the file content from the the given file path from
+// the remote VM
+func RetrieveContent(ctx context.Context, logger *log.Logger, vm *VM, remotePath string) (content string, err error) {
+	if IsWindows(vm.ImageSpec) {
+		out, err := RunRemotely(ctx, logger, vm, fmt.Sprintf("Get-Content -Path '%s' -Raw", remotePath))
+		return out.Stdout, err
+	}
+	out, err := RunRemotely(ctx, logger, vm, fmt.Sprintf("sudo cat "+remotePath))
+	return out.Stdout, err
 }
 
 // envVarMapToBashPrefix converts a map of env variable name to value into a string

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -4745,7 +4745,7 @@ func TestNoNvmlOtelReceiverWithoutGpu(t *testing.T) {
 		}
 
 		if strings.Contains(otelConfig, "nvml") {
-			t.Errorf("expects the nvml receiver not in the Otel configuration for VMs without GPU. Otel config: " + otelConfig)
+			t.Error("expects the nvml receiver not in the Otel configuration for VMs without GPU. Otel config: " + otelConfig)
 		}
 	})
 }

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -67,6 +67,7 @@ import (
 	feature_tracking_metadata "github.com/GoogleCloudPlatform/ops-agent/integration_test/feature_tracking"
 	"github.com/GoogleCloudPlatform/ops-agent/integration_test/gce"
 	"github.com/GoogleCloudPlatform/ops-agent/integration_test/metadata"
+	"github.com/GoogleCloudPlatform/ops-agent/integration_test/util"
 	"github.com/google/uuid"
 	"go.uber.org/multierr"
 	"golang.org/x/exp/slices"
@@ -209,6 +210,12 @@ func writeToSystemLog(ctx context.Context, logger *log.Logger, vm *gce.VM, paylo
 		return fmt.Errorf("writeToSystemLog() failed to write %q to %s: %v", line, location, err)
 	}
 	return nil
+}
+
+// retrieveOtelConfig retrieves the file content of the generated Otel config
+// file from the remote VM
+func retrieveOtelConfig(ctx context.Context, logger *log.Logger, vm *gce.VM) (content string, err error) {
+	return gce.RetrieveContent(ctx, logger, vm, util.GetOtelConfigPath(vm.ImageSpec))
 }
 
 func TestParseMultilineFileJava(t *testing.T) {
@@ -4732,12 +4739,13 @@ func TestNoNvmlOtelReceiverWithoutGpu(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		time.Sleep(60 * time.Second)
-		_, err := gce.QueryLog(ctx, logger, vm, "syslog", time.Hour, `jsonPayload.message=~"Nvidia|nvml"`, 5)
-		if err == nil {
-			t.Error("expected no logs to contain Nvidia or nvml when the instance has no gpu")
-		} else if !strings.Contains(err.Error(), "not found, exhausted retries") {
-			t.Fatalf("unexpected error: %v", err)
+		otelConfig, err := retrieveOtelConfig(ctx, logger, vm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if strings.Contains(otelConfig, "nvml") {
+			t.Errorf("expects the nvml receiver not in the Otel configuration for VMs without GPU. Otel config: " + otelConfig)
 		}
 	})
 }

--- a/integration_test/util/util.go
+++ b/integration_test/util/util.go
@@ -29,6 +29,13 @@ func GetConfigPath(imageSpec string) string {
 	return "/etc/google-cloud-ops-agent/config.yaml"
 }
 
+func GetOtelConfigPath(imageSpec string) string {
+	if gce.IsWindows(imageSpec) {
+		return `C:\ProgramData\Google\Cloud Operations\Ops Agent\generated_configs\otel\otel.yaml`
+	}
+	return "/var/run/google-cloud-ops-agent-opentelemetry-collector/otel.yaml"
+}
+
 // DumpPointerArray formats the given array of pointers-to-structs as a strings
 // using the given format, rather than just formatting them as addresses.
 // format is usually either "%v" or "%+v".


### PR DESCRIPTION
## Description
Update `TestNoNvmlOtelReceiverWithoutGpu` to check the generated otel config and assert that nvml receiver is not in the generated config when the VM has no GPU. 

## Related issue
[b/341109955](http://b/341109955)

## How has this been tested?
Integration test passing. 
Tested locally to make sure the test reports correct error when the generated otel config is not presented in the VM. 

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
