### PR TITLE
Use new slices for log_statements

### DIFF
--- a/confgenerator/otel/processors.go
+++ b/confgenerator/otel/processors.go
@@ -98,7 +98,7 @@ func CumulativeToDelta(metrics ...string) Component {
 		Type: "cumulativetodelta",
 		Config: map[string]interface{}{
 			"include": map[string]interface{}{
-				"metrics": metrics,
+				"metrics":    metrics,
 				"match_type": "strict",
 			},
 		},
@@ -157,9 +157,11 @@ func Transform(statementType, context string, statements ottl.Statements) Compon
 		Type: "transform",
 		Config: map[string]any{
 			"error_mode": "ignore",
-			fmt.Sprintf("%s_statements", statementType): map[string]any{
-				"context":    context,
-				"statements": statements,
+			fmt.Sprintf("%s_statements", statementType): []map[string]any{
+				{
+					"context":    context,
+					"statements": statements,
+				},
 			},
 		},
 	}
@@ -190,10 +192,12 @@ func TransformationMetrics(queries ...TransformQuery) Component {
 	}
 	return Component{
 		Type: "transform",
-		Config: map[string]map[string]interface{}{
-			"metric_statements": {
-				"context":    "datapoint",
-				"statements": queryStrings,
+		Config: map[string]any{
+			"metric_statements": []map[string]any{
+				{
+					"context":    "datapoint",
+					"statements": queryStrings,
+				},
 			},
 		},
 	}

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux-gpu/otel.yaml
@@ -478,7 +478,7 @@ processors:
   transform/otlp_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux/otel.yaml
@@ -449,7 +449,7 @@ processors:
   transform/otlp_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/otel.yaml
@@ -521,7 +521,7 @@ processors:
   transform/otlp_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/otel.yaml
@@ -521,7 +521,7 @@ processors:
   transform/otlp_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel.yaml
@@ -461,7 +461,7 @@ processors:
   transform/logs_p1_sample__logs_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], body["source"]) where (body != nil and body["source"] != nil)
@@ -550,7 +550,7 @@ processors:
   transform/sample__logs_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -567,7 +567,7 @@ processors:
   transform/syslog_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel.yaml
@@ -432,7 +432,7 @@ processors:
   transform/logs_p1_sample__logs_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], body["source"]) where (body != nil and body["source"] != nil)
@@ -521,7 +521,7 @@ processors:
   transform/sample__logs_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -538,7 +538,7 @@ processors:
   transform/syslog_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel.yaml
@@ -504,7 +504,7 @@ processors:
   transform/logs_p1_sample__logs_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], body["source"]) where (body != nil and body["source"] != nil)
@@ -593,7 +593,7 @@ processors:
   transform/sample__logs_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -610,7 +610,7 @@ processors:
   transform/windows__event__log_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], body["channel"]) where (body != nil and body["channel"] != nil)
@@ -686,7 +686,7 @@ processors:
   transform/windows__event__log_1:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -703,7 +703,7 @@ processors:
   transform/windows__event__log_1_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], body["channel"]) where (body != nil and body["channel"] != nil)
@@ -779,7 +779,7 @@ processors:
   transform/windows__event__log_1_1:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -796,7 +796,7 @@ processors:
   transform/windows__event__log_2_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], body["channel"]) where (body != nil and body["channel"] != nil)
@@ -872,7 +872,7 @@ processors:
   transform/windows__event__log_2_1:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel.yaml
@@ -504,7 +504,7 @@ processors:
   transform/logs_p1_sample__logs_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], body["source"]) where (body != nil and body["source"] != nil)
@@ -593,7 +593,7 @@ processors:
   transform/sample__logs_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -610,7 +610,7 @@ processors:
   transform/windows__event__log_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], body["channel"]) where (body != nil and body["channel"] != nil)
@@ -686,7 +686,7 @@ processors:
   transform/windows__event__log_1:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -703,7 +703,7 @@ processors:
   transform/windows__event__log_1_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], body["channel"]) where (body != nil and body["channel"] != nil)
@@ -779,7 +779,7 @@ processors:
   transform/windows__event__log_1_1:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -796,7 +796,7 @@ processors:
   transform/windows__event__log_2_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], body["channel"]) where (body != nil and body["channel"] != nil)
