### PR TITLE
Add the ability to specify gcloud configuration directory in tests.

### DIFF
--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -727,10 +727,10 @@ func windowsEnvironment(environment map[string]string) string {
 // about PackageLocation, see the documentation for the PackageLocation struct.
 func InstallOpsAgent(ctx context.Context, logger *log.Logger, vm *gce.VM, location PackageLocation) error {
 	if location.packagesInGCS != "" && location.repoSuffix != "" {
-		return fmt.Errorf("invalid PackageLocation: cannot provide both location.packagesInGCS and location.repoSuffix. location=%#v")
+		return fmt.Errorf("invalid PackageLocation: cannot provide both location.packagesInGCS and location.repoSuffix. location=%#v", location)
 	}
 	if location.artifactRegistryRegion != "" && location.repoSuffix == "" {
-		return fmt.Errorf("invalid PackageLocation: location.artifactRegistryRegion was nonempty yet location.repoSuffix was empty. location=%#v")
+		return fmt.Errorf("invalid PackageLocation: location.artifactRegistryRegion was nonempty yet location.repoSuffix was empty. location=%#v", location)
 	}
 
 	if location.packagesInGCS != "" {
@@ -851,6 +851,7 @@ func CommonSetupWithExtraCreateArgumentsAndMetadata(t *testing.T, imageSpec stri
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), gce.SuggestedTimeout)
 	t.Cleanup(cancel)
+	ctx = gce.WithGcloudConfigDir(ctx, t.TempDir())
 
 	logger := gce.SetupLogger(t)
 	logger.ToMainLog().Println("Calling SetupVM(). For details, see VM_initialization.txt.")

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -220,7 +220,7 @@ func init() {
 		log.Fatalf("init() failed to make a temporary directory for ssh keys: %v", err)
 	}
 	privateKeyFile = filepath.Join(keysDir, "gce_testing_key")
-	if _, err := runCommand(ctx, log.Default(), nil, []string{"ssh-keygen", "-t", "rsa", "-f", privateKeyFile, "-C", sshUserName, "-N", ""}); err != nil {
+	if _, err := runCommand(ctx, log.Default(), nil, []string{"ssh-keygen", "-t", "rsa", "-f", privateKeyFile, "-C", sshUserName, "-N", ""}, nil); err != nil {
 		log.Fatalf("init() failed to generate new public+private key pair: %v", err)
 	}
 	publicKeyFile = privateKeyFile + ".pub"
@@ -699,7 +699,8 @@ func (writer *ThreadSafeWriter) Write(p []byte) (int, error) {
 // and stderr, and an error if the binary had a nonzero exit code.
 // args is a slice containing the binary to invoke along with all its arguments,
 // e.g. {"echo", "hello"}.
-func runCommand(ctx context.Context, logger *log.Logger, stdin io.Reader, args []string) (CommandOutput, error) {
+// env is a map containing environment variables to set for the command.
+func runCommand(ctx context.Context, logger *log.Logger, stdin io.Reader, args []string, env map[string]string) (CommandOutput, error) {
 	var output CommandOutput
 	if len(args) < 1 {
 		return output, fmt.Errorf("runCommand() needs a nonempty argument slice, got %v", args)
@@ -715,6 +716,13 @@ func runCommand(ctx context.Context, logger *log.Logger, stdin io.Reader, args [
 	interleavedWriter := &ThreadSafeWriter{guarded: &interleavedBuilder}
 	cmd.Stdout = io.MultiWriter(&stdoutBuilder, interleavedWriter)
 	cmd.Stderr = io.MultiWriter(&stderrBuilder, interleavedWriter)
+	if len(env) > 0 {
+		environment := []string{}
+		for k, v := range env {
+			environment = append(environment, fmt.Sprintf("%s=%s", k, v))
+		}
+		cmd.Env = environment
+	}
 
 	err := cmd.Run()
 
@@ -731,6 +739,17 @@ func runCommand(ctx context.Context, logger *log.Logger, stdin io.Reader, args [
 	return output, err
 }
 
+const (
+	gcloudConfigDirKey = "__gcloud_config_dir__"
+)
+
+// WithGcloudConfigDir returns a context that records the desired value of the
+// gcloud configuration directory. Invoking RunGcloud with that context will
+// set the configuration directory for the gcloud command to that value.
+func WithGcloudConfigDir(ctx context.Context, directory string) context.Context {
+	return context.WithValue(ctx, gcloudConfigDirKey, directory)
+}
+
 // RunGcloud invokes a gcloud binary from runfiles and waits until it finishes.
 // Returns the stdout and stderr and an error if the binary had a nonzero exit
 // code. args is a slice containing the arguments to pass to gcloud.
@@ -741,7 +760,11 @@ func runCommand(ctx context.Context, logger *log.Logger, stdin io.Reader, args [
 // http://go/sdi-gcloud-vs-api
 func RunGcloud(ctx context.Context, logger *log.Logger, stdin string, args []string) (CommandOutput, error) {
 	logger.Printf("Running command: gcloud %v", args)
-	return runCommand(ctx, logger, strings.NewReader(stdin), append([]string{gcloudPath}, args...))
+	env := make(map[string]string)
+	if configDir := ctx.Value(gcloudConfigDirKey); configDir != nil {
+		env["CLOUDSDK_CONFIG"] = configDir.(string)
+	}
+	return runCommand(ctx, logger, strings.NewReader(stdin), append([]string{gcloudPath}, args...), env)
 }
 
 var (
@@ -816,7 +839,7 @@ func RunRemotelyStdin(ctx context.Context, logger *log.Logger, vm *VM, stdin io.
 	args = append(args, "-oIdentityFile="+privateKeyFile)
 	args = append(args, sshOptions...)
 	args = append(args, wrappedCommand)
-	return runCommand(ctx, logger, stdin, args)
+	return runCommand(ctx, logger, stdin, args, nil)
 }
 
 // UploadContent takes an io.Reader and uploads its contents as a file to a

--- a/integration_test/gce/gce_testing_test.go
+++ b/integration_test/gce/gce_testing_test.go
@@ -56,6 +56,7 @@ func SetupLoggerAndVM(t *testing.T, platform string) (context.Context, *logging.
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), gce.SuggestedTimeout)
 	t.Cleanup(cancel)
+	ctx = gce.WithGcloudConfigDir(ctx, t.TempDir())
 
 	logger := gce.SetupLogger(t)
 	options := gce.VMOptions{

--- a/integration_test/third_party_apps_test/main_test.go
+++ b/integration_test/third_party_apps_test/main_test.go
@@ -983,6 +983,7 @@ func TestThirdPartyApps(t *testing.T) {
 
 			ctx, cancel := context.WithTimeout(context.Background(), gce.SuggestedTimeout)
 			defer cancel()
+			ctx = gce.WithGcloudConfigDir(ctx, t.TempDir())
 
 			var err error
 			for attempt := 1; attempt <= 4; attempt++ {


### PR DESCRIPTION
## Description
Add the ability to specify a unique `gcloud` configuration directory per test.
This should prevent errors like:
```
ERROR: (gcloud.beta.compute.instances.create) You do not currently have an active account selected.
```

Also fix a compilation bug in `agents.go` that manifests with newer Go versions.

## Related issue
[b/352054649](http://b/352054649)

## How has this been tested?
Integration tests.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
