### PR TITLE
project.yaml: update opensuse-leap image in tests

### DIFF
--- a/integration_test/third_party_apps_test/main_test.go
+++ b/integration_test/third_party_apps_test/main_test.go
@@ -726,6 +726,7 @@ func isCriticalFile(f string) bool {
 		"integration_test/agents/agents.go",
 		"integration_test/gce/gce_testing.go",
 		"integration_test/third_party_apps_test/main_test.go",
+		"project.yaml",
 	} {
 		if f == criticalFile {
 			return true

--- a/project.yaml
+++ b/project.yaml
@@ -166,6 +166,7 @@ targets:
           - suse-sap-cloud:sles-15-sp2-sap
           - suse-sap-cloud:sles-15-sp5-sap
           - opensuse-cloud:opensuse-leap
+          - opensuse-cloud=opensuse-leap-15-5-v20240516-x86-64
           - opensuse-cloud=opensuse-leap-15-6-v20240612-x86-64
       aarch64:
         test_distros:

--- a/project.yaml
+++ b/project.yaml
@@ -174,6 +174,8 @@ targets:
           - suse-cloud:sles-15-arm64
           exhaustive:
           - opensuse-cloud:opensuse-leap-arm64
+          - opensuse-cloud=opensuse-leap-15-5-v20240516-arm64
+          - opensuse-cloud=opensuse-leap-15-6-v20240612-arm64
   windows:
     package_extension:
       goo

--- a/project.yaml
+++ b/project.yaml
@@ -166,7 +166,7 @@ targets:
           - suse-sap-cloud:sles-15-sp2-sap
           - suse-sap-cloud:sles-15-sp5-sap
           - opensuse-cloud:opensuse-leap
-          - opensuse-cloud=opensuse-leap-15-4-v20231208-x86-64
+          - opensuse-cloud=opensuse-leap-15-6-v20240612-x86-64
       aarch64:
         test_distros:
           representative:


### PR DESCRIPTION
Related bug: [b/347736748](http://b/347736748)

Found new image by running:

```
~ gcloud compute images list --project opensuse-cloud --no-standard-images
NAME                                 PROJECT         FAMILY               DEPRECATED  STATUS
opensuse-leap-15-5-v20240516-arm64   opensuse-cloud  opensuse-leap-arm64              READY
opensuse-leap-15-5-v20240516-x86-64  opensuse-cloud  opensuse-leap                    READY
opensuse-leap-15-6-v20240612-arm64   opensuse-cloud  opensuse-leap-arm64              READY
opensuse-leap-15-6-v20240612-x86-64  opensuse-cloud  opensuse-leap                    READY
```

And then picked the latest one