### PR TITLE
Internal: Flag to redirect test installs to stable release

### DIFF
--- a/kokoro/scripts/utils/louhi.sh
+++ b/kokoro/scripts/utils/louhi.sh
@@ -28,14 +28,17 @@ function populate_env_vars_from_louhi_tag_if_present() {
   # Example value: louhi/2.46.0/shortref/windows/x86_64/start
   if [[ -n "${_LOUHI_TAG_NAME:-}" ]]; then
     local -a _LOUHI_TAG_COMPONENTS=(${_LOUHI_TAG_NAME//\// })  
-    export REPO_SUFFIX="${_LOUHI_TAG_COMPONENTS[2]}"  # the shortref is the repo suffix
     TARGET="${_LOUHI_TAG_COMPONENTS[3]}"
     ARCH="${_LOUHI_TAG_COMPONENTS[4]}"
-    export ARTIFACT_REGISTRY_PROJECT="${_STAGING_ARTIFACTS_PROJECT_ID}"  # Louhi is responsible for passing this.
 
-    EXT=$(yaml project.yaml "['targets']['${TARGET}']['package_extension']")
-    if [[ "${EXT}" == "deb" ]]; then
-      export REPO_CODENAME="${TARGET}-${ARCH}"
+    if [[ "${_USE_TEST_REPO:-1}" == "1" ]]; then
+      export REPO_SUFFIX="${_LOUHI_TAG_COMPONENTS[2]}"  # the shortref is the repo suffix
+      export ARTIFACT_REGISTRY_PROJECT="${_STAGING_ARTIFACTS_PROJECT_ID}"  # Louhi is responsible for passing this.
+
+      EXT=$(yaml project.yaml "['targets']['${TARGET}']['package_extension']")
+      if [[ "${EXT}" == "deb" ]]; then
+        export REPO_CODENAME="${TARGET}-${ARCH}"
+      fi
     fi
   fi
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
