### PR TITLE
integration_test: skip ML image for certain 3P apps where it doesn't install

### DIFF
--- a/integration_test/third_party_apps_test/applications/dcgm/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/dcgm/metadata.yaml
@@ -37,6 +37,7 @@ gpu_platforms: # p4, p100 don't emit DCGM profiling metrics
     platforms:
       - centos-cloud:centos-7
       - debian-cloud:debian-11
+      - ml-images:common-gpu-debian-11-py310
       - rocky-linux-cloud:rocky-linux-8
       - rocky-linux-cloud:rocky-linux-9
       - suse-cloud:sles-15

--- a/integration_test/third_party_apps_test/applications/mongodb3.6/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mongodb3.6/metadata.yaml
@@ -28,8 +28,16 @@ minimum_supported_agent_version:
 supported_operating_systems: linux
 platforms_to_skip:
   # MongoDB3.6 hit end of life in 2021 and is not supported on various distros.
+  - debian-cloud:debian-10
+  - debian-cloud:debian-11
+  - debian-cloud:debian-11-arm64
+  - debian-cloud:debian-12
+  - debian-cloud:debian-12-arm64
+  - ml-images:common-gpu-debian-11-py310
   - rocky-linux-cloud:rocky-linux-9
   - rocky-linux-cloud:rocky-linux-9-arm64
+  - suse-cloud:sles-15
+  - suse-cloud:sles-15-arm64
   - ubuntu-os-cloud:ubuntu-2004-lts
   - ubuntu-os-cloud:ubuntu-2004-lts-arm64
   - ubuntu-os-cloud:ubuntu-2204-lts
@@ -38,13 +46,6 @@ platforms_to_skip:
   - ubuntu-os-cloud:ubuntu-2310-arm64
   - ubuntu-os-cloud:ubuntu-2404-lts-amd64
   - ubuntu-os-cloud:ubuntu-2404-lts-arm64
-  - debian-cloud:debian-10
-  - debian-cloud:debian-11
-  - debian-cloud:debian-11-arm64
-  - debian-cloud:debian-12
-  - debian-cloud:debian-12-arm64
-  - suse-cloud:sles-15
-  - suse-cloud:sles-15-arm64
 supported_app_version: ["2.6", "3.0+", "4.0+", "5.0"]
 expected_metrics:
   - type: workload.googleapis.com/mongodb.cache.operations

--- a/integration_test/third_party_apps_test/applications/mysql5.7/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mysql5.7/metadata.yaml
@@ -43,6 +43,7 @@ platforms_to_skip:
   - debian-cloud:debian-11-arm64
   - debian-cloud:debian-12
   - debian-cloud:debian-12-arm64
+  - ml-images:common-gpu-debian-11-py310
   - ubuntu-os-cloud:ubuntu-2004-lts
   - ubuntu-os-cloud:ubuntu-2004-lts-arm64
   - ubuntu-os-cloud:ubuntu-2204-lts

--- a/integration_test/third_party_apps_test/applications/nvml/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/nvml/metadata.yaml
@@ -45,6 +45,7 @@ gpu_platforms:
       - centos-cloud:centos-7
       - debian-cloud:debian-10
       - debian-cloud:debian-11
+      - ml-images:common-gpu-debian-11-py310
       - rocky-linux-cloud:rocky-linux-8
       - rocky-linux-cloud:rocky-linux-9
       - suse-cloud:sles-15

--- a/integration_test/third_party_apps_test/applications/oracledb/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/oracledb/metadata.yaml
@@ -54,6 +54,12 @@ platforms_to_skip:
   - debian-cloud:debian-11-arm64
   - debian-cloud:debian-12
   - debian-cloud:debian-12-arm64
+  - ml-images:common-gpu-debian-11-py310
+  - rocky-linux-cloud:rocky-linux-9
+  - rocky-linux-cloud:rocky-linux-9-arm64
+  - suse-cloud:sles-12
+  - suse-cloud:sles-15
+  - suse-cloud:sles-15-arm64
   - ubuntu-os-cloud:ubuntu-2004-lts
   - ubuntu-os-cloud:ubuntu-2004-lts-arm64
   - ubuntu-os-cloud:ubuntu-2204-lts
@@ -62,11 +68,6 @@ platforms_to_skip:
   - ubuntu-os-cloud:ubuntu-2310-arm64
   - ubuntu-os-cloud:ubuntu-2404-lts-amd64
   - ubuntu-os-cloud:ubuntu-2404-lts-arm64
-  - suse-cloud:sles-12
-  - suse-cloud:sles-15
-  - suse-cloud:sles-15-arm64
-  - rocky-linux-cloud:rocky-linux-9
-  - rocky-linux-cloud:rocky-linux-9-arm64
 supported_app_version: ["12.2", "18c", "19c", "21c"]
 expected_metrics:
   - type: workload.googleapis.com/oracle.backup.latest


### PR DESCRIPTION
Skipping the 3P tests on new image that don't support it

## Related issue
HEAD is broken by #1684.
[b/301084986](http://b/301084986)

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
