### PR TITLE
Fix Cassandra testing on SLES.

### DIFF
--- a/integration_test/third_party_apps_test/applications/cassandra/enable
+++ b/integration_test/third_party_apps_test/applications/cassandra/enable
@@ -25,21 +25,6 @@ logging:
       type: cassandra_debug
     cassandra_gc:
       type: cassandra_gc
-    cassandra_sles_system:
-      type: cassandra_system
-      include_paths:
-      # This path is specific to SLES integration tests manual install
-      - /home/test_user/apache-cassandra/logs/system*.log
-    cassandra_sles_debug:
-      type: cassandra_debug
-      include_paths:
-      # This path is specific to SLES integration tests manual install
-      - /home/test_user/apache-cassandra/logs/debug*.log
-    cassandra_sles_gc:
-      type: cassandra_gc
-      include_paths:
-      # This path is specific to SLES integration tests manual install
-      - /home/test_user/apache-cassandra/logs/gc.log.*.current
   service:
     pipelines:
       cassandra:
@@ -47,9 +32,6 @@ logging:
           - cassandra_system
           - cassandra_debug
           - cassandra_gc
-          - cassandra_sles_system
-          - cassandra_sles_debug
-          - cassandra_sles_gc
 EOF
 
 sudo service google-cloud-ops-agent restart

--- a/integration_test/third_party_apps_test/applications/cassandra/features.yaml
+++ b/integration_test/third_party_apps_test/applications/cassandra/features.yaml
@@ -21,35 +21,11 @@ features:
     module: logging
     key: "[0].enabled"
     value: true
-  - feature: receivers:cassandra_debug
-    module: logging
-    key: "[2].enabled"
-    value: true
-  - feature: receivers:cassandra_debug
-    module: logging
-    key: "[2].include_paths.__length"
-    value: 1
   - feature: receivers:cassandra_gc
     module: logging
     key: "[1].enabled"
     value: true
-  - feature: receivers:cassandra_gc
-    module: logging
-    key: "[3].enabled"
-    value: true
-  - feature: receivers:cassandra_gc
-    module: logging
-    key: "[3].include_paths.__length"
-    value: 1
   - feature: receivers:cassandra_system
     module: logging
-    key: "[4].enabled"
-    value: true
-  - feature: receivers:cassandra_system
-    module: logging
-    key: "[4].include_paths.__length"
-    value: 1
-  - feature: receivers:cassandra_system
-    module: logging
-    key: "[5].enabled"
+    key: "[2].enabled"
     value: true

--- a/integration_test/third_party_apps_test/applications/cassandra/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/cassandra/metadata.yaml
@@ -48,9 +48,6 @@ minimum_supported_agent_version:
 supported_operating_systems: linux
 # TODO: Fix errors and enable tests on all platforms.
 platforms_to_skip:
-  - suse-cloud:sles-12 # QueryLog() failed: cassandra_system not found, exhausted retries; QueryLog() failed: cassandra_debug not found, exhausted retries; QueryLog() failed: cassandra_gc not found, exhausted retries
-  - suse-cloud:sles-15 # QueryLog() failed: cassandra_system not found, exhausted retries; QueryLog() failed: cassandra_debug not found, exhausted retries; QueryLog() failed: cassandra_gc not found, exhausted retries
-  - suse-cloud:sles-15-arm64
   - debian-cloud:debian-12 # QueryLog() failed: cassandra_system not found, exhausted retries; QueryLog() failed: cassandra_debug not found, exhausted retries; QueryLog() failed: cassandra_gc not found, exhausted retries
   - debian-cloud:debian-12-arm64 # QueryLog() failed: cassandra_system not found, exhausted retries; QueryLog() failed: cassandra_debug not found, exhausted retries; QueryLog() failed: cassandra_gc not found, exhausted retries
   - ubuntu-os-cloud:ubuntu-2004-lts # GPG error [...] the public key is not available: NO_PUBKEY AA8E81B4331F7F50 NO_PUBKEY 112695A0E562B32A

--- a/integration_test/third_party_apps_test/applications/cassandra/sles/install
+++ b/integration_test/third_party_apps_test/applications/cassandra/sles/install
@@ -13,8 +13,8 @@ fi
 sudo zypper -n refresh
 
 # SLES 15 SP5 has moved Java 8 to a legacy module
-if [[ "${SUSE_VERSION}" == 15 ]]; then
-  sudo SUSEConnect --product sle-module-legacy/15.5/$(uname -m)
+if [[ "${ID}" == sles && "${SUSE_VERSION}" == 15 ]]; then
+  sudo SUSEConnect --product "sle-module-legacy/${VERSION_ID}/$(uname -m)"
 fi
 
 sudo zypper -n install java-1_8_0-openjdk java-1_8_0-openjdk-devel
@@ -26,5 +26,8 @@ curl -OL https://storage.googleapis.com/ops-agents-public-buckets-vendored-deps/
 tar xzvf apache-cassandra-4.1.3-bin.tar.gz
 mv apache-cassandra-4.1.3 apache-cassandra
 
-apache-cassandra/bin/cassandra -f &
-ps -f -p $!
+# The default location for cassandra logs is /var/log/cassandra.
+sudo mkdir -m 755 -p /var/log/cassandra
+sudo chown $USER /var/log/cassandra
+CASSANDRA_LOG_DIR=/var/log/cassandra apache-cassandra/bin/cassandra -R -p cassandra.pid
+ps -f -p $(cat cassandra.pid)


### PR DESCRIPTION
## Description
This PR fixes Cassandra tests on SLES/SUSE by allowing it to run as root, running it in the background, and fixing the SUSEConnect invocation.

It also tells Cassandra on SLES to write logs to the expected location, and removes the now-unnecessary block of config and the extraneous expected features.

## Related issue
[b/355567725](http://b/355567725)

## How has this been tested?
Integration tests: [f80aea7e-bc6d-4dcd-8ef1-8c738bb63456](https://btx.cloud.google.com/invocations/f80aea7e-bc6d-4dcd-8ef1-8c738bb63456).

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
