### PR TITLE
Clean up and update metadata files for IIS, MSSQL, and MySQL/MariaDB.

### DIFF
--- a/integration_test/third_party_apps_test/applications/iis/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/iis/metadata.yaml
@@ -166,5 +166,5 @@ configuration_options:
           default: 60s
           description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
         - name: receiver_version
-          default: null
+          default: "1"
           description: Version of the metrics collected; use `2` to collect v2 metrics.

--- a/integration_test/third_party_apps_test/applications/iis/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/iis/metadata.yaml
@@ -13,17 +13,15 @@
 # limitations under the License.
 
 public_url: "https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/iis"
-app_url: "https://www.iis.net/"
+app_url: "https://docs.microsoft.com/iis/"
 short_name: IIS
-long_name: IIS
+long_name: Internet Information Services
 logo_path: /stackdriver/images/iis.png # supplied by google technical writer
 description: |-
-  The Internet Information Services (IIS) integration collects metrics from your
-  IIS web servers. The metrics provide connection information and also data on
-  transferred bytes.
-
-  When using the Ops Agent on a Microsoft Windows VM, the agent automatically
-  collects IIS metrics. No additional configuration is required.
+  The Internet Information Services (IIS) integration collects telemetry from
+  your IIS web servers. The metrics provide connection information
+  and also data on transferred bytes. The integration also collects information
+  from access logs.
 minimum_supported_agent_version:
   metrics: 2.15.0
   logging: 2.14.0

--- a/integration_test/third_party_apps_test/applications/iisv1/enable
+++ b/integration_test/third_party_apps_test/applications/iisv1/enable
@@ -1,0 +1,25 @@
+$ErrorActionPreference = 'Stop'
+
+# This config gets merged with the built-in Ops Agent config, which already
+# includes the v1 receiver in the default pipeline.
+
+# Create a back up of the existing file so existing configurations are not lost.
+Copy-Item -Path 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml' -Destination 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml.bak'
+
+# Configure the Ops Agent.
+Add-Content 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml' "
+logging:
+  receivers:
+    iis_access:
+      type: iis_access
+  service:
+    pipelines:
+      iis:
+        receivers:
+        - iis_access
+"
+
+# Stop-Service may fail if the service isn't in a Running state yet.
+(Get-Service google-cloud-ops-agent*).WaitForStatus('Running', '00:03:00')
+Stop-Service google-cloud-ops-agent -Force
+Start-Service google-cloud-ops-agent*

--- a/integration_test/third_party_apps_test/applications/iisv1/exercise
+++ b/integration_test/third_party_apps_test/applications/iisv1/exercise
@@ -1,0 +1,2 @@
+# generate log
+curl http://localhost:80/forbidden?something=something

--- a/integration_test/third_party_apps_test/applications/iisv1/features.yaml
+++ b/integration_test/third_party_apps_test/applications/iisv1/features.yaml
@@ -1,0 +1,5 @@
+features:
+- module: logging
+  feature: receivers:iis_access
+  key: "[0].enabled"
+  value: "true"

--- a/integration_test/third_party_apps_test/applications/iisv1/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/iisv1/metadata.yaml
@@ -13,19 +13,20 @@
 # limitations under the License.
 
 public_url: "https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/iis"
-app_url: "https://www.iis.net/"
+app_url: "https://docs.microsoft.com/iis/"
 short_name: IIS
-long_name: IIS
+long_name: Internet Information Services
 logo_path: /stackdriver/images/iis.png # supplied by google technical writer
 description: |-
-  The Internet Information Services (IIS) integration collects metrics from your
-  IIS web servers. The metrics provide connection information and also data on
-  transferred bytes.
+  The Internet Information Services (IIS) integration collects telemetry from
+  your IIS web servers. The metrics provide connection information
+  and also data on transferred bytes. The integration also collects information
+  from access logs.
 
   When using the Ops Agent on a Microsoft Windows VM, the agent automatically
   collects IIS metrics. No additional configuration is required.
 minimum_supported_agent_version:
-  metrics: 2.15.0
+  metrics: 1.0.0
   logging: 2.14.0
 supported_operating_systems: windows
 supported_app_version: ["8.5", "10.0"]

--- a/integration_test/third_party_apps_test/applications/iisv1/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/iisv1/metadata.yaml
@@ -134,5 +134,5 @@ configuration_options:
           default: 60s
           description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
         - name: receiver_version