@@ -872,7 +872,7 @@ processors:
   transform/windows__event__log_2_1:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel.yaml
@@ -461,7 +461,7 @@ processors:
   transform/log__source__id1_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -478,7 +478,7 @@ processors:
   transform/logs_pipeline1_log__source__id1_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - set(cache["__parsed_json"], ParseJSON(body["key_1"])) where (body != nil and body["key_1"] != nil)
       - delete_key(body, "key_1") where ((body != nil and body["key_1"] != nil) and (cache != nil and cache["__parsed_json"] != nil))
@@ -533,7 +533,7 @@ processors:
   transform/syslog_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel.yaml
@@ -432,7 +432,7 @@ processors:
   transform/log__source__id1_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -449,7 +449,7 @@ processors:
   transform/logs_pipeline1_log__source__id1_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - set(cache["__parsed_json"], ParseJSON(body["key_1"])) where (body != nil and body["key_1"] != nil)
       - delete_key(body, "key_1") where ((body != nil and body["key_1"] != nil) and (cache != nil and cache["__parsed_json"] != nil))
@@ -504,7 +504,7 @@ processors:
   transform/syslog_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel.yaml
@@ -504,7 +504,7 @@ processors:
   transform/log__source__id1_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -521,7 +521,7 @@ processors:
   transform/logs_pipeline1_log__source__id1_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - set(cache["__parsed_json"], ParseJSON(body["key_1"])) where (body != nil and body["key_1"] != nil)
       - delete_key(body, "key_1") where ((body != nil and body["key_1"] != nil) and (cache != nil and cache["__parsed_json"] != nil))
@@ -576,7 +576,7 @@ processors:
   transform/windows__event__log_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], body["channel"]) where (body != nil and body["channel"] != nil)
@@ -652,7 +652,7 @@ processors:
   transform/windows__event__log_1:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -669,7 +669,7 @@ processors:
   transform/windows__event__log_1_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], body["channel"]) where (body != nil and body["channel"] != nil)
@@ -745,7 +745,7 @@ processors:
   transform/windows__event__log_1_1:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -762,7 +762,7 @@ processors:
   transform/windows__event__log_2_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], body["channel"]) where (body != nil and body["channel"] != nil)
@@ -838,7 +838,7 @@ processors:
   transform/windows__event__log_2_1:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel.yaml
@@ -504,7 +504,7 @@ processors:
   transform/log__source__id1_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -521,7 +521,7 @@ processors:
   transform/logs_pipeline1_log__source__id1_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - set(cache["__parsed_json"], ParseJSON(body["key_1"])) where (body != nil and body["key_1"] != nil)
       - delete_key(body, "key_1") where ((body != nil and body["key_1"] != nil) and (cache != nil and cache["__parsed_json"] != nil))
@@ -576,7 +576,7 @@ processors:
   transform/windows__event__log_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], body["channel"]) where (body != nil and body["channel"] != nil)
@@ -652,7 +652,7 @@ processors:
   transform/windows__event__log_1:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -669,7 +669,7 @@ processors:
   transform/windows__event__log_1_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], body["channel"]) where (body != nil and body["channel"] != nil)
@@ -745,7 +745,7 @@ processors:
   transform/windows__event__log_1_1:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -762,7 +762,7 @@ processors:
   transform/windows__event__log_2_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], body["channel"]) where (body != nil and body["channel"] != nil)
@@ -838,7 +838,7 @@ processors:
   transform/windows__event__log_2_1:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
@@ -461,7 +461,7 @@ processors:
   transform/log__source__id1_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -478,7 +478,7 @@ processors:
   transform/syslog_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel.yaml
@@ -432,7 +432,7 @@ processors:
   transform/log__source__id1_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -449,7 +449,7 @@ processors:
   transform/syslog_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
@@ -504,7 +504,7 @@ processors:
   transform/log__source__id1_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -521,7 +521,7 @@ processors:
   transform/windows__event__log_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], body["channel"]) where (body != nil and body["channel"] != nil)
@@ -597,7 +597,7 @@ processors:
   transform/windows__event__log_1:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -614,7 +614,7 @@ processors:
   transform/windows__event__log_1_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], body["channel"]) where (body != nil and body["channel"] != nil)
