### PR TITLE
Stop pre-installed jupyter service on DLVM images

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1299,6 +1299,14 @@ func attemptCreateInstance(ctx context.Context, logger *log.Logger, options VMOp
 		}
 	}
 
+	// Pre-installed jupyter services on DLVM images cause port conflicts for third-party apps.
+	// See b/347107292.
+	if IsDLVMImage(vm.ImageSpec) {
+		if _, err := RunRemotely(ctx, logger, vm, "sudo service jupyter stop || true"); err != nil {
+			return nil, fmt.Errorf("attemptCreateInstance() failed to stop pre-installed jupyter service: %v", err)
+		}
+	}
+
 	return vm, nil
 }
 
@@ -1324,6 +1332,10 @@ func IsRHEL(imageSpec string) bool {
 
 func isRHEL7SAPHA(imageSpec string) bool {
 	return strings.Contains(imageSpec, "rhel-7") && strings.HasPrefix(imageSpec, "rhel-sap-cloud")
+}
+
+func IsDLVMImage(imageSpec string) bool {
+	return strings.HasPrefix(imageSpec, "ml-images")
 }
 
 func IsARM(imageSpec string) bool {


### PR DESCRIPTION
This should prevent a port conflict when testing third-party apps.

## Description
<!--- Describe your changes in detail. -->

## Related issue
[b/347107292](http://b/347107292)

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