-          default: null
+          default: "1"
           description: Version of the metrics collected; use `2` to collect v2 metrics.

--- a/integration_test/third_party_apps_test/applications/iisv1/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/iisv1/metadata.yaml
@@ -30,63 +30,28 @@ minimum_supported_agent_version:
 supported_operating_systems: windows
 supported_app_version: ["8.5", "10.0"]
 expected_metrics:
-  # v2 metrics
-  - type: workload.googleapis.com/iis.request.count
+  # v1 metrics
+  - type: agent.googleapis.com/iis/current_connections
+    value_type: DOUBLE
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: agent.googleapis.com/iis/network/transferred_bytes_count
     value_type: INT64
     kind: CUMULATIVE
     monitored_resource: gce_instance
     labels:
-      request: .*
+      direction: .*
+  - type: agent.googleapis.com/iis/new_connection_count
+    value_type: INT64
+    kind: CUMULATIVE
+    monitored_resource: gce_instance
+  - type: agent.googleapis.com/iis/request_count
+    value_type: INT64
+    kind: CUMULATIVE
+    monitored_resource: gce_instance
+    labels:
+      http_method: .*
     representative: true
-  - type: workload.googleapis.com/iis.request.rejected
-    value_type: INT64
-    kind: CUMULATIVE
-    monitored_resource: gce_instance
-  - type: workload.googleapis.com/iis.request.queue.count
-    value_type: INT64
-    kind: GAUGE
-    monitored_resource: gce_instance
-  - type: workload.googleapis.com/iis.request.queue.age.max
-    value_type: INT64
-    kind: GAUGE
-    monitored_resource: gce_instance
-    optional: true
-  - type: workload.googleapis.com/iis.network.file.count
-    value_type: INT64
-    kind: CUMULATIVE
-    monitored_resource: gce_instance
-    labels:
-      direction: .*
-  - type: workload.googleapis.com/iis.network.blocked
-    value_type: INT64
-    kind: CUMULATIVE
-    monitored_resource: gce_instance
-  - type: workload.googleapis.com/iis.network.io
-    value_type: INT64
-    kind: CUMULATIVE
-    monitored_resource: gce_instance
-    labels:
-      direction: .*
-  - type: workload.googleapis.com/iis.connection.attempt.count
-    value_type: INT64
-    kind: CUMULATIVE
-    monitored_resource: gce_instance
-  - type: workload.googleapis.com/iis.connection.active
-    value_type: INT64
-    kind: GAUGE
-    monitored_resource: gce_instance
-  - type: workload.googleapis.com/iis.connection.anonymous
-    value_type: INT64
-    kind: CUMULATIVE
-    monitored_resource: gce_instance
-  - type: workload.googleapis.com/iis.thread.active
-    value_type: INT64
-    kind: GAUGE
-    monitored_resource: gce_instance
-  - type: workload.googleapis.com/iis.uptime
-    value_type: INT64
-    kind: GAUGE
-    monitored_resource: gce_instance
 expected_logs:
   - log_name: iis_access
     fields:

--- a/integration_test/third_party_apps_test/applications/iisv1/windows/install
+++ b/integration_test/third_party_apps_test/applications/iisv1/windows/install
@@ -1,0 +1,5 @@
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+Install-WindowsFeature -name Web-Server
+
+Start-WebSite -Name "Default Web Site"

--- a/integration_test/third_party_apps_test/applications/mariadb/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mariadb/metadata.yaml
@@ -33,9 +33,9 @@ configure_integration: |-
   server using a Unix socket and Unix authentication as the `root` user.
 
   The `mysql_error` logging receiver collects logs from the default file paths