@@ -690,7 +690,7 @@ processors:
   transform/windows__event__log_1_1:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -707,7 +707,7 @@ processors:
   transform/windows__event__log_2_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], body["channel"]) where (body != nil and body["channel"] != nil)
@@ -783,7 +783,7 @@ processors:
   transform/windows__event__log_2_1:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel.yaml
@@ -504,7 +504,7 @@ processors:
   transform/log__source__id1_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -521,7 +521,7 @@ processors:
   transform/windows__event__log_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], body["channel"]) where (body != nil and body["channel"] != nil)
@@ -597,7 +597,7 @@ processors:
   transform/windows__event__log_1:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -614,7 +614,7 @@ processors:
   transform/windows__event__log_1_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], body["channel"]) where (body != nil and body["channel"] != nil)
@@ -690,7 +690,7 @@ processors:
   transform/windows__event__log_1_1:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)
@@ -707,7 +707,7 @@ processors:
   transform/windows__event__log_2_0:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], body["channel"]) where (body != nil and body["channel"] != nil)
@@ -783,7 +783,7 @@ processors:
   transform/windows__event__log_2_1:
     error_mode: ignore
     log_statements:
-      context: log
+    - context: log
       statements:
       - delete_key(cache, "__field_0") where (cache != nil and cache["__field_0"] != nil)
       - set(cache["__field_0"], attributes["compute.googleapis.com/resource_name"]) where (attributes != nil and attributes["compute.googleapis.com/resource_name"] != nil)

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux-gpu/otel.yaml
@@ -470,7 +470,7 @@ processors:
     - gcp
   transform/aerospike_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["node_name"], resource.attributes["aerospike.node.name"])
       - set(attributes["namespace_name"], resource.attributes["aerospike.namespace"])

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux/otel.yaml
@@ -441,7 +441,7 @@ processors:
     - gcp
   transform/aerospike_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["node_name"], resource.attributes["aerospike.node.name"])
       - set(attributes["namespace_name"], resource.attributes["aerospike.namespace"])

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows-2012/otel.yaml
@@ -513,7 +513,7 @@ processors:
     - gcp
   transform/aerospike_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["node_name"], resource.attributes["aerospike.node.name"])
       - set(attributes["namespace_name"], resource.attributes["aerospike.namespace"])

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows/otel.yaml
@@ -513,7 +513,7 @@ processors:
     - gcp
   transform/aerospike_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["node_name"], resource.attributes["aerospike.node.name"])
       - set(attributes["namespace_name"], resource.attributes["aerospike.namespace"])

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux-gpu/otel.yaml
@@ -476,7 +476,7 @@ processors:
     - gcp
   transform/apache_3:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["server_name"], resource.attributes["apache.server.name"])
 receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux/otel.yaml
@@ -447,7 +447,7 @@ processors:
     - gcp
   transform/apache_3:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["server_name"], resource.attributes["apache.server.name"])
 receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows-2012/otel.yaml
@@ -519,7 +519,7 @@ processors:
     - gcp
   transform/apache_3:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["server_name"], resource.attributes["apache.server.name"])
 receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows/otel.yaml
@@ -519,7 +519,7 @@ processors:
     - gcp
   transform/apache_3:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["server_name"], resource.attributes["apache.server.name"])
 receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux-gpu/otel.yaml
@@ -476,7 +476,7 @@ processors:
     - gcp
   transform/apache_3:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["server_name"], resource.attributes["apache.server.name"])
 receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux/otel.yaml
@@ -447,7 +447,7 @@ processors:
     - gcp
   transform/apache_3:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["server_name"], resource.attributes["apache.server.name"])
 receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows-2012/otel.yaml
@@ -519,7 +519,7 @@ processors:
     - gcp
   transform/apache_3:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["server_name"], resource.attributes["apache.server.name"])
 receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows/otel.yaml
@@ -519,7 +519,7 @@ processors:
     - gcp
   transform/apache_3:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["server_name"], resource.attributes["apache.server.name"])
 receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux-gpu/otel.yaml
