### PR TITLE
Windows: Print all arguments passed to service

### DIFF
--- a/cmd/google_cloud_ops_agent_diagnostics/main_windows.go
+++ b/cmd/google_cloud_ops_agent_diagnostics/main_windows.go
@@ -72,7 +72,10 @@ func (s *service) Execute(args []string, r <-chan svc.ChangeRequest, changes cha
 
 	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
 	changes <- svc.Status{State: svc.StartPending}
-	if err := s.parseFlags(args); err != nil {
+
+	allArgs := append([]string{}, os.Args[1:]...)
+	allArgs = append(allArgs, args[1:]...)
+	if err := s.parseFlags(allArgs); err != nil {
 		s.log.Error(DiagnosticsEventID, fmt.Sprintf("failed to parse arguments: %v", err))
 		return false, ERROR_INVALID_PARAMETER
 	}
@@ -122,9 +125,5 @@ func (s *service) parseFlags(args []string) error {
 	s.log.Info(DiagnosticsEventID, fmt.Sprintf("args: %#v", args))
 	var fs flag.FlagSet
 	fs.StringVar(&s.userConf, "config", "", "path to the user specified agent config")
-	s.log.Info(DiagnosticsEventID, s.userConf)
-
-	allArgs := append([]string{}, os.Args[1:]...)
-	allArgs = append(allArgs, args[1:]...)
-	return fs.Parse(allArgs)
+	return fs.Parse(args)
 }

--- a/cmd/ops_agent_windows/run_windows.go
+++ b/cmd/ops_agent_windows/run_windows.go
@@ -59,7 +59,10 @@ func (s *service) Execute(args []string, r <-chan svc.ChangeRequest, changes cha
 	defer cancel()
 	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
 	changes <- svc.Status{State: svc.StartPending}
-	if err := s.parseFlags(args); err != nil {
+
+	allArgs := append([]string{}, os.Args[1:]...)
+	allArgs = append(allArgs, args[1:]...)
+	if err := s.parseFlags(allArgs); err != nil {
 		s.log.Error(EngineEventID, fmt.Sprintf("failed to parse arguments: %v", err))
 		// ERROR_INVALID_ARGUMENT
 		return false, 0x00000057
@@ -104,10 +107,7 @@ func (s *service) parseFlags(args []string) error {
 	var fs flag.FlagSet
 	fs.StringVar(&s.userConf, "in", "", "path to the user specified agent config")
 	fs.StringVar(&s.outDirectory, "out", "", "directory to write generated configuration files to")
-
-	allArgs := append([]string{}, os.Args[1:]...)
-	allArgs = append(allArgs, args[1:]...)
-	return fs.Parse(allArgs)
+	return fs.Parse(args)
 }
 
 func (s *service) checkForStandaloneAgents(unified *confgenerator.UnifiedConfig) error {


### PR DESCRIPTION
## Description
Previously we were only printing the service start arguments (which we don't populate) and not the actual command-line arguments (which we do populate).

Also remove a line that was printing garbage.

## Related issue
[b/333974153](http://b/333974153)

## How has this been tested?
Will let presubmits run

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
