### PR TITLE
Consider case when `optional` log fields may be missing in `third_party_apps_tests`.

### DIFF
--- a/integration_test/third_party_apps_test/applications/vault/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/vault/metadata.yaml
@@ -182,6 +182,7 @@ expected_logs:
       - name: jsonPayload.auth
         type: struct
         description: ''
+        optional: true
       - name: jsonPayload.request
         type: struct
         description: ''

--- a/integration_test/third_party_apps_test/main_test.go
+++ b/integration_test/third_party_apps_test/main_test.go
@@ -173,11 +173,11 @@ func constructQuery(logName string, fields []*metadata.LogField) string {
 	var parts []string
 	for _, field := range fields {
 		if field.ValueRegex != "" {
+			guard := ""
 			if field.Optional {
-				parts = append(parts, fmt.Sprintf(`(NOT %s:* OR %s=~"%s")`, field.Name, field.Name, field.ValueRegex))
-			} else {
-				parts = append(parts, fmt.Sprintf(`%s=~"%s"`, field.Name, field.ValueRegex))
+				guard = fmt.Sprintf(`NOT %s:* OR `, field.Name)
 			}
+			parts = append(parts, fmt.Sprintf(`(%s%s=~"%s")`, guard, field.Name, field.ValueRegex))
 		}
 	}
 

--- a/integration_test/third_party_apps_test/main_test.go
+++ b/integration_test/third_party_apps_test/main_test.go
@@ -173,7 +173,11 @@ func constructQuery(logName string, fields []*metadata.LogField) string {
 	var parts []string
 	for _, field := range fields {
 		if field.ValueRegex != "" {
-			parts = append(parts, fmt.Sprintf(`%s=~"%s"`, field.Name, field.ValueRegex))
+			if field.Optional {
+				parts = append(parts, fmt.Sprintf(`(NOT %s:* OR %s=~"%s)"`, field.Name, field.Name, field.ValueRegex))
+			} else {
+				parts = append(parts, fmt.Sprintf(`%s=~"%s"`, field.Name, field.ValueRegex))
+			}
 		}
 	}
 

--- a/integration_test/third_party_apps_test/main_test.go
+++ b/integration_test/third_party_apps_test/main_test.go
@@ -174,7 +174,7 @@ func constructQuery(logName string, fields []*metadata.LogField) string {
 	for _, field := range fields {
 		if field.ValueRegex != "" {
 			if field.Optional {
-				parts = append(parts, fmt.Sprintf(`(NOT %s:* OR %s=~"%s)"`, field.Name, field.Name, field.ValueRegex))
+				parts = append(parts, fmt.Sprintf(`(NOT %s:* OR %s=~"%s")`, field.Name, field.Name, field.ValueRegex))
 			} else {
 				parts = append(parts, fmt.Sprintf(`%s=~"%s"`, field.Name, field.ValueRegex))
 			}


### PR DESCRIPTION
## Description
Currently `constructQuery` doesn't consider the case where an `optional` log field may be completely `missing` (see [missing fields in log query language](https://cloud.google.com/logging/docs/view/logging-query-language#missing_fields)).

When vault was upgraded from 1.17.2 to 1.17.3, the field `jsonPayload.auth` is omitted when `token_type=default`. See https://github.com/hashicorp/vault/compare/v1.17.2...v1.17.3 . Setting `jsonPayload.auth` as `optional` due to this update.

## Related issue
b/358355216

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
