### PR TITLE
Internal: Tell release builds to update the docker cache

### DIFF
--- a/kokoro/scripts/build/build_package.ps1
+++ b/kokoro/scripts/build/build_package.ps1
@@ -64,11 +64,11 @@ Invoke-Program docker create --name $name $tag
 Invoke-Program docker cp "${name}:/work/out" $env:KOKORO_ARTIFACTS_DIR
 
 
-# Tell our continuous build to update the cache. Our other builds do not
-# write to any kind of cache, for example a per-PR cache, because the
-# push takes a few minutes and adds little value over just using the continuous
-# build's cache.
-if ($env:KOKORO_ROOT_JOB_TYPE -eq 'CONTINUOUS_INTEGRATION') {
+# Tell our continuous build and release builds to update the cache.
+# Our presubmits do not write to any kind of cache, for example a per-PR cache,
+# because the push takes a few minutes and adds little value over just using
+# the continuous build's cache.
+if (($env:KOKORO_ROOT_JOB_TYPE -eq 'CONTINUOUS_INTEGRATION') -or ($env:KOKORO_JOB_TYPE -eq 'RELEASE')) {
   Invoke-Program docker image tag $tag $cache_location
   Invoke-Program docker push $cache_location
 }


### PR DESCRIPTION
## Description
This is a stab at getting windows release builds to take less than an hour.

## Related issue
(release builds are slow)

## How has this been tested?
presubmits only, sorry.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
