### PR TITLE
Use environment variables for file list arguments.

### DIFF
--- a/.github/workflows/pr_presubmit.yaml
+++ b/.github/workflows/pr_presubmit.yaml
@@ -36,4 +36,8 @@ jobs:
       # `steps.get_labels.outputs.*` gives us the names of all labels for the PR
     - run: echo "labels=$(go run ./ci/get_labels -url=${{ github.event.pull_request.url }})" >> "$GITHUB_OUTPUT"
       id: get_labels
-    - run: go test ./ci -added='${{ steps.files.outputs.added }}' -modified='${{ steps.files.outputs.modified }}' -labels='${{ steps.get_labels.outputs.labels }}' -base-dir="base_checkout" -tags=ci
+    - run: go test ./ci -added="$ADDED_FILES" -modified="$MODIFIED_FILES" -labels="$PR_LABELS" -base-dir="base_checkout" -tags=ci
+      env:
+        ADDED_FILES: ${{ steps.files.outputs.added }}
+        MODIFIED_FILES: ${{ steps.files.outputs.modified }}
+        PR_LABELS: ${{ steps.get_labels.outputs.labels }}


### PR DESCRIPTION
## Description
It's easier to include file lists verbatim if they are in environment variables.

## Related issue
[b/349924588](http://b/349924588)

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