@@ -560,7 +560,7 @@ processors:
     - gcp
   transform/couchbase_3:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - convert_gauge_to_sum("cumulative", true) where metric.name == "workload.googleapis.com/couchbase.bucket.error.oom.count"
       - set(metric.description, "Number of out of memory errors.") where metric.name == "workload.googleapis.com/couchbase.bucket.error.oom.count"

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux/otel.yaml
@@ -531,7 +531,7 @@ processors:
     - gcp
   transform/couchbase_3:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - convert_gauge_to_sum("cumulative", true) where metric.name == "workload.googleapis.com/couchbase.bucket.error.oom.count"
       - set(metric.description, "Number of out of memory errors.") where metric.name == "workload.googleapis.com/couchbase.bucket.error.oom.count"

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows-2012/otel.yaml
@@ -603,7 +603,7 @@ processors:
     - gcp
   transform/couchbase_3:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - convert_gauge_to_sum("cumulative", true) where metric.name == "workload.googleapis.com/couchbase.bucket.error.oom.count"
       - set(metric.description, "Number of out of memory errors.") where metric.name == "workload.googleapis.com/couchbase.bucket.error.oom.count"

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows/otel.yaml
@@ -603,7 +603,7 @@ processors:
     - gcp
   transform/couchbase_3:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - convert_gauge_to_sum("cumulative", true) where metric.name == "workload.googleapis.com/couchbase.bucket.error.oom.count"
       - set(metric.description, "Number of out of memory errors.") where metric.name == "workload.googleapis.com/couchbase.bucket.error.oom.count"

--- a/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux-gpu/otel.yaml
@@ -535,7 +535,7 @@ processors:
     - gcp
   transform/dcgm_5:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["model"], resource.attributes["gpu.model"])
       - set(attributes["gpu_number"], resource.attributes["gpu.number"])

--- a/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux/otel.yaml
@@ -506,7 +506,7 @@ processors:
     - gcp
   transform/dcgm_5:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["model"], resource.attributes["gpu.model"])
       - set(attributes["gpu_number"], resource.attributes["gpu.number"])

--- a/confgenerator/testdata/goldens/metrics-receiver_dcgm_v2/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_dcgm_v2/golden/linux-gpu/otel.yaml
@@ -513,7 +513,7 @@ processors:
     - gcp
   transform/dcgm_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["model"], resource.attributes["gpu.model"])
       - set(attributes["gpu_number"], resource.attributes["gpu.number"])

