### PR TITLE
Install terraform in test containers

### DIFF
--- a/kokoro/scripts/test/go_test.Dockerfile
+++ b/kokoro/scripts/test/go_test.Dockerfile
@@ -15,6 +15,12 @@ RUN apt-get update
 
 RUN apt-get install --yes python3-yaml
 
+RUN apt-get update && apt-get install -y gnupg software-properties-common
+
+RUN wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list
+RUN apt update && apt install terraform
+
 # Install go/grte.
 COPY grte-runtimes.deb /install/grte-debs/
 RUN dpkg -i /install/grte-debs/*.deb


### PR DESCRIPTION
## Description
This will install terraform in test containers so that we may run our CI on the terraform modules
