### PR TITLE
Postgres log field names did not match default log_line_prefix

### DIFF
--- a/apps/postgresql.go
+++ b/apps/postgresql.go
@@ -113,13 +113,15 @@ func (p LoggingProcessorPostgresql) Components(ctx context.Context, tag string, 
 		LoggingProcessorParseRegexComplex: confgenerator.LoggingProcessorParseRegexComplex{
 			Parsers: []confgenerator.RegexParser{
 				{
-					// Limited logging documentation: https://www.postgresql.org/docs/10/runtime-config-logging.html
+					// This parser matches most distributions' defaults by our testing
+					// log_line_prefix = '%m [%p] '
+					// log_line_prefix = '%m [%p] %q%u@%d '
 					// Sample line: 2022-01-12 20:57:58.378 UTC [26241] LOG:  starting PostgreSQL 14.1 (Debian 14.1-1.pgdg100+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit
 					// Sample line: 2022-01-12 20:59:25.169 UTC [27445] postgres@postgres FATAL:  Peer authentication failed for user "postgres"
 					// Sample line: 2022-01-12 21:49:13.989 UTC [27836] postgres@postgres LOG:  duration: 1.074 ms  statement: select *
 					//    from pg_database
 					//    where 1=1;
-					Regex: `^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)`,
+					Regex: `^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)`,
 					Parser: confgenerator.ParserShared{
 						TimeKey:    "time",
 						TimeFormat: "%Y-%m-%d %H:%M:%S.%L %z",

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux-gpu/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux-gpu/fluent_bit_parser.conf
@@ -1,7 +1,7 @@
 [PARSER]
     Format      regex
     Name        postgresql.postgresql_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/fluent_bit_parser.conf
@@ -1,7 +1,7 @@
 [PARSER]
     Format      regex
     Name        postgresql.postgresql_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/fluent_bit_parser.conf
@@ -8,7 +8,7 @@
 [PARSER]
     Format      regex
     Name        postgresql.postgresql_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/fluent_bit_parser.conf
@@ -8,7 +8,7 @@
 [PARSER]
     Format      regex
     Name        postgresql.postgresql_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux-gpu/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux-gpu/fluent_bit_parser.conf
@@ -1,7 +1,7 @@
 [PARSER]
     Format      regex
     Name        postgresql_custom.postgresql_custom_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer
@@ -9,7 +9,7 @@
 [PARSER]
     Format      regex
     Name        postgresql_default.postgresql_default_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer
@@ -22,7 +22,7 @@
 [PARSER]
     Format      regex
     Name        postgresql_syslog_error.postgresql_syslog_general.0.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux/fluent_bit_parser.conf
@@ -1,7 +1,7 @@
 [PARSER]
     Format      regex
     Name        postgresql_custom.postgresql_custom_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer
@@ -9,7 +9,7 @@
 [PARSER]
     Format      regex
     Name        postgresql_default.postgresql_default_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer
@@ -22,7 +22,7 @@
 [PARSER]
     Format      regex
     Name        postgresql_syslog_error.postgresql_syslog_general.0.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/fluent_bit_parser.conf
@@ -8,7 +8,7 @@
 [PARSER]
     Format      regex
     Name        postgresql_custom.postgresql_custom_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer
@@ -16,7 +16,7 @@
 [PARSER]
     Format      regex
     Name        postgresql_default.postgresql_default_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer
@@ -29,7 +29,7 @@
 [PARSER]
     Format      regex
     Name        postgresql_syslog_error.postgresql_syslog_general.0.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/fluent_bit_parser.conf
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/fluent_bit_parser.conf
@@ -8,7 +8,7 @@
 [PARSER]
     Format      regex
     Name        postgresql_custom.postgresql_custom_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer
@@ -16,7 +16,7 @@
 [PARSER]
     Format      regex
     Name        postgresql_default.postgresql_default_general.postgresql.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer
@@ -29,7 +29,7 @@
 [PARSER]
     Format      regex
     Name        postgresql_syslog_error.postgresql_syslog_general.0.0
-    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<role>\S*)@(?<user>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
+    Regex       ^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?<tid>\d+)\](?:\s+(?<user>\S*)@(?<database>\S*))?\s*(?<level>\w+):\s+(?<message>[\s\S]*)
     Time_Format %Y-%m-%d %H:%M:%S.%L %z
     Time_Key    time
     Types       tid:integer

--- a/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
@@ -189,14 +189,14 @@ expected_logs:
       - name: jsonPayload.tid
         type: number
         description: Thread ID where the log originated
-      - name: jsonPayload.database
-        type: string
-        description: Database name for the action being logged when relevant
-        optional: true
       - name: jsonPayload.user
         type: string
         optional: true
         description: Authenticated user for the action being logged when relevant
+      - name: jsonPayload.database
+        type: string
+        description: Database name for the action being logged when relevant
+        optional: true
       - name: severity
         type: string
         description: ""

--- a/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
@@ -189,9 +189,9 @@ expected_logs:
       - name: jsonPayload.tid
         type: number
         description: Thread ID where the log originated
-      - name: jsonPayload.role
+      - name: jsonPayload.database
         type: string
-        description: Authenticated role for the action being logged when relevant
+        description: Database name for the action being logged when relevant
         optional: true
       - name: jsonPayload.user
         type: string


### PR DESCRIPTION
## Description
Discovered in the course of https://github.com/GoogleCloudPlatform/ops-agent/pull/1724 - previously the parser expected the session data in a default log to be `role@user` when it was actually `user@database`. Renamed and fixed the regex.

## How has this been tested?
Tested primarily in kokoro in the above listed PR.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [X] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [X] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
