### PR TITLE
Change syslog dependency to Recommends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,9 +7,8 @@ Standards-Version: 3.9.4
 
 Package: google-cloud-ops-agent
 Architecture: any
-Depends: rsyslog | system-log-daemon,
-         ${shlibs:Depends},
-         ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Recommends: rsyslog | system-log-daemon
 Conflicts: stackdriver-agent, google-fluentd
 Description: Google Cloud Ops Agent
  The Google Cloud Ops Agent collects metrics and logs from the system.


### PR DESCRIPTION
## Description
While a syslog daemon is required for full desired Ops Agent functionality, our previous reliance on the presence of a syslog daemon was provided by the dependency specified in the `google-compute-engine` package, which is a `Recommends` dependency.

This PR changes the syslog daemon dependency in the Ops Agent deb package to `Recommends` instead of `Depends`.

## Related issue
[b/339061751](http://b/339061751)

## How has this been tested?
Manually tested the workflow where we install Ops Agent without installing `rsyslog`:

`make build` to get a local `deb` package.  
Created a new Debian 12 GCE VM.  
Remove `rsyslog` from the VM:
```
sudo apt purge rsyslog
```
Copied the deb package to the VM. Install it without installing Recommended packages:
```
sudo apt install --no-install-recommends ./google-cloud-ops-agent_2.49.0~debian12_amd64.deb
```
`rsyslog` was not installed, verified with:
```
dpkg -l | grep rsyslog
```

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [x] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
