### PR TITLE
Ensure all start_states for multiline logs look for start characters

### DIFF
--- a/apps/cassandra.go
+++ b/apps/cassandra.go
@@ -109,7 +109,7 @@ func javaLogParsingComponents(ctx context.Context, processorType, tag, uid strin
 			{
 				StateName: "start_state",
 				NextState: "cont",
-				Regex:     `[A-Z]+\s+\[[^\]]+\] \d+`,
+				Regex:     `^[A-Z]+\s+\[[^\]]+\] \d+`,
 			},
 			{
 				StateName: "cont",

--- a/apps/flink.go
+++ b/apps/flink.go
@@ -106,7 +106,7 @@ func (p LoggingProcessorFlink) Components(ctx context.Context, tag string, uid s
 			{
 				StateName: "start_state",
 				NextState: "cont",
-				Regex:     `\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+`,
+				Regex:     `^\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+`,
 			},
 			{
 				StateName: "cont",

--- a/apps/hbase.go
+++ b/apps/hbase.go
@@ -91,7 +91,7 @@ func (p LoggingProcessorHbaseSystem) Components(ctx context.Context, tag string,
 			{
 				StateName: "start_state",
 				NextState: "cont",
-				Regex:     `\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\,\d{3,6}`,
+				Regex:     `^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\,\d{3,6}`,
 			},
 			{
 				StateName: "cont",

--- a/apps/kafka.go
+++ b/apps/kafka.go
@@ -108,7 +108,7 @@ func (p LoggingProcessorKafka) Components(ctx context.Context, tag string, uid s
 			{
 				StateName: "start_state",
 				NextState: "cont",
-				Regex:     `\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]`,
+				Regex:     `^\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]`,
 			},
 			{
 				StateName: "cont",

--- a/apps/postgresql.go
+++ b/apps/postgresql.go
@@ -111,15 +111,32 @@ func (LoggingProcessorPostgresql) Type() string {
 func (p LoggingProcessorPostgresql) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
 	c := confgenerator.LoggingProcessorParseMultilineRegex{
 		LoggingProcessorParseRegexComplex: confgenerator.LoggingProcessorParseRegexComplex{
+			// Limited logging documentation: https://www.postgresql.org/docs/10/runtime-config-logging.html
 			Parsers: []confgenerator.RegexParser{
 				{
-					// Limited logging documentation: https://www.postgresql.org/docs/10/runtime-config-logging.html
+					// This parser matches most distributions' defaults by our testing
+					// log_line_prefix = '%m [%p] '
+					// log_line_prefix = '%m [%p] %u@%d '
 					// Sample line: 2022-01-12 20:57:58.378 UTC [26241] LOG:  starting PostgreSQL 14.1 (Debian 14.1-1.pgdg100+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit
 					// Sample line: 2022-01-12 20:59:25.169 UTC [27445] postgres@postgres FATAL:  Peer authentication failed for user "postgres"
 					// Sample line: 2022-01-12 21:49:13.989 UTC [27836] postgres@postgres LOG:  duration: 1.074 ms  statement: select *
 					//    from pg_database
 					//    where 1=1;
-					Regex: `^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)`,
+					Regex: `^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)`,
+					Parser: confgenerator.ParserShared{
+						TimeKey:    "time",
+						TimeFormat: "%Y-%m-%d %H:%M:%S.%L %z",
+						Types: map[string]string{
+							"tid": "integer",
+						},
+					},
+				},
+				{
+					// This parser matches the default log_line_prefix from SLES12 in our testing
+					// log_line_prefix = '%m %d %u [%p]'
+					// Sample line: 2024-05-30 15:34:26.572 UTC postgres postgres [23958]STATEMENT:  INSERT INTO
+					//					test2 (id) VALUES('1970-01-01 00:00:00.123 UTC');
+					Regex: `^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*(?:\s+(?<database>\S*)\s+(?<user>\S*))?\s*\[(?<tid>\d+)\]\s*(?<level>\w+):\s+(?<message>[\s\S]*)`,
 					Parser: confgenerator.ParserShared{
 						TimeKey:    "time",
 						TimeFormat: "%Y-%m-%d %H:%M:%S.%L %z",
@@ -184,7 +201,7 @@ type LoggingReceiverPostgresql struct {
 func (r LoggingReceiverPostgresql) Components(ctx context.Context, tag string) []fluentbit.Component {
 	if len(r.IncludePaths) == 0 {
 		r.IncludePaths = []string{
-			// Default log paths for Debain / Ubuntu
+			// Default log paths for Debian / Ubuntu
 			"/var/log/postgresql/postgresql*.log",
 			// Default log paths for SLES
 			"/var/lib/pgsql/data/log/postgresql*.log",

--- a/apps/postgresql.go
+++ b/apps/postgresql.go
@@ -134,7 +134,7 @@ func (p LoggingProcessorPostgresql) Components(ctx context.Context, tag string, 
 			{
 				StateName: "start_state",
 				NextState: "cont",
-				Regex:     `\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+`,
+				Regex:     `^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+`,
 			},
 			{
 				StateName: "cont",

--- a/apps/postgresql.go
+++ b/apps/postgresql.go
@@ -116,7 +116,7 @@ func (p LoggingProcessorPostgresql) Components(ctx context.Context, tag string, 
 				{
 					// This parser matches most distributions' defaults by our testing
 					// log_line_prefix = '%m [%p] '
-					// log_line_prefix = '%m [%p] %u@%d '
+					// log_line_prefix = '%m [%p] %q%u@%d '
 					// Sample line: 2022-01-12 20:57:58.378 UTC [26241] LOG:  starting PostgreSQL 14.1 (Debian 14.1-1.pgdg100+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit
 					// Sample line: 2022-01-12 20:59:25.169 UTC [27445] postgres@postgres FATAL:  Peer authentication failed for user "postgres"
 					// Sample line: 2022-01-12 21:49:13.989 UTC [27836] postgres@postgres LOG:  duration: 1.074 ms  statement: select *

--- a/apps/rabbitmq.go
+++ b/apps/rabbitmq.go
@@ -100,7 +100,7 @@ func (r LoggingReceiverRabbitmq) Components(ctx context.Context, tag string) []f
 		{
 			StateName: "start_state",
 			NextState: "cont",
-			Regex:     `\d+-\d+-\d+ \d+:\d+:\d+\.\d+\+\d+:\d+`,
+			Regex:     `^\d+-\d+-\d+ \d+:\d+:\d+\.\d+\+\d+:\d+`,
 		},
 		{
 			StateName: "cont",

--- a/apps/solr.go
+++ b/apps/solr.go
@@ -81,7 +81,7 @@ func (p LoggingProcessorSolrSystem) Components(ctx context.Context, tag string, 
 			{
 				StateName: "start_state",
 				NextState: "cont",
-				Regex:     `\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s[A-z]+\s{1,5}`,
+				Regex:     `^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s[A-z]+\s{1,5}`,
 			},
 			{
 				StateName: "cont",

--- a/apps/tomcat.go
+++ b/apps/tomcat.go
@@ -92,7 +92,7 @@ func (p LoggingProcessorTomcatSystem) Components(ctx context.Context, tag string
 			{
 				StateName: "start_state",
 				NextState: "cont",
-				Regex:     `\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}`,
+				Regex:     `^\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}`,
 			},
 			{
 				StateName: "cont",

--- a/apps/wildfly.go
+++ b/apps/wildfly.go
@@ -133,7 +133,7 @@ func (r LoggingReceiverWildflySystem) Components(ctx context.Context, tag string
 		{
 			StateName: "start_state",
 			NextState: "cont",
-			Regex:     `\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}`,
+			Regex:     `^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}`,
 		},
 		{
 			StateName: "cont",

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux-gpu/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux-gpu/fluent_bit_parser.conf
@@ -47,7 +47,7 @@
 [MULTILINE_PARSER]
     Name cassandra.cassandra_debug.cassandra_debug.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
@@ -59,5 +59,5 @@
 [MULTILINE_PARSER]
     Name cassandra.cassandra_system.cassandra_system.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux/fluent_bit_parser.conf
@@ -47,7 +47,7 @@
 [MULTILINE_PARSER]
     Name cassandra.cassandra_debug.cassandra_debug.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
@@ -59,5 +59,5 @@
 [MULTILINE_PARSER]
     Name cassandra.cassandra_system.cassandra_system.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows-2012/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows-2012/fluent_bit_parser.conf
@@ -54,7 +54,7 @@
 [MULTILINE_PARSER]
     Name cassandra.cassandra_debug.cassandra_debug.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
@@ -66,5 +66,5 @@
 [MULTILINE_PARSER]
     Name cassandra.cassandra_system.cassandra_system.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows/fluent_bit_parser.conf
@@ -54,7 +54,7 @@
 [MULTILINE_PARSER]
     Name cassandra.cassandra_debug.cassandra_debug.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
@@ -66,5 +66,5 @@
 [MULTILINE_PARSER]
     Name cassandra.cassandra_system.cassandra_system.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/linux-gpu/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/linux-gpu/fluent_bit_parser.conf
@@ -190,7 +190,7 @@
 [MULTILINE_PARSER]
     Name cassandra_custom.cassandra_custom_debug.cassandra_debug.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
@@ -202,13 +202,13 @@
 [MULTILINE_PARSER]
     Name cassandra_custom.cassandra_custom_system.cassandra_system.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
     Name cassandra_default.cassandra_default_debug.cassandra_debug.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
@@ -220,19 +220,19 @@
 [MULTILINE_PARSER]
     Name cassandra_default.cassandra_default_system.cassandra_system.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_debug.0.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_debug.1.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
@@ -244,13 +244,13 @@
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_gc.0.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_gc.1.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
@@ -262,13 +262,13 @@
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_system.0.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_system.1.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/linux/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/linux/fluent_bit_parser.conf
@@ -190,7 +190,7 @@
 [MULTILINE_PARSER]
     Name cassandra_custom.cassandra_custom_debug.cassandra_debug.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
@@ -202,13 +202,13 @@
 [MULTILINE_PARSER]
     Name cassandra_custom.cassandra_custom_system.cassandra_system.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
     Name cassandra_default.cassandra_default_debug.cassandra_debug.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
@@ -220,19 +220,19 @@
 [MULTILINE_PARSER]
     Name cassandra_default.cassandra_default_system.cassandra_system.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_debug.0.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_debug.1.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
@@ -244,13 +244,13 @@
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_gc.0.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_gc.1.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
@@ -262,13 +262,13 @@
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_system.0.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_system.1.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows-2012/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows-2012/fluent_bit_parser.conf
@@ -197,7 +197,7 @@
 [MULTILINE_PARSER]
     Name cassandra_custom.cassandra_custom_debug.cassandra_debug.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
@@ -209,13 +209,13 @@
 [MULTILINE_PARSER]
     Name cassandra_custom.cassandra_custom_system.cassandra_system.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
     Name cassandra_default.cassandra_default_debug.cassandra_debug.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
@@ -227,19 +227,19 @@
 [MULTILINE_PARSER]
     Name cassandra_default.cassandra_default_system.cassandra_system.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_debug.0.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_debug.1.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
@@ -251,13 +251,13 @@
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_gc.0.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_gc.1.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
@@ -269,13 +269,13 @@
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_system.0.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_system.1.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows/fluent_bit_parser.conf
@@ -197,7 +197,7 @@
 [MULTILINE_PARSER]
     Name cassandra_custom.cassandra_custom_debug.cassandra_debug.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
@@ -209,13 +209,13 @@
 [MULTILINE_PARSER]
     Name cassandra_custom.cassandra_custom_system.cassandra_system.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
     Name cassandra_default.cassandra_default_debug.cassandra_debug.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
@@ -227,19 +227,19 @@
 [MULTILINE_PARSER]
     Name cassandra_default.cassandra_default_system.cassandra_system.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_debug.0.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_debug.1.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
@@ -251,13 +251,13 @@
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_gc.0.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_gc.1.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
@@ -269,13 +269,13 @@
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_system.0.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]
     Name cassandra_syslog_system.cassandra_syslog_system.1.multiline
     Type regex
-    rule "start_state"    "[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
+    rule "start_state"    "^[A-Z]+\s+\[[^\]]+\] \d+"    "cont"
     rule "cont"    "^(?![A-Z]+\s+\[[^\]]+\] \d+)"    "cont"
 
 [MULTILINE_PARSER]

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux-gpu/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux-gpu/fluent_bit_parser.conf
@@ -22,5 +22,5 @@
 [MULTILINE_PARSER]
     Name flink.flink.flink.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+)"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux/fluent_bit_parser.conf
@@ -22,5 +22,5 @@
 [MULTILINE_PARSER]
     Name flink.flink.flink.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+)"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows-2012/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows-2012/fluent_bit_parser.conf
@@ -29,5 +29,5 @@
 [MULTILINE_PARSER]
     Name flink.flink.flink.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+)"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows/fluent_bit_parser.conf
@@ -29,5 +29,5 @@
 [MULTILINE_PARSER]
     Name flink.flink.flink.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+)"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux-gpu/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux-gpu/fluent_bit_parser.conf
@@ -22,5 +22,5 @@
 [MULTILINE_PARSER]
     Name hbase.hbase_system.hbase_system.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\,\d{3,6}"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\,\d{3,6}"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\,\d{3,6})"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux/fluent_bit_parser.conf
@@ -22,5 +22,5 @@
 [MULTILINE_PARSER]
     Name hbase.hbase_system.hbase_system.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\,\d{3,6}"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\,\d{3,6}"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\,\d{3,6})"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows-2012/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows-2012/fluent_bit_parser.conf
@@ -29,5 +29,5 @@
 [MULTILINE_PARSER]
     Name hbase.hbase_system.hbase_system.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\,\d{3,6}"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\,\d{3,6}"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\,\d{3,6})"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows/fluent_bit_parser.conf
@@ -29,5 +29,5 @@
 [MULTILINE_PARSER]
     Name hbase.hbase_system.hbase_system.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\,\d{3,6}"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\,\d{3,6}"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\,\d{3,6})"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux-gpu/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux-gpu/fluent_bit_parser.conf
@@ -22,5 +22,5 @@
 [MULTILINE_PARSER]
     Name kafka.kafka.kafka.multiline
     Type regex
-    rule "start_state"    "\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
+    rule "start_state"    "^\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
     rule "cont"    "^(?!\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\])"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux/fluent_bit_parser.conf
@@ -22,5 +22,5 @@
 [MULTILINE_PARSER]
     Name kafka.kafka.kafka.multiline
     Type regex
-    rule "start_state"    "\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
+    rule "start_state"    "^\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
     rule "cont"    "^(?!\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\])"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows-2012/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows-2012/fluent_bit_parser.conf
@@ -29,5 +29,5 @@
 [MULTILINE_PARSER]
     Name kafka.kafka.kafka.multiline
     Type regex
-    rule "start_state"    "\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
+    rule "start_state"    "^\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
     rule "cont"    "^(?!\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\])"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows/fluent_bit_parser.conf
@@ -29,5 +29,5 @@
 [MULTILINE_PARSER]
     Name kafka.kafka.kafka.multiline
     Type regex
-    rule "start_state"    "\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
+    rule "start_state"    "^\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
     rule "cont"    "^(?!\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\])"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/linux-gpu/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/linux-gpu/fluent_bit_parser.conf
@@ -34,11 +34,11 @@
 [MULTILINE_PARSER]
     Name kafka_custom.kafka_custom.kafka.multiline
     Type regex
-    rule "start_state"    "\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
+    rule "start_state"    "^\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
     rule "cont"    "^(?!\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\])"    "cont"
 
 [MULTILINE_PARSER]
     Name kafka_syslog.kafka_syslog.0.multiline
     Type regex
-    rule "start_state"    "\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
+    rule "start_state"    "^\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
     rule "cont"    "^(?!\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\])"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/linux/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/linux/fluent_bit_parser.conf
@@ -34,11 +34,11 @@
 [MULTILINE_PARSER]
     Name kafka_custom.kafka_custom.kafka.multiline
     Type regex
-    rule "start_state"    "\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
+    rule "start_state"    "^\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
     rule "cont"    "^(?!\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\])"    "cont"
 
 [MULTILINE_PARSER]
     Name kafka_syslog.kafka_syslog.0.multiline
     Type regex
-    rule "start_state"    "\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
+    rule "start_state"    "^\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
     rule "cont"    "^(?!\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\])"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows-2012/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows-2012/fluent_bit_parser.conf
@@ -41,11 +41,11 @@
 [MULTILINE_PARSER]
     Name kafka_custom.kafka_custom.kafka.multiline
     Type regex
-    rule "start_state"    "\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
+    rule "start_state"    "^\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
     rule "cont"    "^(?!\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\])"    "cont"
 
 [MULTILINE_PARSER]
     Name kafka_syslog.kafka_syslog.0.multiline
     Type regex
-    rule "start_state"    "\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
+    rule "start_state"    "^\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
     rule "cont"    "^(?!\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\])"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows/fluent_bit_parser.conf
@@ -41,11 +41,11 @@
 [MULTILINE_PARSER]
     Name kafka_custom.kafka_custom.kafka.multiline
     Type regex
-    rule "start_state"    "\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
+    rule "start_state"    "^\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
     rule "cont"    "^(?!\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\])"    "cont"
 
 [MULTILINE_PARSER]
     Name kafka_syslog.kafka_syslog.0.multiline
     Type regex
-    rule "start_state"    "\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
+    rule "start_state"    "^\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\]"    "cont"
     rule "cont"    "^(?!\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\])"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux-gpu/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux-gpu/fluent_bit_main.conf
@@ -108,6 +108,7 @@
     Name         parser
     Reserve_Data True
     Parser       postgresql.postgresql_general.postgresql.0
+    Parser       postgresql.postgresql_general.postgresql.1
 
 [FILTER]
     Match  postgresql.postgresql_general

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux-gpu/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux-gpu/fluent_bit_parser.conf
@@ -1,7 +1,15 @@
 [PARSER]
     Format      regex
     Name        postgresql.postgresql_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Time_Format %Y-%m-%d %H:%M:%S.%L %z
+    Time_Key    time
+    Types       tid:integer
+
+[PARSER]
+    Format      regex
+    Name        postgresql.postgresql_general.postgresql.1
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*(?:\s+(?<database>\S*)\s+(?<user>\S*))?\s*\[(?<tid>\d+)\]\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux-gpu/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux-gpu/fluent_bit_parser.conf
@@ -23,5 +23,5 @@
 [MULTILINE_PARSER]
     Name postgresql.postgresql_general.postgresql.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/fluent_bit_main.conf
@@ -108,6 +108,7 @@
     Name         parser
     Reserve_Data True
     Parser       postgresql.postgresql_general.postgresql.0
+    Parser       postgresql.postgresql_general.postgresql.1
 
 [FILTER]
     Match  postgresql.postgresql_general

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/fluent_bit_parser.conf
@@ -1,7 +1,15 @@
 [PARSER]
     Format      regex
     Name        postgresql.postgresql_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Time_Format %Y-%m-%d %H:%M:%S.%L %z
+    Time_Key    time
+    Types       tid:integer
+
+[PARSER]
+    Format      regex
+    Name        postgresql.postgresql_general.postgresql.1
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*(?:\s+(?<database>\S*)\s+(?<user>\S*))?\s*\[(?<tid>\d+)\]\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/fluent_bit_parser.conf
@@ -23,5 +23,5 @@
 [MULTILINE_PARSER]
     Name postgresql.postgresql_general.postgresql.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/fluent_bit_main.conf
@@ -151,6 +151,7 @@
     Name         parser
     Reserve_Data True
     Parser       postgresql.postgresql_general.postgresql.0
+    Parser       postgresql.postgresql_general.postgresql.1
 
 [FILTER]
     Match  postgresql.postgresql_general

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/fluent_bit_parser.conf
@@ -30,5 +30,5 @@
 [MULTILINE_PARSER]
     Name postgresql.postgresql_general.postgresql.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/fluent_bit_parser.conf
@@ -8,7 +8,15 @@
 [PARSER]
     Format      regex
     Name        postgresql.postgresql_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Time_Format %Y-%m-%d %H:%M:%S.%L %z
+    Time_Key    time
+    Types       tid:integer
+
+[PARSER]
+    Format      regex
+    Name        postgresql.postgresql_general.postgresql.1
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*(?:\s+(?<database>\S*)\s+(?<user>\S*))?\s*\[(?<tid>\d+)\]\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/fluent_bit_main.conf
@@ -151,6 +151,7 @@
     Name         parser
     Reserve_Data True
     Parser       postgresql.postgresql_general.postgresql.0
+    Parser       postgresql.postgresql_general.postgresql.1
 
 [FILTER]
     Match  postgresql.postgresql_general

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/fluent_bit_parser.conf
@@ -30,5 +30,5 @@
 [MULTILINE_PARSER]
     Name postgresql.postgresql_general.postgresql.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/fluent_bit_parser.conf
@@ -8,7 +8,15 @@
 [PARSER]
     Format      regex
     Name        postgresql.postgresql_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Time_Format %Y-%m-%d %H:%M:%S.%L %z
+    Time_Key    time
+    Types       tid:integer
+
+[PARSER]
+    Format      regex
+    Name        postgresql.postgresql_general.postgresql.1
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*(?:\s+(?<database>\S*)\s+(?<user>\S*))?\s*\[(?<tid>\d+)\]\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux-gpu/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux-gpu/fluent_bit_main.conf
@@ -133,6 +133,7 @@
     Name         parser
     Reserve_Data True
     Parser       postgresql_custom.postgresql_custom_general.postgresql.0
+    Parser       postgresql_custom.postgresql_custom_general.postgresql.1
 
 [FILTER]
     Match  postgresql_custom.postgresql_custom_general
@@ -170,6 +171,7 @@
     Name         parser
     Reserve_Data True
     Parser       postgresql_default.postgresql_default_general.postgresql.0
+    Parser       postgresql_default.postgresql_default_general.postgresql.1
 
 [FILTER]
     Match  postgresql_default.postgresql_default_general
@@ -207,6 +209,7 @@
     Name         parser
     Reserve_Data True
     Parser       postgresql_syslog_error.postgresql_syslog_general.0.0
+    Parser       postgresql_syslog_error.postgresql_syslog_general.0.1
 
 [FILTER]
     Match  postgresql_syslog_error.postgresql_syslog_general

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux-gpu/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux-gpu/fluent_bit_parser.conf
@@ -44,17 +44,17 @@
 [MULTILINE_PARSER]
     Name postgresql_custom.postgresql_custom_general.postgresql.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)"    "cont"
 
 [MULTILINE_PARSER]
     Name postgresql_default.postgresql_default_general.postgresql.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)"    "cont"
 
 [MULTILINE_PARSER]
     Name postgresql_syslog_error.postgresql_syslog_general.0.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux-gpu/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux-gpu/fluent_bit_parser.conf
@@ -1,7 +1,15 @@
 [PARSER]
     Format      regex
     Name        postgresql_custom.postgresql_custom_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Time_Format %Y-%m-%d %H:%M:%S.%L %z
+    Time_Key    time
+    Types       tid:integer
+
+[PARSER]
+    Format      regex
+    Name        postgresql_custom.postgresql_custom_general.postgresql.1
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*(?:\s+(?<database>\S*)\s+(?<user>\S*))?\s*\[(?<tid>\d+)\]\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer
@@ -9,7 +17,15 @@
 [PARSER]
     Format      regex
     Name        postgresql_default.postgresql_default_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Time_Format %Y-%m-%d %H:%M:%S.%L %z
+    Time_Key    time
+    Types       tid:integer
+
+[PARSER]
+    Format      regex
+    Name        postgresql_default.postgresql_default_general.postgresql.1
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*(?:\s+(?<database>\S*)\s+(?<user>\S*))?\s*\[(?<tid>\d+)\]\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer
@@ -22,7 +38,15 @@
 [PARSER]
     Format      regex
     Name        postgresql_syslog_error.postgresql_syslog_general.0.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Time_Format %Y-%m-%d %H:%M:%S.%L %z
+    Time_Key    time
+    Types       tid:integer
+
+[PARSER]
+    Format      regex
+    Name        postgresql_syslog_error.postgresql_syslog_general.0.1
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*(?:\s+(?<database>\S*)\s+(?<user>\S*))?\s*\[(?<tid>\d+)\]\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux/fluent_bit_main.conf
@@ -133,6 +133,7 @@
     Name         parser
     Reserve_Data True
     Parser       postgresql_custom.postgresql_custom_general.postgresql.0
+    Parser       postgresql_custom.postgresql_custom_general.postgresql.1
 
 [FILTER]
     Match  postgresql_custom.postgresql_custom_general
@@ -170,6 +171,7 @@
     Name         parser
     Reserve_Data True
     Parser       postgresql_default.postgresql_default_general.postgresql.0
+    Parser       postgresql_default.postgresql_default_general.postgresql.1
 
 [FILTER]
     Match  postgresql_default.postgresql_default_general
@@ -207,6 +209,7 @@
     Name         parser
     Reserve_Data True
     Parser       postgresql_syslog_error.postgresql_syslog_general.0.0
+    Parser       postgresql_syslog_error.postgresql_syslog_general.0.1
 
 [FILTER]
     Match  postgresql_syslog_error.postgresql_syslog_general

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux/fluent_bit_parser.conf
@@ -44,17 +44,17 @@
 [MULTILINE_PARSER]
     Name postgresql_custom.postgresql_custom_general.postgresql.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)"    "cont"
 
 [MULTILINE_PARSER]
     Name postgresql_default.postgresql_default_general.postgresql.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)"    "cont"
 
 [MULTILINE_PARSER]
     Name postgresql_syslog_error.postgresql_syslog_general.0.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux/fluent_bit_parser.conf
@@ -1,7 +1,15 @@
 [PARSER]
     Format      regex
     Name        postgresql_custom.postgresql_custom_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Time_Format %Y-%m-%d %H:%M:%S.%L %z
+    Time_Key    time
+    Types       tid:integer
+
+[PARSER]
+    Format      regex
+    Name        postgresql_custom.postgresql_custom_general.postgresql.1
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*(?:\s+(?<database>\S*)\s+(?<user>\S*))?\s*\[(?<tid>\d+)\]\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer
@@ -9,7 +17,15 @@
 [PARSER]
     Format      regex
     Name        postgresql_default.postgresql_default_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Time_Format %Y-%m-%d %H:%M:%S.%L %z
+    Time_Key    time
+    Types       tid:integer
+
+[PARSER]
+    Format      regex
+    Name        postgresql_default.postgresql_default_general.postgresql.1
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*(?:\s+(?<database>\S*)\s+(?<user>\S*))?\s*\[(?<tid>\d+)\]\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer
@@ -22,7 +38,15 @@
 [PARSER]
     Format      regex
     Name        postgresql_syslog_error.postgresql_syslog_general.0.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Time_Format %Y-%m-%d %H:%M:%S.%L %z
+    Time_Key    time
+    Types       tid:integer
+
+[PARSER]
+    Format      regex
+    Name        postgresql_syslog_error.postgresql_syslog_general.0.1
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*(?:\s+(?<database>\S*)\s+(?<user>\S*))?\s*\[(?<tid>\d+)\]\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/fluent_bit_main.conf
@@ -176,6 +176,7 @@
     Name         parser
     Reserve_Data True
     Parser       postgresql_custom.postgresql_custom_general.postgresql.0
+    Parser       postgresql_custom.postgresql_custom_general.postgresql.1
 
 [FILTER]
     Match  postgresql_custom.postgresql_custom_general
@@ -213,6 +214,7 @@
     Name         parser
     Reserve_Data True
     Parser       postgresql_default.postgresql_default_general.postgresql.0
+    Parser       postgresql_default.postgresql_default_general.postgresql.1
 
 [FILTER]
     Match  postgresql_default.postgresql_default_general
@@ -250,6 +252,7 @@
     Name         parser
     Reserve_Data True
     Parser       postgresql_syslog_error.postgresql_syslog_general.0.0
+    Parser       postgresql_syslog_error.postgresql_syslog_general.0.1
 
 [FILTER]
     Match  postgresql_syslog_error.postgresql_syslog_general

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/fluent_bit_parser.conf
@@ -51,17 +51,17 @@
 [MULTILINE_PARSER]
     Name postgresql_custom.postgresql_custom_general.postgresql.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)"    "cont"
 
 [MULTILINE_PARSER]
     Name postgresql_default.postgresql_default_general.postgresql.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)"    "cont"
 
 [MULTILINE_PARSER]
     Name postgresql_syslog_error.postgresql_syslog_general.0.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/fluent_bit_parser.conf
@@ -8,7 +8,15 @@
 [PARSER]
     Format      regex
     Name        postgresql_custom.postgresql_custom_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Time_Format %Y-%m-%d %H:%M:%S.%L %z
+    Time_Key    time
+    Types       tid:integer
+
+[PARSER]
+    Format      regex
+    Name        postgresql_custom.postgresql_custom_general.postgresql.1
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*(?:\s+(?<database>\S*)\s+(?<user>\S*))?\s*\[(?<tid>\d+)\]\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer
@@ -16,7 +24,15 @@
 [PARSER]
     Format      regex
     Name        postgresql_default.postgresql_default_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Time_Format %Y-%m-%d %H:%M:%S.%L %z
+    Time_Key    time
+    Types       tid:integer
+
+[PARSER]
+    Format      regex
+    Name        postgresql_default.postgresql_default_general.postgresql.1
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*(?:\s+(?<database>\S*)\s+(?<user>\S*))?\s*\[(?<tid>\d+)\]\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer
@@ -29,7 +45,15 @@
 [PARSER]
     Format      regex
     Name        postgresql_syslog_error.postgresql_syslog_general.0.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Time_Format %Y-%m-%d %H:%M:%S.%L %z
+    Time_Key    time
+    Types       tid:integer
+
+[PARSER]
+    Format      regex
+    Name        postgresql_syslog_error.postgresql_syslog_general.0.1
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*(?:\s+(?<database>\S*)\s+(?<user>\S*))?\s*\[(?<tid>\d+)\]\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/fluent_bit_main.conf
@@ -176,6 +176,7 @@
     Name         parser
     Reserve_Data True
     Parser       postgresql_custom.postgresql_custom_general.postgresql.0
+    Parser       postgresql_custom.postgresql_custom_general.postgresql.1
 
 [FILTER]
     Match  postgresql_custom.postgresql_custom_general
@@ -213,6 +214,7 @@
     Name         parser
     Reserve_Data True
     Parser       postgresql_default.postgresql_default_general.postgresql.0
+    Parser       postgresql_default.postgresql_default_general.postgresql.1
 
 [FILTER]
     Match  postgresql_default.postgresql_default_general
@@ -250,6 +252,7 @@
     Name         parser
     Reserve_Data True
     Parser       postgresql_syslog_error.postgresql_syslog_general.0.0
+    Parser       postgresql_syslog_error.postgresql_syslog_general.0.1
 
 [FILTER]
     Match  postgresql_syslog_error.postgresql_syslog_general

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/fluent_bit_parser.conf
@@ -51,17 +51,17 @@
 [MULTILINE_PARSER]
     Name postgresql_custom.postgresql_custom_general.postgresql.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)"    "cont"
 
 [MULTILINE_PARSER]
     Name postgresql_default.postgresql_default_general.postgresql.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)"    "cont"
 
 [MULTILINE_PARSER]
     Name postgresql_syslog_error.postgresql_syslog_general.0.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/fluent_bit_parser.conf
@@ -8,7 +8,15 @@
 [PARSER]
     Format      regex
     Name        postgresql_custom.postgresql_custom_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Time_Format %Y-%m-%d %H:%M:%S.%L %z
+    Time_Key    time
+    Types       tid:integer
+
+[PARSER]
+    Format      regex
+    Name        postgresql_custom.postgresql_custom_general.postgresql.1
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*(?:\s+(?<database>\S*)\s+(?<user>\S*))?\s*\[(?<tid>\d+)\]\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer
@@ -16,7 +24,15 @@
 [PARSER]
     Format      regex
     Name        postgresql_default.postgresql_default_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Time_Format %Y-%m-%d %H:%M:%S.%L %z
+    Time_Key    time
+    Types       tid:integer
+
+[PARSER]
+    Format      regex
+    Name        postgresql_default.postgresql_default_general.postgresql.1
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*(?:\s+(?<database>\S*)\s+(?<user>\S*))?\s*\[(?<tid>\d+)\]\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer
@@ -29,7 +45,15 @@
 [PARSER]
     Format      regex
     Name        postgresql_syslog_error.postgresql_syslog_general.0.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Time_Format %Y-%m-%d %H:%M:%S.%L %z
+    Time_Key    time
+    Types       tid:integer
+
+[PARSER]
+    Format      regex
+    Name        postgresql_syslog_error.postgresql_syslog_general.0.1
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*(?:\s+(?<database>\S*)\s+(?<user>\S*))?\s*\[(?<tid>\d+)\]\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux-gpu/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux-gpu/fluent_bit_parser.conf
@@ -30,5 +30,5 @@
     flush_timeout 5000
     name          multiline.rabbitmq.rabbitmq
     type          regex
-    rule          "start_state"    "\d+-\d+-\d+ \d+:\d+:\d+\.\d+\+\d+:\d+"    "cont"
+    rule          "start_state"    "^\d+-\d+-\d+ \d+:\d+:\d+\.\d+\+\d+:\d+"    "cont"
     rule          "cont"    "^(?!\d+-\d+-\d+ \d+:\d+:\d+\.\d+\+\d+:\d+)"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux/fluent_bit_parser.conf
@@ -30,5 +30,5 @@
     flush_timeout 5000
     name          multiline.rabbitmq.rabbitmq
     type          regex
-    rule          "start_state"    "\d+-\d+-\d+ \d+:\d+:\d+\.\d+\+\d+:\d+"    "cont"
+    rule          "start_state"    "^\d+-\d+-\d+ \d+:\d+:\d+\.\d+\+\d+:\d+"    "cont"
     rule          "cont"    "^(?!\d+-\d+-\d+ \d+:\d+:\d+\.\d+\+\d+:\d+)"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows-2012/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows-2012/fluent_bit_parser.conf
@@ -37,5 +37,5 @@
     flush_timeout 5000
     name          multiline.rabbitmq.rabbitmq
     type          regex
-    rule          "start_state"    "\d+-\d+-\d+ \d+:\d+:\d+\.\d+\+\d+:\d+"    "cont"
+    rule          "start_state"    "^\d+-\d+-\d+ \d+:\d+:\d+\.\d+\+\d+:\d+"    "cont"
     rule          "cont"    "^(?!\d+-\d+-\d+ \d+:\d+:\d+\.\d+\+\d+:\d+)"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows/fluent_bit_parser.conf
@@ -37,5 +37,5 @@
     flush_timeout 5000
     name          multiline.rabbitmq.rabbitmq
     type          regex
-    rule          "start_state"    "\d+-\d+-\d+ \d+:\d+:\d+\.\d+\+\d+:\d+"    "cont"
+    rule          "start_state"    "^\d+-\d+-\d+ \d+:\d+:\d+\.\d+\+\d+:\d+"    "cont"
     rule          "cont"    "^(?!\d+-\d+-\d+ \d+:\d+:\d+\.\d+\+\d+:\d+)"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux-gpu/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux-gpu/fluent_bit_parser.conf
@@ -22,5 +22,5 @@
 [MULTILINE_PARSER]
     Name solr.solr_system.solr_system.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s[A-z]+\s{1,5}"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s[A-z]+\s{1,5}"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s[A-z]+\s{1,5})"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux/fluent_bit_parser.conf
@@ -22,5 +22,5 @@
 [MULTILINE_PARSER]
     Name solr.solr_system.solr_system.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s[A-z]+\s{1,5}"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s[A-z]+\s{1,5}"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s[A-z]+\s{1,5})"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows-2012/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows-2012/fluent_bit_parser.conf
@@ -29,5 +29,5 @@
 [MULTILINE_PARSER]
     Name solr.solr_system.solr_system.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s[A-z]+\s{1,5}"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s[A-z]+\s{1,5}"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s[A-z]+\s{1,5})"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows/fluent_bit_parser.conf
@@ -29,5 +29,5 @@
 [MULTILINE_PARSER]
     Name solr.solr_system.solr_system.multiline
     Type regex
-    rule "start_state"    "\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s[A-z]+\s{1,5}"    "cont"
+    rule "start_state"    "^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s[A-z]+\s{1,5}"    "cont"
     rule "cont"    "^(?!\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s[A-z]+\s{1,5})"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux-gpu/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux-gpu/fluent_bit_parser.conf
@@ -31,5 +31,5 @@
 [MULTILINE_PARSER]
     Name tomcat.tomcat_system.tomcat_system.multiline
     Type regex
-    rule "start_state"    "\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
+    rule "start_state"    "^\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
     rule "cont"    "^(?!\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3})"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux/fluent_bit_parser.conf
@@ -31,5 +31,5 @@
 [MULTILINE_PARSER]
     Name tomcat.tomcat_system.tomcat_system.multiline
     Type regex
-    rule "start_state"    "\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
+    rule "start_state"    "^\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
     rule "cont"    "^(?!\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3})"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows-2012/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows-2012/fluent_bit_parser.conf
@@ -38,5 +38,5 @@
 [MULTILINE_PARSER]
     Name tomcat.tomcat_system.tomcat_system.multiline
     Type regex
-    rule "start_state"    "\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
+    rule "start_state"    "^\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
     rule "cont"    "^(?!\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3})"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows/fluent_bit_parser.conf
@@ -38,5 +38,5 @@
 [MULTILINE_PARSER]
     Name tomcat.tomcat_system.tomcat_system.multiline
     Type regex
-    rule "start_state"    "\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
+    rule "start_state"    "^\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
     rule "cont"    "^(?!\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3})"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/linux-gpu/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/linux-gpu/fluent_bit_parser.conf
@@ -89,23 +89,23 @@
 [MULTILINE_PARSER]
     Name tomcat_custom.tomcat_custom_system.tomcat_system.multiline
     Type regex
-    rule "start_state"    "\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
+    rule "start_state"    "^\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
     rule "cont"    "^(?!\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3})"    "cont"
 
 [MULTILINE_PARSER]
     Name tomcat_default.tomcat_default_system.tomcat_system.multiline
     Type regex
-    rule "start_state"    "\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
+    rule "start_state"    "^\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
     rule "cont"    "^(?!\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3})"    "cont"
 
 [MULTILINE_PARSER]
     Name tomcat_syslog_system.tomcat_syslog_access.0.multiline
     Type regex
-    rule "start_state"    "\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
+    rule "start_state"    "^\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
     rule "cont"    "^(?!\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3})"    "cont"
 
 [MULTILINE_PARSER]
     Name tomcat_syslog_system.tomcat_syslog_system.0.multiline
     Type regex
-    rule "start_state"    "\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
+    rule "start_state"    "^\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
     rule "cont"    "^(?!\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3})"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/linux/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/linux/fluent_bit_parser.conf
@@ -89,23 +89,23 @@
 [MULTILINE_PARSER]
     Name tomcat_custom.tomcat_custom_system.tomcat_system.multiline
     Type regex
-    rule "start_state"    "\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
+    rule "start_state"    "^\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
     rule "cont"    "^(?!\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3})"    "cont"
 
 [MULTILINE_PARSER]
     Name tomcat_default.tomcat_default_system.tomcat_system.multiline
     Type regex
-    rule "start_state"    "\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
+    rule "start_state"    "^\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
     rule "cont"    "^(?!\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3})"    "cont"
 
 [MULTILINE_PARSER]
     Name tomcat_syslog_system.tomcat_syslog_access.0.multiline
     Type regex
-    rule "start_state"    "\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
+    rule "start_state"    "^\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
     rule "cont"    "^(?!\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3})"    "cont"
 
 [MULTILINE_PARSER]
     Name tomcat_syslog_system.tomcat_syslog_system.0.multiline
     Type regex
-    rule "start_state"    "\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
+    rule "start_state"    "^\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
     rule "cont"    "^(?!\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3})"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows-2012/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows-2012/fluent_bit_parser.conf
@@ -96,23 +96,23 @@
 [MULTILINE_PARSER]
     Name tomcat_custom.tomcat_custom_system.tomcat_system.multiline
     Type regex
-    rule "start_state"    "\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
+    rule "start_state"    "^\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
     rule "cont"    "^(?!\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3})"    "cont"
 
 [MULTILINE_PARSER]
     Name tomcat_default.tomcat_default_system.tomcat_system.multiline
     Type regex
-    rule "start_state"    "\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
+    rule "start_state"    "^\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
     rule "cont"    "^(?!\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3})"    "cont"
 
 [MULTILINE_PARSER]
     Name tomcat_syslog_system.tomcat_syslog_access.0.multiline
     Type regex
-    rule "start_state"    "\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
+    rule "start_state"    "^\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
     rule "cont"    "^(?!\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3})"    "cont"
 
 [MULTILINE_PARSER]
     Name tomcat_syslog_system.tomcat_syslog_system.0.multiline
     Type regex
-    rule "start_state"    "\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
+    rule "start_state"    "^\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
     rule "cont"    "^(?!\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3})"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows/fluent_bit_parser.conf
@@ -96,23 +96,23 @@
 [MULTILINE_PARSER]
     Name tomcat_custom.tomcat_custom_system.tomcat_system.multiline
     Type regex
-    rule "start_state"    "\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
+    rule "start_state"    "^\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
     rule "cont"    "^(?!\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3})"    "cont"
 
 [MULTILINE_PARSER]
     Name tomcat_default.tomcat_default_system.tomcat_system.multiline
     Type regex
-    rule "start_state"    "\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
+    rule "start_state"    "^\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
     rule "cont"    "^(?!\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3})"    "cont"
 
 [MULTILINE_PARSER]
     Name tomcat_syslog_system.tomcat_syslog_access.0.multiline
     Type regex
-    rule "start_state"    "\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
+    rule "start_state"    "^\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
     rule "cont"    "^(?!\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3})"    "cont"
 
 [MULTILINE_PARSER]
     Name tomcat_syslog_system.tomcat_syslog_system.0.multiline
     Type regex
-    rule "start_state"    "\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
+    rule "start_state"    "^\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}"    "cont"
     rule "cont"    "^(?!\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3})"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux-gpu/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux-gpu/fluent_bit_parser.conf
@@ -23,5 +23,5 @@
     flush_timeout 5000
     name          multiline.wildfly_system.wildfly_system
     type          regex
-    rule          "start_state"    "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}"    "cont"
+    rule          "start_state"    "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}"    "cont"
     rule          "cont"    "^(?!\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux/fluent_bit_parser.conf
@@ -23,5 +23,5 @@
     flush_timeout 5000
     name          multiline.wildfly_system.wildfly_system
     type          regex
-    rule          "start_state"    "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}"    "cont"
+    rule          "start_state"    "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}"    "cont"
     rule          "cont"    "^(?!\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows-2012/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows-2012/fluent_bit_parser.conf
@@ -30,5 +30,5 @@
     flush_timeout 5000
     name          multiline.wildfly_system.wildfly_system
     type          regex
-    rule          "start_state"    "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}"    "cont"
+    rule          "start_state"    "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}"    "cont"
     rule          "cont"    "^(?!\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})"    "cont"

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows/fluent_bit_parser.conf
@@ -30,5 +30,5 @@
     flush_timeout 5000
     name          multiline.wildfly_system.wildfly_system
     type          regex
-    rule          "start_state"    "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}"    "cont"
+    rule          "start_state"    "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}"    "cont"
     rule          "cont"    "^(?!\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})"    "cont"

--- a/integration_test/third_party_apps_test/applications/postgresql/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/postgresql/debian_ubuntu/install
@@ -2,7 +2,7 @@ set -e
 
 sudo apt-get -y install gnupg wget
 sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-wget --no-verbose --output-document=/etc/apt/trusted.gpg.d/postgresql.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc
+sudo wget --no-verbose --output-document=/etc/apt/trusted.gpg.d/postgresql.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc
 sudo apt-get -y update
 sudo apt-get install -y postgresql-14
 

--- a/integration_test/third_party_apps_test/applications/postgresql/exercise
+++ b/integration_test/third_party_apps_test/applications/postgresql/exercise
@@ -1,7 +1,11 @@
 set -e
 
 sudo su postgres -c "PGPASSWORD=abc123 psql postgres -h localhost -c  \"CREATE TABLE test1 (id serial PRIMARY KEY);\""
-sudo su postgres -c "PGPASSWORD=abc123 psql postgres -h localhost -c \"CREATE TABLE test2 (id serial PRIMARY KEY);\""
+sudo su postgres -c "PGPASSWORD=abc123 psql postgres -h localhost -c \"CREATE TABLE test2 (id text PRIMARY KEY);\""
 sudo su postgres -c "PGPASSWORD=abc123 psql postgres -h localhost -c \"CREATE INDEX otelindex ON test1(id);\""
 sudo su postgres -c "PGPASSWORD=abc123 psql postgres -h localhost -c \"CREATE INDEX otel2index ON test2(id);\""
-sudo su postgres -c "PGPASSWORD=abc123 psql postgres -h localhost -c \"INSERT INTO test2 (id) VALUES(67);\""
+sudo su postgres -c "PGPASSWORD=abc123 psql postgres -h localhost -c \"INSERT INTO 
+test2 (id) VALUES('1970-01-01 00:00:00.123 UTC');\""
+# second insert should fail and log a multiline with an extra timestamp, allowing us to test multiline log parsing
+sudo su postgres -c "PGPASSWORD=abc123 psql postgres -h localhost -c \"INSERT INTO 
+test2 (id) VALUES('1970-01-01 00:00:00.123 UTC');\""

--- a/integration_test/third_party_apps_test/applications/postgresql/exercise
+++ b/integration_test/third_party_apps_test/applications/postgresql/exercise
@@ -8,4 +8,4 @@ sudo su postgres -c "PGPASSWORD=abc123 psql postgres -h localhost -c \"INSERT IN
 test2 (id) VALUES('1970-01-01 00:00:00.123 UTC');\""
 # second insert should fail and log a multiline with an extra timestamp, allowing us to test multiline log parsing
 sudo su postgres -c "PGPASSWORD=abc123 psql postgres -h localhost -c \"INSERT INTO 
-test2 (id) VALUES('1970-01-01 00:00:00.123 UTC');\""
+test2 (id) VALUES('1970-01-01 00:00:00.123 UTC');\"" || true # || true to prevent `set -e` from exiting the script on failed double insert

--- a/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
@@ -193,8 +193,10 @@ expected_logs:
       - name: jsonPayload.database
         type: string
         description: Database name for the action being logged when relevant
+        optional: true
       - name: jsonPayload.user
         type: string
+        optional: true
         description: Authenticated user for the action being logged when relevant
       - name: severity
         type: string

--- a/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
@@ -190,9 +190,9 @@ expected_logs:
       - name: jsonPayload.tid
         type: number
         description: Thread ID where the log originated
-      - name: jsonPayload.role
+      - name: jsonPayload.database
         type: string
-        description: Authenticated role for the action being logged when relevant
+        description: Database name for the action being logged when relevant
         optional: true
       - name: jsonPayload.user
         type: string

--- a/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
@@ -180,11 +180,11 @@ expected_logs:
     fields:
       - name: jsonPayload.message
         # There should be a line break between INTO and test2, this regex tests our multiline parsing
-        value_regex: '.*STATEMENT:  INSERT INTO\s+test2 \(id\) VALUES\(''1970-01-01 00:00:00\.123 UTC''\).*'
+        value_regex: '.*INSERT INTO\s+test2 \(id\) VALUES\(''1970-01-01 00:00:00\.123 UTC''\).*'
         type: string
         description: Log of the database action
       - name: jsonPayload.level
-        value_regex: LOG
+        value_regex: STATEMENT
         type: string
         description: Log severity or type of database interaction type for some logs
       - name: jsonPayload.tid

--- a/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
@@ -179,7 +179,8 @@ expected_logs:
   - log_name: postgresql_general
     fields:
       - name: jsonPayload.message
-        value_regex: .*starting PostgreSQL.*
+        # There should be a line break between INTO and test2, this regex tests our multiline parsing
+        value_regex: '.*STATEMENT:  INSERT INTO\s+test2 (id) VALUES(''1970-01-01 00:00:00.123 UTC\'').*'
         type: string
         description: Log of the database action
       - name: jsonPayload.level

--- a/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
@@ -180,7 +180,7 @@ expected_logs:
     fields:
       - name: jsonPayload.message
         # There should be a line break between INTO and test2, this regex tests our multiline parsing
-        value_regex: '.*STATEMENT:  INSERT INTO\s+test2 (id) VALUES(''1970-01-01 00:00:00.123 UTC\'').*'
+        value_regex: '.*STATEMENT:  INSERT INTO\s+test2 \(id\) VALUES\(''1970-01-01 00:00:00\.123 UTC\''\).*'
         type: string
         description: Log of the database action
       - name: jsonPayload.level

--- a/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
@@ -191,11 +191,9 @@ expected_logs:
         type: number
         description: Thread ID where the log originated
       - name: jsonPayload.database
-        value_regex: postgres
         type: string
         description: Database name for the action being logged when relevant
       - name: jsonPayload.user
-        value_regex: postgres
         type: string
         description: Authenticated user for the action being logged when relevant
       - name: severity

--- a/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
@@ -191,12 +191,12 @@ expected_logs:
         type: number
         description: Thread ID where the log originated
       - name: jsonPayload.database
+        value_regex: postgres
         type: string
         description: Database name for the action being logged when relevant
-        optional: true
       - name: jsonPayload.user
+        value_regex: postgres
         type: string
-        optional: true
         description: Authenticated user for the action being logged when relevant
       - name: severity
         type: string

--- a/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
@@ -180,7 +180,7 @@ expected_logs:
     fields:
       - name: jsonPayload.message
         # There should be a line break between INTO and test2, this regex tests our multiline parsing
-        value_regex: '.*STATEMENT:  INSERT INTO\s+test2 \(id\) VALUES\(''1970-01-01 00:00:00\.123 UTC\''\).*'
+        value_regex: '.*STATEMENT:  INSERT INTO\s+test2 \(id\) VALUES\(''1970-01-01 00:00:00\.123 UTC''\).*'
         type: string
         description: Log of the database action
       - name: jsonPayload.level


### PR DESCRIPTION
## Description
1. Ensure that all multiline regexes specify the start of line character for their start_state. This resolves an ongoing customer issue with postgres audit logs.
2. Adds parser for SLES12 default log format for postgresql
3. Fixes existing postgresql parser to appropriately parse database and user from log.

## Related issue
https://metabug.corp.google.com/entity/145251722?audience=43
[b/316922937](http://b/316922937)

## How has this been tested?
Tested in integration tests in kokoro.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [X] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