--- a/confgenerator/testdata/goldens/metrics-receiver_dcgm_v2/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_dcgm_v2/golden/linux/otel.yaml
@@ -484,7 +484,7 @@ processors:
     - gcp
   transform/dcgm_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["model"], resource.attributes["gpu.model"])
       - set(attributes["gpu_number"], resource.attributes["gpu.number"])

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux-gpu/otel.yaml
@@ -494,7 +494,7 @@ processors:
     - gcp
   transform/flink_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["host_name"], resource.attributes["host.name"])
       - set(attributes["taskmanager_id"], resource.attributes["flink.taskmanager.id"])

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux/otel.yaml
@@ -465,7 +465,7 @@ processors:
     - gcp
   transform/flink_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["host_name"], resource.attributes["host.name"])
       - set(attributes["taskmanager_id"], resource.attributes["flink.taskmanager.id"])

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows-2012/otel.yaml
@@ -537,7 +537,7 @@ processors:
     - gcp
   transform/flink_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["host_name"], resource.attributes["host.name"])
       - set(attributes["taskmanager_id"], resource.attributes["flink.taskmanager.id"])

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows/otel.yaml
@@ -537,7 +537,7 @@ processors:
     - gcp
   transform/flink_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["host_name"], resource.attributes["host.name"])
       - set(attributes["taskmanager_id"], resource.attributes["flink.taskmanager.id"])

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux-gpu/otel.yaml
@@ -474,7 +474,7 @@ processors:
     - gcp
   transform/postgresql_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["postgresql.database.name"])
       - set(attributes["table"], resource.attributes["postgresql.table.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux/otel.yaml
@@ -445,7 +445,7 @@ processors:
     - gcp
   transform/postgresql_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["postgresql.database.name"])
       - set(attributes["table"], resource.attributes["postgresql.table.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows-2012/otel.yaml
@@ -517,7 +517,7 @@ processors:
     - gcp
   transform/postgresql_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["postgresql.database.name"])
       - set(attributes["table"], resource.attributes["postgresql.table.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows/otel.yaml
@@ -517,7 +517,7 @@ processors:
     - gcp
   transform/postgresql_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["postgresql.database.name"])
       - set(attributes["table"], resource.attributes["postgresql.table.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux-gpu/otel.yaml
@@ -474,7 +474,7 @@ processors:
     - gcp
   transform/postgresql_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["postgresql.database.name"])
       - set(attributes["table"], resource.attributes["postgresql.table.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux/otel.yaml
@@ -445,7 +445,7 @@ processors:
     - gcp
   transform/postgresql_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["postgresql.database.name"])
       - set(attributes["table"], resource.attributes["postgresql.table.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows-2012/otel.yaml
@@ -517,7 +517,7 @@ processors:
     - gcp
   transform/postgresql_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["postgresql.database.name"])
       - set(attributes["table"], resource.attributes["postgresql.table.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows/otel.yaml
@@ -517,7 +517,7 @@ processors:
     - gcp
   transform/postgresql_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["postgresql.database.name"])
       - set(attributes["table"], resource.attributes["postgresql.table.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux-gpu/otel.yaml
@@ -474,7 +474,7 @@ processors:
     - gcp
   transform/postgresql_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["postgresql.database.name"])
       - set(attributes["table"], resource.attributes["postgresql.table.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux/otel.yaml
@@ -445,7 +445,7 @@ processors:
     - gcp
   transform/postgresql_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["postgresql.database.name"])
       - set(attributes["table"], resource.attributes["postgresql.table.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows-2012/otel.yaml
@@ -517,7 +517,7 @@ processors:
     - gcp
   transform/postgresql_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["postgresql.database.name"])
       - set(attributes["table"], resource.attributes["postgresql.table.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows/otel.yaml
@@ -517,7 +517,7 @@ processors:
     - gcp
   transform/postgresql_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["postgresql.database.name"])
       - set(attributes["table"], resource.attributes["postgresql.table.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux-gpu/otel.yaml
@@ -474,7 +474,7 @@ processors:
     - gcp
   transform/postgresql_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["postgresql.database.name"])
       - set(attributes["table"], resource.attributes["postgresql.table.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux/otel.yaml
@@ -445,7 +445,7 @@ processors:
     - gcp
   transform/postgresql_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["postgresql.database.name"])
       - set(attributes["table"], resource.attributes["postgresql.table.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows-2012/otel.yaml
@@ -517,7 +517,7 @@ processors:
     - gcp
   transform/postgresql_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["postgresql.database.name"])
       - set(attributes["table"], resource.attributes["postgresql.table.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows/otel.yaml
@@ -517,7 +517,7 @@ processors:
     - gcp
   transform/postgresql_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["postgresql.database.name"])
       - set(attributes["table"], resource.attributes["postgresql.table.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux-gpu/otel.yaml
@@ -456,7 +456,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux/otel.yaml
@@ -427,7 +427,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/otel.yaml
@@ -499,7 +499,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/otel.yaml
@@ -499,7 +499,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux-gpu/otel.yaml
@@ -456,7 +456,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux/otel.yaml
@@ -427,7 +427,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows-2012/otel.yaml
@@ -499,7 +499,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows/otel.yaml
@@ -499,7 +499,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux-gpu/otel.yaml
@@ -456,7 +456,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux/otel.yaml
@@ -427,7 +427,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/otel.yaml
@@ -499,7 +499,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/otel.yaml
@@ -499,7 +499,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux-gpu/otel.yaml
@@ -456,7 +456,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux/otel.yaml
@@ -427,7 +427,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/otel.yaml
@@ -499,7 +499,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/otel.yaml
@@ -499,7 +499,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux-gpu/otel.yaml
@@ -456,7 +456,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux/otel.yaml
@@ -427,7 +427,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/otel.yaml
@@ -499,7 +499,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/otel.yaml
@@ -499,7 +499,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux-gpu/otel.yaml
@@ -456,7 +456,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux/otel.yaml
@@ -427,7 +427,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/otel.yaml
@@ -499,7 +499,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/otel.yaml
@@ -499,7 +499,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux-gpu/otel.yaml
@@ -456,7 +456,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux/otel.yaml
@@ -427,7 +427,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/otel.yaml
@@ -499,7 +499,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/otel.yaml
@@ -499,7 +499,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux-gpu/otel.yaml
@@ -456,7 +456,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux/otel.yaml
@@ -427,7 +427,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows-2012/otel.yaml
@@ -499,7 +499,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows/otel.yaml
@@ -499,7 +499,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux-gpu/otel.yaml
@@ -456,7 +456,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux/otel.yaml
@@ -427,7 +427,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows-2012/otel.yaml
@@ -499,7 +499,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows/otel.yaml
@@ -499,7 +499,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux-gpu/otel.yaml
@@ -456,7 +456,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux/otel.yaml
@@ -427,7 +427,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/otel.yaml
@@ -499,7 +499,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/otel.yaml
@@ -499,7 +499,7 @@ processors:
     - gcp
   transform/prometheus_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(resource.attributes["location"], attributes["location"])
       - set(resource.attributes["cluster"], attributes["cluster"])

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux-gpu/otel.yaml
@@ -470,7 +470,7 @@ processors:
     - gcp
   transform/rabbitmq_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux/otel.yaml
@@ -441,7 +441,7 @@ processors:
     - gcp
   transform/rabbitmq_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows-2012/otel.yaml
@@ -513,7 +513,7 @@ processors:
     - gcp
   transform/rabbitmq_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows/otel.yaml
@@ -513,7 +513,7 @@ processors:
     - gcp
   transform/rabbitmq_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux-gpu/otel.yaml
@@ -470,7 +470,7 @@ processors:
     - gcp
   transform/rabbitmq_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux/otel.yaml
@@ -441,7 +441,7 @@ processors:
     - gcp
   transform/rabbitmq_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows-2012/otel.yaml
@@ -513,7 +513,7 @@ processors:
     - gcp
   transform/rabbitmq_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows/otel.yaml
@@ -513,7 +513,7 @@ processors:
     - gcp
   transform/rabbitmq_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux-gpu/otel.yaml
@@ -470,7 +470,7 @@ processors:
     - gcp
   transform/rabbitmq_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux/otel.yaml
@@ -441,7 +441,7 @@ processors:
     - gcp
   transform/rabbitmq_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows-2012/otel.yaml
@@ -513,7 +513,7 @@ processors:
     - gcp
   transform/rabbitmq_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows/otel.yaml
@@ -513,7 +513,7 @@ processors:
     - gcp
   transform/rabbitmq_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux-gpu/otel.yaml
@@ -470,7 +470,7 @@ processors:
     - gcp
   transform/rabbitmq_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux/otel.yaml
@@ -441,7 +441,7 @@ processors:
     - gcp
   transform/rabbitmq_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows-2012/otel.yaml
@@ -513,7 +513,7 @@ processors:
     - gcp
   transform/rabbitmq_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows/otel.yaml
@@ -513,7 +513,7 @@ processors:
     - gcp
   transform/rabbitmq_2:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux-gpu/otel.yaml
@@ -476,7 +476,7 @@ processors:
     - gcp
   transform/saphana_3:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["host"], resource.attributes["saphana.host"])
 receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux/otel.yaml
@@ -447,7 +447,7 @@ processors:
     - gcp
   transform/saphana_3:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["host"], resource.attributes["saphana.host"])
 receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows-2012/otel.yaml
@@ -519,7 +519,7 @@ processors:
     - gcp
   transform/saphana_3:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["host"], resource.attributes["saphana.host"])
 receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows/otel.yaml
@@ -519,7 +519,7 @@ processors:
     - gcp
   transform/saphana_3:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["host"], resource.attributes["saphana.host"])
 receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux-gpu/otel.yaml
@@ -514,7 +514,7 @@ processors:
     - gcp
   transform/vault_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - convert_summary_count_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"
       - convert_summary_sum_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux/otel.yaml
@@ -485,7 +485,7 @@ processors:
     - gcp
   transform/vault_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - convert_summary_count_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"
       - convert_summary_sum_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows-2012/otel.yaml
@@ -557,7 +557,7 @@ processors:
     - gcp
   transform/vault_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - convert_summary_count_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"
       - convert_summary_sum_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows/otel.yaml
@@ -557,7 +557,7 @@ processors:
     - gcp
   transform/vault_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - convert_summary_count_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"
       - convert_summary_sum_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux-gpu/otel.yaml
@@ -514,7 +514,7 @@ processors:
     - gcp
   transform/vault_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - convert_summary_count_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"
       - convert_summary_sum_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux/otel.yaml
@@ -485,7 +485,7 @@ processors:
     - gcp
   transform/vault_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - convert_summary_count_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"
       - convert_summary_sum_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows-2012/otel.yaml
@@ -557,7 +557,7 @@ processors:
     - gcp
   transform/vault_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - convert_summary_count_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"
       - convert_summary_sum_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows/otel.yaml
@@ -557,7 +557,7 @@ processors:
     - gcp
   transform/vault_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - convert_summary_count_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"
       - convert_summary_sum_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux-gpu/otel.yaml
@@ -514,7 +514,7 @@ processors:
     - gcp
   transform/vault_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - convert_summary_count_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"
       - convert_summary_sum_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux/otel.yaml
@@ -485,7 +485,7 @@ processors:
     - gcp
   transform/vault_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - convert_summary_count_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"
       - convert_summary_sum_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows-2012/otel.yaml
@@ -557,7 +557,7 @@ processors:
     - gcp
   transform/vault_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - convert_summary_count_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"
       - convert_summary_sum_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows/otel.yaml
@@ -557,7 +557,7 @@ processors:
     - gcp
   transform/vault_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - convert_summary_count_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"
       - convert_summary_sum_val_to_sum("cumulative",  true) where metric.name == "vault_azure_delete"

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/otel.yaml
@@ -523,13 +523,13 @@ processors:
     - gcp
   transform/iis__v2_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["site"], resource.attributes["iis.site"])
       - set(attributes["app_pool"], resource.attributes["iis.application_pool"])
   transform/iis__v2_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - keep_keys(resource.attributes, [])
 receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/otel.yaml
@@ -523,13 +523,13 @@ processors:
     - gcp
   transform/iis__v2_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["site"], resource.attributes["iis.site"])
       - set(attributes["app_pool"], resource.attributes["iis.application_pool"])
   transform/iis__v2_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - keep_keys(resource.attributes, [])
 receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/otel.yaml
@@ -486,13 +486,13 @@ processors:
     - gcp
   transform/iis_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["site"], resource.attributes["iis.site"])
       - set(attributes["app_pool"], resource.attributes["iis.application_pool"])
   transform/iis_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - keep_keys(resource.attributes, [])
 receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/otel.yaml
@@ -486,13 +486,13 @@ processors:
     - gcp
   transform/iis_0:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["site"], resource.attributes["iis.site"])
       - set(attributes["app_pool"], resource.attributes["iis.application_pool"])
   transform/iis_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - keep_keys(resource.attributes, [])
 receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/otel.yaml
@@ -516,7 +516,7 @@ processors:
     - gcp
   transform/mssql__v2_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["sqlserver.database.name"])
 receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/otel.yaml
@@ -516,7 +516,7 @@ processors:
     - gcp
   transform/mssql__v2_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["sqlserver.database.name"])
 receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/otel.yaml
@@ -498,7 +498,7 @@ processors:
     - gcp
   transform/mssql_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["sqlserver.database.name"])
 receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/otel.yaml
@@ -498,7 +498,7 @@ processors:
     - gcp
   transform/mssql_1:
     metric_statements:
-      context: datapoint
+    - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["sqlserver.database.name"])
 receivers:


### PR DESCRIPTION
## Description
Map-style config was removed in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16773. Slice-style config has been supported for some time so this should work without a collector upgrade.

## Related issue
N/A

## How has this been tested?
Updated unit tests, will let integration tests run.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
