### PR TITLE
Clean up and update application metadata files.

### DIFF
--- a/ci/minimum_supported_agent_version_test.go
+++ b/ci/minimum_supported_agent_version_test.go
@@ -138,5 +138,5 @@ func unmarshalYamlFromFile(dir string, i interface{}) error {
 	if err != nil {
 		return err
 	}
-	return metadata.UnmarshalAndValidate(bytes, i)
+	return metadata.UnmarshalAndValidate(dir, bytes, i)
 }

--- a/integration_test/metadata/integration_metadata.go
+++ b/integration_test/metadata/integration_metadata.go
@@ -121,13 +121,16 @@ type IntegrationMetadata struct {
 	ExpectedMetricsContainer `yaml:",inline"`
 }
 
-func UnmarshalAndValidate(data []byte, i interface{}) error {
+func UnmarshalAndValidate(fullPath string, data []byte, i interface{}) error {
 	data = bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
 
 	v := NewIntegrationMetadataValidator()
 	// Note: Unmarshaler does not protect when only the key being declared.
 	// https://github.com/goccy/go-yaml/issues/313
-	return yaml.UnmarshalWithOptions(data, i, yaml.DisallowUnknownField(), yaml.Validator(v))
+	if err := yaml.UnmarshalWithOptions(data, i, yaml.DisallowUnknownField(), yaml.Validator(v)); err != nil {
+		return fmt.Errorf("%s%w", fullPath, err)
+	}
+	return nil
 }
 
 func SliceContains(slice []string, toFind string) bool {

--- a/integration_test/metadata/integration_metadata.go
+++ b/integration_test/metadata/integration_metadata.go
@@ -54,7 +54,7 @@ type ExpectedMetric struct {
 	UnavailableOn []string `yaml:"unavailable_on,omitempty" validate:"excluded_with=Representative"`
 }
 
-type LogFields struct {
+type LogField struct {
 	Name        string `yaml:"name" validate:"required"`
 	ValueRegex  string `yaml:"value_regex"`
 	Type        string `yaml:"type" validate:"required"`
@@ -66,8 +66,8 @@ type LogFields struct {
 }
 
 type ExpectedLog struct {
-	LogName string       `yaml:"log_name" validate:"required"`
-	Fields  []*LogFields `yaml:"fields" validate:"required,dive"`
+	LogName string      `yaml:"log_name" validate:"required"`
+	Fields  []*LogField `yaml:"fields" validate:"required,dive"`
 }
 
 type MinimumSupportedAgentVersion struct {

--- a/integration_test/metadata/integration_metadata.go
+++ b/integration_test/metadata/integration_metadata.go
@@ -127,7 +127,7 @@ func UnmarshalAndValidate(fullPath string, data []byte, i interface{}) error {
 	v := NewIntegrationMetadataValidator()
 	// Note: Unmarshaler does not protect when only the key being declared.
 	// https://github.com/goccy/go-yaml/issues/313
-	if err := yaml.UnmarshalWithOptions(data, i, yaml.DisallowUnknownField(), yaml.Validator(v)); err != nil {
+	if err := yaml.UnmarshalWithOptions(data, i, yaml.DisallowUnknownField(), yaml.DisallowDuplicateKey(), yaml.Validator(v)); err != nil {
 		return fmt.Errorf("%s%w", fullPath, err)
 	}
 	return nil

--- a/integration_test/metadata/integration_metadata.go
+++ b/integration_test/metadata/integration_metadata.go
@@ -67,7 +67,7 @@ type LogField struct {
 
 type ExpectedLog struct {
 	LogName string      `yaml:"log_name" validate:"required"`
-	Fields  []*LogField `yaml:"fields" validate:"required,dive"`
+	Fields  []*LogField `yaml:"fields" validate:"required,unique=Name,dive"`
 }
 
 type MinimumSupportedAgentVersion struct {

--- a/integration_test/metadata/integration_metadata_test.go
+++ b/integration_test/metadata/integration_metadata_test.go
@@ -36,7 +36,7 @@ func getTestFile(t *testing.T, dirName, fileName string) string {
 	filePath := path.Join(testdataDir, dirName, fileName)
 	contents, err := os.ReadFile(filePath)
 	if err != nil {
-		t.Fatal("could not read dirName: " + filePath)
+		t.Fatal("could not read file: " + filePath)
 	}
 	return strings.ReplaceAll(string(contents), "\r\n", "\n")
 }
@@ -63,7 +63,8 @@ func testMetadataValidation(t *testing.T, dir string) {
 	yamlStr := getTestFile(t, dir, inputYamlName)
 
 	var md metadata.IntegrationMetadata
-	actualError := metadata.UnmarshalAndValidate([]byte(yamlStr), &md)
+	// The fullPath will be ignored anyway.
+	actualError := metadata.UnmarshalAndValidate("", []byte(yamlStr), &md)
 
 	actualErrorStr := ""
 	if actualError != nil {

--- a/integration_test/metadata/testdata/integration-metadata_log-field-description_bad-quotes/golden_error
+++ b/integration_test/metadata/testdata/integration-metadata_log-field-description_bad-quotes/golden_error
@@ -1,1 +1,1 @@
-[40:22] Key: 'LogFields.Description' Error:Field validation for 'Description' failed on the 'excludesall' tag
+[40:22] Key: 'LogField.Description' Error:Field validation for 'Description' failed on the 'excludesall' tag

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -2334,10 +2334,8 @@ func testDefaultMetrics(ctx context.Context, t *testing.T, logger *log.Logger, v
 		t.Fatal(err)
 	}
 
-	var agentMetrics struct {
-		ExpectedMetrics []*metadata.ExpectedMetric `yaml:"expected_metrics" validate:"onetrue=Representative,unique=Type,dive"`
-	}
-	err = yaml.UnmarshalStrict(bytes, &agentMetrics)
+	var agentMetrics metadata.ExpectedMetricsContainer
+	err = metadata.UnmarshalAndValidate(bytes, &agentMetrics)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -2329,13 +2329,14 @@ func testDefaultMetrics(ctx context.Context, t *testing.T, logger *log.Logger, v
 		}
 	}
 
-	bytes, err := os.ReadFile(path.Join("agent_metrics", "metadata.yaml"))
+	agentMetricsMetadata := path.Join("agent_metrics", "metadata.yaml")
+	bytes, err := os.ReadFile(agentMetricsMetadata)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	var agentMetrics metadata.ExpectedMetricsContainer
-	err = metadata.UnmarshalAndValidate(bytes, &agentMetrics)
+	err = metadata.UnmarshalAndValidate(agentMetricsMetadata, bytes, &agentMetrics)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration_test/third_party_apps_test/applications/active_directory_ds/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/active_directory_ds/metadata.yaml
@@ -18,8 +18,8 @@ long_name: Active Directory Domain Services (AD DS)
 supported_app_version: ["windows-server-2016", "windows-server-2019"]
 logo_path: /stackdriver/images/active_directory_ds.png # supplied by google technical writer
 description: |-
-  Active Directory Domain Services stores information about objects on the network so that administrators and users
-  can easily access this information.
+  Active Directory Domain Services (AD DS) stores information about objects on the
+  network so that administrators and users can easily access this information.
 configure_integration: |-
   By default, Active Directory Windows event logs and performance counters are enabled.
 restart_after_install: true
@@ -29,21 +29,21 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: The value must be active_directory_ds.
+          description: The value must be `active_directory_ds`.
   metrics:
     - type: active_directory_ds
       fields:
         - name: type
           default: null
-          description: The value must be active_directory_ds.
+          description: The value must be `active_directory_ds`.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
 expected_logs:
   - log_name: active_directory_ds
     fields:
       - name: jsonPayload.Message
-        value_regex: (?s)^Microsoft Active Directory Domain Services startup complete.* # The (?s) part will make the . match with newline as well. See https://github.com/google/re2/blob/main/doc/syntax.txt#L65,L68 
+        value_regex: (?s)^Microsoft Active Directory Domain Services startup complete.* # The (?s) part will make the . match with newline as well. See https://github.com/google/re2/blob/main/doc/syntax.txt#L65,L68
         type: string
         description: "The log message."
       - name: jsonPayload.RecordNumber

--- a/integration_test/third_party_apps_test/applications/activemq/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/activemq/metadata.yaml
@@ -24,7 +24,7 @@ description: |-
   and expired messages.
 configure_integration: |-
   You must enable JMX support in the ActiveMQ [broker
-  configuration](https://activemq.apache.org/jmx){:class="external"}.
+  configuration](https://activemq.apache.org/jmx).
 minimum_supported_agent_version:
   metrics: 2.11.0
   logging: 2.15.0

--- a/integration_test/third_party_apps_test/applications/activemq/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/activemq/metadata.yaml
@@ -18,9 +18,10 @@ short_name: ActiveMQ
 long_name: Apache ActiveMQ
 logo_path: /stackdriver/images/activemq.png # supplied by google technical writer
 description: |-
-  The Apache ActiveMQ integration collects storage usage and message metrics.
-  Storage metrics include memory and disk usage. Message metrics include number of
-  waiting messages, average wait time, and expired messages.
+  The Apache ActiveMQ integration writes logs and collects storage usage and
+  message metrics. Storage metrics include memory and disk usage.
+  Message metrics include number of waiting messages, average wait time,
+  and expired messages.
 minimum_supported_agent_version:
   metrics: 2.11.0
   logging: 2.15.0
@@ -102,14 +103,14 @@ expected_logs:
       - name: jsonPayload.message
         value_regex: '(activemq\[[0-9]+\]|activemq):'
         type: string
-        description: null
+        description: ''
 configuration_options:
   metrics:
     - type: activemq
       fields:
         - name: type
           default: null
-          description: This value must be activemq.
+          description: This value must be `activemq`.
         - name: endpoint
           default: http://localhost:1099
           description: The URL of the node to monitor.
@@ -121,4 +122,4 @@ configuration_options:
           description: The configured password if JMX is configured to require authentication.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.

--- a/integration_test/third_party_apps_test/applications/activemq/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/activemq/metadata.yaml
@@ -22,6 +22,9 @@ description: |-
   message metrics. Storage metrics include memory and disk usage.
   Message metrics include number of waiting messages, average wait time,
   and expired messages.
+configure_integration: |-
+  You must enable JMX support in the ActiveMQ [broker
+  configuration](https://activemq.apache.org/jmx){:class="external"}.
 minimum_supported_agent_version:
   metrics: 2.11.0
   logging: 2.15.0

--- a/integration_test/third_party_apps_test/applications/activemq/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/activemq/metadata.yaml
@@ -29,7 +29,7 @@ minimum_supported_agent_version:
   metrics: 2.11.0
   logging: 2.15.0
 supported_operating_systems: linux
-supported_app_version: ["Classic 5.8.x-5.16.x", "Artemis 2.x"]
+supported_app_version: ["Classic 5.8.x through 5.16.x", "Artemis 2.x"]
 expected_metrics:
   - type: workload.googleapis.com/activemq.connection.count
     value_type: INT64

--- a/integration_test/third_party_apps_test/applications/aerospike/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/aerospike/metadata.yaml
@@ -109,7 +109,7 @@ configuration_options:
           description: This value must be `aerospike`.
         - name: collection_interval
           default: 60s
-          description: A [time.Duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
         - name: endpoint
           default: localhost:3000
           description: Address of the Aerospike system, formatted as host:port.
@@ -124,7 +124,7 @@ configuration_options:
           description: The configured password if Aerospike is configured to require authentication.
         - name: timeout
           default: 20s
-          description: Timeout for requests to the Aerospike system, a [time.Duration](https://pkg.go.dev/time#ParseDuration) value such as `30s` or `5m`.
+          description: Timeout for requests to the Aerospike system, a [time duration](https://pkg.go.dev/time#ParseDuration) value such as `30s` or `5m`.
 minimum_supported_agent_version:
   metrics: 2.18.2
   logging: 2.23.0

--- a/integration_test/third_party_apps_test/applications/apache/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/apache/metadata.yaml
@@ -25,7 +25,7 @@ description: |-
 configure_integration: |-
   To collect telemetry from your Apache Web Server, you must configure the
   server's `httpd.conf` file to enable the
-  [`mod_status` plugin](https://httpd.apache.org/docs/2.4/mod/mod_status.html){: .external}.
+  [`mod_status` plugin](https://httpd.apache.org/docs/2.4/mod/mod_status.html).
 
   Many Apache installations enable this plugin by default. To see if the
   plugin is enabled on your VM instance, run:

--- a/integration_test/third_party_apps_test/applications/apache/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/apache/metadata.yaml
@@ -25,8 +25,7 @@ description: |-
 configure_integration: |-
   To collect telemetry from your Apache Web Server, you must configure the
   server's `httpd.conf` file to enable the
-  [`mod_status` plugin](https://httpd.apache.org/docs/2.4/mod/mod_status.html)
-  {: .external}.
+  [`mod_status` plugin](https://httpd.apache.org/docs/2.4/mod/mod_status.html){: .external}.
 
   Many Apache installations enable this plugin by default. To see if the
   plugin is enabled on your VM instance, run:
@@ -151,7 +150,7 @@ expected_logs:
       - name: jsonPayload.module
         value_regex: core
         type: string
-        description: apache module where the log originated
+        description: Apache module where the log originated
       - name: jsonPayload.message
         value_regex: .*file permissions deny server access.*
         type: string
@@ -159,7 +158,7 @@ expected_logs:
       - name: jsonPayload.errorCode
         value_regex: .*Permission denied.*
         type: string
-        description: apache error code
+        description: Apache error code
       - name: jsonPayload.pid
         type: string
         description: Process ID
@@ -182,45 +181,45 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: This value must be apache_access.
+          description: This value must be `apache_access`.
         - name: include_paths
           default: '[/var/log/apache2/access.log,/var/log/apache2/access_log,/var/log/httpd/access_log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `/var/log/apache*/*.log`.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
     - type: apache_error
       fields:
         - name: type
           default: null
-          description: This value must be apache_error.
+          description: This value must be `apache_error`.
         - name: include_paths
           default: '[/var/log/apache2/error.log,/var/log/apache2/error_log,/var/log/httpd/error_log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/apache*/*.log.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `/var/log/apache*/*.log`.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: apache
       fields:
         - name: type
           default: null
-          description: This value must be apache.
+          description: This value must be `apache`.
         - name: server_status_url
           default: http://localhost:80/server-status?auto
-          description: The URL exposed by the mod_status module.
+          description: The URL exposed by the `mod_status` module.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.

--- a/integration_test/third_party_apps_test/applications/cassandra/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/cassandra/metadata.yaml
@@ -212,62 +212,62 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: The value must be cassandra_system.
+          description: This value must be `cassandra_system`.
         - name: include_paths
           default: '[/var/log/cassandra/system*.log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/cassandra/system*.log.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `/var/log/cassandra/system*.log`.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
     - type: cassandra_debug
       fields:
         - name: type
           default: null
-          description: The value must be cassandra_debug.
+          description: This value must be `cassandra_debug`.
         - name: include_paths
           default: '[/var/log/cassandra/debug*.log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/cassandra/system*.log.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `/var/log/cassandra/system*.log`.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
     - type: cassandra_gc
       fields:
         - name: type
           default: null
-          description: The value must be cassandra_gc.
+          description: This value must be `cassandra_gc`.
         - name: include_paths
           default: '[/var/log/cassandra/gc.log.*.current]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/cassandra/system*.log.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `/var/log/cassandra/system*.log`.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: cassandra
       fields:
         - name: type
           default: null
-          description: The value must be cassandra.
+          description: This value must be `cassandra`.
         - name: endpoint
           default: localhost:7199
-          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of service:jmx:<protocol>:<sap> or host:port. Values in host:port form are used to create a service URL of service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi.
+          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
         - name: collect_jvm_metrics
           default: true
           description: Configures the receiver to also collect the supported JVM metrics.
@@ -279,4 +279,4 @@ configuration_options:
           description: The configured password if JMX is configured to require authentication.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.

--- a/integration_test/third_party_apps_test/applications/cassandra/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/cassandra/metadata.yaml
@@ -267,7 +267,7 @@ configuration_options:
           description: This value must be `cassandra`.
         - name: endpoint
           default: localhost:7199
-          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
+          description: The [JMX Service URL](https://docs.oracle.com/javase/8/docs/api/javax/management/remote/JMXServiceURL.html) or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
         - name: collect_jvm_metrics
           default: true
           description: Configures the receiver to also collect the supported JVM metrics.

--- a/integration_test/third_party_apps_test/applications/couchbase/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/couchbase/metadata.yaml
@@ -51,9 +51,6 @@ expected_logs:
       - name: severity
         type: string
         description: ''
-      - name: timestamp
-        type: string
-        description: ''
   - log_name: couchbase_http_access
     fields:
       - name: httpRequest.remoteIp
@@ -104,9 +101,6 @@ expected_logs:
       - name: severity
         type: string
         description: ''
-      - name: timestamp
-        type: string
-        description: ''
   - log_name: couchbase_goxdcr
     fields:
       - name: jsonPayload.message
@@ -121,9 +115,6 @@ expected_logs:
         description: Log entry severity for the couchbase log
         optional: true
       - name: severity
-        type: string
-        description: ''
-      - name: timestamp
         type: string
         description: ''
 expected_metrics:

--- a/integration_test/third_party_apps_test/applications/couchbase/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/couchbase/metadata.yaml
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 app_url: "https://www.couchbase.com/"
-short_name: couchbase
+short_name: Couchbase
 long_name: Couchbase
+logo_path: /stackdriver/images/integrations/couchbase.png # supplied by google technical writer
 description: |-
   The Couchbase integration collects bucket metrics such as operations, memory usage, and ejections. The integration collects metrics from the Prometheus server exposed on a node.
 supported_app_version: ["6.5", "6.6", "7.0"]
@@ -190,9 +191,9 @@ configuration_options:
           default: 60s
           description: A [time.Duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
         - name: username
-          description: The username used to connect to the couchbase server.
+          description: The username used to connect to the Couchbase server.
         - name: password
-          description: The password used to connect to the couchbase server.
+          description: The password used to connect to the Couchbase server.
 minimum_supported_agent_version:
   metrics: 2.18.2
   logging: 2.18.2

--- a/integration_test/third_party_apps_test/applications/couchbase/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/couchbase/metadata.yaml
@@ -38,11 +38,11 @@ expected_logs:
         optional: true
       - name: jsonPayload.source
         type: string
-        description: ''
+        description: Source where the log originated
         optional: true
       - name: jsonPayload.type
         type: string
-        description: ''
+        description: The type of log
         optional: true
       - name: jsonPayload.level
         type: string
@@ -114,7 +114,7 @@ expected_logs:
         description: "Log message"
       - name: jsonPayload.log_type
         type: string
-        description: ''
+        description: The name of the component that is issuing the cross-datacenter log
         optional: true
       - name: jsonPayload.level
         type: string

--- a/integration_test/third_party_apps_test/applications/couchbase/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/couchbase/metadata.yaml
@@ -17,7 +17,10 @@ short_name: Couchbase
 long_name: Couchbase
 logo_path: /stackdriver/images/integrations/couchbase.png # supplied by google technical writer
 description: |-
-  The Couchbase integration collects bucket metrics such as operations, memory usage, and ejections. The integration collects metrics from the Prometheus server exposed on a node.
+  The Couchbase integration collects bucket metrics such as operations,
+  memory usage, and ejections. The integration collects metrics from the
+  Prometheus server exposed on a node. The integration also collects Couchbase
+  general, HTTP access, and cross-datacenter ("goxdcr") logs.
 supported_app_version: ["6.5", "6.6", "7.0"]
 expected_logs:
   - log_name: couchbase_general

--- a/integration_test/third_party_apps_test/applications/couchdb/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/couchdb/metadata.yaml
@@ -87,11 +87,11 @@ expected_logs:
       - name: jsonPayload.node
         value_regex: couchdb
         type: string
-        description: node instance name
+        description: Node instance name
       - name: jsonPayload.path
         value_regex: /forbidden
         type: string
-        description: request path
+        description: Request path
       - name: jsonPayload.remote_user
         value_regex: undefined
         type: string
@@ -99,7 +99,7 @@ expected_logs:
       - name: jsonPayload.status_message
         value_regex: ok
         type: string
-        description: status code message
+        description: Status code message
       - name: jsonPayload.pid
         type: string
         description: Process ID
@@ -108,7 +108,7 @@ expected_logs:
         description: Log message
       - name: jsonPayload.host
         type: string
-        description: host instance name
+        description: Host instance name
       - name: jsonPayload.level
         type: string
         description: Log entry level
@@ -153,28 +153,28 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: The value must be couchdb.
+          description: This value must be `couchdb`.
         - name: include_paths
           default: '[/var/log/couchdb/couchdb.log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/couchdb*/*.log.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `/var/log/couchdb*/*.log`.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: couchdb
       fields:
         - name: type
           default: null
-          description: The value must be couchdb.
+          description: This value must be `couchdb`.
         - name: server_status_url
           default: http://localhost:5984
-          description: The URL exposed by couchdb.
+          description: The URL exposed by CouchDB.
         - name: username
           default: null
           description: The username used to connect to the server.
@@ -183,4 +183,4 @@ configuration_options:
           description: The password used to connect to the server.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.

--- a/integration_test/third_party_apps_test/applications/couchdb/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/couchdb/metadata.yaml
@@ -38,7 +38,7 @@ platforms_to_skip:
   - ubuntu-os-cloud:ubuntu-2404-lts-arm64
   - debian-cloud:debian-12
   - debian-cloud:debian-12-arm64
-supported_app_version: ["2.3+", "3.1+"]
+supported_app_version: ["2.3.x", "3.1 and higher"]
 expected_metrics:
   - type: workload.googleapis.com/couchdb.average_request_time
     value_type: DOUBLE

--- a/integration_test/third_party_apps_test/applications/dcgm/enable
+++ b/integration_test/third_party_apps_test/applications/dcgm/enable
@@ -1,5 +1,5 @@
 # Configures Ops Agent to collect telemetry from the app and restart Ops Agent.
-set -e 
+set -e
 
 # Create a back up of the existing file so existing configurations are not lost.
 sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak

--- a/integration_test/third_party_apps_test/applications/dcgm/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/dcgm/metadata.yaml
@@ -14,10 +14,10 @@
 
 app_url: "https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/index.html"
 short_name: NVIDIA DCGM
-long_name: NVIDIA DataCenter GPU Manager (DCGM)
-logo_path: /images/partners/todo.png # supplied by google technical writer
+long_name: NVIDIA Data Center GPU Manager (DCGM)
+logo_path: /stackdriver/images/integrations/nvidia.png # supplied by google technical writer
 description: |-
-  The NVIDIA DataCenter GPU Manager (DCGM) integration collects advanced GPU metrics,
+  The NVIDIA Data Center GPU Manager (DCGM) integration collects advanced GPU metrics,
   including SM block utilization, Pipe utilization, PCIe and NVLink traffic.
 configure_integration: |-
   You must install DCGM and run the DCGM daemon service.
@@ -101,13 +101,13 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: This value must be dcgm.
+          description: This value must be `dcgm`.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
         - name: endpoint
           default: localhost:5555
-          description: The DCGM service endpoint specified as 'hostname:port'
+          description: The DCGM service endpoint specified as `hostname:port`.
 minimum_supported_agent_version:
   metrics: 2.38.0
 public_url: https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party-nvidia

--- a/integration_test/third_party_apps_test/applications/dcgm/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/dcgm/metadata.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-app_url: "https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/index.html"
+app_url: "https://developer.nvidia.com/dcgm"
 short_name: NVIDIA DCGM
 long_name: NVIDIA Data Center GPU Manager (DCGM)
 logo_path: /stackdriver/images/integrations/nvidia.png # supplied by google technical writer

--- a/integration_test/third_party_apps_test/applications/elasticsearch/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/elasticsearch/metadata.yaml
@@ -19,14 +19,14 @@ long_name: Elasticsearch
 logo_path: /stackdriver/images/elasticsearch.png # supplied by google technical writer
 description: |-
   Elasticsearch is an open-source search server, based on the
-  [Lucene](https://lucene.apache.org/){: .external} search library. It runs in a Java virtual
+  [Lucene](https://lucene.apache.org/) search library. It runs in a Java virtual
   machine on top of a number of operating systems. The `elasticsearch` receiver
   collects node- and cluster-level telemetry from your Elasticsearch instances.
 configure_integration: |-
   If you enable [Elasticsearch security
-  features](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/secure-cluster.html){: .external},
+  features](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/secure-cluster.html),
   you must configure a user with the `monitor` or `manage` [cluster
-  privilege](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/security-privileges.html#privileges-list-cluster){: .external}.
+  privilege](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/security-privileges.html#privileges-list-cluster).
 minimum_supported_agent_version:
   metrics: 2.21.0
   logging: 2.9.0

--- a/integration_test/third_party_apps_test/applications/elasticsearch/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/elasticsearch/metadata.yaml
@@ -26,8 +26,7 @@ configure_integration: |-
   If you enable [Elasticsearch security
   features](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/secure-cluster.html){: .external},
   you must configure a user with the `monitor` or `manage` [cluster
-  privilege](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/security-privileges.html#privileges-list-cluster)
-  {: .external}.
+  privilege](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/security-privileges.html#privileges-list-cluster){: .external}.
 minimum_supported_agent_version:
   metrics: 2.32.0
   logging: 2.9.0

--- a/integration_test/third_party_apps_test/applications/elasticsearch/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/elasticsearch/metadata.yaml
@@ -28,7 +28,7 @@ configure_integration: |-
   you must configure a user with the `monitor` or `manage` [cluster
   privilege](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/security-privileges.html#privileges-list-cluster){: .external}.
 minimum_supported_agent_version:
-  metrics: 2.32.0
+  metrics: 2.21.0
   logging: 2.9.0
 supported_operating_systems: linux
 supported_app_version: ["7.9+"]

--- a/integration_test/third_party_apps_test/applications/elasticsearch/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/elasticsearch/metadata.yaml
@@ -331,7 +331,7 @@ expected_logs:
         optional: true
       - name: jsonPayload.cluster.uuid
         type: string
-        description: 'The uuid of the cluster emitting the log record'
+        description: 'The UUID of the cluster emitting the log record'
         optional: true
       - name: jsonPayload.node.name
         type: string
@@ -339,7 +339,7 @@ expected_logs:
         optional: true
       - name: jsonPayload.node.uuid
         type: string
-        description: 'The uuid of the node emitting the log record'
+        description: 'The UUID of the node emitting the log record'
         optional: true
       - name: jsonPayload.cluster
         type: string
@@ -379,60 +379,60 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: The value must be elasticsearch_json.
+          description: This value must be `elasticsearch_json`.
         - name: include_paths
           default: '[/var/log/elasticsearch/*_server.json, /var/log/elasticsearch/*_deprecation.json, /var/log/elasticsearch/*_index_search_slowlog.json, /var/log/elasticsearch/*_index_indexing_slowlog.json, /var/log/elasticsearch/*_audit.json]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
     - type: elasticsearch_gc
       fields:
         - name: type
           default: null
-          description: The value must be elasticsearch_gc.
+          description: This value must be `elasticsearch_gc`.
         - name: include_paths
           default: '[/var/log/elasticsearch/gc.log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: elasticsearch
       fields:
         - name: type
           default: null
-          description: This value must be elasticsearch.
+          description: This value must be `elasticsearch`.
         - name: endpoint
           default: http://localhost:92002
           description: The base URL for the Elasticsearch REST API.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
         - name: username
           default: null
-          description: Username for authentication with Elasticsearch. Required if password is set.
+          description: Username for authentication with Elasticsearch. Required if `password` is set.
         - name: password
           default: null
-          description: Password for authentication with Elasticsearch. Required if username is set.
+          description: Password for authentication with Elasticsearch. Required if `username` is set.
         - name: insecure
           default: true
-          description: Sets whether or not to use a secure TLS connection. If set to false, then TLS is enabled.
+          description: Sets whether or not to use a secure TLS connection. If set to `false`, then TLS is enabled.
         - name: insecure_skip_verify
           default: false
-          description: Sets whether or not to skip verifying the certificate. If insecure is set to true, then the insecure_skip_verify value is not used.
+          description: Sets whether or not to skip verifying the certificate. If `insecure` is set to `true`, then the `insecure_skip_verify` value is not used.
         - name: cert_file
           default: null
           description: Path to the TLS certificate to use for mTLS-required connections.

--- a/integration_test/third_party_apps_test/applications/flink/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/flink/metadata.yaml
@@ -273,11 +273,11 @@ expected_logs:
     fields:
       - name: jsonPayload.message
         type: string
-        description: ''
+        description: Log message, including detailed stacktrace where provided
       - name: jsonPayload.source
         value_regex: org.apache.flink.runtime.entrypoint.ClusterEntrypoint
         type: string
-        description: ''
+        description: The source Java class of the log entry
       - name: jsonPayload.level
         type: string
         description: Log entry level

--- a/integration_test/third_party_apps_test/applications/flink/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/flink/metadata.yaml
@@ -15,9 +15,11 @@
 app_url: "https://flink.apache.org/"
 short_name: Flink
 long_name: Apache Flink
+logo_path: /stackdriver/images/integrations/flink.png # supplied by google technical writer
 description: |-
-  The Apache Flink integration collects client, jobmanager and taskmanager logs and parses them into a JSON payload.
-  The result includes fields for source, level, and message.
+  The Apache Flink integration collects client, jobmanager and taskmanager logs
+  and parses them into a JSON payload.  The result includes fields for source,
+  level, and message.
 platforms_to_skip:
   # Flink only supports Java 11, which has no installation candidate for Debian 12
   - debian-cloud:debian-12
@@ -289,31 +291,31 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: The value must be flink.
+          description: This value must be `flink`.
         - name: include_paths
           default: '[/opt/flink/log/flink-*-standalonesession-*.log, /opt/flink/log/flink-*-taskexecutor-*.log, /opt/flink/log/flink-*-client-*.log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: flink
       fields:
         - name: type
           default: null
-          description: The value must be flink.
+          description: This value must be `flink`.
         - name: endpoint
           default: http://localhost:8081
-          description: The URL exposed by flink.
+          description: The URL exposed by Flink.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
 minimum_supported_agent_version:
   logging: 2.17.0
   metrics: 2.18.1

--- a/integration_test/third_party_apps_test/applications/hadoop/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/hadoop/metadata.yaml
@@ -120,28 +120,28 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: This value must be hadoop.
+          description: This value must be `hadoop`.
         - name: include_paths
           default: '[/opt/hadoop/logs/hadoop-*.log, /opt/hadoop/logs/yarn-*.log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: hadoop
       fields:
         - name: type
           default: null
-          description: This value must be hadoop.
+          description: This value must be `hadoop`.
         - name: endpoint
           default: localhost:8004
-          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of service:jmx:<protocol>:<sap> or host:port. Values in host:port form are used to create a service URL of service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi.
+          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
         - name: collect_jvm_metrics
           default: true
           description: Configures the receiver to also collect the supported JVM metrics.
@@ -153,4 +153,4 @@ configuration_options:
           description: The configured password if JMX is configured to require authentication.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.

--- a/integration_test/third_party_apps_test/applications/hadoop/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/hadoop/metadata.yaml
@@ -141,7 +141,7 @@ configuration_options:
           description: This value must be `hadoop`.
         - name: endpoint
           default: localhost:8004
-          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
+          description: The [JMX Service URL](https://docs.oracle.com/javase/8/docs/api/javax/management/remote/JMXServiceURL.html) or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
         - name: collect_jvm_metrics
           default: true
           description: Configures the receiver to also collect the supported JVM metrics.

--- a/integration_test/third_party_apps_test/applications/hbase/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/hbase/metadata.yaml
@@ -388,28 +388,28 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: This value must be hbase_system.
+          description: This value must be `hbase_system`.
         - name: include_paths
           default: '[/opt/hbase/logs/hbase-*-regionserver-*.log, /opt/hbase/logs/hbase-*-master-*.log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/hbase*/*.log.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `/var/log/hbase*/*.log`.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: hbase
       fields:
         - name: type
           default: null
-          description: This value must be hbase.
+          description: This value must be `hbase`.
         - name: endpoint
           default: localhost:10101
-          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of service:jmx:<protocol>:<sap> or host:port. Values in host:port form are used to create a service URL of service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi.
+          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
         - name: collect_jvm_metrics
           default: true
           description: Configures the receiver to also collect the supported JVM metrics.
@@ -421,4 +421,4 @@ configuration_options:
           description: The configured password if JMX is configured to require authentication.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.

--- a/integration_test/third_party_apps_test/applications/hbase/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/hbase/metadata.yaml
@@ -409,7 +409,7 @@ configuration_options:
           description: This value must be `hbase`.
         - name: endpoint
           default: localhost:10101
-          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
+          description: The [JMX Service URL](https://docs.oracle.com/javase/8/docs/api/javax/management/remote/JMXServiceURL.html) or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
         - name: collect_jvm_metrics
           default: true
           description: Configures the receiver to also collect the supported JVM metrics.

--- a/integration_test/third_party_apps_test/applications/iis/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/iis/metadata.yaml
@@ -145,10 +145,6 @@ expected_logs:
         type: string
         description: "Contents of the `Referer` header"
         optional: true
-      - name: httpRequest.userAgent
-        type: string
-        description: ""
-        optional: true
       - name: jsonPayload.sc_substatus
         type: string
         description: "The server's IP and port that was requested"

--- a/integration_test/third_party_apps_test/applications/iis/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/iis/metadata.yaml
@@ -25,8 +25,8 @@ description: |-
   When using the Ops Agent on a Microsoft Windows VM, the agent automatically
   collects IIS metrics. No additional configuration is required.
 minimum_supported_agent_version:
-  metrics: 2.10.0
-  logging: 2.10.0
+  metrics: 2.15.0
+  logging: 2.14.0
 supported_operating_systems: windows
 supported_app_version: ["8.5", "10.0"]
 expected_metrics:
@@ -147,10 +147,10 @@ expected_logs:
         optional: true
       - name: jsonPayload.sc_substatus
         type: string
-        description: "The server's IP and port that was requested"
+        description: "The substatus error code"
       - name: jsonPayload.sc_win32_status
         type: string
-        description: "The server's IP and port that was requested"
+        description: "The Windows status code"
       - name: jsonPayload.time_taken
         type: string
         description: "The length of time that the action took, in milliseconds"
@@ -169,7 +169,7 @@ configuration_options:
           default: null
           description: This value must be `iis_access`.
         - name: include_paths
-          default: "['C:\\inetpub\\logs\\LogFiles\\W3SVC1\\u_ex*]"
+          default: "['C:\\inetpub\\logs\\LogFiles\\W3SVC1\\u_ex*']"
           description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `C:\inetpub\logs\LogFiles\W3SVC1\u_ex*`.
         - name: exclude_paths
           default: null
@@ -191,4 +191,4 @@ configuration_options:
           description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
         - name: receiver_version
           default: null
-          description: Establishes the version of the metric collection implementation.
+          description: Version of the metrics collected; use `2` to collect v2 metrics.

--- a/integration_test/third_party_apps_test/applications/iis/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/iis/metadata.yaml
@@ -171,28 +171,28 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: This value must be iis_access.
+          description: This value must be `iis_access`.
         - name: include_paths
           default: "['C:\\inetpub\\logs\\LogFiles\\W3SVC1\\u_ex*]"
           description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `C:\inetpub\logs\LogFiles\W3SVC1\u_ex*`.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: iis
       fields:
         - name: type
           default: null
-          description: This value must be iis.
+          description: This value must be `iis`.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
         - name: receiver_version
           default: null
           description: Establishes the version of the metric collection implementation.

--- a/integration_test/third_party_apps_test/applications/jetty/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/jetty/metadata.yaml
@@ -21,6 +21,27 @@ description: |-
   The Jetty integration collects session and thread-usage metrics. The
   integration also collects access and system logs. Access logs are parsed
   into a JSON payload focused on request details.
+configure_integration: |-
+  To collect metrics from this integration, you must expose a
+  [Java Management Extensions (JMX)](https://www.oracle.com/java/technologies/javase/javamanagement.html){:class="external"}
+  endpoint.
+
+  To expose a JMX endpoint, you must set the `com.sun.management.jmxremote.port`
+  system property when starting the JVM. We also recommend setting the
+  `com.sun.management.jmxremote.rmi.port` system property to the same port. To
+  expose a JMX endpoint remotely, you must also set the `java.rmi.server.hostname`
+  system property.
+
+  By default, these properties are set in the Jetty `/etc/jetty-jmx.xml` file.
+
+  To set system properties by using command-line arguments, prepend the property
+  name with `-D` when starting the JVM. For example, to set
+  `com.sun.management.jmxremote.port` to port 1099, specify the following when
+  starting the JVM:
+
+  <pre>
+  -Dcom.sun.management.jmxremote.port=1099
+  </pre>
 minimum_supported_agent_version:
   metrics: 2.17.0
   logging: 2.16.0

--- a/integration_test/third_party_apps_test/applications/jetty/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/jetty/metadata.yaml
@@ -118,6 +118,11 @@ expected_logs:
       - name: severity
         type: string
         description: ''
+  - log_name: syslog
+    fields:
+      - name: jsonPayload.message
+        type: string
+        description: 'Log message'
 configuration_options:
   logs:
     - type: jetty_access
@@ -145,7 +150,7 @@ configuration_options:
           description: This value must be `jetty`.
         - name: endpoint
           default: localhost:1099
-          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
+          description: The [JMX Service URL](https://docs.oracle.com/javase/8/docs/api/javax/management/remote/JMXServiceURL.html) or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
         - name: collect_jvm_metrics
           default: true
           description: Configures the receiver to also collect the supported JVM metrics.

--- a/integration_test/third_party_apps_test/applications/jetty/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/jetty/metadata.yaml
@@ -23,7 +23,7 @@ description: |-
   into a JSON payload focused on request details.
 configure_integration: |-
   To collect metrics from this integration, you must expose a
-  [Java Management Extensions (JMX)](https://www.oracle.com/java/technologies/javase/javamanagement.html){:class="external"}
+  [Java Management Extensions (JMX)](https://www.oracle.com/java/technologies/javase/javamanagement.html)
   endpoint.
 
   To expose a JMX endpoint, you must set the `com.sun.management.jmxremote.port`

--- a/integration_test/third_party_apps_test/applications/jetty/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/jetty/metadata.yaml
@@ -25,7 +25,7 @@ minimum_supported_agent_version:
   metrics: 2.17.0
   logging: 2.16.0
 supported_operating_systems: linux
-supported_app_version: ["11.x", "10.x", "9.4.x"]
+supported_app_version: ["9.4.x", "10.x", "11.x"]
 expected_metrics:
   - type: workload.googleapis.com/jetty.select.count
     value_type: INT64
@@ -103,28 +103,28 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: The value must be jetty_access.
+          description: This value must be `jetty_access`.
         - name: include_paths
           default: '["/opt/logs/*.request.log"]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: jetty
       fields:
         - name: type
           default: null
-          description: This value must be jetty.
+          description: This value must be `jetty`.
         - name: endpoint
           default: localhost:1099
-          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of service:jmx:<protocol>:<sap> or host:port. Values in host:port form are used to create a service URL of service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi.
+          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
         - name: collect_jvm_metrics
           default: true
           description: Configures the receiver to also collect the supported JVM metrics.
@@ -136,4 +136,4 @@ configuration_options:
           description: The configured password if JMX is configured to require authentication.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.

--- a/integration_test/third_party_apps_test/applications/jvm/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/jvm/metadata.yaml
@@ -19,7 +19,7 @@ long_name: JVM
 logo_path: /stackdriver/images/java.png # supplied by google technical writer
 description: |-
   The JVM integration collects JVM metrics exposed through [Java Management
-  Extensions (JMX)](https://www.oracle.com/java/technologies/javase/javamanagement.html){: .external}.
+  Extensions (JMX)](https://www.oracle.com/java/technologies/javase/javamanagement.html).
   The integration primarily collects metrics on memory and garbage collection.
   Additional runtime metrics, such as thread count and classes loaded, are also
   available.

--- a/integration_test/third_party_apps_test/applications/jvm/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/jvm/metadata.yaml
@@ -128,10 +128,10 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: This value must be jvm.
+          description: This value must be `jvm`.
         - name: endpoint
           default: localhost:9999
-          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of service:jmx:<protocol>:<sap> or host:port. Values in host:port form are used to create a service URL of service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi.
+          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
         - name: username
           default: null
           description: The configured username if JMX is configured to require authentication.
@@ -140,4 +140,4 @@ configuration_options:
           description: The configured password if JMX is configured to require authentication.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.

--- a/integration_test/third_party_apps_test/applications/jvm/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/jvm/metadata.yaml
@@ -131,7 +131,7 @@ configuration_options:
           description: This value must be `jvm`.
         - name: endpoint
           default: localhost:9999
-          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
+          description: The [JMX Service URL](https://docs.oracle.com/javase/8/docs/api/javax/management/remote/JMXServiceURL.html) or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
         - name: username
           default: null
           description: The configured username if JMX is configured to require authentication.

--- a/integration_test/third_party_apps_test/applications/kafka/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/kafka/metadata.yaml
@@ -121,9 +121,6 @@ expected_logs:
       - name: severity
         type: string
         description: ''
-      - name: timestamp
-        type: string
-        description: 'Time that the request was received.'
 configuration_options:
   logs:
     - type: kafka

--- a/integration_test/third_party_apps_test/applications/kafka/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/kafka/metadata.yaml
@@ -151,7 +151,7 @@ configuration_options:
           description: This value must be `kafka`.
         - name: stub_status_url
           default: localhost:9999
-          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
+          description: The [JMX Service URL](https://docs.oracle.com/javase/8/docs/api/javax/management/remote/JMXServiceURL.html) or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
         - name: collect_jvm_metrics
           default: true
           description: Configures the receiver to also collect the supported JVM metrics.

--- a/integration_test/third_party_apps_test/applications/kafka/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/kafka/metadata.yaml
@@ -130,28 +130,28 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: The value must be kafka.
+          description: This value must be `kafka`.
         - name: include_paths
           default: '[/var/log/kafka/*.log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/kafka*/*.log.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `/var/log/kafka*/*.log`.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: kafka
       fields:
         - name: type
           default: null
-          description: This value must be kafka.
+          description: This value must be `kafka`.
         - name: stub_status_url
           default: localhost:9999
-          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of service:jmx:<protocol>:<sap> or host:port. Values in host:port form are used to create a service URL of service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi.
+          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
         - name: collect_jvm_metrics
           default: true
           description: Configures the receiver to also collect the supported JVM metrics.
@@ -163,4 +163,4 @@ configuration_options:
           description: The configured password if JMX is configured to require authentication.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.

--- a/integration_test/third_party_apps_test/applications/kafka/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/kafka/metadata.yaml
@@ -105,15 +105,15 @@ expected_logs:
       - name: jsonPayload.message
         value_regex: .*Waiting until connected.*
         type: string
-        description: ''
+        description: 'Log message, including detailed stacktrace where provided'
       - name: jsonPayload.source
         value_regex: ZooKeeperClient Kafka server
         type: string
-        description: ''
+        description: 'Module and/or thread where the log originated.'
       - name: jsonPayload.logger
         value_regex: kafka.zookeeper.ZooKeeperClient
         type: string
-        description: ''
+        description: 'Name of the logger where the log originated.'
       - name: jsonPayload.level
         type: string
         description: Log entry level
@@ -123,7 +123,7 @@ expected_logs:
         description: ''
       - name: timestamp
         type: string
-        description: ''
+        description: 'Time that the request was received.'
 configuration_options:
   logs:
     - type: kafka

--- a/integration_test/third_party_apps_test/applications/kafka/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/kafka/metadata.yaml
@@ -44,7 +44,7 @@ minimum_supported_agent_version:
   metrics: 2.10.0
   logging: 2.10.0
 supported_operating_systems: linux
-supported_app_version: [">=0.8", "<=3.0.0"]
+supported_app_version: ["0.8 through 3.0.0", ""] # Indicate multiple versions.
 expected_metrics:
   - type: workload.googleapis.com/kafka.isr.operation.count
     value_type: INT64

--- a/integration_test/third_party_apps_test/applications/mariadb/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mariadb/metadata.yaml
@@ -16,7 +16,7 @@ public_url: "https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agen
 app_url: "http://www.mariadb.com/"
 short_name: MariaDB
 long_name: MariaDB
-logo_path: /images/launcher/logos/mariadb.png # supplied by google technical writer
+logo_path: /stackdriver/images/mariadb.png # supplied by google technical writer
 description: |-
   The MariaDB integration collects performance metrics related to
   InnoDB, the buffer pool, and various other operations. It also collects general,

--- a/integration_test/third_party_apps_test/applications/mariadb/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mariadb/metadata.yaml
@@ -36,7 +36,7 @@ configure_integration: |-
   shown in the table below. On some platforms, MariaDB logs to `journald` by
   default instead of a file. Configure MariaDB to log to a file instead by
   setting `log_error` in the MariaDB configuration.
-  [Learn more](https://mariadb.com/kb/en/error-log/#writing-the-error-log-to-a-file)
+  [Learn more](https://mariadb.com/kb/en/error-log/#writing-the-error-log-to-a-file){: .external}
   about configuring `log_error`.
 supported_operating_systems: linux
 platforms_to_skip:
@@ -292,59 +292,59 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: This value must be mysql_error.
+          description: This value must be `mysql_error`.
         - name: include_paths
           default: '[/var/log/mysqld.log, /var/log/mysql/mysqld.log, /var/log/mysql/error.log, /run/mysqld/mysqld.err, /var/lib/mysql/${HOSTNAME}.err]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/mysql/*.log.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `/var/log/mysql/*.log`.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
     - type: mysql_general
       fields:
         - name: type
           default: null
-          description: This value must be mysql_general.
+          description: This value must be `mysql_general`.
         - name: include_paths
           default: '[/var/lib/mysql/${HOSTNAME}.log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
     - type: mysql_slow
       fields:
         - name: type
           default: null
-          description: This value must be mysql_slow.
+          description: This value must be `mysql_slow`.
         - name: include_paths
           default: '[/var/lib/mysql/${HOSTNAME}-slow.log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: mysql
       fields:
         - name: type
           default: null
-          description: This value must be mysql.
+          description: This value must be `mysql`.
         - name: endpoint
           default: localhost:3306
           description: The url exposed by MySQL.
@@ -356,10 +356,10 @@ configuration_options:
           description: The password used to connect to the server.
         - name: application_version
           default: null
-          description: The version of mysql (major.minor) being monitored. Replication metrics are supported for version 5.7 by setting this to the value 5.7.
+          description: The version of mysql (major.minor) being monitored. Replication metrics are supported for version 5.7 by setting this to the value `5.7`.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
 minimum_supported_agent_version:
   metrics: 2.37.0
   logging: 2.37.0

--- a/integration_test/third_party_apps_test/applications/mariadb/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mariadb/metadata.yaml
@@ -38,6 +38,9 @@ configure_integration: |-
   setting `log_error` in the MariaDB configuration.
   [Learn more](https://mariadb.com/kb/en/error-log/#writing-the-error-log-to-a-file){: .external}
   about configuring `log_error`.
+minimum_supported_agent_version:
+  metrics: 2.37.0
+  logging: 2.37.0
 supported_operating_systems: linux
 platforms_to_skip:
   # TODO: Enable MariaDB testing on all supported platforms.
@@ -49,7 +52,7 @@ platforms_to_skip:
   - suse-cloud:sles-12
   - suse-cloud:sles-15
   - suse-cloud:sles-15-arm64
-supported_app_version: ["10.1.X through 10.7.X"]
+supported_app_version: ["10.1.X through 10.7.X", ""] # Indicate multiple versions.
 expected_metrics:
   - type: workload.googleapis.com/mysql.buffer_pool_data_pages
     value_type: INT64
@@ -360,6 +363,3 @@ configuration_options:
         - name: collection_interval
           default: 60s
           description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
-minimum_supported_agent_version:
-  metrics: 2.37.0
-  logging: 2.37.0

--- a/integration_test/third_party_apps_test/applications/mariadb/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mariadb/metadata.yaml
@@ -36,7 +36,7 @@ configure_integration: |-
   shown in the table below. On some platforms, MariaDB logs to `journald` by
   default instead of a file. Configure MariaDB to log to a file instead by
   setting `log_error` in the MariaDB configuration.
-  [Learn more](https://mariadb.com/kb/en/error-log/#writing-the-error-log-to-a-file){: .external}
+  [Learn more](https://mariadb.com/kb/en/error-log/#writing-the-error-log-to-a-file)
   about configuring `log_error`.
 minimum_supported_agent_version:
   metrics: 2.37.0

--- a/integration_test/third_party_apps_test/applications/memcached/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/memcached/metadata.yaml
@@ -91,10 +91,10 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: memcached.
+          description: This value must be `memcached`.
         - name: endpoint
           default: localhost:3306
           description: The URL, or Unix socket file path, for your Memcached server.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.

--- a/integration_test/third_party_apps_test/applications/mongodb/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mongodb/metadata.yaml
@@ -155,7 +155,7 @@ expected_logs:
     fields:
       - name: jsonPayload.component
         type: string
-        description: Categorization of the log message. A full list can be found [here](https://docs.mongodb.com/manual/reference/log-messages/#std-label-log-message-components)
+        description: Categorization of the log message. A full list can be found in the [MongoDB documentation](https://docs.mongodb.com/manual/reference/log-messages/#std-label-log-message-components).
       - name: jsonPayload.ctx
         type: string
         description: The name of the thread issuing the log statement
@@ -188,49 +188,49 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: This value must be mongodb.
+          description: This value must be `mongodb`.
         - name: include_paths
           default: '[/var/log/mongodb/mongod.log*]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/mongodb/*.log.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `/var/log/mongodb/*.log`.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: mongodb
       fields:
         - name: type
           default: null
-          description: This value must be mongodb.
+          description: This value must be `mongodb`.
         - name: endpoint
-          default: http://localhost:27017
-          description: The hostname, IP address, or UNIX domain socket. A port can be specified like <hostname>:<port>. If no port is specified the default 27017 will be used.
+          default: localhost:27017
+          description: The hostname, IP address, or UNIX domain socket. A port can be specified like `<hostname>:<port>`. If no port is specified the default 27017 will be used.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
         - name: username
           default: null
-          description: Username for authentication with the MongoDB instance. Required if password is set.
+          description: Username for authentication with the MongoDB instance. Required if `password` is set.
         - name: password
           default: null
-          description: Password for authentication with the MongoDB instance. Required if username is set.
+          description: Password for authentication with the MongoDB instance. Required if `username` is set.
         - name: insecure
           default: true
-          description: Sets whether or not to use a secure TLS connection. If set to false, then TLS is enabled.
+          description: Sets whether or not to use a secure TLS connection. If set to `false`, then TLS is enabled.
         - name: insecure_skip_verify
           default: false
-          description: Sets whether or not to skip verifying the certificate. If insecure is set to true, then the insecure_skip_verify value is not used.
+          description: Sets whether or not to skip verifying the certificate. If `insecure` is set to `true`, then the `insecure_skip_verify` value is not used.
         - name: cert_file
           default: null
           description: Path to the TLS certificate to use for mTLS-required connections.
         - name: key_file
           default: null
-          description: Path to the TLS key to use for mTLS-required connections.
+          description: Path to the TLS key to use for mTLS-required connections, for example, the key used in `--tlsCertificateKeyFile`.
         - name: ca_file
           default: null
           description: Path to the CA certificate. As a client, this verifies the server certificate. If empty, the receiver uses the system root CA.

--- a/integration_test/third_party_apps_test/applications/mongodb/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mongodb/metadata.yaml
@@ -39,7 +39,7 @@ platforms_to_skip:
   - debian-cloud:debian-12
   - debian-cloud:debian-12-arm64
   - suse-cloud:sles-15-arm64
-supported_app_version: ["2.6", "3.0+", "4.0+", "5.0", "6.0"]
+supported_app_version: ["2.6", "3.x", "4.x", "5.0", "6.0"]
 expected_metrics:
   - type: workload.googleapis.com/mongodb.cache.operations
     value_type: INT64

--- a/integration_test/third_party_apps_test/applications/mongodb/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mongodb/metadata.yaml
@@ -22,6 +22,12 @@ description: |-
   of operations and objects, as well as resource usage. The integration also
   collects logs and parses them into a JSON payload. The result includes fields
   for context, component, level, and message.
+
+  Note: Metrics for MongoDB are collected on a per-collection level.
+  A _collection_ is a group of documents and is analogous to a table in
+  a relational database. A MongoDB integration with a high number of
+  collections will produce a high volume of metrics, which can have cost
+  implications.
 minimum_supported_agent_version:
   metrics: 2.19.0
   logging: 2.10.0

--- a/integration_test/third_party_apps_test/applications/mongodb3.6/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mongodb3.6/metadata.yaml
@@ -22,6 +22,12 @@ description: |-
   of operations and objects, as well as resource usage. The integration also
   collects logs and parses them into a JSON payload. The result includes fields
   for context, component, level, and message.
+
+  Note: Metrics for MongoDB are collected on a per-collection level.
+  A _collection_ is a group of documents and is analogous to a table in
+  a relational database. A MongoDB integration with a high number of
+  collections will produce a high volume of metrics, which can have cost
+  implications.
 minimum_supported_agent_version:
   metrics: 2.19.0
   logging: 2.10.0

--- a/integration_test/third_party_apps_test/applications/mongodb3.6/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mongodb3.6/metadata.yaml
@@ -194,7 +194,7 @@ expected_logs:
     fields:
       - name: jsonPayload.component
         type: string
-        description: Categorization of the log message. A full list can be found [here](https://docs.mongodb.com/manual/reference/log-messages/#std-label-log-message-components)
+        description: Categorization of the log message. A full list can be found in the [MongoDB documentation](https://docs.mongodb.com/manual/reference/log-messages/#std-label-log-message-components).
       - name: jsonPayload.ctx
         type: string
         description: The name of the thread issuing the log statement
@@ -232,49 +232,49 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: This value must be mongodb.
+          description: This value must be `mongodb`.
         - name: include_paths
           default: '[/var/log/mongodb/mongod.log*]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/mongodb/*.log.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `/var/log/mongodb/*.log`.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: mongodb
       fields:
         - name: type
           default: null
-          description: This value must be mongodb.
+          description: This value must be `mongodb`.
         - name: endpoint
-          default: http://localhost:27017
-          description: The hostname, IP address, or UNIX domain socket. A port can be specified like <hostname>:<port>. If no port is specified the default 27017 will be used.
+          default: localhost:27017
+          description: The hostname, IP address, or UNIX domain socket. A port can be specified like `<hostname>:<port>`. If no port is specified the default 27017 will be used.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
         - name: username
           default: null
-          description: Username for authentication with the MongoDB instance. Required if password is set.
+          description: Username for authentication with the MongoDB instance. Required if `password` is set.
         - name: password
           default: null
-          description: Password for authentication with the MongoDB instance. Required if username is set.
+          description: Password for authentication with the MongoDB instance. Required if `username` is set.
         - name: insecure
           default: true
-          description: Sets whether or not to use a secure TLS connection. If set to false, then TLS is enabled.
+          description: Sets whether or not to use a secure TLS connection. If set to `false`, then TLS is enabled.
         - name: insecure_skip_verify
           default: false
-          description: Sets whether or not to skip verifying the certificate. If insecure is set to true, then the insecure_skip_verify value is not used.
+          description: Sets whether or not to skip verifying the certificate. If `insecure` is set to `true`, then the `insecure_skip_verify` value is not used.
         - name: cert_file
           default: null
           description: Path to the TLS certificate to use for mTLS-required connections.
         - name: key_file
           default: null
-          description: Path to the TLS key to use for mTLS-required connections.
+          description: Path to the TLS key to use for mTLS-required connections, for example, the key used in `--tlsCertificateKeyFile`.
         - name: ca_file
           default: null
           description: Path to the CA certificate. As a client, this verifies the server certificate. If empty, the receiver uses the system root CA.

--- a/integration_test/third_party_apps_test/applications/mssql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mssql/metadata.yaml
@@ -17,7 +17,19 @@ app_url: "https://docs.microsoft.com/en-us/sql/sql-server"
 short_name: SQL Server
 long_name: Microsoft SQL Server
 logo_path: /stackdriver/images/mssql.png # supplied by google technical writer
-description: "The v1 Microsoft SQL Server integration collects metrics from your SQL Server\ninstances. The metrics provide transaction-rate information and also data on\nopen connections.\n\nThe v2 Microsoft SQL Server integration collects metrics from your SQL Server\ninstances and databases. Page, batch, lock, and user connection count information\nis provided at the instance level. Transaction and transaction log information\nis provided at the database level. \n\nFor more information on SQL Server, see the\n[SQL Server](https://docs.microsoft.com/en-us/sql/sql-server)\ndocumentation."
+description: |-
+  The v1 Microsoft SQL Server integration collects metrics from your SQL Server
+  instances. The metrics provide transaction-rate information and also data on
+  open connections.
+
+  The v2 Microsoft SQL Server integration collects metrics from your SQL Server
+  instances and databases. Page, batch, lock, and user connection count information
+  is provided at the instance level. Transaction and transaction log information
+  is provided at the database level.
+
+  For more information on SQL Server, see the
+  [SQL Server](https://docs.microsoft.com/en-us/sql/sql-server){: .external}
+  documentation.
 minimum_supported_agent_version:
   metrics: 2.15.0
 supported_operating_systems: windows
@@ -142,10 +154,10 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: This value must be mssql.
+          description: This value must be `mssql`.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
         - name: receiver_version
           default: "1"
           description: Either 1 or 2. Version 2 has many more metrics available.

--- a/integration_test/third_party_apps_test/applications/mssql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mssql/metadata.yaml
@@ -160,4 +160,4 @@ configuration_options:
           description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
         - name: receiver_version
           default: "1"
-          description: Either 1 or 2. Version 2 has many more metrics available.
+          description: Version of the metrics collected; use `2` to collect v2 metrics.

--- a/integration_test/third_party_apps_test/applications/mssql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mssql/metadata.yaml
@@ -28,7 +28,7 @@ description: |-
   is provided at the database level.
 
   For more information on SQL Server, see the
-  [SQL Server](https://docs.microsoft.com/en-us/sql/sql-server){: .external}
+  [SQL Server](https://docs.microsoft.com/en-us/sql/sql-server)
   documentation.
 minimum_supported_agent_version:
   metrics: 2.15.0

--- a/integration_test/third_party_apps_test/applications/mysql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mysql/metadata.yaml
@@ -298,59 +298,59 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: This value must be mysql_error.
+          description: This value must be `mysql_error`.
         - name: include_paths
           default: '[/var/log/mysqld.log, /var/log/mysql/mysqld.log, /var/log/mysql/error.log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/mysql/*.log.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `/var/log/mysql/*.log`.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
     - type: mysql_general
       fields:
         - name: type
           default: null
-          description: This value must be mysql_general.
+          description: This value must be `mysql_general`.
         - name: include_paths
           default: '[/var/lib/mysql/${HOSTNAME}.log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
     - type: mysql_slow
       fields:
         - name: type
           default: null
-          description: This value must be mysql_slow.
+          description: This value must be `mysql_slow`.
         - name: include_paths
           default: '[/var/lib/mysql/${HOSTNAME}-slow.log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: mysql
       fields:
         - name: type
           default: null
-          description: This value must be mysql.
+          description: This value must be `mysql`.
         - name: endpoint
           default: localhost:3306
           description: The url exposed by MySQL.
@@ -362,7 +362,7 @@ configuration_options:
           description: The password used to connect to the server.
         - name: application_version
           default: null
-          description: The version of mysql (major.minor) being monitored. Replication metrics are supported for version 5.7 by setting this to the value 5.7.
+          description: The version of mysql (major.minor) being monitored. Replication metrics are supported for version 5.7 by setting this to the value `5.7`.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.

--- a/integration_test/third_party_apps_test/applications/mysql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mysql/metadata.yaml
@@ -41,7 +41,7 @@ platforms_to_skip:
   - debian-cloud:debian-12
   - debian-cloud:debian-12-arm64
   - suse-cloud:sles-15-arm64
-supported_app_version: ["8.0", "5.7"]
+supported_app_version: ["5.7", "8.0"]
 expected_metrics:
   - type: workload.googleapis.com/mysql.buffer_pool_data_pages
     value_type: INT64

--- a/integration_test/third_party_apps_test/applications/mysql5.7/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mysql5.7/metadata.yaml
@@ -31,6 +31,9 @@ configure_integration: |-
 
   The `mysql` receiver connects by default to a local MySQL/MariaDB
   server using a Unix socket and Unix authentication as the `root` user.
+minimum_supported_agent_version:
+  metrics: 2.33.0
+  logging: 2.33.0
 supported_operating_systems: linux
 platforms_to_skip:
   # MySQL5.7 is not supported on various distros.
@@ -50,7 +53,7 @@ platforms_to_skip:
   - ubuntu-os-cloud:ubuntu-2204-lts-arm64
   - ubuntu-os-cloud:ubuntu-2404-lts-amd64
   - ubuntu-os-cloud:ubuntu-2404-lts-arm64
-supported_app_version: ["8.0", "5.7"]
+supported_app_version: ["5.7", "8.0"]
 expected_metrics:
   - type: workload.googleapis.com/mysql.buffer_pool_data_pages
     value_type: INT64
@@ -342,6 +345,3 @@ configuration_options:
         - name: collection_interval
           default: 60s
           description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
-minimum_supported_agent_version:
-  metrics: 2.33.0
-  logging: 2.33.0

--- a/integration_test/third_party_apps_test/applications/mysql5.7/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mysql5.7/metadata.yaml
@@ -274,59 +274,59 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: This value must be mysql_error.
+          description: This value must be `mysql_error`.
         - name: include_paths
           default: '[/var/log/mysqld.log, /var/log/mysql/mysqld.log, /var/log/mysql/error.log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/mysql/*.log.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `/var/log/mysql/*.log`.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
     - type: mysql_general
       fields:
         - name: type
           default: null
-          description: This value must be mysql_general.
+          description: This value must be `mysql_general`.
         - name: include_paths
           default: '[/var/lib/mysql/${HOSTNAME}.log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
     - type: mysql_slow
       fields:
         - name: type
           default: null
-          description: This value must be mysql_slow.
+          description: This value must be `mysql_slow`.
         - name: include_paths
           default: '[/var/lib/mysql/${HOSTNAME}-slow.log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: mysql
       fields:
         - name: type
           default: null
-          description: This value must be mysql.
+          description: This value must be `mysql`.
         - name: endpoint
           default: localhost:3306
           description: The url exposed by MySQL.
@@ -338,10 +338,10 @@ configuration_options:
           description: The password used to connect to the server.
         - name: application_version
           default: null
-          description: The version of mysql (major.minor) being monitored. Replication metrics are supported for version 5.7 by setting this to the value 5.7.
+          description: The version of mysql (major.minor) being monitored. Replication metrics are supported for version 5.7 by setting this to the value `5.7`.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
 minimum_supported_agent_version:
   metrics: 2.33.0
   logging: 2.33.0

--- a/integration_test/third_party_apps_test/applications/nginx/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/nginx/metadata.yaml
@@ -24,8 +24,9 @@ description: |-
   fields mapped to request, client, server, and message.
 configure_integration: |-
   You must enable the `stub_status` module in the nginx configuration file to set
-  up a locally reachable URL, for example, `http://www.example.com/status` for the
-  status page. To enable the `stub_status` module, complete the following steps:
+  up a locally reachable URL, for example, `http://www.example.com/nginx_status`
+  for the status page. To enable the `stub_status` module, complete the following
+  steps:
 
   1. Edit the `status.conf` file, or create the file if it doesn't exist. You can
      find this file in the nginx configuration directory, typically found at
@@ -34,7 +35,7 @@ configure_integration: |-
   1. Add the following lines to the `server` section:
 
      ```none
-     location /status {
+     location /nginx_status {
          stub_status on;
          access_log off;
          allow 127.0.0.1;
@@ -48,7 +49,7 @@ configure_integration: |-
      server {
          listen 80;
          server_name 127.0.0.1;
-         location /status {
+         location /nginx_status {
              stub_status on;
              access_log off;
              allow 127.0.0.1;
@@ -76,7 +77,7 @@ configure_integration: |-
   server {
       listen 80;
       server_name 127.0.0.1;
-      location /status {
+      location /nginx_status {
           stub_status on;
           access_log off;
           allow 127.0.0.1;
@@ -88,7 +89,7 @@ configure_integration: |-
   }
   EOF
   sudo service nginx reload
-  curl http://127.0.0.1:80/status
+  curl http://127.0.0.1:80/nginx_status
   ```
 
   The sample output is:
@@ -102,7 +103,7 @@ configure_integration: |-
 
   Note: `127.0.0.1` can be replaced with the real server name, for example,
   `server_name mynginx.domain.com`. The curl command to verify would be
-  `curl http://mynginx.domain.com:80/status`.
+  `curl http://mynginx.domain.com:80/nginx_status`.
 
   Alternately, instead of using a separate `status.conf` file, you can also
   directly embed the lines to the main `nginx.conf` file, which
@@ -245,48 +246,48 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: The value must be nginx_access.
+          description: This value must be `nginx_access`.
         - name: include_paths
           default: '[/var/log/nginx/access.log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
     - type: "nginx_error"
       fields:
         - name: type
           default: null
-          description: The value must be nginx_error.
+          description: This value must be `nginx_error`.
         - name: include_paths
           default: '[/var/log/nginx/error.log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: nginx
       fields:
         - name: type
           default: null
-          description: This value must be nginx.
+          description: This value must be `nginx`.
         - name: server_status_url
           default: http://localhost/status
           description: The URL exposed by the nginx stub status module.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
 troubleshoot: |-
   On most distributions, nginx comes with `ngx_http_stub_status_module` enabled.
   You can check if the module is enabled by running the following command:

--- a/integration_test/third_party_apps_test/applications/nginx/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/nginx/metadata.yaml
@@ -210,10 +210,10 @@ expected_logs:
         description: Original HTTP request (optional)
       - name: jsonPayload.pid
         type: number
-        description: Process ID
+        description: The process ID issuing the log
       - name: jsonPayload.tid
         type: number
-        description: Thread ID
+        description: Thread ID where the log originated
       - name: jsonPayload.connection
         type: number
         description: Connection ID

--- a/integration_test/third_party_apps_test/applications/nvml/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/nvml/metadata.yaml
@@ -100,9 +100,9 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: This value must be hostmetrics.
+          description: This value must be `hostmetrics`.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
 minimum_supported_agent_version:
   metrics: 2.38.0

--- a/integration_test/third_party_apps_test/applications/oracledb/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/oracledb/metadata.yaml
@@ -15,6 +15,7 @@
 app_url: "https://www.oracle.com/database/"
 short_name: Oracle DB
 long_name: Oracle Database
+logo_path: /stackdriver/images/integrations/oracledb.png # supplied by google technical writer
 description: |-
   The Oracle DB integration collects Oracle DB metrics and logs. The metrics are collected by querying
   relevant monitoring views. This integration writes structured trace logs.
@@ -378,13 +379,13 @@ configuration_options:
     - type: oracledb
       fields:
         - default: null
-          description: This value must be oracledb.
+          description: This value must be `oracledb`.
           name: type
         - default: localhost:1521
-          description: The endpoint used to connect to the oracle DB instance. This field supports either host:port or a unix socket path.
+          description: The endpoint used to connect to the oracle DB instance. This field supports either `host:port` or a Unix socket path.
           name: endpoint
         - default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
           name: collection_interval
         - default: null
           description: The username used to connect to the instance.
@@ -393,61 +394,61 @@ configuration_options:
           description: The password used to connect to the instance.
           name: password
         - default: true
-          description: Sets whether or not to use a secure TLS connection. If set to false, then TLS is enabled.
+          description: Sets whether or not to use a secure TLS connection. If set to `false`, then TLS is enabled.
           name: insecure
         - default: false
-          description: Sets whether or not to skip verifying the certificate. If insecure is set to true, then the insecure_skip_verify value is not used.
+          description: Sets whether or not to skip verifying the certificate. If `insecure` is set to `true`, then the `insecure_skip_verify` value is not used.
           name: insecure_skip_verify
         - default: null
           description: Path to the directory containing the oracle wallet optionally used for authentication and securing connections.
           name: wallet
         - default: null
-          description: The SID of the Oracle database being monitored. Use this _or_ service_name as appropriate.
+          description: The SID of the Oracle database being monitored. Use this field _or_ the `service_name` field as appropriate.
           name: sid
         - default: null
-          description: The Service Name of the Oracle database being monitored. Use this _or_ sid as appropriate.
+          description: The Service Name of the Oracle database being monitored. Use this field _or_ the `sid` field as appropriate.
           name: service_name
   logs:
     - type: oracledb_audit
       fields:
         - name: type
           default: null
-          description: The value must be oracledb_audit.
+          description: This value must be `oracledb_audit`.
         - name: include_paths
           default: null
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths. Cannot be provided with oracle_home.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths. Cannot be provided with the `oracle_home` field.
         - name: oracle_home
           default: null
-          description: Location of the ORACLE_HOME for the environment, when provided it sets the include_paths to `$ORACLE_HOME/admin/*/adump/*.aud`. Cannot be provided with include_paths.
+          description: Location of the `ORACLE_HOME` for the environment, when provided it sets the include_paths to `$ORACLE_HOME/admin/*/adump/*.aud`. Cannot be provided with the `include_paths` field.
         - name: exclude_paths
-          default: '[]'
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          default: null
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
     - type: oracledb_alert
       fields:
         - name: type
           default: null
-          description: The value must be oracledb_alert.
+          description: The value must be `oracledb_alert`.
         - name: include_paths
           default: null
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths. Cannot be provided with oracle_home.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths. Cannot be provided with the `oracle_home` field.
         - name: oracle_home
           default: null
-          description: Location of the ORACLE_HOME for the environment, when provided it sets the include_paths to `$ORACLE_HOME/diag/rdbms/*/*/trace/alert_*.log`. Cannot be provided with include_paths.
+          description: Location of the `ORACLE_HOME` for the environment, when provided it sets the `include_paths` to `$ORACLE_HOME/diag/rdbms/*/*/trace/alert_*.log`. Cannot be provided with the `include_paths` field.
         - name: exclude_paths
-          default: '[]'
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          default: null
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
 minimum_supported_agent_version:
   metrics: 2.22.0
   logging: 2.22.0

--- a/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
@@ -204,31 +204,31 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: The value must be postgresql_general.
+          description: This value must be `postgresql_general`.
         - name: include_paths
           default: "[/var/log/postgresql/postgresql*.log, /var/lib/pgsql/data/log/postgresql*.log, /var/lib/pgsql/*/data/log/postgresql*.log]"
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: postgresql
       fields:
         - name: type
           default: null
-          description: This value must be postgresql.
+          description: This value must be `postgresql`.
         - name: endpoint
           default: /var/run/postgresql/.s.PGSQL.5432
-          description: The hostname:port or socket path starting with / used to connect to the postgresql server.
+          description: The `hostname:port` or Unix socket path starting with `/` used to connect to the PostgreSQL server.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
         - name: username
           default: null
           description: The username used to connect to the server.
@@ -237,10 +237,10 @@ configuration_options:
           description: The password used to connect to the server.
         - name: insecure
           default: true
-          description: Sets whether or not to use a secure TLS connection. If set to false, then TLS is enabled.
+          description: Sets whether or not to use a secure TLS connection. If set to `false`, then TLS is enabled.
         - name: insecure_skip_verify
           default: false
-          description: Sets whether or not to skip verifying the certificate. If insecure is set to true, then the insecure_skip_verify value is not used.
+          description: Sets whether or not to skip verifying the certificate. If `insecure` is set to `true`, then the `insecure_skip_verify` value is not used.
         - name: cert_file
           default: null
           description: Path to the TLS certificate to use for mTLS-required connections.

--- a/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/postgresql/metadata.yaml
@@ -26,7 +26,7 @@ configure_integration: |-
   The `postgresql` receiver connects by default to a local `postgresql`
   server using a Unix socket and Unix authentication as the `root` user.
 minimum_supported_agent_version:
-  metrics: 2.20.0
+  metrics: 2.21.0
   logging: 2.9.0
 supported_operating_systems: linux
 platforms_to_skip:

--- a/integration_test/third_party_apps_test/applications/rabbitmq/centos_rhel/install
+++ b/integration_test/third_party_apps_test/applications/rabbitmq/centos_rhel/install
@@ -11,7 +11,7 @@ sudo yum install -y curl epel-release
 
 # until there is a rabbitmq-server package for rhel 9, use the el8 package
 case "$VERSION_ID" in
-    9*) 
+    9*)
         if [[ "$(uname -m)" == aarch64 ]]; then
           # until the packagecloud.io erlang package has an option for aarch64
           curl -sfL -O https://github.com/rabbitmq/erlang-rpm/releases/download/v26.0.2/erlang-26.0.2-1.el8.aarch64.rpm
@@ -69,6 +69,6 @@ curl -i -u admin:admin \
     -d'{"routing_key":"webq1","arguments":{}}'
 
 sudo rabbitmq-plugins enable rabbitmq_management
-sudo rabbitmqctl add_user "otelu" "otelp"
-sudo rabbitmqctl set_user_tags "otelu" monitoring
-sudo rabbitmqctl set_permissions -p "dev" "otelu" "" "" ".*"
+sudo rabbitmqctl add_user "usr" "pwd"
+sudo rabbitmqctl set_user_tags "usr" monitoring
+sudo rabbitmqctl set_permissions -p "dev" "usr" "" "" ".*"

--- a/integration_test/third_party_apps_test/applications/rabbitmq/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/rabbitmq/debian_ubuntu/install
@@ -6,8 +6,8 @@ sudo apt-get install -y \
     gnupg \
     apt-transport-https \
     debian-keyring \
-    debian-archive-keyring 
-    
+    debian-archive-keyring
+
 curl -1sLf "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc" | \
     sudo gpg --dearmor --output /etc/apt/trusted.gpg.d/rabbitmq.gpg
 
@@ -82,6 +82,6 @@ curl -i -u admin:admin \
     -d'{"routing_key":"webq1","arguments":{}}'
 
 sudo rabbitmq-plugins enable rabbitmq_management
-sudo rabbitmqctl add_user "otelu" "otelp"
-sudo rabbitmqctl set_user_tags "otelu" monitoring
-sudo rabbitmqctl set_permissions -p "dev" "otelu" "" "" ".*"
+sudo rabbitmqctl add_user "usr" "pwd"
+sudo rabbitmqctl set_user_tags "usr" monitoring
+sudo rabbitmqctl set_permissions -p "dev" "usr" "" "" ".*"

--- a/integration_test/third_party_apps_test/applications/rabbitmq/enable
+++ b/integration_test/third_party_apps_test/applications/rabbitmq/enable
@@ -11,8 +11,8 @@ metrics:
   receivers:
     rabbitmq:
       type: rabbitmq
-      username: otelu
-      password: otelp
+      username: usr
+      password: pwd
   service:
     pipelines:
       rabbitmq:

--- a/integration_test/third_party_apps_test/applications/rabbitmq/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/rabbitmq/metadata.yaml
@@ -74,31 +74,31 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: This value must be rabbitmq.
+          description: This value must be `rabbitmq`.
         - name: include_paths
           default: '[var/log/rabbitmq/rabbit*.log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/rabbitmq/*.log.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `/var/log/rabbitmq/*.log`.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: rabbitmq
       fields:
         - name: type
           default: null
-          description: This value must be rabbbitmq.
+          description: This value must be `rabbbitmq`.
         - name: endpoint
           default: http://localhost:15672
           description: The URL of the node to monitor.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
         - name: username
           default: null
           description: The username used to connect to the server.
@@ -107,10 +107,10 @@ configuration_options:
           description: The password used to connect to the server.
         - name: insecure
           default: true
-          description: Sets whether or not to use a secure TLS connection. If set to false, then TLS is enabled.
+          description: Sets whether or not to use a secure TLS connection. If set to `false`, then TLS is enabled.
         - name: insecure_skip_verify
           default: false
-          description: Sets whether or not to skip verifying the certificate. If insecure is set to true, then the insecure_skip_verify value is not used.
+          description: Sets whether or not to skip verifying the certificate. If `insecure` is set to `true`, then the `insecure_skip_verify` value is not used.
         - name: cert_file
           default: null
           description: Path to the TLS certificate to use for mTLS-required connections.

--- a/integration_test/third_party_apps_test/applications/rabbitmq/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/rabbitmq/metadata.yaml
@@ -22,6 +22,13 @@ description: |-
   delivered, published, and dropped messages. The integration also collects
   RabbitMQ logs and parses them into a JSON payload. The result includes process
   ID, level, and message.
+configure_integration: |-
+  You must enable the RabbitMQ management plugin by following the [Getting
+  started](https://www.rabbitmq.com/management.html#getting-started)
+  instructions.
+
+  You must configure a user with the [`monitoring`
+  tag](https://www.rabbitmq.com/management.html#permissions).
 minimum_supported_agent_version:
   metrics: 2.29.0
   logging: 2.12.0
@@ -60,7 +67,7 @@ expected_logs:
         optional: true
       - name: jsonPayload.message
         type: string
-        description: Log message
+        description: Log message, including detailed stacktrace where provided
       - name: jsonPayload.severity
         type: string
         description: Log entry level

--- a/integration_test/third_party_apps_test/applications/rabbitmq/sles/install
+++ b/integration_test/third_party_apps_test/applications/rabbitmq/sles/install
@@ -49,6 +49,6 @@ curl -i -u admin:admin \
     -d'{"routing_key":"webq1","arguments":{}}'
 
 sudo rabbitmq-plugins enable rabbitmq_management
-sudo rabbitmqctl add_user "otelu" "otelp"
-sudo rabbitmqctl set_user_tags "otelu" monitoring
-sudo rabbitmqctl set_permissions -p "dev" "otelu" "" "" ".*"
+sudo rabbitmqctl add_user "usr" "pwd"
+sudo rabbitmqctl set_user_tags "usr" monitoring
+sudo rabbitmqctl set_permissions -p "dev" "usr" "" "" ".*"

--- a/integration_test/third_party_apps_test/applications/redis/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/redis/metadata.yaml
@@ -147,14 +147,14 @@ expected_logs:
       - name: jsonPayload.roleChar
         value_regex: M
         type: string
-        description: redis role character (X, C, S, M)
+        description: Redis role character (X, C, S, M)
       - name: jsonPayload.role
         value_regex: master
         type: string
-        description: translated from redis role character (sentinel, RDB/AOF_writing_child, slave, master)
+        description: Translated from redis role character (sentinel, RDB/AOF_writing_child, slave, master)
       - name: jsonPayload.pid
         type: number
-        description: Process ID
+        description: The process ID issuing the log
       - name: severity
         type: string
         description: ''
@@ -164,40 +164,40 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: This value must be redis.
+          description: This value must be `redis`.
         - name: include_paths
           default: '[/var/log/redis/redis-server.log, /var/log/redis_6379.log, /var/log/redis/redis.log, /var/log/redis/default.log, /var/log/redis/redis_6379.log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/redis/*.log.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `/var/log/redis/*.log`.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: redis
       fields:
         - name: type
           default: null
-          description: This value must be redis.
+          description: This value must be `redis`.
         - name: address
           default: localhost:6379
           description: The URL exposed by Redis.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
         - name: password
           default: null
           description: The password used to connect to the server.
         - name: insecure
           default: true
-          description: Sets whether or not to use a secure TLS connection. If set to false, then TLS is enabled.
+          description: Sets whether or not to use a secure TLS connection. If set to `false`, then TLS is enabled.
         - name: insecure_skip_verify
           default: false
-          description: Sets whether or not to skip verifying the certificate. If insecure is set to true, then the insecure_skip_verify value is not used.
+          description: Sets whether or not to skip verifying the certificate. If `insecure` is set to `true`, then the `insecure_skip_verify` value is not used.
         - name: cert_file
           default: null
           description: Path to the TLS certificate to use for mTLS-required connections.

--- a/integration_test/third_party_apps_test/applications/redis/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/redis/metadata.yaml
@@ -143,7 +143,7 @@ expected_logs:
       - name: jsonPayload.message
         value_regex: Ready to accept connections
         type: string
-        description: ''
+        description: Log message, including detailed stacktrace where provided
       - name: jsonPayload.roleChar
         value_regex: M
         type: string

--- a/integration_test/third_party_apps_test/applications/saphana/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/saphana/metadata.yaml
@@ -15,12 +15,15 @@
 app_url: "https://www.sap.com/products/hana.html"
 short_name: HANA
 long_name: SAP HANA
+logo_path: /stackdriver/images/integrations/saphana.png # supplied by google technical writer
 description: |-
-  The SAP HANA integration collects SAP HANA metrics and logs. The metrics are collected by querying
-  relevant monitoring views. This integration writes structured trace logs.
+  The SAP HANA integration collects SAP HANA metrics and logs. The metrics are
+  collected by querying relevant monitoring views. This integration writes
+  structured trace logs.
 configure_integration: |-
-  To collect metrics, a monitoring user requires `SELECT` access to the relevant monitoring views. The following sql
-  script should create a monitoring role and apply it to a monitoring user if executed by
+  To collect metrics, a monitoring user requires `SELECT` access to the relevant
+  monitoring views. The following SQL script creates a monitoring role and applies
+  it to a monitoring user if executed by
   a user with sufficient permissions connected to the SAP HANA instance.
 
   <pre>
@@ -429,13 +432,13 @@ configuration_options:
     - type: saphana
       fields:
         - default: null
-          description: This value must be saphana.
+          description: This value must be `saphana`.
           name: type
         - default: localhost:30015
-          description: The hostname:port used to connect to the saphana instance.
+          description: The `hostname:port` used to connect to the SAP HANA instance.
           name: endpoint
         - default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
           name: collection_interval
         - default: null
           description: The username used to connect to the instance.
@@ -444,10 +447,10 @@ configuration_options:
           description: The password used to connect to the instance.
           name: password
         - default: true
-          description: Sets whether or not to use a secure TLS connection. If set to false, then TLS is enabled.
+          description: Sets whether or not to use a secure TLS connection. If set to `false`, then TLS is enabled.
           name: insecure
         - default: false
-          description: Sets whether or not to skip verifying the certificate. If insecure is set to true, then the insecure_skip_verify value is not used.
+          description: Sets whether or not to skip verifying the certificate. If `insecure` is set to `true`, then the `insecure_skip_verify` value is not used.
           name: insecure_skip_verify
         - default: null
           description: Path to the TLS certificate to use for mTLS-required connections.
@@ -463,19 +466,19 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: The value must be saphana.
+          description: The value must be `saphana`.
         - name: include_paths
           default: '[/usr/sap/*/HDB*/${HOSTNAME}/trace/*.trc]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths.
         - name: exclude_paths
           default: '[/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver_history*.trc, /usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*loads*.trc, /usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*executed_statements*.trc]'
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
 minimum_supported_agent_version:
   metrics: 2.18.1
   logging: 2.18.1

--- a/integration_test/third_party_apps_test/applications/solr/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/solr/metadata.yaml
@@ -175,28 +175,28 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: The value must be solr_system.
+          description: This value must be `solr_system`.
         - name: include_paths
           default: '[/var/solr/logs/solr.log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: solr
       fields:
         - name: type
           default: null
-          description: This value must be solr.
+          description: This value must be `solr`.
         - name: endpoint
           default: localhost:18983
-          description: The JMX Service URL or host and port used to construct the Service URL. Must be in the form of host:port. Values in host:port form will be used to create a Service URL of service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi.
+          description: The JMX Service URL or host and port used to construct the Service URL. Must be in the form of `host:port`. Values in `host:port` form will be used to create a Service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
         - name: username
           default: null
           description: The configured username if JMX is configured to require authentication..
@@ -205,4 +205,4 @@ configuration_options:
           description: The configured password if JMX is configured to require authentication.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.

--- a/integration_test/third_party_apps_test/applications/solr/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/solr/metadata.yaml
@@ -148,7 +148,7 @@ expected_logs:
         optional: true
       - name: jsonPayload.level
         type: string
-        description: ''
+        description: Log entry level
         optional: true
       - name: jsonPayload.shard
         type: string
@@ -199,7 +199,7 @@ configuration_options:
           description: The [JMX Service URL](https://docs.oracle.com/javase/8/docs/api/javax/management/remote/JMXServiceURL.html) or host and port used to construct the Service URL. Must be in the form of `host:port`. Values in `host:port` form will be used to create a Service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
         - name: username
           default: null
-          description: The configured username if JMX is configured to require authentication..
+          description: The configured username if JMX is configured to require authentication.
         - name: password
           default: null
           description: The configured password if JMX is configured to require authentication.

--- a/integration_test/third_party_apps_test/applications/solr/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/solr/metadata.yaml
@@ -196,7 +196,7 @@ configuration_options:
           description: This value must be `solr`.
         - name: endpoint
           default: localhost:18983
-          description: The JMX Service URL or host and port used to construct the Service URL. Must be in the form of `host:port`. Values in `host:port` form will be used to create a Service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
+          description: The [JMX Service URL](https://docs.oracle.com/javase/8/docs/api/javax/management/remote/JMXServiceURL.html) or host and port used to construct the Service URL. Must be in the form of `host:port`. Values in `host:port` form will be used to create a Service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
         - name: username
           default: null
           description: The configured username if JMX is configured to require authentication..

--- a/integration_test/third_party_apps_test/applications/tomcat/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/tomcat/metadata.yaml
@@ -23,7 +23,7 @@ description: |-
   access and Catalina logs. Access logs are parsed into a JSON payload
   focused on request details, whereas Catalina logs are parsed for general
   details. The `tomcat` receiver collects telemetry from the Tomcat server's Java
-  Virtual Machine (JVM) via [JMX](https://www.oracle.com/java/technologies/javase/javamanagement.html).
+  Virtual Machine (JVM) via [JMX](https://www.oracle.com/java/technologies/javase/javamanagement.html){: .external}.
 configure_integration: |-
   To expose a JMX endpoint, you must set the `com.sun.management.jmxremote.port`
   system property when starting the JVM. We also recommend setting the
@@ -165,45 +165,45 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: The value must be tomcat_system.
+          description: The value must be `tomcat_system`.
         - name: include_paths
           default: '[/opt/tomcat/logs/catalina.out]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
     - type: tomcat_access
       fields:
         - name: type
           default: null
-          description: The value must be tomcat_access.
+          description: The value must be `tomcat_access`.
         - name: include_paths
           default: '[/opt/tomcat/logs/localhost_access_log*.txt]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: tomcat
       fields:
         - name: type
           default: null
-          description: This value must be tomcat.
+          description: This value must be `tomcat`.
         - name: endpoint
           default: localhost:8050
-          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of service:jmx:<protocol>:<sap> or host:port. Values in host:port form are used to create a service URL of service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi.
+          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
         - name: collect_jvm_metrics
           default: true
           description: Configures the receiver to also collect the supported JVM metrics.
@@ -215,4 +215,4 @@ configuration_options:
           description: The configured password if JMX is configured to require authentication.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.

--- a/integration_test/third_party_apps_test/applications/tomcat/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/tomcat/metadata.yaml
@@ -203,7 +203,7 @@ configuration_options:
           description: This value must be `tomcat`.
         - name: endpoint
           default: localhost:8050
-          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
+          description: The [JMX Service URL](https://docs.oracle.com/javase/8/docs/api/javax/management/remote/JMXServiceURL.html) or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
         - name: collect_jvm_metrics
           default: true
           description: Configures the receiver to also collect the supported JVM metrics.

--- a/integration_test/third_party_apps_test/applications/tomcat/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/tomcat/metadata.yaml
@@ -23,7 +23,7 @@ description: |-
   access and Catalina logs. Access logs are parsed into a JSON payload
   focused on request details, whereas Catalina logs are parsed for general
   details. The `tomcat` receiver collects telemetry from the Tomcat server's Java
-  Virtual Machine (JVM) via [JMX](https://www.oracle.com/java/technologies/javase/javamanagement.html){: .external}.
+  Virtual Machine (JVM) via [JMX](https://www.oracle.com/java/technologies/javase/javamanagement.html).
 configure_integration: |-
   To expose a JMX endpoint, you must set the `com.sun.management.jmxremote.port`
   system property when starting the JVM. We also recommend setting the

--- a/integration_test/third_party_apps_test/applications/tomcat/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/tomcat/metadata.yaml
@@ -105,7 +105,7 @@ expected_logs:
       - name: jsonPayload.source
         value_regex: org.apache.catalina.startup.Catalina.start
         type: string
-        description: source of where the log originated
+        description: Source of where the log originated
       - name: jsonPayload.level
         type: string
         description: Log entry level

--- a/integration_test/third_party_apps_test/applications/varnish/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/varnish/metadata.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-short_name: varnish
+short_name: Varnish
 app_url: "https://varnish-cache.org/"
 long_name: Varnish HTTP Cache
 logo_path: /images/partners/varnish-logo.png # supplied by google technical writer
@@ -21,10 +21,18 @@ description: |-
   It monitors the number of objects entering and exiting the cache,
   as well as the number of sessions and backend connections.
   The integration also collects Varnish logs and parses them
-  into a standardized json payload.
+  into a standardized JSON payload.
 supported_app_version: ["6.x", "7.0.x"]
 configure_integration: |-
-  The Varnish logging processor processes logs using [varnishncsa](https://varnish-cache.org/docs/6.0/reference/varnishncsa.html){: .external}. Varnish can enable varnishncsa logging by following [this](https://docs.varnish-software.com/tutorials/enabling-logging-with-varnishncsa/){: .external} guide depending on os. By default, logs write to /var/log/varnish/varnishncsa.log. If another file is chosen, the user will have to also update the receiver configuration. Logs are expected to be in the default format and a logrotation should be setup.
+  The Varnish logging processor processes logs using
+  [varnishncsa](https://varnish-cache.org/docs/6.0/reference/varnishncsa.html){: .external}.
+  Varnish can enable varnishncsa logging by following this [guide](https://docs.varnish-software.com/tutorials/enabling-logging-with-varnishncsa/){: .external},
+  depending on the operating system.
+
+  By default, logs are written to `/var/log/varnish/varnishncsa.log`. If you
+  choose another destination, you must update the receiver configuration.
+  Logs are expected to be in the default format, and a log rotation should be
+  set up.
 expected_metrics:
   - type: workload.googleapis.com/varnish.backend.connection.count
     value_type: INT64
@@ -89,34 +97,34 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: This value must be varnish.
+          description: This value must be `varnish`.
         - name: include_paths
           default: '[/var/log/varnish/varnishncsa.log]'
-          description: A varnishncsa default log path to read by tailing each file.
+          description: A `varnishncsa` default log path to read by tailing each file.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: varnish
       fields:
         - name: type
           default: null
-          description: This value must be varnish.
+          description: This value must be `varnish`.
         - name: cache_dir
           default: null
-          description: This specifies the cache dir instance name to use when collecting metrics. If not specified, this will default to the host.
+          description: This specifies the cache dir instance name to use when collecting metrics. If not specified, defaults to the host.
         - name: exec_dir
           default: null
-          description: The directory where the varnishadm and varnishstat executables are located. If not provided, will default to relying on the executables being in the user's PATH.
+          description: The directory where the `varnishadm` and `varnishstat` executables are located. If not provided, relies on the executables being in the user's `PATH`.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
 minimum_supported_agent_version:
   metrics: 2.15.0
   logging: 2.16.0

--- a/integration_test/third_party_apps_test/applications/varnish/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/varnish/metadata.yaml
@@ -25,8 +25,8 @@ description: |-
 supported_app_version: ["6.x", "7.0.x"]
 configure_integration: |-
   The Varnish logging processor processes logs using
-  [varnishncsa](https://varnish-cache.org/docs/6.0/reference/varnishncsa.html){: .external}.
-  Varnish can enable varnishncsa logging by following this [guide](https://docs.varnish-software.com/tutorials/enabling-logging-with-varnishncsa/){: .external},
+  [varnishncsa](https://varnish-cache.org/docs/6.0/reference/varnishncsa.html).
+  Varnish can enable varnishncsa logging by following this [guide](https://docs.varnish-software.com/tutorials/enabling-logging-with-varnishncsa/),
   depending on the operating system.
 
   By default, logs are written to `/var/log/varnish/varnishncsa.log`. If you

--- a/integration_test/third_party_apps_test/applications/vault/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/vault/metadata.yaml
@@ -324,10 +324,6 @@ expected_logs:
         type: string
         description: This is the display name set by the auth method role or explicitly at secret creation time.
         optional: true
-      - name: jsonPayload.response.data.display_name
-        type: string
-        description: This is the display name set by the auth method role or explicitly at secret creation time.
-        optional: true
       - name: jsonPayload.response.data.entity_id
         type: string
         description: This is a token entity identifier.

--- a/integration_test/third_party_apps_test/applications/vault/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/vault/metadata.yaml
@@ -17,7 +17,9 @@ short_name: Vault
 long_name: Hashicorp Vault
 logo_path: /stackdriver/images/integrations/vault.png # supplied by google technical writer
 description: |-
-  Vault is an identity-based secrets and encryption management system. This integration collects Vault's audit logs. The integration also collects token, memory, and storage metrics.
+  Vault is an identity-based secrets and encryption management system.
+  This integration collects Vault's audit logs. The integration also collects
+  token, memory, and storage metrics.
 configure_integration: |-
   To collect telemetry from your Vault instance, you must set the
   `prometheus_retention_time` field to a non-zero value in your HCL or
@@ -39,7 +41,7 @@ configure_integration: |-
 
   If you are initializing Vault for the first time, then you can use the
   following script to generate a root token. Otherwise, see [Generate Root Tokens
-  Using Unseal Keys](https://developer.hashicorp.com/vault/tutorials/operations/generate-root){: .external} for information about generating a root token.
+  Using Unseal Keys](https://developer.hashicorp.com/vault/tutorials/operations/generate-root) for information about generating a root token.
 
   ```bash
   export VAULT_ADDR=http://localhost:8200

--- a/integration_test/third_party_apps_test/applications/vault/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/vault/metadata.yaml
@@ -15,10 +15,13 @@
 app_url: "https://www.vaultproject.io/"
 short_name: Vault
 long_name: Hashicorp Vault
+logo_path: /stackdriver/images/integrations/vault.png # supplied by google technical writer
 description: |-
   Vault is an identity-based secrets and encryption management system. This integration collects Vault's audit logs. The integration also collects token, memory, and storage metrics.
 configure_integration: |-
-  To collect telemetry from your Vault instance, you must enable the prometheus_retention_time to a non-zero value in your HCL or JSON Vault configuration file.
+  To collect telemetry from your Vault instance, you must set the
+  `prometheus_retention_time` field to a non-zero value in your HCL or
+  JSON Vault configuration file.
 
   <pre>
   Full configuration options can be found at https://www.vaultproject.io/docs/configuration
@@ -28,15 +31,17 @@ configure_integration: |-
   }
   </pre>
 
-  Additionally a root user is required to enable audit log collection and to create a prometheus-metrics ACL policy.
-  A root token is used to add a policy that has read capabilities to /sys/metrics.
+  Additionally, a root user is required to enable audit-log collection and to
+  create a prometheus-metrics ACL policy.
+  A root token is used to add a policy that has read capabilities to the
+  `/sys/metrics` endpoint.
   This policy is used to create a Vault token with sufficient permission to collect Vault metrics.
-  The following script is a quick start to get up and running.
+
+  If you are initializing Vault for the first time, then you can use the
+  following script to generate a root token. Otherwise, see [Generate Root Tokens
+  Using Unseal Keys](https://developer.hashicorp.com/vault/tutorials/operations/generate-root){: .external} for information about generating a root token.
 
   ```bash
-  # If you are initializing Vault for the first time, use this script to generate a root token.
-  # Otherwise see [here](https://developer.hashicorp.com/vault/tutorials/operations/generate-root) how to generate a root token.
-
   export VAULT_ADDR=http://localhost:8200
   # Create simple Vault initialization with 1 key share and a key threshold of 1.
   vault operator init -key-shares=1 -key-threshold=1 | head -n3 | cat > .vault-init
@@ -56,7 +61,7 @@ configure_integration: |-
   EOF
 
   # Create an example token with the prometheus-metrics policy to access Vault metrics.
-  # This token is used as a `$VAULT_TOKEN` in your Ops Agent configuration for Vault.
+  # This token is used as `$VAULT_TOKEN` in your Ops Agent configuration for Vault.
   vault token create -field=token -policy prometheus-metrics > prometheus-token
   ```
 supported_operating_systems: linux
@@ -342,7 +347,7 @@ configuration_options:
           description: The value must be `vault_audit`.
         - name: include_paths
           default: null
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths.
         - name: exclude_paths
           default: null
           description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
@@ -351,7 +356,7 @@ configuration_options:
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a time duration, for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: vault
       fields:
@@ -360,7 +365,7 @@ configuration_options:
           description: This value must be `vault`.
         - name: endpoint
           default: localhost:8200
-          description: The 'hostname:port' used by vault
+          description: The 'hostname:port' used by Vault.
         - name: token
           default: localhost:8200
           description: Token used for authentication.
@@ -369,13 +374,13 @@ configuration_options:
           description: The path for metrics collection.
         - name: collection_interval
           default: 60s
-          description: A [`time.Duration`](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
         - name: insecure
           default: true
           description: Sets whether or not to use a secure TLS connection. If set to `false`, then TLS is enabled.
         - name: insecure_skip_verify
           default: false
-          description: Sets whether or not to skip verifying the certificate. If `insecure` is set to `true`, then the 'insecure_skip_verify` value is not used.
+          description: Sets whether or not to skip verifying the certificate. If `insecure` is set to `true`, then the `insecure_skip_verify` value is not used.
         - name: cert_file
           default: null
           description: Path to the TLS certificate to use for mTLS-required connections.

--- a/integration_test/third_party_apps_test/applications/vault/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/vault/metadata.yaml
@@ -330,9 +330,6 @@ expected_logs:
         type: string
         description: This is a token entity identifier.
         optional: true
-      - name: timestamp
-        type: string ([`Timestamp`](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp))
-        description: Time the request was received
       - name: severity
         type: string
         description: ''

--- a/integration_test/third_party_apps_test/applications/wildfly/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/wildfly/metadata.yaml
@@ -21,13 +21,6 @@ description: |-
   The WildFly integration collects WildFly logs and parses them into a JSON
   payload. The result includes source, message code, level, and message.
 configure_integration: |-
-  To collect and ingest WildFly logs, you must
-  [install Ops Agent]({{install_path}}/install-index) version 2.12.0 or higher.
-
-  This receiver supports WildFly versions 25.x and 26.x.
-
-  ## Configure your WildFly instance {: #configure-instance }
-
   To expose the JMX endpoint remotely, you must set the
   `jboss.bind.address.management` system property. By default, this property is
   set in WildFly's configuration. The default WildFly installation requires no JMX
@@ -165,28 +158,28 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: The value must be wildfly_system.
+          description: The value must be `wildfly_system`.
         - name: include_paths
           default: '[/opt/wildfly/standalone/log/server.log, /opt/wildfly/domain/servers/*/log/server.log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/wildfly*/*.log.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `/var/log/wildfly*/*.log`.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: wildfly
       fields:
         - name: type
           default: null
-          description: This value must be wildfly.
+          description: This value must be `wildfly`.
         - name: endpoint
           default: service:jmx:remote+http://localhost:9990
-          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of service:jmx:<protocol>:<sap> or host:port. Values in host:port form are used to create a service URL of service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi.
+          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
         - name: username
           default: null
           description: The configured username if JMX is configured to require authentication.
@@ -195,7 +188,7 @@ configuration_options:
           description: The configured password if JMX is configured to require authentication.
         - name: additional_jars
           default: /opt/wildfly/bin/client/jboss-client.jar
-          description: The path to the jboss-client.jar file, which is required to monitor WildFly through JMX.
+          description: The path to the `jboss-client.jar` file, which is required to monitor WildFly through JMX.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.

--- a/integration_test/third_party_apps_test/applications/wildfly/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/wildfly/metadata.yaml
@@ -179,7 +179,7 @@ configuration_options:
           description: This value must be `wildfly`.
         - name: endpoint
           default: service:jmx:remote+http://localhost:9990
-          description: The JMX Service URL or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
+          description: The [JMX Service URL](https://docs.oracle.com/javase/8/docs/api/javax/management/remote/JMXServiceURL.html) or host and port used to construct the service URL. This value must be in the form of `service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form are used to create a service URL of `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
         - name: username
           default: null
           description: The configured username if JMX is configured to require authentication.

--- a/integration_test/third_party_apps_test/applications/zookeeper/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/zookeeper/metadata.yaml
@@ -120,28 +120,28 @@ configuration_options:
       fields:
         - name: type
           default: null
-          description: The value must be zookeeper_general.
+          description: The value must be `zookeeper_general`.
         - name: include_paths
           default: '[/opt/zookeeper/logs/zookeeper-*.out, /var/log/zookeeper/zookeeper.log]'
-          description: A list of filesystem paths to read by tailing each file. A wild card (*) can be used in the paths; for example, /var/log/zookeeper*/*.log.
+          description: A list of filesystem paths to read by tailing each file. A wild card (`*`) can be used in the paths; for example, `/var/log/zookeeper*/*.log`.
         - name: exclude_paths
           default: null
-          description: A list of filesystem path patterns to exclude from the set matched by include_paths.
+          description: A list of filesystem path patterns to exclude from the set matched by `include_paths`.
         - name: record_log_file_path
           default: false
           description: If set to `true`, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the `agent.googleapis.com/log_file_path` label. When using a wildcard, only the path of the file from which the record was obtained is recorded.
         - name: wildcard_refresh_interval
           default: 60s
-          description: The interval at which wildcard file paths in include_paths are refreshed. Given as a time duration, for example 30s or 2m. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
+          description: The interval at which wildcard file paths in `include_paths` are refreshed. Given as a [time duration](https://pkg.go.dev/time#ParseDuration), for example `30s` or `2m`. This property might be useful under high logging throughputs where log files are rotated faster than the default interval.
   metrics:
     - type: zookeeper
       fields:
         - name: type
           default: null
-          description: This value must be zookeeper.
+          description: This value must be `zookeeper`.
         - name: endpoint
           default: localhost:2181
           description: The URL exposed by ZooKeeper.
         - name: collection_interval
           default: 60s
-          description: A time.Duration value, such as 30s or 5m.
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.

--- a/integration_test/third_party_apps_test/main_test.go
+++ b/integration_test/third_party_apps_test/main_test.go
@@ -681,11 +681,12 @@ func fetchAppsAndMetadata(t *testing.T) map[string]metadata.IntegrationMetadata 
 	for _, file := range files {
 		app := file.Name()
 		var integrationMetadata metadata.IntegrationMetadata
-		testCaseBytes, err := scriptsDir.ReadFile(path.Join("applications", app, "metadata.yaml"))
+		applicationMetadata := path.Join("applications", app, "metadata.yaml")
+		testCaseBytes, err := scriptsDir.ReadFile(applicationMetadata)
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = metadata.UnmarshalAndValidate(testCaseBytes, &integrationMetadata)
+		err = metadata.UnmarshalAndValidate(applicationMetadata, testCaseBytes, &integrationMetadata)
 		if err != nil {
 			t.Fatalf("could not validate contents of applications/%v/metadata.yaml: %v", app, err)
 		}

--- a/integration_test/third_party_apps_test/main_test.go
+++ b/integration_test/third_party_apps_test/main_test.go
@@ -169,7 +169,7 @@ func updateSSHKeysForActiveDirectory(ctx context.Context, logger *log.Logger, vm
 //	field name => field value regex
 //
 // into a query filter to pass to the logging API.
-func constructQuery(logName string, fields []*metadata.LogFields) string {
+func constructQuery(logName string, fields []*metadata.LogField) string {
 	var parts []string
 	for _, field := range fields {
 		if field.ValueRegex != "" {
@@ -188,12 +188,12 @@ func constructQuery(logName string, fields []*metadata.LogFields) string {
 
 // logFieldsMapWithPrefix returns a field name => LogField mapping where all the fieldnames have the provided prefix.
 // Note that the map will omit the prefix in the returned map.
-func logFieldsMapWithPrefix(log *metadata.ExpectedLog, prefix string) map[string]*metadata.LogFields {
+func logFieldsMapWithPrefix(log *metadata.ExpectedLog, prefix string) map[string]*metadata.LogField {
 	if log == nil {
 		return nil
 	}
 
-	fieldsMap := make(map[string]*metadata.LogFields)
+	fieldsMap := make(map[string]*metadata.LogField)
 	for _, entry := range log.Fields {
 		if strings.HasPrefix(entry.Name, prefix) {
 			fieldsMap[strings.TrimPrefix(entry.Name, prefix)] = entry
@@ -204,7 +204,7 @@ func logFieldsMapWithPrefix(log *metadata.ExpectedLog, prefix string) map[string
 }
 
 // verifyLogField verifies that the actual field retrieved from Cloud Logging is as expected.
-func verifyLogField(fieldName, actualField string, expectedFields map[string]*metadata.LogFields) error {
+func verifyLogField(fieldName, actualField string, expectedFields map[string]*metadata.LogField) error {
 	expectedField, ok := expectedFields[fieldName]
 	if !ok {
 		// Not expecting this field. It could however be populated with some default zero-values when we
@@ -247,7 +247,7 @@ func verifyLogField(fieldName, actualField string, expectedFields map[string]*me
 //	and then verifying the fields against the expected fields.
 //
 // This should be added if some of the integrations expect to create nested fields.
-func verifyJsonPayload(actualPayload interface{}, expectedPayload map[string]*metadata.LogFields) error {
+func verifyJsonPayload(actualPayload interface{}, expectedPayload map[string]*metadata.LogField) error {
 	var multiErr error
 	actualPayloadFields := actualPayload.(*structpb.Struct).GetFields()
 	for expectedKey, expectedValue := range expectedPayload {
@@ -407,8 +407,8 @@ func verifyLog(actualLog *cloudlogging.Entry, expectedLog *metadata.ExpectedLog)
 
 // stripUnavailableFields removes the fields that are listed as unavailable_on
 // the current image spec.
-func stripUnavailableFields(fields []*metadata.LogFields, imageSpec string) []*metadata.LogFields {
-	var result []*metadata.LogFields
+func stripUnavailableFields(fields []*metadata.LogField, imageSpec string) []*metadata.LogField {
+	var result []*metadata.LogField
 	for _, field := range fields {
 		if !metadata.SliceContains(field.UnavailableOn, imageSpec) {
 			result = append(result, field)

--- a/integration_test/validate_metadata_test.go
+++ b/integration_test/validate_metadata_test.go
@@ -38,7 +38,7 @@ func TestValidateMetadataOfThirdPartyApps(t *testing.T) {
 		app := path.Base(path.Dir(fullPath))
 		t.Run(app, func(t *testing.T) {
 			t.Parallel()
-			err := metadata.UnmarshalAndValidate(contents, &metadata.IntegrationMetadata{})
+			err := metadata.UnmarshalAndValidate(fullPath, contents, &metadata.IntegrationMetadata{})
 			if err != nil {
 				t.Error(err)
 			}
@@ -74,7 +74,7 @@ func TestThirdPartyPublicUrls(t *testing.T) {
 		t.Run(app, func(t *testing.T) {
 			t.Parallel()
 			integrationMetadata := &metadata.IntegrationMetadata{}
-			err := metadata.UnmarshalAndValidate(contents, integrationMetadata)
+			err := metadata.UnmarshalAndValidate(fullPath, contents, integrationMetadata)
 			if integrationMetadata.PublicUrl == "" {
 				// The public doc isn't available yet.
 				return
@@ -114,7 +114,7 @@ func walkThirdPartyApps(fn func(app string, contents []byte) error) error {
 
 func TestValidateMetadataOfAgentMetric(t *testing.T) {
 
-	err := metadata.UnmarshalAndValidate(agentMetricsMetadata, &metadata.ExpectedMetricsContainer{})
+	err := metadata.UnmarshalAndValidate("ops_agent_test/agent_metrics/metadata.yaml", agentMetricsMetadata, &metadata.ExpectedMetricsContainer{})
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
## Description
Bring the third-party application `metadata.yaml` files up-to-date with the public docs, in preparation for eventually using them as the source of truth.

Also add some more YAML validation and improve test output.

## Related issue
[b/240700717](http://b/240700717)

## How has this been tested?
Except for the new code, which was tested by unit tests, all of the `metadata.yaml` changes have been run through an automatic doc generator and compared with the existing documentation. Some of the changes also update the scripts that run in the third-party application tests — those have passed.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
