### PR TITLE
[Testing] Ubuntu/Debian GPU driver: ping to CUDA 12.5 for V100 P4 P100

### DIFF
--- a/integration_test/third_party_apps_test/applications/dcgm/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/dcgm/debian_ubuntu/install
@@ -18,7 +18,22 @@ if [[ $ID == debian ]]; then
     sudo add-apt-repository contrib
 fi
 sudo apt update
-sudo apt -y install cuda 
+
+# TODO(b/357944360): confirm if the older GPUs can use >= 560 driver (CUDA 12.6
+# or newer) and then remove this case statement
+DEVICE_CODE=$(lspci -n | grep -Po '10de:[\w\d]{4}')
+case $DEVICE_CODE in
+    # V100 | P4 | P100
+    10de:1db1|10de:1bb3|10de:15f8)
+        # For GPUs older than Turing (Volta: V100, Pascal: P4, P100), ping the
+        # version to CUDA 12.5 (driver 555)
+        sudo apt -y install cuda-12-5 
+        ;;
+    *)
+        # For newer GPUs, install the latest version
+        sudo apt -y install cuda
+        ;;
+esac
 
 # check NVIDIA driver installation succeeded
 nvidia-smi

--- a/integration_test/third_party_apps_test/applications/dcgm/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/dcgm/debian_ubuntu/install
@@ -20,10 +20,13 @@ fi
 sudo apt update
 
 # TODO(b/357944360): confirm if the older GPUs can use >= 560 driver (CUDA 12.6
-# or newer) and then remove this case statement
+# or newer) and then remove this case statement 
+# In https://docs.nvidia.com/datacenter/tesla/index.html once the 560 doc is up,
+# check supported GPU section https://screenshot.googleplex.com/9hzxLLvaWVZHu9E
 DEVICE_CODE=$(lspci -n | grep -Po '10de:[\w\d]{4}')
 case $DEVICE_CODE in
     # V100 | P4 | P100
+    # Device PCIe ID lookup: https://envytools.readthedocs.io/en/latest/hw/pciid.html
     10de:1db1|10de:1bb3|10de:15f8)
         # For GPUs older than Turing (Volta: V100, Pascal: P4, P100), ping the
         # version to CUDA 12.5 (driver 555)

--- a/integration_test/third_party_apps_test/applications/nvml/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/nvml/debian_ubuntu/install
@@ -18,7 +18,22 @@ if [[ $ID == debian ]]; then
     sudo add-apt-repository contrib
 fi
 sudo apt update
-sudo apt -y install cuda 
+
+# TODO(b/357944360): confirm if the older GPUs can use >= 560 driver (CUDA 12.6
+# or newer) and then remove this case statement
+DEVICE_CODE=$(lspci -n | grep -Po '10de:[\w\d]{4}')
+case $DEVICE_CODE in
+    # V100 | P4 | P100
+    10de:1db1|10de:1bb3|10de:15f8)
+        # For GPUs older than Turing (Volta: V100, Pascal: P4, P100), ping the
+        # version to CUDA 12.5 (driver 555)
+        sudo apt -y install cuda-12-5 
+        ;;
+    *)
+        # For newer GPUs, install the latest version
+        sudo apt -y install cuda
+        ;;
+esac
 
 # check NVIDIA driver installation succeeded
 nvidia-smi

--- a/integration_test/third_party_apps_test/applications/nvml/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/nvml/debian_ubuntu/install
@@ -20,10 +20,13 @@ fi
 sudo apt update
 
 # TODO(b/357944360): confirm if the older GPUs can use >= 560 driver (CUDA 12.6
-# or newer) and then remove this case statement
+# or newer) and then remove this case statement 
+# In https://docs.nvidia.com/datacenter/tesla/index.html once the 560 doc is up,
+# check supported GPU section https://screenshot.googleplex.com/9hzxLLvaWVZHu9E
 DEVICE_CODE=$(lspci -n | grep -Po '10de:[\w\d]{4}')
 case $DEVICE_CODE in
     # V100 | P4 | P100
+    # Device PCIe ID lookup: https://envytools.readthedocs.io/en/latest/hw/pciid.html
     10de:1db1|10de:1bb3|10de:15f8)
         # For GPUs older than Turing (Volta: V100, Pascal: P4, P100), ping the
         # version to CUDA 12.5 (driver 555)


### PR DESCRIPTION
## Description
The latest CUDA 12.6 appears to be not working for GPUs older than Turing architecture. Ping to the previously working CUDA 12.5 for those GPUs. 

Note that since we only test those GPUs on Focal, this PR only updates the Ubuntu/Debian `install` script. 

## Related issue
[b/357828767](http://b/357828767)

## How has this been tested?
Integration tests pass on Focal. 

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
