### PR TITLE
Internal: test repo and vm names can't have underscores

### DIFF
--- a/kokoro/scripts/test/start_soak_test.sh
+++ b/kokoro/scripts/test/start_soak_test.sh
@@ -17,7 +17,7 @@ populate_env_vars_from_louhi_tag_if_present
 # if TARGET & ARCH are set, retrieve the soak distro from project.yaml
 if [[ -n "${TARGET:-}" && -n "${ARCH:-}" ]]; then
   DISTRO=$(yaml project.yaml "['targets']['${TARGET}']['architectures']['${ARCH}']['soak_distro']")
-  export VM_NAME="soak-test-${RELEASE_ID}-${TARGET}-${ARCH}-${LABEL}"
+  export VM_NAME="soak-test-${RELEASE_ID}-${TARGET}-${ARCH//_/-}-${LABEL}"
   export DISTRO
 fi
 

--- a/kokoro/scripts/utils/louhi.sh
+++ b/kokoro/scripts/utils/louhi.sh
@@ -38,7 +38,7 @@ function populate_env_vars_from_louhi_tag_if_present() {
 
       EXT=$(yaml project.yaml "['targets']['${TARGET}']['package_extension']")
       if [[ "${EXT}" == "deb" ]]; then
-        export REPO_CODENAME="${TARGET}-${ARCH}"
+        export REPO_CODENAME="${TARGET}-${ARCH//_/-}"
       fi
     fi
   fi


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
