### PR TITLE
Update go version used by integration tests

### DIFF
--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -4111,10 +4111,10 @@ func installGolang(ctx context.Context, logger *log.Logger, vm *gce.VM) error {
 		return err
 	}
 
-	// To update this, first run `mirror_content.sh` in this directory. Example:
+	// To update this, first run `mirror_content.sh` under `integration_test`. Example:
 	//   ./mirror_content.sh https://go.dev/dl/go1.21.4.linux-{amd64,arm64}.tar.gz
 	// Then update this version.
-	goVersion := "1.21.4"
+	goVersion := "1.22.7"
 
 	goArch := "amd64"
 	if gce.IsARM(vm.ImageSpec) {


### PR DESCRIPTION
## Description
Our OTLP tests have started to fail because the OTel SDK at HEAD now requires golang 1.22. This PR upgrades the golang version used in the tests to match.

The corresponding 1.22.7 amd64 and arm64 payloads have already been mirrored to our GCS bucket.

## Related issue
N/A noticed in passing

## How has this been tested?
Will let presubmits run.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
