### PR TITLE
Skip OracleDB tests on `ml-images:common-gpu-debian-11-py310`

### DIFF
--- a/integration_test/third_party_apps_test/applications/oracledb/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/oracledb/metadata.yaml
@@ -54,6 +54,7 @@ platforms_to_skip:
   - debian-cloud:debian-11-arm64
   - debian-cloud:debian-12
   - debian-cloud:debian-12-arm64
+  - ml-images:common-gpu-debian-11-py310
   - ubuntu-os-cloud:ubuntu-2004-lts
   - ubuntu-os-cloud:ubuntu-2004-lts-arm64
   - ubuntu-os-cloud:ubuntu-2204-lts


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
`ml-images:common-gpu-debian-11-py310` is based on debian 11, which we skip.
Presubmits didn't catch in #1684

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
