### PR TITLE
Internal: pass Louhi vars into soak test launcher

### DIFF
--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -48,24 +48,14 @@ set -o pipefail
 cd "$(readlink -f "$(dirname "$0")")"
 cd ../../../
 
-# Source the common utilities, for track_flakiness.
+# Source the common utilities.
 source kokoro/scripts/utils/common.sh
+source kokoro/scripts/utils/louhi.sh
 
 track_flakiness
 
 # Avoids "fatal: detected dubious ownership in repository" errors on Kokoro containers.
 git config --global --add safe.directory "$(pwd)"
-
-# A helper for parsing YAML files.
-# Ex: VALUE=$(yaml ~/my_yaml_file.yaml "['a_key']")
-function yaml() {
-  python3 -c "import yaml
-data=yaml.safe_load(open('$1'))$2
-if type(data)==list:
-  print(','.join(str(elem) for elem in data))
-else:
- print(data)"
-}
 
 # A helper function for joining a bash array.
 # Ex. join_by , a b c -> a,b,c
@@ -86,17 +76,7 @@ function set_image_specs() {
   fi
   # if _LOUHI_TAG_NAME is defined, set TARGET and ARCH env vars by parsing it.
   # Example value: louhi/2.46.0/shortref/windows/x86_64/start
-  if [[ -n "${_LOUHI_TAG_NAME:-}" ]]; then
-    local -a _LOUHI_TAG_COMPONENTS=(${_LOUHI_TAG_NAME//\// })  
-    export REPO_SUFFIX="${_LOUHI_TAG_COMPONENTS[2]}"  # the shortref is the repo suffix
-    TARGET="${_LOUHI_TAG_COMPONENTS[3]}"
-    ARCH="${_LOUHI_TAG_COMPONENTS[4]}"
-    export ARTIFACT_REGISTRY_PROJECT="${_STAGING_ARTIFACTS_PROJECT_ID}"  # Louhi is responsible for passing this.
-    EXT=$(yaml project.yaml "['targets']['${TARGET}']['package_extension']")
-    if [[ "${EXT}" == "deb" ]]; then
-      export REPO_CODENAME="${TARGET}-${ARCH}"
-    fi
-  fi
+  read_louhi_tag
   # if TARGET is not set, return an error
   if [[ -z "${TARGET:-}" ]]; then
     echo "At least one of TARGET/IMAGE_SPECS must be set." 1>&2

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -76,7 +76,11 @@ function set_image_specs() {
   fi
   # if _LOUHI_TAG_NAME is defined, set TARGET and ARCH env vars by parsing it.
   # Example value: louhi/2.46.0/shortref/windows/x86_64/start
-  read_louhi_tag
+  parse_louhi_tag
+  EXT=$(yaml project.yaml "['targets']['${TARGET}']['package_extension']")
+  if [[ "${EXT}" == "deb" ]]; then
+    export REPO_CODENAME="${TARGET}-${ARCH}"
+  fi
   # if TARGET is not set, return an error
   if [[ -z "${TARGET:-}" ]]; then
     echo "At least one of TARGET/IMAGE_SPECS must be set." 1>&2

--- a/kokoro/scripts/test/start_soak_test.sh
+++ b/kokoro/scripts/test/start_soak_test.sh
@@ -13,13 +13,12 @@ cd ../../../
 source kokoro/scripts/utils/louhi.sh
 
 # For soak tests run by Louhi
-read_louhi_tag
+parse_louhi_tag
 # if TARGET & ARCH are set, retrieve the soak distro from project.yaml
 if [[ -n "${TARGET:-}" && -n "${ARCH:-}" ]]; then
   DISTRO=$(yaml project.yaml "['targets']['${TARGET}']['architectures']['${ARCH}']['soak_distro']")
-  VM_NAME="soak-test-${REPO_SUFFIX}-${LABEL}"
+  export VM_NAME="soak-test-${REPO_SUFFIX}-${LABEL}"
   export DISTRO
-  export VM_NAME
 fi
 
 for GIT_ALIAS in git github; do

--- a/kokoro/scripts/test/start_soak_test.sh
+++ b/kokoro/scripts/test/start_soak_test.sh
@@ -5,6 +5,13 @@ set -u
 set -x
 set -o pipefail
 
+# cd to the root of the git repo containing this script ($0).
+cd "$(readlink -f "$(dirname "$0")")"
+cd ../../../
+
+# Source the common utilities.
+source kokoro/scripts/utils/louhi.sh
+
 for GIT_ALIAS in git github; do
   CANDIDATE_LOCATION="${KOKORO_ARTIFACTS_DIR}/${GIT_ALIAS}/unified_agents/integration_test/soak_test/cmd/launcher"
   if [[ -d "${CANDIDATE_LOCATION}" ]]; then
@@ -12,6 +19,16 @@ for GIT_ALIAS in git github; do
     break
   fi
 done
+
+# For soak tests run by Louhi
+read_louhi_tag
+# if TARGET & ARCH are set, retrieve the soak distro from project.yaml
+if [[ -n "${TARGET:-}" && -n "${ARCH:-}" ]]; then
+  DISTRO=$(yaml project.yaml "['targets']['${TARGET}']['architectures']['${ARCH}']['soak_distro']")
+  VM_NAME="soak-test-${REPO_SUFFIX}-${LABEL}"
+  export DISTRO
+  export VM_NAME
+fi
 
 LOG_RATE=${LOG_RATE-1000} \
 LOG_SIZE_IN_BYTES=${LOG_SIZE_IN_BYTES-1000} \

--- a/kokoro/scripts/test/start_soak_test.sh
+++ b/kokoro/scripts/test/start_soak_test.sh
@@ -12,14 +12,6 @@ cd ../../../
 # Source the common utilities.
 source kokoro/scripts/utils/louhi.sh
 
-for GIT_ALIAS in git github; do
-  CANDIDATE_LOCATION="${KOKORO_ARTIFACTS_DIR}/${GIT_ALIAS}/unified_agents/integration_test/soak_test/cmd/launcher"
-  if [[ -d "${CANDIDATE_LOCATION}" ]]; then
-    cd "${CANDIDATE_LOCATION}"
-    break
-  fi
-done
-
 # For soak tests run by Louhi
 read_louhi_tag
 # if TARGET & ARCH are set, retrieve the soak distro from project.yaml
@@ -29,6 +21,14 @@ if [[ -n "${TARGET:-}" && -n "${ARCH:-}" ]]; then
   export DISTRO
   export VM_NAME
 fi
+
+for GIT_ALIAS in git github; do
+  CANDIDATE_LOCATION="${KOKORO_ARTIFACTS_DIR}/${GIT_ALIAS}/unified_agents/integration_test/soak_test/cmd/launcher"
+  if [[ -d "${CANDIDATE_LOCATION}" ]]; then
+    cd "${CANDIDATE_LOCATION}"
+    break
+  fi
+done
 
 LOG_RATE=${LOG_RATE-1000} \
 LOG_SIZE_IN_BYTES=${LOG_SIZE_IN_BYTES-1000} \

--- a/kokoro/scripts/utils/louhi.sh
+++ b/kokoro/scripts/utils/louhi.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A helper for parsing YAML files.
+# Ex: VALUE=$(yaml ~/my_yaml_file.yaml "['a_key']")
+function yaml() {
+  python3 -c "import yaml
+data=yaml.safe_load(open('$1'))$2
+if type(data)==list:
+  print(','.join(str(elem) for elem in data))
+else:
+ print(data)"
+}
+
+function read_louhi_tag() {
+  # if _LOUHI_TAG_NAME is defined, set TARGET and ARCH env vars by parsing it.
+  # Example value: louhi/2.46.0/shortref/windows/x86_64/start
+  if [[ -n "${_LOUHI_TAG_NAME:-}" ]]; then
+    local -a _LOUHI_TAG_COMPONENTS=(${_LOUHI_TAG_NAME//\// })  
+    export REPO_SUFFIX="${_LOUHI_TAG_COMPONENTS[2]}"  # the shortref is the repo suffix
+    TARGET="${_LOUHI_TAG_COMPONENTS[3]}"
+    ARCH="${_LOUHI_TAG_COMPONENTS[4]}"
+    export ARTIFACT_REGISTRY_PROJECT="${_STAGING_ARTIFACTS_PROJECT_ID}"  # Louhi is responsible for passing this.
+    EXT=$(yaml project.yaml "['targets']['${TARGET}']['package_extension']")
+    if [[ "${EXT}" == "deb" ]]; then
+      export REPO_CODENAME="${TARGET}-${ARCH}"
+    fi
+  fi
+}

--- a/kokoro/scripts/utils/louhi.sh
+++ b/kokoro/scripts/utils/louhi.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +23,7 @@ else:
  print(data)"
 }
 
-function read_louhi_tag() {
+function parse_louhi_tag() {
   # if _LOUHI_TAG_NAME is defined, set TARGET and ARCH env vars by parsing it.
   # Example value: louhi/2.46.0/shortref/windows/x86_64/start
   if [[ -n "${_LOUHI_TAG_NAME:-}" ]]; then
@@ -33,9 +32,5 @@ function read_louhi_tag() {
     TARGET="${_LOUHI_TAG_COMPONENTS[3]}"
     ARCH="${_LOUHI_TAG_COMPONENTS[4]}"
     export ARTIFACT_REGISTRY_PROJECT="${_STAGING_ARTIFACTS_PROJECT_ID}"  # Louhi is responsible for passing this.
-    EXT=$(yaml project.yaml "['targets']['${TARGET}']['package_extension']")
-    if [[ "${EXT}" == "deb" ]]; then
-      export REPO_CODENAME="${TARGET}-${ARCH}"
-    fi
   fi
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
For launching soak tests via Louhi.

Includes a `util/louhi.sh` for common functionality.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->
[337841307](337841307)

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
