### PR TITLE
Use explicit slash-dot for copy paths

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -748,6 +748,14 @@ func getGcloudConfigDir(ctx context.Context) (string, error) {
 	return out.Stdout, nil
 }
 
+// getDirectoryWithTrailingDot returns the given directory with
+// a trailing '/.'.
+func getDirectoryWithTrailingDot(directory string) string {
+	// Can't just use filepath.Join(directory, "."), because it eats dot path
+	// segments. See https://stackoverflow.com/questions/51669486/filepath-join-removes-dot/51670536#51670536
+	return filepath.Clean(directory) + string(filepath.Separator) + "."
+}
+
 // SetupGcloudConfigDir sets up a new gcloud configuration directory.
 // This copies the contents of the context-specified configuration directory
 // into the new directory.
@@ -758,7 +766,9 @@ func SetupGcloudConfigDir(ctx context.Context, directory string) error {
 		return err
 	}
 	// TODO: Replace with os.CopyFS() once available.
-	if _, err := runCommand(ctx, log.New(io.Discard, "", 0), nil, []string{"cp", "-r", filepath.Join(currentConfigDir, "."), filepath.Join(directory, ".")}, nil); err != nil {
+	from := getDirectoryWithTrailingDot(currentConfigDir)
+	to := getDirectoryWithTrailingDot(directory)
+	if _, err := runCommand(ctx, log.New(io.Discard, "", 0), nil, []string{"cp", "-r", from, to}, nil); err != nil {
 		return err
 	}
 	return nil

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -752,7 +752,7 @@ func getGcloudConfigDir(ctx context.Context) (string, error) {
 // a trailing '/.'.
 func getDirectoryWithTrailingDot(directory string) string {
 	// Can't just use filepath.Join(directory, "."), because it eats dot path
-	// segments. See https://stackoverflow.com/questions/51669486/filepath-join-removes-dot/51670536#51670536
+	// segments. See https://stackoverflow.com/a/51670536.
 	return filepath.Clean(directory) + string(filepath.Separator) + "."
 }
 


### PR DESCRIPTION
## Description
Follow-on to #1761. `filepath.Join(directory, ".")` can trim the dot away which messes up the gcloud config copy operation; this PR adds the dot explicitly without using `filepath.Join`.

## Related issue
[b/352054649](http://b/352054649)

## How has this been tested?
Tested and succeeded locally.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
