### PR TITLE
remove centos7 and buster

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -24,27 +24,6 @@ targets:
         test_distros:
           representative:
           - debian-cloud:debian-11-arm64
-  buster:
-    package_extension:
-      deb
-    architectures:
-      x86_64:
-        test_distros:
-          representative:
-          - debian-cloud:debian-10
-  centos7:
-    package_extension:
-      rpm
-    repo_name:
-      el7
-    architectures:
-      x86_64:
-        test_distros:
-          representative:
-          - centos-cloud:centos-7
-          exhaustive:
-          - rhel-cloud:rhel-7
-          - rhel-sap-cloud:rhel-7-9-sap-ha
   centos8:
     package_extension:
       rpm


### PR DESCRIPTION
## Description
CentOS 7 and Debian 10 Buster are EOL. Remove them from the project spec.

## Related issue
[b/350698170](http://b/350698170) and [b/350698983](http://b/350698983)

## How has this been tested?
Integration tests in this PR.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
