### PR TITLE
Testing: Using CUDA 12.4 for RHEL/Centos GPU Tests

### DIFF
--- a/integration_test/third_party_apps_test/applications/dcgm/centos_rhel/install
+++ b/integration_test/third_party_apps_test/applications/dcgm/centos_rhel/install
@@ -89,7 +89,7 @@ handle_common() {
                 ;;
             *)
                 # Ref: https://developer.nvidia.com/cuda-12-2-2-download-archive?target_os=Linux&target_arch=x86_64&Distribution=RHEL&target_version=8&target_type=rpm_network
-                sudo yum -y module install nvidia-driver:latest
+                sudo yum -y module install nvidia-driver:550
                 ;;
         esac
     }

--- a/integration_test/third_party_apps_test/applications/nvml/centos_rhel/install
+++ b/integration_test/third_party_apps_test/applications/nvml/centos_rhel/install
@@ -55,7 +55,7 @@ install_cuda_from_package_manager() {
             sudo yum -y install cuda-12-3
             ;;
         *)
-            sudo yum -y install cuda
+            sudo yum -y install cuda-12-4
             ;;
     esac
     verify_driver
@@ -109,7 +109,7 @@ handle_common() {
                 ;;
             *)
                 # Ref: https://developer.nvidia.com/cuda-12-2-2-download-archive?target_os=Linux&target_arch=x86_64&Distribution=RHEL&target_version=8&target_type=rpm_network
-                sudo yum -y module install nvidia-driver:latest
+                sudo yum -y module install nvidia-driver:550
                 ;;
         esac
     }


### PR DESCRIPTION
## Description
CUDA 12.5 (w/ driver 555) becomes available but has broken dependencies in the repo. Temporarily pin the installation script to install 12.4.

## Related issue
[b/341977759](http://b/341977759)

## How has this been tested?
RHEL/Centos GPU tests passing in presubmit. 

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
