### PR TITLE
Internal: add `opensuse-leap` to suse special handling in tests

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1262,7 +1262,7 @@ func attemptCreateInstance(ctx context.Context, logger *log.Logger, options VMOp
 		vm.OS = *os
 	}
 
-	if vm.OS.ID == "opensuse" || vm.OS.ID == "sles" || vm.OS.ID == "sles_sap" {
+	if vm.OS.ID == "opensuse" || vm.OS.ID == "opensuse-leap" || vm.OS.ID == "sles" || vm.OS.ID == "sles_sap" {
 		// Set download.max_silent_tries to 5 (by default, it is commented out in
 		// the config file). This should help with issues like b/211003972.
 		if _, err := RunRemotely(ctx, logger, vm, "sudo sed -i -E 's/.*download.max_silent_tries.*/download.max_silent_tries = 5/g' /etc/zypp/zypp.conf"); err != nil {
@@ -1550,7 +1550,7 @@ func InstallGsutilIfNeeded(ctx context.Context, logger *log.Logger, vm *VM) erro
 
 	// SUSE seems to be the only distro without gsutil, so what follows is all
 	// very SUSE-specific.
-	if vm.OS.ID != "opensuse" && vm.OS.ID != "sles" && vm.OS.ID != "sles_sap" {
+	if vm.OS.ID != "opensuse" && vm.OS.ID != "opensuse-leap" && vm.OS.ID != "sles" && vm.OS.ID != "sles_sap" {
 		return installErr("gsutil", vm.OS.ID)
 	}
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->
b/337015263

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
