### PR TITLE
Remove Debian 11 ARM from building and testing configurations

### DIFF
--- a/integration_test/third_party_apps_test/applications/couchbase/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/couchbase/metadata.yaml
@@ -208,6 +208,5 @@ platforms_to_skip:
   # couchbase is not supported on various distros.
   # https://docs.couchbase.com/server/current/install/install-platforms.html
   - rocky-linux-cloud:rocky-linux-9
-  - debian-cloud:debian-11-arm64
   - debian-cloud:debian-12
 public_url: https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/couchbase

--- a/integration_test/third_party_apps_test/applications/mongodb3.6/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mongodb3.6/metadata.yaml
@@ -35,7 +35,6 @@ supported_operating_systems: linux
 platforms_to_skip:
   # MongoDB3.6 hit end of life in 2021 and is not supported on various distros.
   - debian-cloud:debian-11
-  - debian-cloud:debian-11-arm64
   - debian-cloud:debian-12
   - debian-cloud:debian-12-arm64
   - ml-images:common-gpu-debian-11-py310

--- a/integration_test/third_party_apps_test/applications/mysql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mysql/metadata.yaml
@@ -33,7 +33,6 @@ minimum_supported_agent_version:
 supported_operating_systems: linux
 platforms_to_skip:
   # MySQL is not currently supported on various distros.
-  - debian-cloud:debian-11-arm64
   - debian-cloud:debian-12
   - debian-cloud:debian-12-arm64
   - suse-cloud:sles-15-arm64

--- a/integration_test/third_party_apps_test/applications/mysql5.7/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mysql5.7/metadata.yaml
@@ -43,7 +43,6 @@ platforms_to_skip:
   - rocky-linux-cloud:rocky-linux-9
   - rocky-linux-cloud:rocky-linux-9-arm64
   - debian-cloud:debian-11
-  - debian-cloud:debian-11-arm64
   - debian-cloud:debian-12
   - debian-cloud:debian-12-arm64
   - ml-images:common-gpu-debian-11-py310

--- a/integration_test/third_party_apps_test/applications/oracledb/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/oracledb/metadata.yaml
@@ -51,7 +51,6 @@ supported_operating_systems: linux
 # Oracle DB is difficult to install on these platforms.
 platforms_to_skip:
   - debian-cloud:debian-11
-  - debian-cloud:debian-11-arm64
   - debian-cloud:debian-12
   - debian-cloud:debian-12-arm64
   - ml-images:common-gpu-debian-11-py310

--- a/project.yaml
+++ b/project.yaml
@@ -20,10 +20,6 @@ targets:
           representative:
           - debian-cloud:debian-11
           - ml-images:common-gpu-debian-11-py310
-      aarch64:
-        test_distros:
-          representative:
-          - debian-cloud:debian-11-arm64
   centos8:
     package_extension:
       rpm


### PR DESCRIPTION
## Description
Debian 11 ARM is [EOS](https://screenshot.googleplex.com/8x6Uc7aabQ32rSk) as of August 15, 2024.

## Related issue
[b/362502002](http://b/362502002)

## How has this been tested?
Integration tests passing. 

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
