### PR TITLE
[Testing] GPU driver on Rocky 9/Centos 8: using EPEL repo for missing packages

### DIFF
--- a/integration_test/third_party_apps_test/applications/dcgm/centos_rhel/install
+++ b/integration_test/third_party_apps_test/applications/dcgm/centos_rhel/install
@@ -26,7 +26,9 @@ install_driver_from_runfile() {
 }
 
 setup_repo() {
-    sudo yum install -y yum-utils
+    # Enable EPEL (Extra Packages for Enterprise Linux) for packages such as DKMS
+    # Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#prepare-rhel-9-rocky-9
+    sudo yum install -y yum-utils epel-release
     sudo yum-config-manager \
         --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel$VERSION_ID/x86_64/cuda-rhel$VERSION_ID.repo
     sudo yum clean all
@@ -81,17 +83,8 @@ handle_rhel7() {
 
 handle_common() {
     install_driver_package() {
-        #TODO: b/332690428 - Remove this temporary fix for Rocky Linux 9 rocky-linux-9-v20240313 with kernel 5.14.0-362.18.1.el9_3.0.1.x86_64 
-        case $(uname -r) in
-            5.14.0-362.18.1.el9_3.0.1.x86_64) 
-                sudo ln -s /lib/modules/5.14.0-362.18.1.el9_3.0.1.x86_64 /lib/modules/5.14.0-362.18.1.el9_3.x86_64
-                sudo yum -y module install nvidia-driver:545
-                ;;
-            *)
-                # Ref: https://developer.nvidia.com/cuda-12-2-2-download-archive?target_os=Linux&target_arch=x86_64&Distribution=RHEL&target_version=8&target_type=rpm_network
-                sudo yum -y module install nvidia-driver:550
-                ;;
-        esac
+        # Ref: https://developer.nvidia.com/cuda-12-2-2-download-archive?target_os=Linux&target_arch=x86_64&Distribution=RHEL&target_version=8&target_type=rpm_network
+        sudo yum -y module install nvidia-driver
     }
 
     remove_driver_package() {

--- a/integration_test/third_party_apps_test/applications/nvml/centos_rhel/install
+++ b/integration_test/third_party_apps_test/applications/nvml/centos_rhel/install
@@ -40,7 +40,9 @@ install_cuda_from_runfile() {
 }
 
 setup_repo() {
-    sudo yum install -y yum-utils
+    # Enable EPEL (Extra Packages for Enterprise Linux) for packages such as DKMS
+    # Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#prepare-rhel-9-rocky-9
+    sudo yum install -y yum-utils epel-release
     sudo yum-config-manager \
         --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel$VERSION_ID/x86_64/cuda-rhel$VERSION_ID.repo
     sudo yum clean all
@@ -49,15 +51,7 @@ setup_repo() {
 install_cuda_from_package_manager() {
     setup_repo
     install_driver_package
-    #TODO: b/332690428 - Remove this temporary fix for Rocky Linux 9 rocky-linux-9-v20240313 with kernel 5.14.0-362.18.1.el9_3.0.1.x86_64 
-    case $(uname -r) in
-        5.14.0-362.18.1.el9_3.0.1.x86_64) 
-            sudo yum -y install cuda-12-3
-            ;;
-        *)
-            sudo yum -y install cuda-12-4
-            ;;
-    esac
+    sudo yum -y install cuda
     verify_driver
 }
 
@@ -101,17 +95,8 @@ handle_rhel7() {
 
 handle_common() {
     install_driver_package() {
-        #TODO: b/332690428 - Remove this temporary fix for Rocky Linux 9 rocky-linux-9-v20240313 with kernel 5.14.0-362.18.1.el9_3.0.1.x86_64 
-        case $(uname -r) in
-            5.14.0-362.18.1.el9_3.0.1.x86_64) 
-                sudo ln -s /lib/modules/5.14.0-362.18.1.el9_3.0.1.x86_64 /lib/modules/5.14.0-362.18.1.el9_3.x86_64
-                sudo yum -y module install nvidia-driver:545
-                ;;
-            *)
-                # Ref: https://developer.nvidia.com/cuda-12-2-2-download-archive?target_os=Linux&target_arch=x86_64&Distribution=RHEL&target_version=8&target_type=rpm_network
-                sudo yum -y module install nvidia-driver:550
-                ;;
-        esac
+        # Ref: https://developer.nvidia.com/cuda-12-2-2-download-archive?target_os=Linux&target_arch=x86_64&Distribution=RHEL&target_version=8&target_type=rpm_network
+        sudo yum -y module install nvidia-driver
     }
 
     remove_driver_package() {


### PR DESCRIPTION
## Description
Enable EPEL (Extra Packages for Enterprise Linux) to install the missing package when installing the NVIDIA driver on Rocky Linux 9 and Centos 8. 

Also remove a previous temporary fix: the GCE images has been updated so the fix is no longer needed. 

## Related issue
[b/346323392](http://b/346323392)
[b/332690428](http://b/332690428)

## How has this been tested?
NVML and DCGM Integration tests passing for Rocky 9 and Centos 8.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