-  shown in the following table. On some platforms, MariaDB logs to `journald` by
-  default instead of a file. To configure MariaDB to log to a file instead,
-  set the `log_error` in the MariaDB configuration. For more information
+  shown in the following table. On some platforms, MariaDB logs to `journald`
+  by default instead of to file. To configure MariaDB to log to a file instead,
+  set the `log_error` option in the MariaDB configuration. For more information
   about `log_error` configuration, see [Writing the Error Log to a
   File](https://mariadb.com/kb/en/error-log/#writing-the-error-log-to-a-file).
 minimum_supported_agent_version:

--- a/integration_test/third_party_apps_test/applications/mariadb/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mariadb/metadata.yaml
@@ -29,15 +29,15 @@ configure_integration: |-
   relational database management system (RDBMS). To collect logs and metrics for
   MariaDB, use the `mysql` receivers.
 
-  The `mysql` metrics receiver connects by default to a local MySQL/MariaDB
+  The `mysql` metrics receiver connects by default to a local MariaDB
   server using a Unix socket and Unix authentication as the `root` user.
 
   The `mysql_error` logging receiver collects logs from the default file paths
-  shown in the table below. On some platforms, MariaDB logs to `journald` by
-  default instead of a file. Configure MariaDB to log to a file instead by
-  setting `log_error` in the MariaDB configuration.
-  [Learn more](https://mariadb.com/kb/en/error-log/#writing-the-error-log-to-a-file)
-  about configuring `log_error`.
+  shown in the following table. On some platforms, MariaDB logs to `journald` by
+  default instead of a file. To configure MariaDB to log to a file instead,
+  set the `log_error` in the MariaDB configuration. For more information
+  about `log_error` configuration, see [Writing the Error Log to a
+  File](https://mariadb.com/kb/en/error-log/#writing-the-error-log-to-a-file).
 minimum_supported_agent_version:
   metrics: 2.37.0
   logging: 2.37.0

--- a/integration_test/third_party_apps_test/applications/mssql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mssql/metadata.yaml
@@ -148,5 +148,5 @@ configuration_options:
           default: 60s
           description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
         - name: receiver_version
-          default: null
+          default: "1"
           description: Version of the metrics collected; use `2` to collect v2 metrics.

--- a/integration_test/third_party_apps_test/applications/mssql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mssql/metadata.yaml
@@ -31,6 +31,10 @@ description: |-
 minimum_supported_agent_version:
   metrics: 2.15.0
 supported_operating_systems: windows
+platforms_to_skip:
+  # Skip non-sql images.
+  - windows-cloud:windows-2016-core
+  - windows-cloud:windows-2022
 supported_app_version: ["11.x", "12.x", "13.x", "14.x", "15.x"]
 expected_metrics:
   # v2 metrics

--- a/integration_test/third_party_apps_test/applications/mssql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mssql/metadata.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 public_url: "https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/mssql"
-app_url: "https://docs.microsoft.com/en-us/sql/sql-server"
+app_url: "https://docs.microsoft.com/sql/sql-server/"
 short_name: SQL Server
 long_name: Microsoft SQL Server
 logo_path: /stackdriver/images/mssql.png # supplied by google technical writer
@@ -27,9 +27,7 @@ description: |-
   is provided at the instance level. Transaction and transaction log information
   is provided at the database level.
 
-  For more information on SQL Server, see the
-  [SQL Server](https://docs.microsoft.com/en-us/sql/sql-server)
-  documentation.
+  This integration doesn't support SQL Server named instances.
 minimum_supported_agent_version:
   metrics: 2.15.0
 supported_operating_systems: windows
@@ -146,5 +144,5 @@ configuration_options:
           default: 60s
           description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
         - name: receiver_version
-          default: "1"
+          default: null
           description: Version of the metrics collected; use `2` to collect v2 metrics.

--- a/integration_test/third_party_apps_test/applications/mssql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mssql/metadata.yaml
@@ -35,25 +35,12 @@ minimum_supported_agent_version:
 supported_operating_systems: windows
 supported_app_version: ["11.x", "12.x", "13.x", "14.x", "15.x"]
 expected_metrics:
-  # v1 metrics
-  - type: agent.googleapis.com/mssql/connections/user
-    value_type: DOUBLE
-    kind: GAUGE
-    monitored_resource: gce_instance
-    representative: true
-  - type: agent.googleapis.com/mssql/transaction_rate
-    value_type: DOUBLE
-    kind: GAUGE
-    monitored_resource: gce_instance
-  - type: agent.googleapis.com/mssql/write_transaction_rate
-    value_type: DOUBLE
-    kind: GAUGE
-    monitored_resource: gce_instance
   # v2 metrics
   - type: workload.googleapis.com/sqlserver.user.connection.count
     value_type: INT64
     kind: GAUGE
     monitored_resource: gce_instance
+    representative: true
   - type: workload.googleapis.com/sqlserver.lock.wait_time.avg
     value_type: DOUBLE
     kind: GAUGE

--- a/integration_test/third_party_apps_test/applications/mssqlv1/enable
+++ b/integration_test/third_party_apps_test/applications/mssqlv1/enable
@@ -1,0 +1,16 @@
+$ErrorActionPreference = 'Stop'
+
+# This config gets merged with the built-in Ops Agent config, which already
+# includes the v1 receiver in the default pipeline.
+
+# Create a back up of the existing file so existing configurations are not lost.
+Copy-Item -Path 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml' -Destination 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml.bak'
+
+# Configure the Ops Agent.
+Add-Content 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml' "
+"
+
+# Stop-Service may fail if the service isn't in a Running state yet.
+(Get-Service google-cloud-ops-agent*).WaitForStatus('Running', '00:03:00')
+Stop-Service google-cloud-ops-agent -Force
+Start-Service google-cloud-ops-agent*

--- a/integration_test/third_party_apps_test/applications/mssqlv1/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mssqlv1/metadata.yaml
@@ -31,6 +31,10 @@ description: |-
 minimum_supported_agent_version:
   metrics: 1.0.0
 supported_operating_systems: windows
+platforms_to_skip:
+  # Skip non-sql images.
+  - windows-cloud:windows-2016-core
+  - windows-cloud:windows-2022
 supported_app_version: ["11.x", "12.x", "13.x", "14.x", "15.x"]
 expected_metrics:
   # v1 metrics

--- a/integration_test/third_party_apps_test/applications/mssqlv1/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mssqlv1/metadata.yaml
@@ -1,0 +1,64 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+public_url: "https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/mssql"
+app_url: "https://docs.microsoft.com/en-us/sql/sql-server"
+short_name: SQL Server
+long_name: Microsoft SQL Server
+logo_path: /stackdriver/images/mssql.png # supplied by google technical writer
+description: |-
+  The v1 Microsoft SQL Server integration collects metrics from your SQL Server
+  instances. The metrics provide transaction-rate information and also data on
+  open connections.
+
+  The v2 Microsoft SQL Server integration collects metrics from your SQL Server
+  instances and databases. Page, batch, lock, and user connection count information
+  is provided at the instance level. Transaction and transaction log information
+  is provided at the database level.
+
+  For more information on SQL Server, see the
+  [SQL Server](https://docs.microsoft.com/en-us/sql/sql-server)
+  documentation.
+minimum_supported_agent_version:
+  metrics: 2.15.0
+supported_operating_systems: windows
+supported_app_version: ["11.x", "12.x", "13.x", "14.x", "15.x"]
+expected_metrics:
+  # v1 metrics
+  - type: agent.googleapis.com/mssql/connections/user
+    value_type: DOUBLE
+    kind: GAUGE
+    monitored_resource: gce_instance
+    representative: true
+  - type: agent.googleapis.com/mssql/transaction_rate
+    value_type: DOUBLE
+    kind: GAUGE
+    monitored_resource: gce_instance
+  - type: agent.googleapis.com/mssql/write_transaction_rate
+    value_type: DOUBLE
+    kind: GAUGE
+    monitored_resource: gce_instance
+configuration_options:
+  metrics:
+    - type: mssql
+      fields:
+        - name: type
+          default: null
+          description: This value must be `mssql`.
+        - name: collection_interval
+          default: 60s
+          description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
+        - name: receiver_version
+          default: "1"
+          description: Version of the metrics collected; use `2` to collect v2 metrics.

--- a/integration_test/third_party_apps_test/applications/mssqlv1/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mssqlv1/metadata.yaml
@@ -62,5 +62,5 @@ configuration_options:
           default: 60s
           description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
         - name: receiver_version
-          default: null
+          default: "1"
           description: Version of the metrics collected; use `2` to collect v2 metrics.

--- a/integration_test/third_party_apps_test/applications/mssqlv1/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mssqlv1/metadata.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 public_url: "https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/mssql"
-app_url: "https://docs.microsoft.com/en-us/sql/sql-server"
+app_url: "https://docs.microsoft.com/sql/sql-server/"
 short_name: SQL Server
 long_name: Microsoft SQL Server
 logo_path: /stackdriver/images/mssql.png # supplied by google technical writer
@@ -27,11 +27,9 @@ description: |-
   is provided at the instance level. Transaction and transaction log information
   is provided at the database level.
 
-  For more information on SQL Server, see the
-  [SQL Server](https://docs.microsoft.com/en-us/sql/sql-server)
-  documentation.
+  This integration doesn't support SQL Server named instances.
 minimum_supported_agent_version:
-  metrics: 2.15.0
+  metrics: 1.0.0
 supported_operating_systems: windows
 supported_app_version: ["11.x", "12.x", "13.x", "14.x", "15.x"]
 expected_metrics:
@@ -60,5 +58,5 @@ configuration_options:
           default: 60s
           description: A [time duration](https://pkg.go.dev/time#ParseDuration) value, such as `30s` or `5m`.
         - name: receiver_version
-          default: "1"
+          default: null
           description: Version of the metrics collected; use `2` to collect v2 metrics.

--- a/integration_test/third_party_apps_test/applications/mssqlv1/windows/install
+++ b/integration_test/third_party_apps_test/applications/mssqlv1/windows/install
@@ -1,0 +1,1 @@
+# MSSQL integration will be tested on images with MSSQL pre-installed

--- a/integration_test/third_party_apps_test/applications/mysql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mysql/metadata.yaml
@@ -18,18 +18,14 @@ short_name: MySQL
 long_name: MySQL
 logo_path: /images/launcher/logos/mysql.png # supplied by google technical writer
 description: |-
-  The MySQL/MariaDB integration collects performance metrics related to
+  The MySQL integration collects performance metrics related to
   InnoDB, the buffer pool, and various other operations. It also collects general,
   error, and slow-query logs and parses them into a JSON payload. Error logs are
   parsed for their error code and subsystem. Slow-query logs are parsed into
   key-value pairs that describe the performance of a query, including query time
   and rows examined.
 configure_integration: |-
-  MariaDB is a community-developed, commercially supported fork of the MySQL
-  relational database management system (RDBMS). To collect logs and metrics for
-  MariaDB, use the `mysql` receivers.
-
-  The `mysql` receiver connects by default to a local MySQL/MariaDB
+  The `mysql` receiver connects by default to a local MySQL
   server using a Unix socket and Unix authentication as the `root` user.
 minimum_supported_agent_version:
   metrics: 2.32.0

--- a/integration_test/third_party_apps_test/main_test.go
+++ b/integration_test/third_party_apps_test/main_test.go
@@ -922,22 +922,27 @@ func determineTestsToSkip(tests []test, impactedApps map[string]bool) {
 		}
 		if metadata.SliceContains(test.metadata.PlatformsToSkip, test.imageSpec) {
 			tests[i].skipReason = "Skipping test due to 'platforms_to_skip' entry in metadata.yaml"
+			continue
 		}
 		for _, gpuPlatform := range test.metadata.GpuPlatforms {
 			if test.gpu != nil && test.gpu.model == gpuPlatform.Model && !metadata.SliceContains(gpuPlatform.Platforms, test.imageSpec) {
 				tests[i].skipReason = "Skipping test due to 'gpu_platforms.platforms' entry in metadata.yaml"
+				continue
 			}
 		}
 		if reason := incompatibleOperatingSystem(test); reason != "" {
 			tests[i].skipReason = reason
+			continue
 		}
-		if test.app == "mssql" && strings.HasPrefix(test.imageSpec, "windows-cloud") {
+		if strings.HasPrefix(test.app, "mssql") && strings.HasPrefix(test.imageSpec, "windows-cloud") {
 			tests[i].skipReason = "Skipping MSSQL test because this version of Windows doesn't have MSSQL"
+			continue
 		}
 		isSAPHANAImageSpec := test.imageSpec == SAPHANAImageSpec
 		isSAPHANAApp := test.app == SAPHANAApp
 		if isSAPHANAImageSpec != isSAPHANAApp {
 			tests[i].skipReason = fmt.Sprintf("Skipping %v because we only want to test %v on %v", test.app, SAPHANAApp, SAPHANAImageSpec)
+			continue
 		}
 	}
 }

--- a/integration_test/third_party_apps_test/main_test.go
+++ b/integration_test/third_party_apps_test/main_test.go
@@ -518,7 +518,7 @@ func runMetricsTestCases(ctx context.Context, logger *log.Logger, vm *gce.VM, me
 		err = multierr.Append(err, <-c)
 	}
 
-	if fc == nil {
+	if fc == nil || len(fc.Features) == 0 {
 		logger.Printf("skipping feature tracking integration tests")
 		return err
 	}


### PR DESCRIPTION
## Description
Bring the third-party `metadata.yaml` files for IIS, MSSQL, and MySQL/MariaDB up-to-date with the public docs, in preparation for eventually using them as the source of truth.

A follow-on to #1772.

## Related issue
[b/240700717](http://b/240700717)
[b/356682372](http://b/356682372)

## How has this been tested?
All of the `metadata.yaml` changes have been run through an automatic doc generator and compared with the existing documentation. The added third-party application tests have passed.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
