### PR TITLE
apps: `hostmetrics` use mute_process_exe_error

### DIFF
--- a/apps/hostmetrics.go
+++ b/apps/hostmetrics.go
@@ -38,6 +38,7 @@ func (r MetricsReceiverHostmetrics) Pipelines(ctx context.Context) ([]otel.Recei
 	p := platform.FromContext(ctx)
 	processConfig := map[string]interface{}{
 		"mute_process_name_error": true,
+		"mute_process_exe_error": true,
 	}
 	if p.Type == platform.Windows {
 		processConfig["metrics"] = map[string]interface{}{

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux-gpu/otel.yaml
@@ -452,6 +452,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux/otel.yaml
@@ -428,6 +428,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
@@ -438,6 +438,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
@@ -438,6 +438,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/builtin/golden/linux-dataproc/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/linux-dataproc/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/builtin/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/builtin/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/builtin/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/builtin/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux-gpu/otel.yaml
@@ -514,6 +514,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux/otel.yaml
@@ -485,6 +485,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   otlp/otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/otel.yaml
@@ -560,6 +560,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   otlp/otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/otel.yaml
@@ -560,6 +560,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   otlp/otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux-gpu/otel.yaml
@@ -492,6 +492,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux/otel.yaml
@@ -463,6 +463,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   otlp/otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows-2012/otel.yaml
@@ -538,6 +538,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   otlp/otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows/otel.yaml
@@ -538,6 +538,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   otlp/otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux-gpu/otel.yaml
@@ -497,6 +497,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux/otel.yaml
@@ -468,6 +468,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   otlp/otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows-2012/otel.yaml
@@ -543,6 +543,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   otlp/otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows/otel.yaml
@@ -543,6 +543,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   otlp/otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux-gpu/otel.yaml
@@ -497,6 +497,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux/otel.yaml
@@ -468,6 +468,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   otlp/otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows-2012/otel.yaml
@@ -543,6 +543,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   otlp/otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows/otel.yaml
@@ -543,6 +543,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   otlp/otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux-gpu/otel.yaml
@@ -497,6 +497,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux/otel.yaml
@@ -468,6 +468,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   otlp/otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -543,6 +543,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   otlp/otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows/otel.yaml
@@ -543,6 +543,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   otlp/otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux-gpu/otel.yaml
@@ -485,6 +485,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux/otel.yaml
@@ -456,6 +456,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   otlp/otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows-2012/otel.yaml
@@ -531,6 +531,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   otlp/otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows/otel.yaml
@@ -531,6 +531,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   otlp/otlp:

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel.yaml
@@ -616,6 +616,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel.yaml
@@ -587,6 +587,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel.yaml
@@ -912,6 +912,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel.yaml
@@ -912,6 +912,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel.yaml
@@ -583,6 +583,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel.yaml
@@ -554,6 +554,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel.yaml
@@ -879,6 +879,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel.yaml
@@ -879,6 +879,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
@@ -528,6 +528,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel.yaml
@@ -499,6 +499,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
@@ -824,6 +824,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel.yaml
@@ -824,6 +824,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux-gpu/otel.yaml
@@ -434,6 +434,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux/otel.yaml
@@ -434,6 +434,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows-2012/otel.yaml
@@ -511,6 +511,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows/otel.yaml
@@ -511,6 +511,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux-gpu/otel.yaml
@@ -438,6 +438,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux/otel.yaml
@@ -438,6 +438,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows-2012/otel.yaml
@@ -523,6 +523,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows/otel.yaml
@@ -523,6 +523,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux-gpu/otel.yaml
@@ -464,6 +464,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux/otel.yaml
@@ -434,6 +434,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows-2012/otel.yaml
@@ -511,6 +511,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows/otel.yaml
@@ -511,6 +511,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux-gpu/otel.yaml
@@ -466,6 +466,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux/otel.yaml
@@ -435,6 +435,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows-2012/otel.yaml
@@ -514,6 +514,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows/otel.yaml
@@ -514,6 +514,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux-gpu/otel.yaml
@@ -466,6 +466,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux/otel.yaml
@@ -435,6 +435,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows-2012/otel.yaml
@@ -514,6 +514,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows/otel.yaml
@@ -514,6 +514,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux-gpu/otel.yaml
@@ -464,6 +464,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux/otel.yaml
@@ -434,6 +434,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows-2012/otel.yaml
@@ -511,6 +511,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows/otel.yaml
@@ -511,6 +511,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux-gpu/otel.yaml
@@ -503,6 +503,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux/otel.yaml
@@ -472,6 +472,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   otlp/otlp:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows-2012/otel.yaml
@@ -551,6 +551,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   otlp/otlp:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows/otel.yaml
@@ -551,6 +551,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   otlp/otlp:

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux-gpu/otel.yaml
@@ -488,6 +488,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux/otel.yaml
@@ -446,6 +446,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows-2012/otel.yaml
@@ -456,6 +456,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows/otel.yaml
@@ -456,6 +456,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux-gpu/otel.yaml
@@ -476,6 +476,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux/otel.yaml
@@ -440,6 +440,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows-2012/otel.yaml
@@ -450,6 +450,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows/otel.yaml
@@ -450,6 +450,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux-gpu/otel.yaml
@@ -452,6 +452,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux/otel.yaml
@@ -428,6 +428,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows-2012/otel.yaml
@@ -438,6 +438,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows/otel.yaml
@@ -438,6 +438,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/activemq:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/activemq:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/activemq:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/activemq:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/activemq:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/activemq:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/activemq:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/activemq:

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux-gpu/otel.yaml
@@ -493,6 +493,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux/otel.yaml
@@ -464,6 +464,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows-2012/otel.yaml
@@ -539,6 +539,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows/otel.yaml
@@ -539,6 +539,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux-gpu/otel.yaml
@@ -494,6 +494,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux/otel.yaml
@@ -465,6 +465,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows-2012/otel.yaml
@@ -540,6 +540,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows/otel.yaml
@@ -540,6 +540,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux-gpu/otel.yaml
@@ -494,6 +494,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux/otel.yaml
@@ -465,6 +465,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows-2012/otel.yaml
@@ -540,6 +540,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows/otel.yaml
@@ -540,6 +540,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/cassandra:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/cassandra:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/cassandra:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/cassandra:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/cassandra:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/cassandra:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/cassandra:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/cassandra:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux-gpu/otel.yaml
@@ -593,6 +593,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux/otel.yaml
@@ -564,6 +564,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/couchbase:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows-2012/otel.yaml
@@ -639,6 +639,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/couchbase:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows/otel.yaml
@@ -639,6 +639,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/couchbase:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/linux-gpu/otel.yaml
@@ -485,6 +485,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/linux/otel.yaml
@@ -456,6 +456,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows-2012/otel.yaml
@@ -531,6 +531,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows/otel.yaml
@@ -531,6 +531,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux-gpu/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux/otel.yaml
@@ -433,6 +433,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux-gpu/otel.yaml
@@ -487,6 +487,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux/otel.yaml
@@ -458,6 +458,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/linux-gpu/otel.yaml
@@ -523,6 +523,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/linux/otel.yaml
@@ -494,6 +494,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows-2012/otel.yaml
@@ -569,6 +569,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows/otel.yaml
@@ -569,6 +569,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/linux-gpu/otel.yaml
@@ -523,6 +523,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/linux/otel.yaml
@@ -494,6 +494,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows-2012/otel.yaml
@@ -569,6 +569,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows/otel.yaml
@@ -569,6 +569,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/linux-gpu/otel.yaml
@@ -523,6 +523,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/linux/otel.yaml
@@ -494,6 +494,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows-2012/otel.yaml
@@ -569,6 +569,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows/otel.yaml
@@ -569,6 +569,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/linux-gpu/otel.yaml
@@ -523,6 +523,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/linux/otel.yaml
@@ -494,6 +494,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows-2012/otel.yaml
@@ -569,6 +569,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows/otel.yaml
@@ -569,6 +569,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/linux-gpu/otel.yaml
@@ -545,6 +545,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/linux/otel.yaml
@@ -516,6 +516,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows-2012/otel.yaml
@@ -591,6 +591,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows/otel.yaml
@@ -591,6 +591,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/linux-gpu/otel.yaml
@@ -525,6 +525,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/linux/otel.yaml
@@ -496,6 +496,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows-2012/otel.yaml
@@ -571,6 +571,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows/otel.yaml
@@ -571,6 +571,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux-gpu/otel.yaml
@@ -434,6 +434,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux/otel.yaml
@@ -434,6 +434,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows-2012/otel.yaml
@@ -511,6 +511,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows/otel.yaml
@@ -511,6 +511,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux-gpu/otel.yaml
@@ -464,6 +464,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux/otel.yaml
@@ -434,6 +434,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows-2012/otel.yaml
@@ -511,6 +511,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows/otel.yaml
@@ -511,6 +511,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux-gpu/otel.yaml
@@ -517,6 +517,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux/otel.yaml
@@ -488,6 +488,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows-2012/otel.yaml
@@ -563,6 +563,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows/otel.yaml
@@ -563,6 +563,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/hadoop:

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/hadoop:

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/hadoop:

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/hadoop:

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/hadoop:

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/hadoop:

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/hadoop:

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/hadoop:

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/linux-gpu/otel.yaml
@@ -487,6 +487,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/hbase__metrics:

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/linux/otel.yaml
@@ -458,6 +458,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/hbase__metrics:

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows-2012/otel.yaml
@@ -533,6 +533,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/hbase__metrics:

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows/otel.yaml
@@ -533,6 +533,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/hbase__metrics:

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/linux-gpu/otel.yaml
@@ -487,6 +487,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/hbase__metrics:

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/linux/otel.yaml
@@ -458,6 +458,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/hbase__metrics:

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows-2012/otel.yaml
@@ -533,6 +533,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/hbase__metrics:

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows/otel.yaml
@@ -533,6 +533,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/hbase__metrics:

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jetty__metrics:

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jetty__metrics:

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jetty__metrics:

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jetty__metrics:

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jetty__metrics:

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jetty__metrics:

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jetty__metrics:

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jetty__metrics:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jvm:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jvm:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jvm:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jvm:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jvm:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jvm:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jvm:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jvm:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jvm:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jvm:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jvm:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jvm:

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/linux-gpu/otel.yaml
@@ -495,6 +495,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/kafka:

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/linux/otel.yaml
@@ -466,6 +466,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/kafka:

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows-2012/otel.yaml
@@ -541,6 +541,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/kafka:

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows/otel.yaml
@@ -541,6 +541,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/kafka:

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/linux-gpu/otel.yaml
@@ -495,6 +495,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/kafka:

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/linux/otel.yaml
@@ -466,6 +466,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/kafka:

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows-2012/otel.yaml
@@ -541,6 +541,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/kafka:

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows/otel.yaml
@@ -541,6 +541,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/kafka:

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/linux-gpu/otel.yaml
@@ -486,6 +486,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   memcached/memcached:

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/linux/otel.yaml
@@ -457,6 +457,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   memcached/memcached:

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows-2012/otel.yaml
@@ -532,6 +532,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   memcached/memcached:

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows/otel.yaml
@@ -532,6 +532,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   memcached/memcached:

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   mongodb/mongodb:

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   mongodb/mongodb:

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   mongodb/mongodb:

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   mongodb/mongodb:

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   mongodb/mongodb:

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   mongodb/mongodb:

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   mongodb/mongodb:

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   mongodb/mongodb:

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/linux-gpu/otel.yaml
@@ -510,6 +510,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   mysql/mysql_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/linux/otel.yaml
@@ -481,6 +481,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   mysql/mysql_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows-2012/otel.yaml
@@ -556,6 +556,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   mysql/mysql_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows/otel.yaml
@@ -556,6 +556,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   mysql/mysql_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/linux-gpu/otel.yaml
@@ -510,6 +510,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   mysql/mysqlmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/linux/otel.yaml
@@ -481,6 +481,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   mysql/mysqlmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows-2012/otel.yaml
@@ -556,6 +556,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   mysql/mysqlmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows/otel.yaml
@@ -556,6 +556,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   mysql/mysqlmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nginx/nginx:

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nginx/nginx:

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nginx/nginx:

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nginx/nginx:

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nginx/nginx:

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nginx/nginx:

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nginx/nginx:

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nginx/nginx:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/linux-gpu/otel.yaml
@@ -505,6 +505,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/linux/otel.yaml
@@ -476,6 +476,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows-2012/otel.yaml
@@ -551,6 +551,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows/otel.yaml
@@ -551,6 +551,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/linux-gpu/otel.yaml
@@ -505,6 +505,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/linux/otel.yaml
@@ -476,6 +476,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows-2012/otel.yaml
@@ -551,6 +551,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows/otel.yaml
@@ -551,6 +551,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/linux-gpu/otel.yaml
@@ -505,6 +505,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/linux/otel.yaml
@@ -476,6 +476,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows-2012/otel.yaml
@@ -551,6 +551,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows/otel.yaml
@@ -551,6 +551,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux-gpu/otel.yaml
@@ -493,6 +493,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux/otel.yaml
@@ -464,6 +464,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   postgresql/postgresql:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows-2012/otel.yaml
@@ -539,6 +539,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   postgresql/postgresql:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows/otel.yaml
@@ -539,6 +539,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   postgresql/postgresql:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux-gpu/otel.yaml
@@ -493,6 +493,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux/otel.yaml
@@ -464,6 +464,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   postgresql/postgresql:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows-2012/otel.yaml
@@ -539,6 +539,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   postgresql/postgresql:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows/otel.yaml
@@ -539,6 +539,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   postgresql/postgresql:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux-gpu/otel.yaml
@@ -493,6 +493,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux/otel.yaml
@@ -464,6 +464,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   postgresql/postgresql:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows-2012/otel.yaml
@@ -539,6 +539,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   postgresql/postgresql:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows/otel.yaml
@@ -539,6 +539,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   postgresql/postgresql:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux-gpu/otel.yaml
@@ -493,6 +493,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux/otel.yaml
@@ -464,6 +464,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   postgresql/postgresql:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows-2012/otel.yaml
@@ -539,6 +539,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   postgresql/postgresql:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows/otel.yaml
@@ -539,6 +539,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   postgresql/postgresql:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux-gpu/otel.yaml
@@ -476,6 +476,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux/otel.yaml
@@ -447,6 +447,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/otel.yaml
@@ -522,6 +522,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/otel.yaml
@@ -522,6 +522,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux-gpu/otel.yaml
@@ -476,6 +476,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux/otel.yaml
@@ -447,6 +447,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows-2012/otel.yaml
@@ -522,6 +522,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows/otel.yaml
@@ -522,6 +522,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux-gpu/otel.yaml
@@ -476,6 +476,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux/otel.yaml
@@ -447,6 +447,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/otel.yaml
@@ -522,6 +522,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/otel.yaml
@@ -522,6 +522,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux-gpu/otel.yaml
@@ -476,6 +476,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux/otel.yaml
@@ -447,6 +447,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/otel.yaml
@@ -522,6 +522,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/otel.yaml
@@ -522,6 +522,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux-gpu/otel.yaml
@@ -476,6 +476,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux/otel.yaml
@@ -447,6 +447,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/otel.yaml
@@ -522,6 +522,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/otel.yaml
@@ -522,6 +522,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux-gpu/otel.yaml
@@ -476,6 +476,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux/otel.yaml
@@ -447,6 +447,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/otel.yaml
@@ -522,6 +522,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/otel.yaml
@@ -522,6 +522,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux-gpu/otel.yaml
@@ -476,6 +476,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux/otel.yaml
@@ -447,6 +447,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/otel.yaml
@@ -522,6 +522,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/otel.yaml
@@ -522,6 +522,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux-gpu/otel.yaml
@@ -476,6 +476,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux/otel.yaml
@@ -447,6 +447,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows-2012/otel.yaml
@@ -522,6 +522,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows/otel.yaml
@@ -522,6 +522,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux-gpu/otel.yaml
@@ -476,6 +476,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux/otel.yaml
@@ -447,6 +447,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows-2012/otel.yaml
@@ -522,6 +522,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows/otel.yaml
@@ -522,6 +522,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux-gpu/otel.yaml
@@ -476,6 +476,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux/otel.yaml
@@ -447,6 +447,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/otel.yaml
@@ -522,6 +522,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/otel.yaml
@@ -522,6 +522,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux-gpu/otel.yaml
@@ -487,6 +487,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux/otel.yaml
@@ -458,6 +458,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows-2012/otel.yaml
@@ -533,6 +533,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows/otel.yaml
@@ -533,6 +533,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux-gpu/otel.yaml
@@ -487,6 +487,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux/otel.yaml
@@ -458,6 +458,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows-2012/otel.yaml
@@ -533,6 +533,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows/otel.yaml
@@ -533,6 +533,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux-gpu/otel.yaml
@@ -487,6 +487,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux/otel.yaml
@@ -458,6 +458,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows-2012/otel.yaml
@@ -533,6 +533,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows/otel.yaml
@@ -533,6 +533,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux-gpu/otel.yaml
@@ -487,6 +487,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux/otel.yaml
@@ -458,6 +458,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows-2012/otel.yaml
@@ -533,6 +533,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows/otel.yaml
@@ -533,6 +533,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/linux-gpu/otel.yaml
@@ -487,6 +487,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/linux/otel.yaml
@@ -458,6 +458,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows-2012/otel.yaml
@@ -533,6 +533,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows/otel.yaml
@@ -533,6 +533,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/linux-gpu/otel.yaml
@@ -487,6 +487,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/linux/otel.yaml
@@ -458,6 +458,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows-2012/otel.yaml
@@ -533,6 +533,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows/otel.yaml
@@ -533,6 +533,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux-gpu/otel.yaml
@@ -491,6 +491,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux/otel.yaml
@@ -462,6 +462,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows-2012/otel.yaml
@@ -537,6 +537,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows/otel.yaml
@@ -537,6 +537,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/solr:

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/solr:

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/solr:

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/solr:

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/tomcat:

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/tomcat:

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/tomcat:

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/tomcat:

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/tomcat:

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/tomcat:

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/tomcat:

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/tomcat:

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux-gpu/otel.yaml
@@ -1158,6 +1158,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux/otel.yaml
@@ -1129,6 +1129,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows-2012/otel.yaml
@@ -1204,6 +1204,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows/otel.yaml
@@ -1204,6 +1204,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux-gpu/otel.yaml
@@ -1158,6 +1158,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux/otel.yaml
@@ -1129,6 +1129,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows-2012/otel.yaml
@@ -1204,6 +1204,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows/otel.yaml
@@ -1204,6 +1204,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux-gpu/otel.yaml
@@ -1158,6 +1158,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux/otel.yaml
@@ -1129,6 +1129,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows-2012/otel.yaml
@@ -1204,6 +1204,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows/otel.yaml
@@ -1204,6 +1204,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/wildfly:

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/wildfly:

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/wildfly:

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/wildfly:

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/wildfly:

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/wildfly:

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/wildfly:

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/wildfly:

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
@@ -493,6 +493,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
@@ -493,6 +493,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows-2012/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows/otel.yaml
@@ -508,6 +508,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux-gpu/otel.yaml
@@ -464,6 +464,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux/otel.yaml
@@ -434,6 +434,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows-2012/otel.yaml
@@ -511,6 +511,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows/otel.yaml
@@ -511,6 +511,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux-gpu/otel.yaml
@@ -464,6 +464,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   nvml/hostmetrics_1:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux/otel.yaml
@@ -434,6 +434,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows-2012/otel.yaml
@@ -511,6 +511,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows/otel.yaml
@@ -511,6 +511,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -493,6 +493,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows/otel.yaml
@@ -493,6 +493,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows-2012/otel.yaml
@@ -528,6 +528,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows/otel.yaml
@@ -528,6 +528,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/otel.yaml
@@ -547,6 +547,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   iis/iis__v2:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/otel.yaml
@@ -547,6 +547,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   iis/iis__v2:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/otel.yaml
@@ -510,6 +510,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   iis/iis:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/otel.yaml
@@ -510,6 +510,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   iis/iis:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/linux-gpu/otel.yaml
@@ -480,6 +480,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jvmmetrics:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/linux/otel.yaml
@@ -451,6 +451,7 @@ receivers:
       network: {}
       paging: {}
       process:
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jvmmetrics:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows-2012/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jvmmetrics:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows/otel.yaml
@@ -526,6 +526,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   jmx/jvmmetrics:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/otel.yaml
@@ -534,6 +534,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/otel.yaml
@@ -534,6 +534,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/otel.yaml
@@ -516,6 +516,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/otel.yaml
@@ -516,6 +516,7 @@ receivers:
         metrics:
           process.handles:
             enabled: true
+        mute_process_exe_error: true
         mute_process_name_error: true
       processes: {}
   prometheus/fluentbit:


### PR DESCRIPTION
## Description
This mutes errors like `error reading process executable for pid N` (noticed on Windows, but the mute applies to Linux as well), similarly to #372.

## Related issue
[b/351056461](http://b/351056461)

## How has this been tested?
Errors visible before this PR: [[build]](https://btx.cloud.google.com/invocations/c1519389-73c0-4d5e-bde4-113c80744713) ([direct link](https://storage.googleapis.com/ops-agents-public-buckets-test-logs/prod/stackdriver_agents/testing/consumer/ops_agent/test/windows_x86_64/2453/20240703-111525/logs/TestDefaultMetricsNoProxy_windows-cloud%3Awindows-2022/open_telemetry_agent_logs.txt))
Errors not visible with this PR: [[build]](https://btx.cloud.google.com/invocations/c3ac9d98-39e3-4cbb-b5d9-61813f9289f2) ([direct link](https://storage.googleapis.com/ops-agents-public-buckets-test-logs/prod/stackdriver_agents/testing/consumer/ops_agent/test/windows_x86_64/2458/20240703-225404/logs/TestDefaultMetricsNoProxy_windows-cloud%3Awindows-2022/open_telemetry_agent_logs.txt))

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [x] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
